### PR TITLE
Add more expressive assert

### DIFF
--- a/include/eve/assert.hpp
+++ b/include/eve/assert.hpp
@@ -1,0 +1,39 @@
+
+//==================================================================================================
+/**
+  EVE - Expressive Vector Engine
+  Copyright 2019 Joel FALCOU
+
+  Licensed under the MIT License <http://opensource.org/licenses/MIT>.
+  SPDX-License-Identifier: MIT
+**/
+//==================================================================================================
+#undef EVE_ASSERT
+#undef EVE_VERIFY
+
+#if defined(EVE_DISABLE_ASSERTS) || defined(NDEBUG)
+
+#define EVE_ASSERT(cond, ... ) ((void)0)
+#define EVE_VERIFY(cond, ... ) ((void)(cond))
+
+#else
+
+#include <cstdlib>
+#include <iostream>
+
+#define EVE_ASSERT(cond, ... )                                                                     \
+do {                                                                                               \
+  if (!(cond))                                                                                     \
+  {                                                                                                \
+    std::cerr << "Assertion '" << #cond << "' failed in " << __FILE__ << ":" << __LINE__ << " - "  \
+              << __VA_ARGS__ << std::endl;                                                         \
+    std::abort();                                                                                  \
+  }                                                                                                \
+} while(0)                                                                                         \
+/**/
+
+#define EVE_VERIFY(cond, ... ) EVE_ASSERT(cond,__VA_ARGS__)
+
+#endif
+
+#endif

--- a/include/eve/memory/align.hpp
+++ b/include/eve/memory/align.hpp
@@ -11,6 +11,7 @@
 #define EVE_MEMORY_ALIGN_HPP_INCLUDED
 
 #include <eve/memory/power_of_2.hpp>
+#include <eve/assert.hpp>
 #include <type_traits>
 #include <cstdint>
 
@@ -28,14 +29,20 @@ namespace eve
   template<typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
   constexpr auto align(T value, over alignment) noexcept
   {
-    assert(is_power_of_2(alignment.value));
+    EVE_ASSERT( is_power_of_2(alignment.value)
+              , alignment.value << " is not a power of 2."
+              );
+
     return (value + alignment.value - 1) & ~(alignment.value - 1);
   }
 
   template<typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
   constexpr auto align(T value, under alignment) noexcept
   {
-    assert(is_power_of_2(alignment.value));
+    EVE_ASSERT( is_power_of_2(alignment.value)
+              , alignment.value << " is not a power of 2."
+              );
+
     return value & ~(alignment.value - 1);
   }
 

--- a/include/eve/memory/aligned_ptr.hpp
+++ b/include/eve/memory/aligned_ptr.hpp
@@ -1,7 +1,7 @@
 //==================================================================================================
 /**
   EVE - Expressive Vector Engine
-  Copyright 2018 Joel FALCOU
+  Copyright 2019 Joel FALCOU
 
   Licensed under the MIT License <http://opensource.org/licenses/MIT>.
   SPDX-License-Identifier: MIT
@@ -11,8 +11,8 @@
 #define EVE_MEMORY_ALIGNED_PTR_HPP_INCLUDED
 
 #include <eve/memory/is_aligned.hpp>
+#include <eve/assert.hpp>
 #include <type_traits>
-#include <cassert>
 
 namespace eve
 {
@@ -34,7 +34,9 @@ namespace eve
     aligned_ptr(pointer p) noexcept
         : pointer_(p)
     {
-      assert(is_aligned<Alignment>(p));
+      EVE_ASSERT( is_aligned<Alignment>(p)
+                , (void*)(p) << " is not aligned on" << Alignment << "."
+                );
     }
 
     template<typename U, std::size_t A, typename = std::enable_if_t<(A >= Alignment)>>
@@ -67,14 +69,20 @@ namespace eve
 
     aligned_ptr &operator+=(std::ptrdiff_t o) noexcept
     {
-      assert(is_aligned<Alignment>(pointer_ + o));
+      EVE_ASSERT( is_aligned<Alignment>(pointer_ + o)
+                , (void*)(pointer_) << " + " << o " is not aligned on" << Alignment << "."
+                );
+
       pointer_ += o;
       return *this;
     }
 
     aligned_ptr &operator-=(std::ptrdiff_t o) noexcept
     {
-      assert(is_aligned<Alignment>(pointer_ - o));
+      EVE_ASSERT( is_aligned<Alignment>(pointer_ - o)
+                , (void*)(pointer_) << " - " << o " is not aligned on" << Alignment << "."
+                );
+
       pointer_ -= o;
       return *this;
     }
@@ -145,7 +153,9 @@ namespace eve
     aligned_ptr(pointer p) noexcept
         : pointer_(p)
     {
-      assert(is_aligned<Alignment>(p));
+      EVE_ASSERT( is_aligned<Alignment>(p)
+                , (void*)(p) << " is not aligned on" << Alignment << "."
+                );
     }
 
     template<typename U,


### PR DESCRIPTION
Add `EVE_ASSERT` and `EVE_VERIFY` macro to allow for more expressive asserts message using stream to convey runtime data from the assertion capture point.