### PR TITLE
Make aggregate wide not use std::array

### DIFF
--- a/include/eve/arch/cpu/as_register.hpp
+++ b/include/eve/arch/cpu/as_register.hpp
@@ -10,7 +10,6 @@
 #ifndef EVE_ARCH_CPU_AS_REGISTER_HPP_INCLUDED
 #define EVE_ARCH_CPU_AS_REGISTER_HPP_INCLUDED
 
-#include <array>
 #include <eve/ext/as_register.hpp>
 #include <eve/forward.hpp>
 
@@ -26,7 +25,11 @@ namespace eve::ext
   struct as_register<Type, Cardinal, eve::aggregated_>
   {
     using substorage_type = eve::wide<Type, typename Cardinal::split_type>;
-    using type            = std::array<substorage_type, 2>;
+    struct type
+    {
+      using value_type = substorage_type;
+      substorage_type lo, hi;
+    };
   };
 }
 

--- a/include/eve/detail/function/simd/common/slice.hpp
+++ b/include/eve/detail/function/simd/common/slice.hpp
@@ -102,7 +102,8 @@ namespace eve::detail
   template<typename T, typename N, typename Slice>
   EVE_FORCEINLINE auto slice(wide<T, N, aggregated_> const &a, Slice const &) noexcept
   {
-    return a.storage()[ Slice::value ];
+    if constexpr(Slice::value == 0) return a.storage().lo;
+    else                            return a.storage().hi;
   }
 }
 

--- a/include/eve/ext/base_wide.hpp
+++ b/include/eve/ext/base_wide.hpp
@@ -67,8 +67,8 @@ namespace eve::detail
   template<typename Type, typename Storage>
   struct wide_iterator<Type, Storage, ::eve::aggregated_>
   {
-    static EVE_FORCEINLINE auto begin(Storage &s) noexcept { return s[ 0 ].begin(); }
-    static EVE_FORCEINLINE auto begin(Storage const &s) noexcept { return s[ 0 ].begin(); }
+    static EVE_FORCEINLINE auto begin(Storage &s) noexcept { return s.lo.begin(); }
+    static EVE_FORCEINLINE auto begin(Storage const &s) noexcept { return s.lo.begin(); }
   };
 }
 

--- a/include/eve/module/core/function/simd/common/store.hpp
+++ b/include/eve/module/core/function/simd/common/store.hpp
@@ -31,8 +31,8 @@ namespace eve::detail
   EVE_FORCEINLINE void
   store_(EVE_SUPPORTS(cpu_), wide<T, N, aggregated_> const &value, T *ptr) noexcept
   {
-    store(value.storage()[ 0 ], ptr);
-    store(value.storage()[ 1 ], ptr + value.storage()[ 1 ].size());
+    store(value.storage().lo, ptr);
+    store(value.storage().hi, ptr + value.storage().hi.size());
   }
 
   template<typename T, typename N, typename ABI>
@@ -61,8 +61,8 @@ namespace eve::detail
          aligned_ptr<T, N>              ptr,
          std::enable_if_t<(wide<T, S, aggregated_>::static_alignment <= N)> * = 0) noexcept
   {
-    store(value.storage()[ 0 ], ptr);
-    store(value.storage()[ 1 ], ptr + value.storage()[ 1 ].size());
+    store(value.storage().lo, ptr);
+    store(value.storage().hi, ptr + value.storage().hi.size());
   }
 
   template<typename T, typename S, std::size_t N, typename ABI>


### PR DESCRIPTION
Using array as storage leads to bad code gen when -fstack-protector is enabled. We use a trivial structure instead.