### PR TITLE
Improve bitwise_cast codegen for logical cases

### DIFF
--- a/include/eve/module/core/function/simd/common/bitwise_mask.hpp
+++ b/include/eve/module/core/function/simd/common/bitwise_mask.hpp
@@ -28,7 +28,7 @@ namespace eve::detail
   EVE_FORCEINLINE auto bitwise_mask_(EVE_SUPPORTS(simd_),
                                      wide<T, N, ABI> const &v) noexcept
   {
-    using t_t = wide<T, N, ABI>; 
+    using t_t = wide<T, N, ABI>;
     return bitwise_cast<t_t>(is_nez(v));
   }
   // -----------------------------------------------------------------------------------------------
@@ -37,7 +37,7 @@ namespace eve::detail
   EVE_FORCEINLINE auto bitwise_mask_(EVE_SUPPORTS(simd_),
                                      wide<logical<T>, N, ABI> const &v) noexcept
   {
-    using t_t = wide<T, N, ABI>; 
+    using t_t = wide<T, N, ABI>;
     return bitwise_cast<t_t>(v);
   }
 

--- a/include/eve/module/core/function/simd/detail/bitwise_cast.hpp
+++ b/include/eve/module/core/function/simd/detail/bitwise_cast.hpp
@@ -52,12 +52,10 @@ namespace eve::detail
 
   // Logical -> Arithmetic with different storage case
   template<typename In, typename Out>
-  EVE_FORCEINLINE auto l2a_cast_(In const &v0, Out const &) noexcept
+  EVE_FORCEINLINE typename Out::type l2a_cast_(In const &v0, Out const &) noexcept
   {
-    using type = wide<typename In::value_type::value_type, typename In::cardinal_type>;
-
-    type tmp((typename type::storage_type)(v0.storage()));
-    return bitwise_cast<typename Out::type>(tmp);
+    using type = wide<typename Out::type::value_type, typename Out::type::cardinal_type>;
+    return (typename type::storage_type)(v0.storage());
   };
 
   // Logical -> Logical with isomorphic storage case


### PR DESCRIPTION
bitwise_cast and bitwise_mask codegen were bad on ARM and PPC. This slight change in how the cast is performed removed unwanted non-inline function calls to bitwise_cast.