### PR TITLE
Add constexpr check for special API variants

### DIFF
--- a/include/eve/arch/arm/spec.hpp
+++ b/include/eve/arch/arm/spec.hpp
@@ -43,6 +43,9 @@ namespace eve
 #  ifndef EVE_NO_DENORMALS
 #    define EVE_NO_DENORMALS
 #  endif
+namespace eve { inline constexpr bool supports_aarch64 = false; }
+#else
+namespace eve { inline constexpr bool supports_aarch64 = true;  }
 #endif
 
 #endif

--- a/include/eve/arch/x86/spec.hpp
+++ b/include/eve/arch/x86/spec.hpp
@@ -69,6 +69,9 @@ namespace eve
 // Additionnal ISA support
 #if defined(EVE_SUPPORTS_FMA3)
 #  include <immintrin.h>
+namespace eve { inline constexpr bool supports_fma3 = true;   }
+#else
+namespace eve { inline constexpr bool supports_fma3 = false;  }
 #endif
 
 #if defined(EVE_SUPPORTS_FMA4)
@@ -78,6 +81,9 @@ namespace eve
 #    include <x86intrin.h>
 #    include <fma4intrin.h>
 #  endif
+namespace eve { inline constexpr bool supports_fma4 = true;   }
+#else
+namespace eve { inline constexpr bool supports_fma4 = false;  }
 #endif
 
 #if defined(EVE_SUPPORTS_XOP)
@@ -87,6 +93,9 @@ namespace eve
 #    include <x86intrin.h>
 #    include <xopintrin.h>
 #  endif
+namespace eve { inline constexpr bool supports_xop = true;  }
+#else
+namespace eve { inline constexpr bool supports_xop = false; }
 #endif
 
 #endif

--- a/test/unit/arch/is_supported.cpp
+++ b/test/unit/arch/is_supported.cpp
@@ -16,8 +16,17 @@
 
 int main()
 {
-  std::cout << "X86-like SIMD extensions\n";
+  std::cout << "Static detections:\n";
   std::cout << "========================\n";
+  std::cout << "FMA3   : " << std::boolalpha << eve::supports_fma3 << "\n";
+  std::cout << "FMA4   : " << std::boolalpha << eve::supports_fma4 << "\n";
+  std::cout << "XOP    : " << std::boolalpha << eve::supports_xop << "\n";
+  std::cout << "AARCH64: " << std::boolalpha << eve::supports_aarch64 << "\n";
+  std::cout << "\n";
+
+  std::cout << "Dynamic detections:\n";
+  std::cout << "========================\n";
+  std::cout << "X86-like SIMD extensions\n";
   std::cout << "SSE2   : " << std::boolalpha << eve::is_supported(eve::sse2) << "\n";
   std::cout << "SSE3   : " << std::boolalpha << eve::is_supported(eve::sse3) << "\n";
   std::cout << "SSSE3  : " << std::boolalpha << eve::is_supported(eve::ssse3) << "\n";
@@ -31,11 +40,9 @@ int main()
 
   std::cout << "\n";
   std::cout << "PPC SIMD extensions\n";
-  std::cout << "========================\n";
 
   std::cout << "\n";
   std::cout << "ARM SIMD extensions\n";
-  std::cout << "========================\n";
 
   return 0;
 }


### PR DESCRIPTION
Special variants like aarch64, fma3, fma4 and xop can now be checked via constexpr