### PR TITLE
Add functional overload for constants

### DIFF
--- a/include/eve/constant/allbits.hpp
+++ b/include/eve/constant/allbits.hpp
@@ -10,6 +10,7 @@
 #ifndef EVE_CONSTANT_ALLBITS_HPP_INCLUDED
 #define EVE_CONSTANT_ALLBITS_HPP_INCLUDED
 
+#include <eve/detail/overload.hpp>
 #include <eve/detail/abi.hpp>
 #include <eve/detail/meta.hpp>
 #include <eve/function/bitwise_cast.hpp>
@@ -18,6 +19,8 @@
 
 namespace eve
 {
+  EVE_MAKE_CALLABLE(allbits_, allbits_);
+
   template<typename T>
   EVE_FORCEINLINE auto Allbits(as_<T> const & = {})
   {
@@ -30,6 +33,8 @@ namespace eve
     else
       return T(bitwise_cast<t_t>(i_t(mask)));
   }
+
+  EVE_MAKE_NAMED_CONSTANT(allbits_, Allbits);
 }
 
 #endif

--- a/include/eve/constant/false.hpp
+++ b/include/eve/constant/false.hpp
@@ -10,6 +10,7 @@
 #ifndef EVE_CONSTANT_FALSE_HPP_INCLUDED
 #define EVE_CONSTANT_FALSE_HPP_INCLUDED
 
+#include <eve/detail/overload.hpp>
 #include <eve/detail/abi.hpp>
 #include <eve/as_logical.hpp>
 #include <eve/is_logical.hpp>
@@ -18,6 +19,8 @@
 
 namespace eve
 {
+  EVE_MAKE_CALLABLE(false_, false_);
+
   template<typename T>
   EVE_FORCEINLINE std::enable_if_t<is_logical_v<T>, as_logical_t<T>> False(as_<T> const & = {})
   {
@@ -27,6 +30,8 @@ namespace eve
   template<typename T>
   EVE_FORCEINLINE std::enable_if_t<!is_logical_v<T>, as_logical_t<T>>
                   False(as_<T> const & = {}) = delete;
+
+  EVE_MAKE_NAMED_CONSTANT(false_, False);
 }
 
 #endif

--- a/include/eve/constant/inf.hpp
+++ b/include/eve/constant/inf.hpp
@@ -10,6 +10,7 @@
 #ifndef EVE_CONSTANT_INF_HPP_INCLUDED
 #define EVE_CONSTANT_INF_HPP_INCLUDED
 
+#include <eve/detail/overload.hpp>
 #include <eve/detail/abi.hpp>
 #include <eve/detail/meta.hpp>
 #include <eve/as.hpp>
@@ -18,6 +19,8 @@
 
 namespace eve
 {
+  EVE_MAKE_CALLABLE(inf_, inf_);
+
   template<typename T>
   EVE_FORCEINLINE auto Inf(as_<T> const & = {}) noexcept
   {
@@ -29,6 +32,7 @@ namespace eve
       return T(std::numeric_limits<t_t>::infinity());
   }
 
+  EVE_MAKE_NAMED_CONSTANT(inf_, Inf);
 }
 
 #endif

--- a/include/eve/constant/minf.hpp
+++ b/include/eve/constant/minf.hpp
@@ -10,6 +10,7 @@
 #ifndef EVE_CONSTANT_MINF_HPP_INCLUDED
 #define EVE_CONSTANT_MINF_HPP_INCLUDED
 
+#include <eve/detail/overload.hpp>
 #include <eve/detail/abi.hpp>
 #include <eve/detail/meta.hpp>
 #include <eve/as.hpp>
@@ -18,6 +19,8 @@
 
 namespace eve
 {
+  EVE_MAKE_CALLABLE(minf_, minf_);
+
   template<typename T>
   EVE_FORCEINLINE auto Minf(as_<T> const & = {}) noexcept
   {
@@ -29,6 +32,7 @@ namespace eve
       return T(-std::numeric_limits<t_t>::infinity());
   }
 
+  EVE_MAKE_NAMED_CONSTANT(minf_, Minf);
 }
 
 #endif

--- a/include/eve/constant/mzero.hpp
+++ b/include/eve/constant/mzero.hpp
@@ -10,6 +10,7 @@
 #ifndef EVE_CONSTANT_MZERO_HPP_INCLUDED
 #define EVE_CONSTANT_MZERO_HPP_INCLUDED
 
+#include <eve/detail/overload.hpp>
 #include <eve/detail/abi.hpp>
 #include <eve/detail/meta.hpp>
 #include <eve/as.hpp>
@@ -17,17 +18,22 @@
 
 namespace eve
 {
+  EVE_MAKE_CALLABLE(mzero_, mzero_);
+
   template<typename T>
   EVE_FORCEINLINE auto Mzero(as_<T> const & = {}) noexcept
   {
     using t_t = detail::value_type_t<T>;
 
-    if constexpr(std::is_same_v<t_t, float>) return T(-0.0f);
+    if constexpr(std::is_same_v<t_t, float>)
+      return T(-0.0f);
     else if constexpr(std::is_same_v<t_t, double>)
       return T(-0.0);
     else
       return T(0);
   }
+
+  EVE_MAKE_NAMED_CONSTANT(mzero_, Mzero);
 }
 
 #endif

--- a/include/eve/constant/nan.hpp
+++ b/include/eve/constant/nan.hpp
@@ -10,6 +10,7 @@
 #ifndef EVE_CONSTANT_NAN_HPP_INCLUDED
 #define EVE_CONSTANT_NAN_HPP_INCLUDED
 
+#include <eve/detail/overload.hpp>
 #include <eve/detail/abi.hpp>
 #include <eve/constant/zero.hpp>
 #include <eve/constant/allbits.hpp>
@@ -19,6 +20,8 @@
 
 namespace eve
 {
+  EVE_MAKE_CALLABLE(nan_, nan_);
+
   template<typename T>
   EVE_FORCEINLINE auto Nan(as_<T> const & = {}) noexcept
   {
@@ -30,6 +33,7 @@ namespace eve
       return Allbits<T>();
   }
 
+  EVE_MAKE_NAMED_CONSTANT(nan_, Nan);
 }
 
 #endif

--- a/include/eve/constant/one.hpp
+++ b/include/eve/constant/one.hpp
@@ -10,16 +10,21 @@
 #ifndef EVE_CONSTANT_ONE_HPP_INCLUDED
 #define EVE_CONSTANT_ONE_HPP_INCLUDED
 
+#include <eve/detail/overload.hpp>
 #include <eve/detail/abi.hpp>
 #include <eve/as.hpp>
 
 namespace eve
 {
+  EVE_MAKE_CALLABLE(one_, one_);
+
   template<typename T>
   EVE_FORCEINLINE auto One(as_<T> const & = {})
   {
     return T(1);
   }
+
+  EVE_MAKE_NAMED_CONSTANT(one_, One);
 }
 
 #endif

--- a/include/eve/constant/true.hpp
+++ b/include/eve/constant/true.hpp
@@ -10,6 +10,7 @@
 #ifndef EVE_CONSTANT_TRUE_HPP_INCLUDED
 #define EVE_CONSTANT_TRUE_HPP_INCLUDED
 
+#include <eve/detail/overload.hpp>
 #include <eve/detail/abi.hpp>
 #include <eve/as_logical.hpp>
 #include <eve/is_logical.hpp>
@@ -18,6 +19,8 @@
 
 namespace eve
 {
+  EVE_MAKE_CALLABLE(true_, true_);
+
   template<typename T>
   EVE_FORCEINLINE std::enable_if_t<is_logical_v<T>, as_logical_t<T>> True(as_<T> const & = {})
   {
@@ -27,6 +30,8 @@ namespace eve
   template<typename T>
   EVE_FORCEINLINE std::enable_if_t<!is_logical_v<T>, as_logical_t<T>>
                   True(as_<T> const & = {}) = delete;
+
+  EVE_MAKE_NAMED_CONSTANT(true_, True);
 }
 
 #endif

--- a/include/eve/constant/zero.hpp
+++ b/include/eve/constant/zero.hpp
@@ -10,16 +10,21 @@
 #ifndef EVE_CONSTANT_ZERO_HPP_INCLUDED
 #define EVE_CONSTANT_ZERO_HPP_INCLUDED
 
+#include <eve/detail/overload.hpp>
 #include <eve/detail/abi.hpp>
 #include <eve/as.hpp>
 
 namespace eve
 {
+  EVE_MAKE_CALLABLE(zero_, zero_);
+
   template<typename T>
   EVE_FORCEINLINE auto Zero(as_<T> const & = {})
   {
     return T(0);
   }
+
+  EVE_MAKE_NAMED_CONSTANT(zero_, Zero);
 }
 
 #endif

--- a/include/eve/detail/overload.hpp
+++ b/include/eve/detail/overload.hpp
@@ -74,6 +74,18 @@
 // Flag a function to support delayed calls on given architecture
 #define EVE_SUPPORTS(ARCH) delay_t const &, ARCH const &
 
+// Create named object for consatnt
+#define EVE_MAKE_NAMED_CONSTANT(TAG, FUNC)                                                         \
+namespace detail                                                                                   \
+{                                                                                                  \
+  template<typename T>                                                                             \
+  EVE_FORCEINLINE constexpr auto TAG(EVE_SUPPORTS(cpu_), as_<T> const &) noexcept                  \
+  {                                                                                                \
+    return FUNC<T>();                                                                              \
+  }                                                                                                \
+}                                                                                                  \
+/**/
+
 // basic type to support delayed calls
 namespace eve::detail
 {


### PR DESCRIPTION
Add a function object for constant generations. This fulfills two goals:
 - make constant behaves like a function in a generic context. Those constant functions await an `as_` instance as a parameter
 - open the door for the upcoming `if_(cond, x, zero_)` interface for optimized select/comparison.