### PR TITLE
:sparkles: - Fix #9 - Support for NO_SIMD mode

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,13 +55,7 @@ docker_aarch64: &docker_aarch64
 ##==================================================================================================
 ## Build configurations
 ##==================================================================================================
-config_gcc_sse2: &config_gcc_sse2
-  <<: *docker_gcc
-config_gcc_sse4: &config_gcc_sse4
-  <<: *docker_gcc
-config_gcc_avx: &config_gcc_avx
-  <<: *docker_gcc
-config_gcc_avx2: &config_gcc_avx2
+config_gcc_x86: &config_gcc_x86
   <<: *docker_gcc
 config_clang_avx2: &config_clang_avx2
   <<: *docker_clang
@@ -141,14 +135,6 @@ jobs:
   ##================================================================================================
   ## Synchronization jobs
   ##================================================================================================
-  sync_arch:
-    <<: *docker_gcc
-    steps:
-      - run: echo "Test arch.unit completed"
-  sync_api:
-    <<: *docker_gcc
-    steps:
-      - run: echo "Test api.unit completed"
   sync_basic:
     <<: *docker_gcc
     steps:
@@ -161,36 +147,43 @@ jobs:
   ##================================================================================================
   ## Basic tests
   ##================================================================================================
+  gcc_emu_basic:
+    <<: *config_gcc_x86
+    environment:
+      TARGET: basic
+      REPLICATION: 8
+      OPTIONS: "-DEVE_NO_SIMD"
+    <<: *steps_test_gcc
   gcc_sse2_basic:
-    <<: *config_gcc_sse2
+    <<: *config_gcc_x86
     environment:
       TARGET: basic
       REPLICATION: 8
       OPTIONS: "-msse2"
     <<: *steps_test_gcc
   gcc_sse4_basic:
-    <<: *config_gcc_sse4
+    <<: *config_gcc_x86
     environment:
       TARGET: basic
       REPLICATION: 8
       OPTIONS: "-msse4.2"
     <<: *steps_test_gcc
   gcc_avx_basic:
-    <<: *config_gcc_avx
+    <<: *config_gcc_x86
     environment:
       TARGET: basic
       REPLICATION: 8
       OPTIONS: "-mavx"
     <<: *steps_test_gcc
   gcc_fma3_basic:
-    <<: *config_gcc_avx
+    <<: *config_gcc_x86
     environment:
       TARGET: basic
       REPLICATION: 8
       OPTIONS: "-mavx -mfma"
     <<: *steps_test_gcc
   gcc_avx2_basic:
-    <<: *config_gcc_avx2
+    <<: *config_gcc_x86
     environment:
       TARGET: basic
       REPLICATION: 8
@@ -228,36 +221,43 @@ jobs:
   ##================================================================================================
   ## Scalar tests
   ##================================================================================================
+  gcc_emu_scalar:
+    <<: *config_gcc_x86
+    environment:
+      TARGET: core.scalar
+      REPLICATION: 8
+      OPTIONS: "-DEVE_NO_SIMD"
+    <<: *steps_test_gcc
   gcc_sse2_scalar:
-    <<: *config_gcc_sse2
+    <<: *config_gcc_x86
     environment:
       TARGET: core.scalar
       REPLICATION: 8
       OPTIONS: "-msse2"
     <<: *steps_test_gcc
   gcc_sse4_scalar:
-    <<: *config_gcc_sse4
+    <<: *config_gcc_x86
     environment:
       TARGET: core.scalar
       REPLICATION: 8
       OPTIONS: "-msse4.2"
     <<: *steps_test_gcc
   gcc_avx_scalar:
-    <<: *config_gcc_avx
+    <<: *config_gcc_x86
     environment:
       TARGET: core.scalar
       REPLICATION: 8
       OPTIONS: "-mavx"
     <<: *steps_test_gcc
   gcc_fma3_scalar:
-    <<: *config_gcc_avx
+    <<: *config_gcc_x86
     environment:
       TARGET: core.scalar
       REPLICATION: 8
       OPTIONS: "-mavx -mfma"
     <<: *steps_test_gcc
   gcc_avx2_scalar:
-    <<: *config_gcc_avx2
+    <<: *config_gcc_x86
     environment:
       TARGET: core.scalar
       REPLICATION: 8
@@ -295,36 +295,43 @@ jobs:
   ##================================================================================================
   ## SIMD tests
   ##================================================================================================
+  gcc_emu_simd:
+    <<: *config_gcc_x86
+    environment:
+      TARGET: core.simd
+      REPLICATION: 2
+      OPTIONS: "-DEVE_NO_SIMD"
+    <<: *steps_test_gcc
   gcc_sse2_simd:
-    <<: *config_gcc_sse2
+    <<: *config_gcc_x86
     environment:
       TARGET: core.simd
       REPLICATION: 2
       OPTIONS: "-msse2"
     <<: *steps_test_gcc
   gcc_sse4_simd:
-    <<: *config_gcc_sse4
+    <<: *config_gcc_x86
     environment:
       TARGET: core.simd
       REPLICATION: 4
       OPTIONS: "-msse4.2"
     <<: *steps_test_gcc
   gcc_avx_simd:
-    <<: *config_gcc_avx
+    <<: *config_gcc_x86
     environment:
       TARGET: core.simd
       REPLICATION: 4
       OPTIONS: "-mavx"
     <<: *steps_test_gcc
   gcc_fma3_simd:
-    <<: *config_gcc_avx
+    <<: *config_gcc_x86
     environment:
       TARGET: core.simd
       REPLICATION: 4
       OPTIONS: "-mavx -mfma"
     <<: *steps_test_gcc
   gcc_avx2_simd:
-    <<: *config_gcc_avx2
+    <<: *config_gcc_x86
     environment:
       TARGET: core.simd
       REPLICATION: 4
@@ -369,6 +376,7 @@ workflows:
       - arm_aarch64_basic
       - arm_neon_basic
       - ppc_vsx_basic
+      - gcc_emu_basic
       - gcc_sse2_basic
       - gcc_sse4_basic
       - gcc_avx_basic
@@ -380,6 +388,7 @@ workflows:
             - arm_aarch64_basic
             - arm_neon_basic
             - ppc_vsx_basic
+            - gcc_emu_basic
             - gcc_sse2_basic
             - gcc_sse4_basic
             - gcc_avx_basic
@@ -397,6 +406,9 @@ workflows:
           requires:
             - sync_basic
       - ppc_vsx_scalar:
+          requires:
+            - sync_basic
+      - gcc_emu_scalar:
           requires:
             - sync_basic
       - gcc_sse2_scalar:
@@ -439,6 +451,9 @@ workflows:
           requires:
             - sync_scalar
       - ppc_vsx_simd:
+          requires:
+            - sync_scalar
+      - gcc_emu_simd:
           requires:
             - sync_scalar
       - gcc_sse2_simd:

--- a/include/eve/arch/arm/predef.hpp
+++ b/include/eve/arch/arm/predef.hpp
@@ -16,7 +16,9 @@
 
 // Detect current highest NEON variant
 #undef EVE_HW_ARM
-#if !defined(EVE_HW_ARM) && (defined(__ARM_NEON__) || defined(_M_ARM) || defined(__aarch64__))
+
+#if !defined(EVE_HW_ARM)  && !defined(EVE_NO_SIMD) && (defined(__ARM_NEON__) ||                     \
+    defined(_M_ARM) || defined(__aarch64__))
 #  define EVE_HW_ARM EVE_NEON_VERSION
 #endif
 

--- a/include/eve/arch/arm/spec.hpp
+++ b/include/eve/arch/arm/spec.hpp
@@ -39,19 +39,4 @@ namespace eve
 #  define EVE_CURRENT_API ::eve::neon128_
 #endif
 
-#if !defined(__aarch64__)
-#  ifndef EVE_NO_DENORMALS
-#    define EVE_NO_DENORMALS
-#  endif
-namespace eve
-{
-  inline constexpr bool supports_aarch64 = false;
-}
-#else
-namespace eve
-{
-  inline constexpr bool supports_aarch64 = true;
-}
-#endif
-
 #endif

--- a/include/eve/arch/as_register.hpp
+++ b/include/eve/arch/as_register.hpp
@@ -12,8 +12,11 @@
 #define EVE_ARCH_AS_REGISTER_HPP_INCLUDED
 
 #include <eve/arch/cpu/as_register.hpp>
+
+#if !defined(EVE_NO_SIMD)
 #include <eve/arch/x86/as_register.hpp>
 #include <eve/arch/ppc/as_register.hpp>
 #include <eve/arch/arm/as_register.hpp>
+#endif
 
 #endif

--- a/include/eve/arch/cpu/spec.hpp
+++ b/include/eve/arch/cpu/spec.hpp
@@ -17,4 +17,70 @@
 #  define EVE_STRICT_EMULATION
 #endif
 
+//==================================================================================================
+// Additionnal ISA support
+#if defined(EVE_SUPPORTS_FMA3)
+#  include <immintrin.h>
+namespace eve
+{
+  inline constexpr bool supports_fma3 = true;
+}
+#else
+namespace eve
+{
+  inline constexpr bool supports_fma3 = false;
+}
+#endif
+
+#if defined(EVE_SUPPORTS_FMA4)
+#  if defined(EVE_COMP_IS_MSVC)
+#    include <intrin.h>
+#  else
+#    include <x86intrin.h>
+#    include <fma4intrin.h>
+#  endif
+namespace eve
+{
+  inline constexpr bool supports_fma4 = true;
+}
+#else
+namespace eve
+{
+  inline constexpr bool supports_fma4 = false;
+}
+#endif
+
+#if defined(EVE_SUPPORTS_XOP)
+#  if defined(EVE_COMP_IS_MSVC)
+#    include <intrin.h>
+#  else
+#    include <x86intrin.h>
+#    include <xopintrin.h>
+#  endif
+namespace eve
+{
+  inline constexpr bool supports_xop = true;
+}
+#else
+namespace eve
+{
+  inline constexpr bool supports_xop = false;
+}
+#endif
+
+#if !defined(__aarch64__)
+#  ifndef EVE_NO_DENORMALS
+#    define EVE_NO_DENORMALS
+#  endif
+namespace eve
+{
+  inline constexpr bool supports_aarch64 = false;
+}
+#else
+namespace eve
+{
+  inline constexpr bool supports_aarch64 = true;
+}
+#endif
+
 #endif

--- a/include/eve/arch/limits.hpp
+++ b/include/eve/arch/limits.hpp
@@ -12,8 +12,11 @@
 #define EVE_ARCH_LIMITS_HPP_INCLUDED
 
 #include <eve/arch/cpu/limits.hpp>
+
+#if !defined(EVE_NO_SIMD)
 #include <eve/arch/x86/limits.hpp>
 #include <eve/arch/ppc/limits.hpp>
 #include <eve/arch/arm/limits.hpp>
+#endif
 
 #endif

--- a/include/eve/arch/ppc/predef.hpp
+++ b/include/eve/arch/ppc/predef.hpp
@@ -17,11 +17,12 @@
 
 // Detect current highest SSEx variant
 #undef EVE_HW_POWERPC
-#if !defined(EVE_HW_POWERPC) && defined(__VSX__)
+
+#if !defined(EVE_HW_POWERPC) && defined(__VSX__) && !defined(EVE_NO_SIMD)
 #  define EVE_HW_POWERPC EVE_VSX_VERSION
 #endif
 
-#if !defined(EVE_HW_POWERPC) && (defined(__ALTIVEC__) || defined(__VEC__))
+#if !defined(EVE_HW_POWERPC) && !defined(EVE_NO_SIMD) && (defined(__ALTIVEC__) || defined(__VEC__))
 #  define EVE_HW_POWERPC EVE_VMX_VERSION
 #endif
 

--- a/include/eve/arch/x86/predef.hpp
+++ b/include/eve/arch/x86/predef.hpp
@@ -53,32 +53,34 @@
 
 // Detect current highest SSEx variant
 #undef EVE_HW_X86
-#if !defined(EVE_HW_X86) && defined(__AVX2__)
+
+#if !defined(EVE_HW_X86) && defined(__AVX2__) && !defined(EVE_NO_SIMD)
 #  define EVE_HW_X86 EVE_AVX2_VERSION
 #endif
 
-#if !defined(EVE_HW_X86) && defined(__AVX__)
+#if !defined(EVE_HW_X86) && defined(__AVX__) && !defined(EVE_NO_SIMD)
 #  define EVE_HW_X86 EVE_AVX_VERSION
 #endif
 
-#if !defined(EVE_HW_X86) && defined(__SSE4_2__)
+#if !defined(EVE_HW_X86) && defined(__SSE4_2__) && !defined(EVE_NO_SIMD)
 #  define EVE_HW_X86 EVE_SSE4_2_VERSION
 #endif
 
-#if !defined(EVE_HW_X86) && defined(__SSE4_1__)
+#if !defined(EVE_HW_X86) && defined(__SSE4_1__) && !defined(EVE_NO_SIMD)
 #  define EVE_HW_X86 EVE_SSE4_1_VERSION
 #endif
 
-#if !defined(EVE_HW_X86) && defined(__SSSE3__)
+#if !defined(EVE_HW_X86) && defined(__SSSE3__) && !defined(EVE_NO_SIMD)
 #  define EVE_HW_X86 EVE_SSSE3_VERSION
 #endif
 
-#if !defined(EVE_HW_X86) && defined(__SSE3__)
+#if !defined(EVE_HW_X86) && defined(__SSE3__) && !defined(EVE_NO_SIMD)
 #  define EVE_HW_X86 EVE_SSE3_VERSION
 #endif
 
 #if !defined(EVE_HW_X86) &&                                                                        \
-    (defined(__SSE2__) || defined(_M_X64) || (defined(_M_IX86_FP) && _M_IX86_FP >= 2))
+    (defined(__SSE2__) || defined(_M_X64) || (defined(_M_IX86_FP) && _M_IX86_FP >= 2)) &&          \
+    !defined(EVE_NO_SIMD)
 #  define EVE_HW_X86 EVE_SSE2_VERSION
 #endif
 

--- a/include/eve/arch/x86/spec.hpp
+++ b/include/eve/arch/x86/spec.hpp
@@ -44,7 +44,7 @@ namespace eve
 
 //==================================================================================================
 // X86 SIMD API
-#if !defined(EVE_CURRENT_API)
+#if !defined(EVE_CURRENT_API) && EVE_HW_X86
 #  if EVE_HW_X86 == EVE_SSE2_VERSION
 #    define EVE_CURRENT_API ::eve::sse2_
 #  elif EVE_HW_X86 == EVE_SSE3_VERSION
@@ -63,56 +63,5 @@ namespace eve
 #endif
 
 // TODO: AVX512 API
-
-//==================================================================================================
-// Additionnal ISA support
-#if defined(EVE_SUPPORTS_FMA3)
-#  include <immintrin.h>
-namespace eve
-{
-  inline constexpr bool supports_fma3 = true;
-}
-#else
-namespace eve
-{
-  inline constexpr bool supports_fma3 = false;
-}
-#endif
-
-#if defined(EVE_SUPPORTS_FMA4)
-#  if defined(EVE_COMP_IS_MSVC)
-#    include <intrin.h>
-#  else
-#    include <x86intrin.h>
-#    include <fma4intrin.h>
-#  endif
-namespace eve
-{
-  inline constexpr bool supports_fma4 = true;
-}
-#else
-namespace eve
-{
-  inline constexpr bool supports_fma4 = false;
-}
-#endif
-
-#if defined(EVE_SUPPORTS_XOP)
-#  if defined(EVE_COMP_IS_MSVC)
-#    include <intrin.h>
-#  else
-#    include <x86intrin.h>
-#    include <xopintrin.h>
-#  endif
-namespace eve
-{
-  inline constexpr bool supports_xop = true;
-}
-#else
-namespace eve
-{
-  inline constexpr bool supports_xop = false;
-}
-#endif
 
 #endif

--- a/include/eve/detail/meta.hpp
+++ b/include/eve/detail/meta.hpp
@@ -9,14 +9,14 @@
 **/
 //==================================================================================================
 #ifndef EVE_DETAIL_META_HPP_INCLUDED
-#  define EVE_DETAIL_META_HPP_INCLUDED
+#define EVE_DETAIL_META_HPP_INCLUDED
 
-#  include <eve/detail/abi.hpp>
-#  include <eve/detail/is_native.hpp>
-#  include <type_traits>
-#  include <utility>
-#  include <cstdint>
-#  include <cstddef>
+#include <eve/detail/abi.hpp>
+#include <eve/detail/is_native.hpp>
+#include <type_traits>
+#include <utility>
+#include <cstdint>
+#include <cstddef>
 
 namespace eve::detail
 {

--- a/include/eve/function/scalar/combine.hpp
+++ b/include/eve/function/scalar/combine.hpp
@@ -13,7 +13,9 @@
 
 #include <eve/function/definition/combine.hpp>
 #include <eve/detail/overload.hpp>
+#include <eve/detail/meta.hpp>
 #include <eve/detail/abi.hpp>
+#include <eve/concept/vectorizable.hpp>
 #include <eve/wide.hpp>
 
 namespace eve::detail
@@ -27,6 +29,7 @@ namespace eve::detail
   template<typename T>
   EVE_FORCEINLINE auto
   combine_(EVE_SUPPORTS(cpu_), logical<T> const &a, logical<T> const &b) noexcept
+  requires( logical<wide<T, fixed<2>>>, Vectorizable<T> )
   {
     return logical<wide<T, fixed<2>>>(a, b);
   }

--- a/include/eve/function/simd/combine.hpp
+++ b/include/eve/function/simd/combine.hpp
@@ -28,8 +28,8 @@ namespace eve::detail
 
   //------------------------------------------------------------------------------------------------
   // Logical
-  template<typename T, typename N, typename ABI, typename Arch>
-  EVE_FORCEINLINE auto combine_(EVE_SUPPORTS(Arch),
+  template<typename T, typename N, typename ABI>
+  EVE_FORCEINLINE auto combine_(EVE_SUPPORTS(cpu_),
                                 logical<wide<T, N, ABI>> const &l,
                                 logical<wide<T, N, ABI>> const &h) noexcept
   {

--- a/include/eve/module/core/function/scalar/add.hpp
+++ b/include/eve/module/core/function/scalar/add.hpp
@@ -9,13 +9,14 @@
 **/
 //==================================================================================================
 #ifndef EVE_MODULE_CORE_FUNCTION_SCALAR_ADD_HPP_INCLUDED
-#  define EVE_MODULE_CORE_FUNCTION_SCALAR_ADD_HPP_INCLUDED
+#define EVE_MODULE_CORE_FUNCTION_SCALAR_ADD_HPP_INCLUDED
 
 //#include <eve/function/saturated.hpp>
 // #include <eve/function/scalar/saturate.hpp>
-#  include <eve/concept/vectorizable.hpp>
-#  include <eve/detail/overload.hpp>
-#  include <eve/detail/abi.hpp>
+#include <eve/concept/vectorizable.hpp>
+#include <eve/detail/overload.hpp>
+#include <eve/detail/meta.hpp>
+#include <eve/detail/abi.hpp>
 // #include <type_traits>
 // #include <limits>
 // #include <climits>

--- a/include/eve/module/core/function/scalar/bitwise_cast.hpp
+++ b/include/eve/module/core/function/scalar/bitwise_cast.hpp
@@ -13,6 +13,7 @@
 
 #include <eve/detail/overload.hpp>
 #include <eve/detail/alias.hpp>
+#include <eve/detail/meta.hpp>
 #include <eve/detail/abi.hpp>
 #include <eve/concept/vectorizable.hpp>
 #include <eve/assert.hpp>

--- a/include/eve/module/core/function/scalar/div.hpp
+++ b/include/eve/module/core/function/scalar/div.hpp
@@ -9,12 +9,12 @@
 **/
 //==================================================================================================
 #ifndef EVE_MODULE_CORE_FUNCTION_SCALAR_DIV_HPP_INCLUDED
-#  define EVE_MODULE_CORE_FUNCTION_SCALAR_DIV_HPP_INCLUDED
+#define EVE_MODULE_CORE_FUNCTION_SCALAR_DIV_HPP_INCLUDED
 
-#  include <eve/detail/overload.hpp>
-#  include <eve/detail/meta.hpp>
-#  include <eve/detail/abi.hpp>
-#  include <eve/concept/vectorizable.hpp>
+#include <eve/detail/overload.hpp>
+#include <eve/detail/meta.hpp>
+#include <eve/detail/abi.hpp>
+#include <eve/concept/vectorizable.hpp>
 
 namespace eve::detail
 {

--- a/include/eve/module/core/function/scalar/mul.hpp
+++ b/include/eve/module/core/function/scalar/mul.hpp
@@ -9,11 +9,12 @@
 **/
 //==================================================================================================
 #ifndef EVE_MODULE_CORE_FUNCTION_SCALAR_MUL_HPP_INCLUDED
-#  define EVE_MODULE_CORE_FUNCTION_SCALAR_MUL_HPP_INCLUDED
+#define EVE_MODULE_CORE_FUNCTION_SCALAR_MUL_HPP_INCLUDED
 
-#  include <eve/detail/overload.hpp>
-#  include <eve/detail/abi.hpp>
-#  include <eve/concept/vectorizable.hpp>
+#include <eve/detail/overload.hpp>
+#include <eve/detail/meta.hpp>
+#include <eve/detail/abi.hpp>
+#include <eve/concept/vectorizable.hpp>
 
 namespace eve::detail
 {

--- a/include/eve/module/core/function/scalar/popcnt.hpp
+++ b/include/eve/module/core/function/scalar/popcnt.hpp
@@ -15,6 +15,7 @@
 #include <eve/detail/compiler.hpp>
 #include <eve/detail/abi.hpp>
 #include <type_traits>
+#include <cstdint>
 
 #if defined(EVE_COMP_IS_MSVC)
 #  include <intrin.h>

--- a/include/eve/module/core/function/scalar/sub.hpp
+++ b/include/eve/module/core/function/scalar/sub.hpp
@@ -9,17 +9,16 @@
 **/
 //==================================================================================================
 #ifndef EVE_MODULE_CORE_FUNCTION_SCALAR_SUB_HPP_INCLUDED
-#  define EVE_MODULE_CORE_FUNCTION_SCALAR_SUB_HPP_INCLUDED
+#define EVE_MODULE_CORE_FUNCTION_SCALAR_SUB_HPP_INCLUDED
 
-#  include <eve/concept/vectorizable.hpp>
-#  include <eve/detail/overload.hpp>
-#  include <eve/detail/abi.hpp>
-#  include <eve/concept/vectorizable.hpp>
+#include <eve/concept/vectorizable.hpp>
+#include <eve/detail/overload.hpp>
+#include <eve/detail/meta.hpp>
+#include <eve/detail/abi.hpp>
+#include <eve/concept/vectorizable.hpp>
 
 namespace eve::detail
 {
-  // -----------------------------------------------------------------------------------------------
-  // Regular case
   template<typename T>
   EVE_FORCEINLINE constexpr auto
   sub_(EVE_SUPPORTS(cpu_), T const &a, T const &b) noexcept requires(T, Vectorizable<T>)

--- a/include/eve/module/core/function/simd/common/add.hpp
+++ b/include/eve/module/core/function/simd/common/add.hpp
@@ -9,15 +9,15 @@
 **/
 //==================================================================================================
 #ifndef EVE_MODULE_CORE_FUNCTION_SIMD_COMMON_ADD_HPP_INCLUDED
-#  define EVE_MODULE_CORE_FUNCTION_SIMD_COMMON_ADD_HPP_INCLUDED
+#define EVE_MODULE_CORE_FUNCTION_SIMD_COMMON_ADD_HPP_INCLUDED
 
-#  include <eve/detail/overload.hpp>
-#  include <eve/detail/skeleton.hpp>
-#  include <eve/detail/abi_cast.hpp>
-#  include <eve/detail/meta.hpp>
-#  include <eve/detail/abi.hpp>
-#  include <eve/forward.hpp>
-#  include <type_traits>
+#include <eve/detail/overload.hpp>
+#include <eve/detail/skeleton.hpp>
+#include <eve/detail/abi_cast.hpp>
+#include <eve/detail/meta.hpp>
+#include <eve/detail/abi.hpp>
+#include <eve/forward.hpp>
+#include <type_traits>
 
 namespace eve::detail
 {

--- a/include/eve/module/core/function/simd/common/div.hpp
+++ b/include/eve/module/core/function/simd/common/div.hpp
@@ -9,17 +9,17 @@
 **/
 //==================================================================================================
 #ifndef EVE_MODULE_CORE_FUNCTION_SIMD_COMMON_DIV_HPP_INCLUDED
-#  define EVE_MODULE_CORE_FUNCTION_SIMD_COMMON_DIV_HPP_INCLUDED
+#define EVE_MODULE_CORE_FUNCTION_SIMD_COMMON_DIV_HPP_INCLUDED
 
-#  include <eve/detail/overload.hpp>
-#  include <eve/detail/skeleton.hpp>
-#  include <eve/detail/is_native.hpp>
-#  include <eve/detail/meta.hpp>
-#  include <eve/detail/abi.hpp>
-#  include <eve/concept/vectorized.hpp>
-#  include <eve/function/mul.hpp>
-#  include <eve/function/rec.hpp>
-#  include <type_traits>
+#include <eve/detail/overload.hpp>
+#include <eve/detail/skeleton.hpp>
+#include <eve/detail/is_native.hpp>
+#include <eve/detail/meta.hpp>
+#include <eve/detail/abi.hpp>
+#include <eve/concept/vectorized.hpp>
+#include <eve/function/mul.hpp>
+#include <eve/function/rec.hpp>
+#include <type_traits>
 
 namespace eve::detail
 {

--- a/include/eve/module/core/function/simd/common/mul.hpp
+++ b/include/eve/module/core/function/simd/common/mul.hpp
@@ -9,15 +9,15 @@
 **/
 //==================================================================================================
 #ifndef EVE_MODULE_CORE_FUNCTION_SIMD_COMMON_MUL_HPP_INCLUDED
-#  define EVE_MODULE_CORE_FUNCTION_SIMD_COMMON_MUL_HPP_INCLUDED
+#define EVE_MODULE_CORE_FUNCTION_SIMD_COMMON_MUL_HPP_INCLUDED
 
-#  include <eve/detail/overload.hpp>
-#  include <eve/detail/skeleton.hpp>
-#  include <eve/detail/is_native.hpp>
-#  include <eve/detail/meta.hpp>
-#  include <eve/detail/abi.hpp>
-#  include <eve/concept/vectorized.hpp>
-#  include <type_traits>
+#include <eve/detail/overload.hpp>
+#include <eve/detail/skeleton.hpp>
+#include <eve/detail/is_native.hpp>
+#include <eve/detail/meta.hpp>
+#include <eve/detail/abi.hpp>
+#include <eve/concept/vectorized.hpp>
+#include <type_traits>
 
 namespace eve::detail
 {


### PR DESCRIPTION
By defining EVE_NO_SIMD, one can deactivate all usage of SIMD intrinsics, leading to a pure emulation mode.