### PR TITLE
Revert API for function adapters

### DIFF
--- a/doc/manual/functions/arithmetic/sqr.rst
+++ b/doc/manual/functions/arithmetic/sqr.rst
@@ -39,7 +39,7 @@ Synopsis
 Options
 *******
 
-  - ``saturated_``: for an integral entry ``a`` the call to ``sqr[saturated_](a)`` return ``Valmax(as(a))`` as soon as the
+  - ``saturated_``: for an integral entry ``a`` the call to ``saturated_(sqr)(a)`` return ``Valmax(as(a))`` as soon as the
     absolute value of ``a`` is greater than ``SqrtValmax(as(a))``
 
 Example

--- a/include/eve/module/core/function/generic/arg.hpp
+++ b/include/eve/module/core/function/generic/arg.hpp
@@ -29,7 +29,7 @@ namespace eve::detail
                                   , T const &a) noexcept
   {
     static_assert ( std::is_floating_point_v<value_type_t<T>>
-                  , "[eve::arg] -this function is not to be used with integral types"
+                  , "[eve::arg] - Function undefined for integral types"
                   );
 
     return if_else(is_negative(a),Pi(as(a)), eve::zero_);
@@ -41,11 +41,11 @@ namespace eve::detail
                                   , T const &a) noexcept
   {
     static_assert ( std::is_floating_point_v<value_type_t<T>>
-                  , "[eve::arg[pedantic_]] -this function is notto be used with integral types"
+                  , "[eve::pedantic_(eve::arg)] - Function undefined for integral types"
                   );
 
     auto r = arg(a);
-#ifndef BOOST_SIMD_NO_NANS
+#ifndef EVE_NO_NANS
     return if_else(is_nan(a),eve::allbits_, r);
 #else
     return r;

--- a/include/eve/module/core/function/scalar/maxmag.hpp
+++ b/include/eve/module/core/function/scalar/maxmag.hpp
@@ -41,7 +41,7 @@ namespace eve::detail
   {
       auto aa0 = eve::abs(a0);
       auto aa1 = eve::abs(a1);
-      return aa0 < aa1 ? a1 : aa1 <  aa0 ? a0 : eve::max[pedantic_](a0, a1);
+      return aa0 < aa1 ? a1 : aa1 <  aa0 ? a0 : eve::pedantic_(eve::max)(a0, a1);
   }
 
   // -----------------------------------------------------------------------------------------------

--- a/include/eve/module/core/function/scalar/minmag.hpp
+++ b/include/eve/module/core/function/scalar/minmag.hpp
@@ -36,7 +36,7 @@ namespace eve::detail
   {
       auto aa0 = eve::abs(a0);
       auto aa1 = eve::abs(a1);
-      return aa0 < aa1 ? a0 : aa1 < aa0 ? a1 : eve::min[pedantic_](a0, a1);
+      return aa0 < aa1 ? a0 : aa1 < aa0 ? a1 : eve::pedantic_(eve::min)(a0, a1);
   }
 
   // -----------------------------------------------------------------------------------------------

--- a/include/eve/module/core/function/scalar/sqr.hpp
+++ b/include/eve/module/core/function/scalar/sqr.hpp
@@ -31,7 +31,7 @@ namespace eve::detail
     {
       if constexpr(std::is_signed_v<T>)
       {
-        return (abs[eve::saturated_](a0) > Sqrtvalmax(as(a0))) ? Valmax(as(a0)) : sqr(a0);
+        return (eve::saturated_(eve::abs)(a0) > Sqrtvalmax(as(a0))) ? Valmax(as(a0)) : sqr(a0);
       }
       else
       {

--- a/include/eve/module/core/function/scalar/trunc.hpp
+++ b/include/eve/module/core/function/scalar/trunc.hpp
@@ -30,20 +30,20 @@ namespace eve::detail
   {
 
     if constexpr(std::is_floating_point_v<T>)
-      return eve::abs(a0) < Maxflint<T>() ? trunc[raw_](a0) : a0;
+      return eve::abs(a0) < Maxflint<T>() ? raw_(trunc)(a0) : a0;
     else
-      return a0; 
+      return a0;
   }
   template<typename T>
   EVE_FORCEINLINE constexpr auto trunc_(EVE_SUPPORTS(cpu_)
-                                  , raw_type const &       
+                                  , raw_type const &
                                   , T const &a0) noexcept requires( T, Arithmetic<T>)
   {
 
     if constexpr(std::is_floating_point_v<T>)
       return static_cast<T>(static_cast<as_integer_t<T>>(a0));
     else
-      return a0; 
+      return a0;
   }
 }
 

--- a/include/eve/module/core/function/simd/arm/neon/rec.hpp
+++ b/include/eve/module/core/function/simd/arm/neon/rec.hpp
@@ -21,7 +21,7 @@ namespace eve::detail
 {
   template<typename T, typename N>
   EVE_FORCEINLINE wide<T, N, neon64_> rec_( EVE_SUPPORTS(neon128_),
-                                            raw_type const &,
+                                            raw_type const & mode,
                                             wide<T, N, neon64_> const &v0
                                           ) noexcept
   {
@@ -38,13 +38,13 @@ namespace eve::detail
     }
     else
     {
-      return rec_(EVE_RETARGET(simd_), raw_, v0);
+      return rec_(EVE_RETARGET(simd_), mode, v0);
     }
   }
 
   template<typename T, typename N>
   EVE_FORCEINLINE wide<T, N, neon128_> rec_ ( EVE_SUPPORTS(neon128_),
-                                              raw_type const &,
+                                              raw_type const& mode,
                                               wide<T, N, neon128_> const &v0
                                             ) noexcept
   {
@@ -61,7 +61,7 @@ namespace eve::detail
     }
     else
     {
-      return rec_(EVE_RETARGET(simd_), raw_, v0);
+      return rec_(EVE_RETARGET(simd_), mode, v0);
     }
   }
 
@@ -80,7 +80,7 @@ namespace eve::detail
     if constexpr( std::is_same_v<T,float>)
     {
       // estimate 1/x with an extra NR step for full precision
-      auto a = refine_rec(v0, rec[raw_](v0) );
+      auto a = refine_rec(v0, raw_(rec)(v0) );
       return refine_rec(v0, a );
     }
     else
@@ -97,7 +97,7 @@ namespace eve::detail
     if constexpr( std::is_floating_point_v<T>)
     {
       // estimate 1/x with an extra NR step for full precision
-      auto a = refine_rec(v0, rec[raw_](v0) );
+      auto a = refine_rec(v0, raw_(rec)(v0) );
       return refine_rec(v0, a );
     }
     else
@@ -108,7 +108,7 @@ namespace eve::detail
 
   template<typename T, typename N>
   EVE_FORCEINLINE wide<T, N, neon64_> rec_( EVE_SUPPORTS(neon128_),
-                                            pedantic_type const &,
+                                            pedantic_type const & mode,
                                             wide<T, N, neon64_> const &v0
                                           ) noexcept
   {
@@ -118,13 +118,13 @@ namespace eve::detail
     }
     else
     {
-      return rec_(EVE_RETARGET(simd_), pedantic_, v0);
+      return rec_(EVE_RETARGET(simd_), mode, v0);
     }
   }
 
   template<typename T, typename N>
   EVE_FORCEINLINE wide<T, N, neon128_> rec_ ( EVE_SUPPORTS(neon128_),
-                                              pedantic_type const &,
+                                              pedantic_type const & mode,
                                               wide<T, N, neon128_> const &v0
                                             ) noexcept
   {
@@ -134,7 +134,7 @@ namespace eve::detail
     }
     else
     {
-      return rec_(EVE_RETARGET(simd_), pedantic_, v0);
+      return rec_(EVE_RETARGET(simd_), mode, v0);
     }
   }
 }

--- a/include/eve/module/core/function/simd/common/dist.hpp
+++ b/include/eve/module/core/function/simd/common/dist.hpp
@@ -19,7 +19,7 @@
 #include <eve/function/is_ltz.hpp>
 #include <eve/function/abs.hpp>
 #include <eve/function/max.hpp>
-#include <eve/function/min.hpp>  
+#include <eve/function/min.hpp>
 #include <eve/forward.hpp>
 #include <type_traits>
 
@@ -67,7 +67,7 @@ namespace eve::detail
       }
     }
   }
-   
+
   // -----------------------------------------------------------------------------------------------
   // saturated_type
   template<typename T, typename U>
@@ -81,11 +81,11 @@ namespace eve::detail
   {
     if constexpr( !is_vectorized_v<U> )
     {
-      return dist(saturated_, v0, T{v1});
+      return saturated_(dist)(v0, T{v1});
     }
     else if constexpr( !is_vectorized_v<T> )
     {
-      return dist(saturated_, U{v0},v1);
+      return saturated_(dist)(U{v0},v1);
     }
     else
     {

--- a/include/eve/module/core/function/simd/common/max.hpp
+++ b/include/eve/module/core/function/simd/common/max.hpp
@@ -83,7 +83,7 @@ namespace eve::detail
   // Pedantic
   template<typename T, typename U>
   EVE_FORCEINLINE  auto max_(EVE_SUPPORTS(cpu_)
-                            , pedantic_type const &
+                            , pedantic_type const&
                             , T const &v0
                             , U const &v1) noexcept
   requires( std::conditional_t<is_vectorized_v<T>,T,U>,
@@ -92,11 +92,11 @@ namespace eve::detail
   {
     if constexpr( !is_vectorized_v<U> )
     {
-      return max(pedantic_, v0, T{v1});
+      return pedantic_(max)(v0, T{v1});
     }
     else if constexpr( !is_vectorized_v<T> )
     {
-      return max(pedantic_, U{v0},v1);
+      return pedantic_(max)(U{v0},v1);
     }
     else
     {

--- a/include/eve/module/core/function/simd/common/maxmag.hpp
+++ b/include/eve/module/core/function/simd/common/maxmag.hpp
@@ -87,11 +87,11 @@ namespace eve::detail
   {
     if constexpr( !is_vectorized_v<U> )
     {
-      return maxmag[eve::pedantic_](a, T{b});
+      return eve::pedantic_(eve::maxmag)(a, T{b});
     }
     else if constexpr( !is_vectorized_v<T> )
     {
-      return maxmag[eve::pedantic_](U{a},b);
+      return eve::pedantic_(eve::maxmag)(U{a},b);
     }
     else
     {
@@ -99,11 +99,11 @@ namespace eve::detail
       {
         if constexpr( is_aggregated_v<typename T::abi_type> )
         {
-          return aggregate( eve::maxmag, eve::pedantic_, a, b);
+          return aggregate( eve::pedantic_(eve::maxmag), a, b);
         }
         else if constexpr( is_emulated_v<typename T::abi_type> )
         {
-          return map( eve::maxmag, eve::pedantic_, a, b);
+          return map( eve::pedantic_(eve::maxmag), a, b);
         }
         else
         {
@@ -111,13 +111,13 @@ namespace eve::detail
           auto ab = eve::abs(b);
           return if_else( is_not_greater_equal(ab, aa), a
                         , if_else( is_not_greater_equal(aa, ab), b
-                                 , eve::max[eve::pedantic_](a, b) ) );
+                                 , eve::pedantic_(eve::max)(a, b) ) );
         }
       }
       else
       {
         static_assert( std::is_same_v<T,U>
-                     , "[eve::maxmag[pedantic_]] - Incompatible types.");
+                     , "[eve::pedantic_(maxmag)] - Incompatible types.");
         return {};
       }
     }

--- a/include/eve/module/core/function/simd/common/minmag.hpp
+++ b/include/eve/module/core/function/simd/common/minmag.hpp
@@ -87,11 +87,11 @@ namespace eve::detail
   {
     if constexpr( !is_vectorized_v<U> )
     {
-      return minmag[eve::pedantic_](a, T{b});
+      return eve::pedantic_(eve::minmag)(a, T{b});
     }
     else if constexpr( !is_vectorized_v<T> )
     {
-      return minmag[eve::pedantic_](U{a},b);
+      return eve::pedantic_(eve::minmag)(U{a},b);
     }
     else
     {
@@ -99,11 +99,11 @@ namespace eve::detail
       {
         if constexpr( is_aggregated_v<typename T::abi_type> )
         {
-          return aggregate( eve::minmag, eve::pedantic_, a, b);
+          return aggregate( eve::pedantic_(eve::minmag), a, b);
         }
         else if constexpr( is_emulated_v<typename T::abi_type> )
         {
-          return map( eve::minmag, eve::pedantic_, a, b);
+          return map( eve::pedantic_(eve::minmag), a, b);
         }
         else
         {
@@ -111,12 +111,12 @@ namespace eve::detail
           auto ab = eve::abs(b);
           return if_else( is_not_greater_equal(aa, ab), a
                         , if_else( is_not_greater_equal(ab, aa), b
-                                 , eve::min[eve::pedantic_](a, b) ) );
+                                 , eve::pedantic_(eve::min)(a, b) ) );
         }
       }
       else
       {
-        static_assert( std::is_same_v<T,U>, "[eve::minmag[pedantic_]] - Incompatible types.");
+        static_assert( std::is_same_v<T,U>, "[eve::pedantic_(minmag)] - Incompatible types.");
         return {};
       }
     }

--- a/include/eve/module/core/function/simd/common/rec.hpp
+++ b/include/eve/module/core/function/simd/common/rec.hpp
@@ -66,18 +66,18 @@ namespace eve::detail
   {
     if constexpr(is_aggregated_v<ABI>)
     {
-      return aggregate(eve::rec[raw_], v);
+      return aggregate(raw_(eve::rec), v);
     }
     else if  constexpr(is_emulated_v<ABI>)
     {
-      return map(eve::rec[raw_], v);
+      return map(raw_(eve::rec), v);
     }
     else
     {
       if constexpr(std::is_floating_point_v<T>)
       {
         // Change to 1/v;
-        return map(eve::rec[raw_], v);
+        return map(raw_(eve::rec), v);
       }
       else
       {
@@ -94,18 +94,18 @@ namespace eve::detail
   {
     if constexpr(is_aggregated_v<ABI>)
     {
-      return aggregate(eve::rec[eve::pedantic_], v);
+      return aggregate(eve::pedantic_(eve::rec), v);
     }
     else if  constexpr(is_emulated_v<ABI>)
     {
-      return map(eve::rec[eve::pedantic_], v);
+      return map(eve::pedantic_(eve::rec), v);
     }
     else
     {
       if constexpr(std::is_floating_point_v<T>)
       {
         // Change to 1/v;
-        return map(eve::rec[eve::pedantic_], v);
+        return map(eve::pedantic_(eve::rec), v);
       }
       else
       {

--- a/include/eve/module/core/function/simd/common/sqr.hpp
+++ b/include/eve/module/core/function/simd/common/sqr.hpp
@@ -34,7 +34,7 @@ namespace eve::detail
     {
       if constexpr(std::is_signed_v<T>)
       {
-        return if_else(abs[eve::saturated_](a0) > Sqrtvalmax(as(a0)), Valmax(as(a0)), sqr(a0));
+        return if_else(eve::saturated_(eve::abs)(a0) > Sqrtvalmax(as(a0)), Valmax(as(a0)), sqr(a0));
       }
       else
       {

--- a/include/eve/module/core/function/simd/ppc/vmx/rec.hpp
+++ b/include/eve/module/core/function/simd/ppc/vmx/rec.hpp
@@ -30,7 +30,7 @@ namespace eve::detail
 {
   template<typename T, typename N>
   EVE_FORCEINLINE wide<T, N, ppc_> rec_ ( EVE_SUPPORTS(vmx_),
-                                          raw_type const &,
+                                          raw_type const & mode,
                                           wide<T, N, ppc_> const &v0
                                         ) noexcept
   {
@@ -40,7 +40,7 @@ namespace eve::detail
     }
     else
     {
-      return rec_(EVE_RETARGET(simd_), raw_, v0);
+      return rec_(EVE_RETARGET(simd_), mode, v0);
     }
   }
 
@@ -51,12 +51,12 @@ namespace eve::detail
   {
     if constexpr( std::is_same_v<double, T>)
     {
-      auto estimate = refine_rec(v0, rec[raw_](v0));
+      auto estimate = refine_rec(v0, raw_(rec)(v0));
       return refine_rec(v0, estimate);
     }
     else if constexpr( std::is_same_v<float, T>)
     {
-      return refine_rec(v0, rec[raw_](v0));
+      return refine_rec(v0, raw_(rec)(v0));
     }
     else
     {
@@ -66,7 +66,7 @@ namespace eve::detail
 
   template<typename T, typename N>
   EVE_FORCEINLINE wide<T, N, ppc_> rec_ ( EVE_SUPPORTS(vmx_),
-                                          pedantic_type const &,
+                                          pedantic_type const& mode,
                                           wide<T, N, ppc_> const &v0
                                         ) noexcept
   {
@@ -90,7 +90,7 @@ namespace eve::detail
     }
     else
     {
-      return rec_(EVE_RETARGET(simd_), pedantic_, v0);
+      return rec_(EVE_RETARGET(simd_), mode, v0);
     }
   }
 }

--- a/include/eve/module/core/function/simd/x86/avx/rec.hpp
+++ b/include/eve/module/core/function/simd/x86/avx/rec.hpp
@@ -41,7 +41,7 @@ namespace eve::detail
 {
   template<typename T, typename N>
   EVE_FORCEINLINE wide<T, N, avx_> rec_ ( EVE_SUPPORTS(avx_),
-                                          raw_type const&,
+                                          raw_type const& mode,
                                           wide<T, N, avx_> const &a0
                                         ) noexcept
   {
@@ -56,7 +56,7 @@ namespace eve::detail
     }
     else
     {
-      return rec_(EVE_RETARGET(simd_), raw_, a0);
+      return rec_(EVE_RETARGET(simd_), mode, a0);
     }
   }
 
@@ -79,7 +79,7 @@ namespace eve::detail
 
   template<typename T, typename N>
   EVE_FORCEINLINE wide<T, N, avx_> rec_ ( EVE_SUPPORTS(avx_),
-                                          pedantic_type const&,
+                                          pedantic_type const& mode,
                                           wide<T, N, avx_> const &a0
                                         ) noexcept
   {
@@ -89,7 +89,7 @@ namespace eve::detail
     }
     else
     {
-      return rec_(EVE_RETARGET(simd_), pedantic_, a0);
+      return rec_(EVE_RETARGET(simd_), mode, a0);
     }
   }
 }

--- a/include/eve/module/core/function/simd/x86/sse2/rec.hpp
+++ b/include/eve/module/core/function/simd/x86/sse2/rec.hpp
@@ -41,7 +41,7 @@ namespace eve::detail
 {
   template<typename T, typename N>
   EVE_FORCEINLINE wide<T, N, sse_> rec_ ( EVE_SUPPORTS(sse2_),
-                                          raw_type const&,
+                                          raw_type const& mode,
                                           wide<T, N, sse_> const &a0
                                         ) noexcept
   {
@@ -56,7 +56,7 @@ namespace eve::detail
     }
     else
     {
-      return rec_(EVE_RETARGET(simd_), raw_, a0);
+      return rec_(EVE_RETARGET(simd_), mode, a0);
     }
   }
 
@@ -79,7 +79,7 @@ namespace eve::detail
 
   template<typename T, typename N>
   EVE_FORCEINLINE wide<T, N, sse_> rec_ ( EVE_SUPPORTS(sse2_),
-                                          pedantic_type const&,
+                                          pedantic_type const& mode,
                                           wide<T, N, sse_> const &a0
                                         ) noexcept
   {
@@ -89,7 +89,7 @@ namespace eve::detail
     }
     else
     {
-      return rec_(EVE_RETARGET(simd_), pedantic_, a0);
+      return rec_(EVE_RETARGET(simd_), mode, a0);
     }
   }
 }

--- a/include/eve/tags.hpp
+++ b/include/eve/tags.hpp
@@ -12,32 +12,56 @@
 #define EVE_TAGS_HPP_INCLUDED
 
 #include <type_traits>
+#include <eve/detail/abi.hpp>
 
 namespace eve
 {
-  struct pedantic_type{};
-  inline constexpr pedantic_type pedantic_ = {};
+  //================================================================================================
+  // Function decorators mark-up used in function overloads
+  struct raw_type       {};
+  struct pedantic_type  {};
+  struct saturated_type {};
+  struct numeric_type   {};
 
-  struct raw_type{};
-  inline constexpr raw_type raw_ = {};
+  //================================================================================================
+  // Function decorator - raw mode
+  template<typename Function> constexpr EVE_FORCEINLINE auto raw_(Function f) noexcept
+  {
+    return [f](auto const&... args) { return f(raw_type{}, args...); };
+  }
 
-  struct saturated_type{};
-  inline constexpr saturated_type saturated_ = {};
+  //================================================================================================
+  // Function decorator - pedantic mode
+  template<typename Function> constexpr EVE_FORCEINLINE auto pedantic_(Function f) noexcept
+  {
+    return [f](auto const&... args) { return f(pedantic_type{}, args...); };
+  }
 
-  struct numeric_type{};
-  inline constexpr numeric_type numeric_ = {};
+  //================================================================================================
+  // Function decorator - saturated mode
+  template<typename Function> constexpr EVE_FORCEINLINE auto saturated_(Function f) noexcept
+  {
+    return [f](auto const&... args) { return f(saturated_type{}, args...); };
+  }
 
-  struct upward_type{};
-  inline constexpr upward_type upward_ = {};
+  //================================================================================================
+  // Function decorator - numeric mode
+  template<typename Function> constexpr EVE_FORCEINLINE auto numeric_(Function f) noexcept
+  {
+    return [f](auto const&... args) { return f(numeric_type{}, args...); };
+  }
 
-  struct downward_type{};
-  inline constexpr downward_type downward_ = {};
+  //================================================================================================
+  // Option types and objects
+  struct upward_type      {};
+  struct downward_type    {};
+  struct toward_zero_type {};
+  struct to_nearest_type  {};
 
-  struct toward_zero_type{};
-  inline constexpr toward_zero_type toward_zero_ = {};
-
-  struct to_nearest_type{};
-  inline constexpr  to_nearest_type to_nearest_ = {};
+  inline constexpr upward_type      upward_       = {};
+  inline constexpr downward_type    downward_     = {};
+  inline constexpr toward_zero_type toward_zero_  = {};
+  inline constexpr to_nearest_type  to_nearest_   = {};
 }
 
 #endif

--- a/test/doc/arg.cpp
+++ b/test/doc/arg.cpp
@@ -11,7 +11,7 @@ using wide_ft = eve::wide <float, eve::fixed<8>>;
 int main()
 {
   using eve::pedantic_;
-  
+
   wide_ft pf = { 0.0f, 1.0f, -1.0f, -2.0f
                 , eve::Mindenormal<float>(), eve::Inf<float>(), eve::Minf<float>(), eve::Nan<float>() };
 
@@ -19,7 +19,7 @@ int main()
     << "---- simd" << '\n'
     << "<- pf =                      " << pf << '\n'
     << "-> eve::arg(pf) =            " << eve::arg(pf) << '\n'
-    << "-> eve::arg[pedantic_](pf) = " << eve::arg[pedantic_](pf) << '\n';
+    << "-> eve::pedantic_(eve::arg)(pf) = " << eve::pedantic_(eve::arg)(pf) << '\n';
 
   float xf = 1.0f;
   float yf = eve::Nan<float>();
@@ -30,6 +30,6 @@ int main()
     << "-> eve::arg(xf) =            " << eve::arg(xf) << '\n'
     << "<- yf =                      " << yf << '\n'
     << "-> eve::arg(yf) =            " << eve::arg(yf) << '\n'
-    << "-> eve::arg[pedantic_](yf) = " << eve::arg[pedantic_](yf) << '\n'; 
+    << "-> eve::pedantic_(eve::arg)(yf) = " << eve::pedantic_(eve::arg)(yf) << '\n';
   return 0;
 }

--- a/test/doc/dist.cpp
+++ b/test/doc/dist.cpp
@@ -1,7 +1,7 @@
 #include <eve/function/dist.hpp>
 #include <eve/wide.hpp>
 #include <eve/constant/valmax.hpp>
-#include <eve/constant/valmin.hpp>   
+#include <eve/constant/valmin.hpp>
 #include <eve/tags.hpp>
 #include <iostream>
 
@@ -9,24 +9,24 @@ using wide_it = eve::wide <int16_t, eve::fixed<4>>;
 
 int main()
 {
-  wide_it pf = { 0, 1, -1, -eve::Valmax<int16_t>() }; 
+  wide_it pf = { 0, 1, -1, -eve::Valmax<int16_t>() };
   wide_it qf = { 1, -1, 0, eve::Valmax<int16_t>() };
 
   std::cout
     << "---- simd" << '\n'
-    << "<- pf =                          " << pf << '\n' 
-    << "<- qf =                          " << qf << '\n' 
+    << "<- pf =                          " << pf << '\n'
+    << "<- qf =                          " << qf << '\n'
     << "-> eve::dist(pf, qf) =            " << eve::dist(pf, qf) << '\n'
-    << "-> eve::dist[eve::saturated_](pf, qf) = " << eve::dist[eve::saturated_](pf, qf) << '\n';   
+    << "-> eve::saturated_(eve::dist)(pf, qf) = " << eve::saturated_(eve::dist)(pf, qf) << '\n';
 
   int16_t xf = -eve::Valmax<int16_t>();
-  int16_t yf = eve::Valmax<int16_t>(); 
+  int16_t yf = eve::Valmax<int16_t>();
 
   std::cout
     << "---- scalar"  << '\n'
     << "<- xf =                          " << xf << '\n'
     << "<- yf =                          " << yf << '\n'
     << "-> eve::dist(xf, yf) =            " << eve::dist(xf, yf) << '\n'
-    << "-> eve::dist[eve::saturated_](xf, yf) = " << eve::dist[eve::saturated_](xf, yf) << '\n';   
+    << "-> eve::saturated_(eve::dist)(xf, yf) = " << eve::saturated_(eve::dist)(xf, yf) << '\n';
   return 0;
 }

--- a/test/doc/if_else_zero.cpp
+++ b/test/doc/if_else_zero.cpp
@@ -21,7 +21,7 @@ int main() {
             << " -> eve::if_else(lsi, pi, eve::zero_) =       "
             << eve::if_else(lsi, pi, eve::zero_) << '\n';
 
-  iT ssi = 3, xi = 3, yi = 4;
+  iT ssi = 3, xi = 3;
   eve::logical<iT>  lssi = false;
 
   std::cout << "---- scalar" << '\n'

--- a/test/doc/if_zero_else.cpp
+++ b/test/doc/if_zero_else.cpp
@@ -21,7 +21,7 @@ int main() {
             << " -> eve::if_else(lsi, eve::zero, pi_) =       "
             << eve::if_else(lsi, eve::zero_, pi) << '\n';
 
-  iT ssi = 3, xi = 3, yi = 4;
+  iT ssi = 3, xi = 3;
   eve::logical<iT>  lssi = false;
 
   std::cout << "---- scalar" << '\n'

--- a/test/doc/max.cpp
+++ b/test/doc/max.cpp
@@ -19,10 +19,10 @@ int main()
 
   std::cout
     << "---- simd" << '\n'
-    << "<- pf =                          " << pf << '\n' 
-    << "<- qf =                          " << qf << '\n' 
+    << "<- pf =                          " << pf << '\n'
+    << "<- qf =                          " << qf << '\n'
     << "-> eve::max(pf, qf) =            " << eve::max(pf, qf) << '\n'
-    << "-> eve::max[pedantic_](pf, qf) = " << eve::max[pedantic_](pf, qf) << '\n';   
+    << "-> eve::pedantic_(eve::max)(pf, qf) = " << eve::pedantic_(eve::max)(pf, qf) << '\n';
 
   float xf = 1.0f;
   float yf = eve::Nan<float>();
@@ -32,6 +32,6 @@ int main()
     << "<- xf =                          " << xf << '\n'
     << "<- yf =                          " << yf << '\n'
     << "-> eve::max(xf, yf) =            " << eve::max(xf, yf) << '\n'
-    << "-> eve::max[pedantic_](xf, yf) = " << eve::max[pedantic_](xf, yf) << '\n';   
+    << "-> eve::pedantic_(eve::max)(xf, yf) = " << eve::pedantic_(eve::max)(xf, yf) << '\n';
   return 0;
 }

--- a/test/doc/max.txt
+++ b/test/doc/max.txt
@@ -2,9 +2,9 @@
 <- pf =                          (0, 1, -1, -2, 1.4013e-45, inf, -inf, -nan)
 <- qf =                          (1.4013e-45, 1, -1, inf, -inf, -nan, 0, -2)
 -> eve::max(pf, qf) =            (1.4013e-45, 1, -1, inf, 1.4013e-45, inf, 0, -nan)
--> eve::max[pedantic_](pf, qf) = (1.4013e-45, 1, -1, inf, 1.4013e-45, inf, 0, -nan)
+-> eve::pedantic_(eve::max)(pf, qf) = (1.4013e-45, 1, -1, inf, 1.4013e-45, inf, 0, -nan)
 ---- scalar
 <- xf =                          1
 <- yf =                          -nan
 -> eve::max(xf, yf) =            1
--> eve::max[pedantic_](xf, yf) = 1
+-> eve::pedantic_(eve::max)(xf, yf) = 1

--- a/test/doc/maxnummag.cpp
+++ b/test/doc/maxnummag.cpp
@@ -19,7 +19,7 @@ int main()
     << "---- simd" << '\n'
     << "<- pf =                  " << pf << '\n'
     << "<- qf =                  " << qf << '\n'
-    << "-> eve::maxmag[eve::numeric_](pf, qf) = " << eve::maxmag[eve::numeric_](pf, qf) << '\n';
+    << "-> eve::numeric_(eve::maxmag)(pf, qf) = " << eve::numeric_(eve::maxmag)(pf, qf) << '\n';
 
   float xf = 1.0f;
   float yf = -2.0f;
@@ -28,6 +28,6 @@ int main()
     << "---- scalar"  << '\n'
     << "<- xf =                  " << xf << '\n'
     << "<- yf =                  " << yf << '\n'
-    << "-> eve::maxmag[eve::numeric_](xf, yf) = " << eve::maxmag[eve::numeric_](xf, yf) << '\n';
+    << "-> eve::numeric_(eve::maxmag)(xf, yf) = " << eve::numeric_(eve::maxmag)(xf, yf) << '\n';
   return 0;
 }

--- a/test/doc/maxnummag.txt
+++ b/test/doc/maxnummag.txt
@@ -1,8 +1,8 @@
 ---- simd
 <- pf =                  (0, 1, -1, -2, 1.4013e-45, inf, -inf, -nan)
 <- qf =                  (1.4013e-45, 1, -1, inf, -inf, -nan, 0, -2)
--> eve::maxmag[eve::numeric_](pf, qf) = (1.4013e-45, 1, -1, inf, -inf, inf, -inf, -2)
+-> eve::numeric_(eve::maxmag)(pf, qf) = (1.4013e-45, 1, -1, inf, -inf, inf, -inf, -2)
 ---- scalar
 <- xf =                  1
 <- yf =                  -2
--> eve::maxmag[eve::numeric_](xf, yf) = -2
+-> eve::numeric_(eve::maxmag)(xf, yf) = -2

--- a/test/doc/minnummag.cpp
+++ b/test/doc/minnummag.cpp
@@ -19,7 +19,7 @@ int main()
     << "---- simd" << '\n'
     << "<- pf =                  " << pf << '\n'
     << "<- qf =                  " << qf << '\n'
-    << "-> eve::minmag[eve::numeric_](pf, qf) = " << eve::minmag[eve::numeric_](pf, qf) << '\n';
+    << "-> eve::numeric_(eve::minmag)(pf, qf) = " << eve::numeric_(eve::minmag)(pf, qf) << '\n';
 
   float xf = 1.0f;
   float yf = -2.0f;
@@ -28,6 +28,6 @@ int main()
     << "---- scalar"  << '\n'
     << "<- xf =                  " << xf << '\n'
     << "<- yf =                  " << yf << '\n'
-    << "-> eve::minmag[eve::numeric_](xf, yf) = " << eve::minmag[eve::numeric_](xf, yf) << '\n';
+    << "-> eve::numeric_(eve::minmag)(xf, yf) = " << eve::numeric_(eve::minmag)(xf, yf) << '\n';
   return 0;
 }

--- a/test/doc/minnummag.txt
+++ b/test/doc/minnummag.txt
@@ -1,8 +1,8 @@
 ---- simd
 <- pf =                  (0, 1, -1, -2, 1.4013e-45, inf, -inf, -nan)
 <- qf =                  (1.4013e-45, 1, -1, inf, -inf, -nan, 0, -2)
--> eve::minmag[eve::numeric_](pf, qf) = (0, 1, -1, -2, 1.4013e-45, inf, 0, -2)
+-> eve::numeric_(eve::minmag)(pf, qf) = (0, 1, -1, -2, 1.4013e-45, inf, 0, -2)
 ---- scalar
 <- xf =                  1
 <- yf =                  -2
--> eve::minmag[eve::numeric_](xf, yf) = 1
+-> eve::numeric_(eve::minmag)(xf, yf) = 1

--- a/test/doc/sqr.cpp
+++ b/test/doc/sqr.cpp
@@ -13,7 +13,7 @@ int main()
 {
   wide_ft pf = { 0.0f, 1.0f, -1.0f, -2.0f
                 , eve::Sqrtvalmax<float>(), eve::Inf<float>(), eve::Minf<float>(), eve::Nan<float>() };
-  int16_t svm =  eve::Sqrtvalmax<int16_t>(); 
+  int16_t svm =  eve::Sqrtvalmax<int16_t>();
   wide_it pi = { 0, 1, -1, -2, svm-1, svm, svm+1, svm+2 };
 
   std::cout
@@ -22,7 +22,7 @@ int main()
     << "-> eve::sqr(pf) = " << eve::sqr(pf) << '\n'
     << "<- pi =                  " << pi << '\n'
     << "-> eve::sqr(pi) = " << eve::sqr(pi) << '\n'
-    << "-> eve::sqr[eve::saturated_](pi) = " << eve::sqr[eve::saturated_](pi) << '\n';
+    << "-> eve::saturated_(eve::sqr)(pi) = " << eve::saturated_(eve::sqr)(pi) << '\n';
 
   float xf = 1.0f;
   int32_t yf = eve::Sqrtvalmax<int32_t>()+10;

--- a/test/unit/module/core/scalar/abs/abs.hpp
+++ b/test/unit/module/core/scalar/abs/abs.hpp
@@ -33,7 +33,7 @@ TTS_CASE("Check eve::abs behavior")
   if constexpr(std::is_signed_v<Type>)
   {
     TTS_EQUAL(eve::abs(static_cast<Type>(-2)), Type(2));
-    TTS_EQUAL(eve::abs[eve::saturated_](eve::Valmin<Type>()), eve::Valmax<Type>()); 
+    TTS_EQUAL(eve::saturated_(eve::abs)(eve::Valmin<Type>()), eve::Valmax<Type>());
   }
 }
 

--- a/test/unit/module/core/scalar/arg/arg.hpp
+++ b/test/unit/module/core/scalar/arg/arg.hpp
@@ -35,14 +35,14 @@ TTS_CASE("Check eve::arg behavior")
 {
   TTS_EQUAL(eve::arg(Type{1}),  eve::Zero<Type>());
   TTS_EQUAL(eve::arg(Type{2}),  eve::Zero<Type>());
-  
+
   TTS_EQUAL(eve::arg(static_cast<Type>(-2)), eve::Pi<Type>());
   TTS_IEEE_EQUAL(eve::arg(eve::Nan<Type>()), eve::Pi<Type>());
   TTS_IEEE_EQUAL(eve::arg(-eve::Nan<Type>()),  eve::Zero<Type>());
-  TTS_IEEE_EQUAL(eve::arg[eve::pedantic_](eve::Nan<Type>()), eve::Nan<Type>());
-  TTS_IEEE_EQUAL(eve::arg[eve::pedantic_](-eve::Nan<Type>()), -eve::Nan<Type>());
-  TTS_EQUAL(eve::arg(eve::Mzero<Type>()), eve::Pi<Type>()); 
-  TTS_EQUAL(eve::arg(eve::Zero<Type>()),   eve::Zero<Type>()); 
+  TTS_IEEE_EQUAL(eve::pedantic_(eve::arg)(eve::Nan<Type>()), eve::Nan<Type>());
+  TTS_IEEE_EQUAL(eve::pedantic_(eve::arg)(-eve::Nan<Type>()), -eve::Nan<Type>());
+  TTS_EQUAL(eve::arg(eve::Mzero<Type>()), eve::Pi<Type>());
+  TTS_EQUAL(eve::arg(eve::Zero<Type>()),   eve::Zero<Type>());
 }
-  
+
 #endif

--- a/test/unit/module/core/scalar/dist/dist.hpp
+++ b/test/unit/module/core/scalar/dist/dist.hpp
@@ -30,9 +30,9 @@ TTS_CASE("Check eve::dist and eve::dist[saturated_]  behavior")
 
   if constexpr(std::is_integral_v<Type> && std::is_signed_v<Type>)
   {
-    TTS_IEEE_EQUAL(eve::dist[eve::saturated_](eve::Valmax<Type>(), eve::Valmin<Type>()), eve::Valmax<Type>());
-    TTS_IEEE_EQUAL(eve::dist[eve::saturated_](eve::Valmax<Type>(), eve::Zero<Type>()), eve::Valmax<Type>());
-    TTS_IEEE_EQUAL(eve::dist[eve::saturated_](eve::Valmin<Type>(), eve::Zero<Type>()), eve::Valmax<Type>());
+    TTS_IEEE_EQUAL(eve::saturated_(eve::dist)(eve::Valmax<Type>(), eve::Valmin<Type>()), eve::Valmax<Type>());
+    TTS_IEEE_EQUAL(eve::saturated_(eve::dist)(eve::Valmax<Type>(), eve::Zero<Type>()), eve::Valmax<Type>());
+    TTS_IEEE_EQUAL(eve::saturated_(eve::dist)(eve::Valmin<Type>(), eve::Zero<Type>()), eve::Valmax<Type>());
   }
 }
 

--- a/test/unit/module/core/scalar/max/max.hpp
+++ b/test/unit/module/core/scalar/max/max.hpp
@@ -30,8 +30,8 @@ TTS_CASE("Check eve::max behavior")
   {
     Type n =  eve::Nan<Type>();
     Type o =  eve::One<Type>();
-    TTS_IEEE_EQUAL(eve::max[eve::pedantic_](n, o), n);
-    TTS_IEEE_EQUAL(eve::max[eve::pedantic_](o, n), o);
+    TTS_IEEE_EQUAL(eve::pedantic_(eve::max)(n, o), n);
+    TTS_IEEE_EQUAL(eve::pedantic_(eve::max)(o, n), o);
   }
 }
 

--- a/test/unit/module/core/scalar/maxmag/maxmag.hpp
+++ b/test/unit/module/core/scalar/maxmag/maxmag.hpp
@@ -37,8 +37,8 @@ TTS_CASE("Check eve::maxmag behavior")
   {
     Type n =  eve::Nan<Type>();
     Type o =  eve::One<Type>();
-    TTS_IEEE_EQUAL(eve::maxmag[eve::pedantic_](n, o), n);
-    TTS_IEEE_EQUAL(eve::maxmag[eve::pedantic_](o, n), o);
+    TTS_IEEE_EQUAL(eve::pedantic_(eve::maxmag)(n, o), n);
+    TTS_IEEE_EQUAL(eve::pedantic_(eve::maxmag)(o, n), o);
   }
 }
 

--- a/test/unit/module/core/scalar/maxnum/maxnum.hpp
+++ b/test/unit/module/core/scalar/maxnum/maxnum.hpp
@@ -20,18 +20,18 @@
 #include <type_traits>
 
 
-TTS_CASE("Check eve::max[eve::numeric_] behavior")
+TTS_CASE("Check eve::numeric_(eve::max) behavior")
 {
-  TTS_EQUAL(eve::max[eve::numeric_](Type{0}, Type{0}), Type{0});
-  TTS_EQUAL(eve::max[eve::numeric_](Type{0}, Type{1}), Type{1});
-  TTS_EQUAL(eve::max[eve::numeric_](Type{1}, Type{0}), Type{1});
-  TTS_EQUAL(eve::max[eve::numeric_](Type{1}, Type{1}), Type{1});
+  TTS_EQUAL(eve::numeric_(eve::max)(Type{0}, Type{0}), Type{0});
+  TTS_EQUAL(eve::numeric_(eve::max)(Type{0}, Type{1}), Type{1});
+  TTS_EQUAL(eve::numeric_(eve::max)(Type{1}, Type{0}), Type{1});
+  TTS_EQUAL(eve::numeric_(eve::max)(Type{1}, Type{1}), Type{1});
   if constexpr(std::is_floating_point_v<Type> )
   {
     Type n =  eve::Nan<Type>();
     Type o =  eve::One<Type>();
-    TTS_IEEE_EQUAL(eve::max[eve::numeric_](n, o), o);
-    TTS_IEEE_EQUAL(eve::max[eve::numeric_](o, n), o);
+    TTS_IEEE_EQUAL(eve::numeric_(eve::max)(n, o), o);
+    TTS_IEEE_EQUAL(eve::numeric_(eve::max)(o, n), o);
   }
 }
 

--- a/test/unit/module/core/scalar/maxnummag/maxnummag.hpp
+++ b/test/unit/module/core/scalar/maxnummag/maxnummag.hpp
@@ -20,25 +20,25 @@
 #include <type_traits>
 
 
-TTS_CASE("Check eve::maxmag[eve::numeric_] behavior")
+TTS_CASE("Check eve::numeric_(eve::maxmag) behavior")
 {
-  TTS_EQUAL(eve::maxmag[eve::numeric_](Type{0}, Type{0}), Type{0});
-  TTS_EQUAL(eve::maxmag[eve::numeric_](Type{0}, Type{1}), Type{1});
-  TTS_EQUAL(eve::maxmag[eve::numeric_](Type{1}, Type{0}), Type{1});
-  TTS_EQUAL(eve::maxmag[eve::numeric_](Type{1}, Type{2}), Type{2});
-  TTS_EQUAL(eve::maxmag[eve::numeric_](Type{2}, Type{1}), Type{2});
+  TTS_EQUAL(eve::numeric_(eve::maxmag)(Type{0}, Type{0}), Type{0});
+  TTS_EQUAL(eve::numeric_(eve::maxmag)(Type{0}, Type{1}), Type{1});
+  TTS_EQUAL(eve::numeric_(eve::maxmag)(Type{1}, Type{0}), Type{1});
+  TTS_EQUAL(eve::numeric_(eve::maxmag)(Type{1}, Type{2}), Type{2});
+  TTS_EQUAL(eve::numeric_(eve::maxmag)(Type{2}, Type{1}), Type{2});
   if constexpr(std::is_signed_v<Type> )
   {
-    TTS_EQUAL(eve::maxmag[eve::numeric_](static_cast<Type>(-3), Type{2}), static_cast<Type>(-3));
-    TTS_EQUAL(eve::maxmag[eve::numeric_](static_cast<Type>(-1), Type{2}), static_cast<Type>(2));
-    TTS_EQUAL(eve::maxmag[eve::numeric_](static_cast<Type>(-1), Type{1}), Type{1});
+    TTS_EQUAL(eve::numeric_(eve::maxmag)(static_cast<Type>(-3), Type{2}), static_cast<Type>(-3));
+    TTS_EQUAL(eve::numeric_(eve::maxmag)(static_cast<Type>(-1), Type{2}), static_cast<Type>(2));
+    TTS_EQUAL(eve::numeric_(eve::maxmag)(static_cast<Type>(-1), Type{1}), Type{1});
   }
   if constexpr(std::is_floating_point_v<Type> )
   {
     Type n =  eve::Nan<Type>();
     Type o =  eve::One<Type>();
-    TTS_IEEE_EQUAL(eve::maxmag[eve::numeric_](n, o), o);
-    TTS_IEEE_EQUAL(eve::maxmag[eve::numeric_](o, n), o);
+    TTS_IEEE_EQUAL(eve::numeric_(eve::maxmag)(n, o), o);
+    TTS_IEEE_EQUAL(eve::numeric_(eve::maxmag)(o, n), o);
   }
 }
 

--- a/test/unit/module/core/scalar/min/min.hpp
+++ b/test/unit/module/core/scalar/min/min.hpp
@@ -30,8 +30,8 @@ TTS_CASE("Check eve::min behavior")
   {
     Type n =  eve::Nan<Type>();
     Type o =  eve::One<Type>();
-    TTS_IEEE_EQUAL(eve::min[eve::pedantic_](n, o), n);
-    TTS_IEEE_EQUAL(eve::min[eve::pedantic_](o, n), o);
+    TTS_IEEE_EQUAL(eve::pedantic_(eve::min)(n, o), n);
+    TTS_IEEE_EQUAL(eve::pedantic_(eve::min)(o, n), o);
   }
 }
 

--- a/test/unit/module/core/scalar/minmag/minmag.hpp
+++ b/test/unit/module/core/scalar/minmag/minmag.hpp
@@ -37,8 +37,8 @@ TTS_CASE("Check eve::minmag behavior")
   {
     Type n =  eve::Nan<Type>();
     Type o =  eve::One<Type>();
-    TTS_IEEE_EQUAL(eve::minmag[eve::pedantic_](n, o), n);
-    TTS_IEEE_EQUAL(eve::minmag[eve::pedantic_](o, n), o);
+    TTS_IEEE_EQUAL(eve::pedantic_(eve::minmag)(n, o), n);
+    TTS_IEEE_EQUAL(eve::pedantic_(eve::minmag)(o, n), o);
   }
 }
 

--- a/test/unit/module/core/scalar/minnum/minnum.hpp
+++ b/test/unit/module/core/scalar/minnum/minnum.hpp
@@ -22,16 +22,16 @@
 
 TTS_CASE("Check eve::min[eve::num] behavior")
 {
-  TTS_EQUAL(eve::min[eve::numeric_](Type{0}, Type{0}), Type{0});
-  TTS_EQUAL(eve::min[eve::numeric_](Type{0}, Type{1}), Type{0});
-  TTS_EQUAL(eve::min[eve::numeric_](Type{1}, Type{0}), Type{0});
-  TTS_EQUAL(eve::min[eve::numeric_](Type{1}, Type{1}), Type{1});
+  TTS_EQUAL(eve::numeric_(eve::min)(Type{0}, Type{0}), Type{0});
+  TTS_EQUAL(eve::numeric_(eve::min)(Type{0}, Type{1}), Type{0});
+  TTS_EQUAL(eve::numeric_(eve::min)(Type{1}, Type{0}), Type{0});
+  TTS_EQUAL(eve::numeric_(eve::min)(Type{1}, Type{1}), Type{1});
   if constexpr(std::is_floating_point_v<Type> )
   {
     Type n =  eve::Nan<Type>();
     Type o =  eve::One<Type>();
-    TTS_IEEE_EQUAL(eve::min[eve::numeric_](n, o), o);
-    TTS_IEEE_EQUAL(eve::min[eve::numeric_](o, n), o);
+    TTS_IEEE_EQUAL(eve::numeric_(eve::min)(n, o), o);
+    TTS_IEEE_EQUAL(eve::numeric_(eve::min)(o, n), o);
   }
 }
 

--- a/test/unit/module/core/scalar/minnummag/minnummag.hpp
+++ b/test/unit/module/core/scalar/minnummag/minnummag.hpp
@@ -20,25 +20,25 @@
 #include <type_traits>
 
 
-TTS_CASE("Check eve::minmag[eve::numeric_] behavior")
+TTS_CASE("Check eve::numeric_(eve::minmag) behavior")
 {
-  TTS_EQUAL(eve::minmag[eve::numeric_](Type{0}, Type{0}), Type{0});
-  TTS_EQUAL(eve::minmag[eve::numeric_](Type{0}, Type{1}), Type{0});
-  TTS_EQUAL(eve::minmag[eve::numeric_](Type{1}, Type{0}), Type{0});
-  TTS_EQUAL(eve::minmag[eve::numeric_](Type{1}, Type{2}), Type{1});
-  TTS_EQUAL(eve::minmag[eve::numeric_](Type{2}, Type{1}), Type{1});
+  TTS_EQUAL(eve::numeric_(eve::minmag)(Type{0}, Type{0}), Type{0});
+  TTS_EQUAL(eve::numeric_(eve::minmag)(Type{0}, Type{1}), Type{0});
+  TTS_EQUAL(eve::numeric_(eve::minmag)(Type{1}, Type{0}), Type{0});
+  TTS_EQUAL(eve::numeric_(eve::minmag)(Type{1}, Type{2}), Type{1});
+  TTS_EQUAL(eve::numeric_(eve::minmag)(Type{2}, Type{1}), Type{1});
   if constexpr(std::is_signed_v<Type> )
   {
-    TTS_EQUAL(eve::minmag[eve::numeric_](static_cast<Type>(-3), Type{2}), Type{2});
-    TTS_EQUAL(eve::minmag[eve::numeric_](static_cast<Type>(-1), Type{2}), static_cast<Type>(-1));
-    TTS_EQUAL(eve::minmag[eve::numeric_](static_cast<Type>(-1), Type{1}), static_cast<Type>(-1));
+    TTS_EQUAL(eve::numeric_(eve::minmag)(static_cast<Type>(-3), Type{2}), Type{2});
+    TTS_EQUAL(eve::numeric_(eve::minmag)(static_cast<Type>(-1), Type{2}), static_cast<Type>(-1));
+    TTS_EQUAL(eve::numeric_(eve::minmag)(static_cast<Type>(-1), Type{1}), static_cast<Type>(-1));
   }
   if constexpr(std::is_floating_point_v<Type> )
   {
     Type n =  eve::Nan<Type>();
     Type o =  eve::One<Type>();
-    TTS_IEEE_EQUAL(eve::minmag[eve::numeric_](n, o), o);
-    TTS_IEEE_EQUAL(eve::minmag[eve::numeric_](o, n), o);
+    TTS_IEEE_EQUAL(eve::numeric_(eve::minmag)(n, o), o);
+    TTS_IEEE_EQUAL(eve::numeric_(eve::minmag)(o, n), o);
   }
 }
 

--- a/test/unit/module/core/scalar/rec/rec.hpp
+++ b/test/unit/module/core/scalar/rec/rec.hpp
@@ -22,7 +22,7 @@
 TTS_CASE("Check rec return type")
 {
   TTS_EXPR_IS(eve::rec(Type(0)),  Type);
-  TTS_EXPR_IS(eve::rec[eve::raw_](Type(0)),  Type);
+  TTS_EXPR_IS(eve::raw_(eve::rec)(Type(0)),  Type);
 }
 
 TTS_CASE("Check eve::rec behavior")
@@ -50,28 +50,28 @@ TTS_CASE("Check eve::rec behavior")
   }
 }
 
-TTS_CASE("Check eve::rec[raw_] behavior")
+TTS_CASE("Check raw_(rec) behavior")
 {
   if constexpr(std::is_floating_point_v<Type>)
   {
-    TTS_EQUAL(eve::rec[eve::raw_]( Type(0)), eve::Inf<Type>()  );
-    TTS_EQUAL(eve::rec[eve::raw_](-Type(0)), eve::Minf<Type>() );
-    TTS_EQUAL(eve::rec[eve::raw_]( Type(1)), Type(1)           );
-    TTS_EQUAL(eve::rec[eve::raw_]( Type(2)), Type(1)/Type(2)   );
+    TTS_EQUAL(eve::raw_(eve::rec)( Type(0)), eve::Inf<Type>()  );
+    TTS_EQUAL(eve::raw_(eve::rec)(-Type(0)), eve::Minf<Type>() );
+    TTS_EQUAL(eve::raw_(eve::rec)( Type(1)), Type(1)           );
+    TTS_EQUAL(eve::raw_(eve::rec)( Type(2)), Type(1)/Type(2)   );
   }
   else
   {
     if constexpr(std::is_signed_v<Type>)
     {
-      TTS_EQUAL(eve::rec[eve::raw_](Type(-1) ), Type(-1));
-      TTS_EQUAL(eve::rec[eve::raw_](Type(-2) ), Type(0));
-      TTS_EQUAL(eve::rec[eve::raw_](Type(-47)), Type(0));
+      TTS_EQUAL(eve::raw_(eve::rec)(Type(-1) ), Type(-1));
+      TTS_EQUAL(eve::raw_(eve::rec)(Type(-2) ), Type(0));
+      TTS_EQUAL(eve::raw_(eve::rec)(Type(-47)), Type(0));
     }
 
-    TTS_EQUAL(eve::rec[eve::raw_](Type(0) ), eve::Valmax<Type>());
-    TTS_EQUAL(eve::rec[eve::raw_](Type(1) ), Type(1));
-    TTS_EQUAL(eve::rec[eve::raw_](Type(2) ), Type(0));
-    TTS_EQUAL(eve::rec[eve::raw_](Type(47)), Type(0));
+    TTS_EQUAL(eve::raw_(eve::rec)(Type(0) ), eve::Valmax<Type>());
+    TTS_EQUAL(eve::raw_(eve::rec)(Type(1) ), Type(1));
+    TTS_EQUAL(eve::raw_(eve::rec)(Type(2) ), Type(0));
+    TTS_EQUAL(eve::raw_(eve::rec)(Type(47)), Type(0));
   }
 }
 

--- a/test/unit/module/core/scalar/sqr/sqr.hpp
+++ b/test/unit/module/core/scalar/sqr/sqr.hpp
@@ -34,7 +34,7 @@ TTS_CASE("Check eve::sqr behavior")
 {
   TTS_EQUAL(eve::sqr(Type{1}), Type(1));
   TTS_EQUAL(eve::sqr(Type{2}), Type(4));
-  
+
   if constexpr(std::is_signed_v<Type>)
   {
     TTS_EQUAL(eve::sqr(static_cast<Type>(-2)), Type(4));
@@ -43,11 +43,11 @@ TTS_CASE("Check eve::sqr behavior")
   {
     TTS_IEEE_EQUAL(eve::sqr(eve::Nan<Type>()), eve::Nan<Type>());
     TTS_IEEE_EQUAL(eve::sqr(-eve::Nan<Type>()), eve::Nan<Type>());
-    TTS_EQUAL(eve::sqr(eve::Mzero<Type>()), Type(0)); 
+    TTS_EQUAL(eve::sqr(eve::Mzero<Type>()), Type(0));
     TTS_EQUAL(eve::sqr(eve::Zero<Type>()),  Type(0));
     if constexpr(std::is_integral_v<Type>)
-      TTS_EQUAL(eve::sqr[eve::saturated_](eve::inc(eve::Sqrtvalmax<Type>())), eve::Valmax<Type>()); 
+      TTS_EQUAL(eve::saturated_(eve::sqr)(eve::inc(eve::Sqrtvalmax<Type>())), eve::Valmax<Type>());
   }
 }
-  
+
 #endif

--- a/test/unit/module/core/simd/maxnummag/maxnummag.hpp
+++ b/test/unit/module/core/simd/maxnummag/maxnummag.hpp
@@ -30,9 +30,9 @@ TTS_CASE_TPL("Check plus behavior on wide",
   using eve::wide;
 
   wide<Type, T> lhs([](auto i, auto) { return i; }), rhs([](auto i, auto c) { return Type(i-c); }),
-    ref([](auto i, auto c) { return eve::maxmag[eve::numeric_](Type(i), Type(i-c)); });
+    ref([](auto i, auto c) { return eve::numeric_(eve::maxmag)(Type(i), Type(i-c)); });
 
-  TTS_EQUAL(ref, eve::maxmag[eve::numeric_](lhs, rhs));
+  TTS_EQUAL(ref, eve::numeric_(eve::maxmag)(lhs, rhs));
 }
 
 TTS_CASE_TPL("Check plus behavior on wide",
@@ -47,12 +47,12 @@ TTS_CASE_TPL("Check plus behavior on wide",
   using eve::wide;
 
   wide<Type, T> lhs([](auto i, auto) { return i; }),
-    ref([](auto i, auto) { return eve::maxmag[eve::numeric_](Type(i), static_cast<Type>(2)); }),
-    refm([](auto i, auto) { return eve::maxmag[eve::numeric_](Type(i), static_cast<Type>(-2)); });
-  TTS_EQUAL(ref, eve::maxmag[eve::numeric_](lhs, static_cast<Type>(2)));
-  TTS_EQUAL(ref, eve::maxmag[eve::numeric_](static_cast<Type>(2), lhs));
-  TTS_EQUAL(refm, eve::maxmag[eve::numeric_](lhs, static_cast<Type>(-2)));
-  TTS_EQUAL(refm, eve::maxmag[eve::numeric_](static_cast<Type>(-2), lhs));
+    ref([](auto i, auto) { return eve::numeric_(eve::maxmag)(Type(i), static_cast<Type>(2)); }),
+    refm([](auto i, auto) { return eve::numeric_(eve::maxmag)(Type(i), static_cast<Type>(-2)); });
+  TTS_EQUAL(ref, eve::numeric_(eve::maxmag)(lhs, static_cast<Type>(2)));
+  TTS_EQUAL(ref, eve::numeric_(eve::maxmag)(static_cast<Type>(2), lhs));
+  TTS_EQUAL(refm, eve::numeric_(eve::maxmag)(lhs, static_cast<Type>(-2)));
+  TTS_EQUAL(refm, eve::numeric_(eve::maxmag)(static_cast<Type>(-2), lhs));
 }
 
 #endif

--- a/test/unit/module/core/simd/minnummag/minnummag.hpp
+++ b/test/unit/module/core/simd/minnummag/minnummag.hpp
@@ -30,9 +30,9 @@ TTS_CASE_TPL("Check plus behavior on wide",
   using eve::wide;
 
   wide<Type, T> lhs([](auto i, auto) { return i; }), rhs([](auto i, auto c) { return Type(i-c); }),
-    ref([](auto i, auto c) { return eve::minmag[eve::numeric_](Type(i), Type(i-c)); });
+    ref([](auto i, auto c) { return eve::numeric_(eve::minmag)(Type(i), Type(i-c)); });
 
-  TTS_EQUAL(ref, eve::minmag[eve::numeric_](lhs, rhs));
+  TTS_EQUAL(ref, eve::numeric_(eve::minmag)(lhs, rhs));
 }
 
 TTS_CASE_TPL("Check plus behavior on wide",
@@ -47,12 +47,12 @@ TTS_CASE_TPL("Check plus behavior on wide",
   using eve::wide;
 
   wide<Type, T> lhs([](auto i, auto) { return i; }),
-    ref([](auto i, auto) { return eve::minmag[eve::numeric_](Type(i), static_cast<Type>(2)); }),
-    refm([](auto i, auto) { return eve::minmag[eve::numeric_](Type(i), static_cast<Type>(-2)); });
-  TTS_EQUAL(ref, eve::minmag[eve::numeric_](lhs, static_cast<Type>(2)));
-  TTS_EQUAL(ref, eve::minmag[eve::numeric_](static_cast<Type>(2), lhs));
-  TTS_EQUAL(refm, eve::minmag[eve::numeric_](lhs, static_cast<Type>(-2)));
-  TTS_EQUAL(refm, eve::minmag[eve::numeric_](static_cast<Type>(-2), lhs));
+    ref([](auto i, auto) { return eve::numeric_(eve::minmag)(Type(i), static_cast<Type>(2)); }),
+    refm([](auto i, auto) { return eve::numeric_(eve::minmag)(Type(i), static_cast<Type>(-2)); });
+  TTS_EQUAL(ref, eve::numeric_(eve::minmag)(lhs, static_cast<Type>(2)));
+  TTS_EQUAL(ref, eve::numeric_(eve::minmag)(static_cast<Type>(2), lhs));
+  TTS_EQUAL(refm, eve::numeric_(eve::minmag)(lhs, static_cast<Type>(-2)));
+  TTS_EQUAL(refm, eve::numeric_(eve::minmag)(static_cast<Type>(-2), lhs));
 }
 
 #endif

--- a/test/unit/module/core/simd/rec/rec.hpp
+++ b/test/unit/module/core/simd/rec/rec.hpp
@@ -59,12 +59,12 @@ TTS_CASE_TPL("Check rec[raw_] behavior on wide",
                       }
                     );
 
-  wide<Type, T> ref([&lhs](auto i, auto) { return eve::rec[eve::raw_](lhs[i]); });
+  wide<Type, T> ref([&lhs](auto i, auto) { return eve::raw_(eve::rec)(lhs[i]); });
 
-  TTS_RELATIVE_EQUAL(ref, eve::rec[eve::raw_](lhs), 0.3);
+  TTS_RELATIVE_EQUAL(ref, eve::raw_(eve::rec)(lhs), 0.3);
 }
 
-TTS_CASE_TPL("Check rec[pedantic_] behavior on wide",
+TTS_CASE_TPL("Check pedantic(rec) behavior on wide",
              fixed<1>,
              fixed<2>,
              fixed<4>,
@@ -82,9 +82,9 @@ TTS_CASE_TPL("Check rec[pedantic_] behavior on wide",
                       }
                     );
 
-  wide<Type, T> ref([&lhs](auto i, auto) { return eve::rec[eve::pedantic_](lhs[i]); });
+  wide<Type, T> ref([&lhs](auto i, auto) { return eve::pedantic_(eve::rec)(lhs[i]); });
 
-  TTS_ULP_EQUAL(ref, eve::rec[eve::pedantic_](lhs), 0.5);
+  TTS_ULP_EQUAL(ref, eve::pedantic_(eve::rec)(lhs), 0.5);
 }
 
 #endif


### PR DESCRIPTION
Instead of using [] on function objects for options like raw, pedantic, etc... we revert back to raw(f) as an API. This allows mixing option and conditional evaluation