### PR TITLE
Robustify the handling of function decorator in check()

### DIFF
--- a/include/eve/detail/overload.hpp
+++ b/include/eve/detail/overload.hpp
@@ -12,6 +12,7 @@
 #define EVE_DETAIL_OVERLOAD_HPP_INCLUDED
 
 #include <eve/arch/spec.hpp>
+#include <eve/detail/meta.hpp>
 #include <eve/detail/abi.hpp>
 #include <utility>
 
@@ -33,7 +34,7 @@
       EVE_FORCEINLINE constexpr auto operator()(Args &&... args) const noexcept                    \
           -> decltype(TAG(delay_t{}, EVE_CURRENT_API{}, std::forward<Args>(args)...))              \
       {                                                                                            \
-        check(delay_t{}, tag::TAG{}, std::forward<Args>(args)...);                                 \
+        check(delay_t{}, ::eve::detail::types<tag::TAG>{}, std::forward<Args>(args)...);           \
         return TAG(delay_t{}, EVE_CURRENT_API{}, std::forward<Args>(args)...);                     \
       };                                                                                           \
     };                                                                                             \
@@ -47,7 +48,7 @@
       EVE_FORCEINLINE constexpr auto operator()(Args &&... args) const noexcept                    \
           -> decltype(TAG(delay_t{}, EVE_CURRENT_API{}, Mode{}, std::forward<Args>(args)...))      \
       {                                                                                            \
-        check(delay_t{}, tag::TAG{}, state_, std::forward<Args>(args)...);                         \
+        check(delay_t{}, ::eve::detail::types<Mode, tag::TAG>{}, std::forward<Args>(args)...);     \
         return TAG(delay_t{}, EVE_CURRENT_API{}, state_, std::forward<Args>(args)...);             \
       };                                                                                           \
     };                                                                                             \
@@ -61,6 +62,9 @@
 
 // Flag a function to support delayed calls on given architecture
 #define EVE_SUPPORTS(ARCH) delay_t const &, ARCH const &
+
+// Flag a function to support delayed calls on given architecture
+#define EVE_MATCH_CALL(...) delay_t const &, ::eve::detail::types<__VA_ARGS__> const &
 
 // Flag a function to support delayed calls on given architecture
 #define EVE_RETARGET(ARCH)                                                                         \

--- a/include/eve/function/definition/arg.hpp
+++ b/include/eve/function/definition/arg.hpp
@@ -23,7 +23,7 @@ namespace eve
   namespace detail
   {
     template<typename T>
-    EVE_FORCEINLINE void check(EVE_SUPPORTS(eve::tag::arg_), T const&)
+    EVE_FORCEINLINE void check(EVE_MATCH_CALL(eve::tag::arg_), T const&)
     {
       static_assert ( std::is_floating_point_v<value_type_t<T>>,
                       "[eve::arg] - No support for integral types"
@@ -31,7 +31,7 @@ namespace eve
     }
 
     template<typename T>
-    EVE_FORCEINLINE void check(EVE_SUPPORTS(eve::tag::arg_), pedantic_type const&, T const&)
+    EVE_FORCEINLINE void check(EVE_MATCH_CALL(pedantic_type, eve::tag::arg_), T const&)
     {
       static_assert ( std::is_floating_point_v<value_type_t<T>>,
                       "[eve::pedantic_(eve::arg)] - No support for integral types"

--- a/include/eve/function/definition/bitwise_shr.hpp
+++ b/include/eve/function/definition/bitwise_shr.hpp
@@ -22,13 +22,13 @@ namespace eve
   namespace detail
   {
     template<typename T, typename S>
-    EVE_FORCEINLINE void check(EVE_SUPPORTS(eve::tag::bitwise_shr_), T const& v, S const& s)
+    EVE_FORCEINLINE void check(EVE_MATCH_CALL(eve::tag::bitwise_shr_), T const& v, S const& s)
     {
       EVE_ASSERT( assert_good_shift<T>(s),
-                  "[ eve::bitwise_shr] Shifting by "  << s
-                                                      << " is out of the range [0, "
-                                                      << sizeof(value_type_t<T>) * 8
-                                                      << "[."
+                  "[eve::bitwise_shr] Shifting by " << s
+                                                    << " is out of the range [0, "
+                                                    << sizeof(value_type_t<T>) * 8
+                                                    << "[."
                 );
     }
   }

--- a/include/eve/function/definition/clamp.hpp
+++ b/include/eve/function/definition/clamp.hpp
@@ -22,7 +22,7 @@ namespace eve
   namespace detail
   {
     template<typename X, typename L, typename H>
-    EVE_FORCEINLINE void check(EVE_SUPPORTS(eve::tag::clamp_), X const&, L const& lo, H const& hi)
+    EVE_FORCEINLINE void check(EVE_MATCH_CALL(eve::tag::clamp_), X const&, L const& lo, H const& hi)
     {
       EVE_ASSERT(assert_all(lo <= hi), "[eve::clamp] Unordered clamp boundaries");
     }

--- a/include/eve/function/definition/conj.hpp
+++ b/include/eve/function/definition/conj.hpp
@@ -22,7 +22,7 @@ namespace eve
   namespace detail
   {
     template<typename T>
-    EVE_FORCEINLINE void check(EVE_SUPPORTS(eve::tag::conj_), T const&)
+    EVE_FORCEINLINE void check(EVE_MATCH_CALL(eve::tag::conj_), T const&)
     {
       static_assert ( std::is_floating_point_v<value_type_t<T>>,
                       "[eve::conj] - No support for integral types"

--- a/include/eve/function/definition/extract.hpp
+++ b/include/eve/function/definition/extract.hpp
@@ -24,7 +24,7 @@ namespace eve
   namespace detail
   {
     template<typename T, typename I>
-    EVE_FORCEINLINE void check( EVE_SUPPORTS(eve::tag::extract_),
+    EVE_FORCEINLINE void check( EVE_MATCH_CALL(eve::tag::extract_),
                                 T const&, I const& i
                               )
     {
@@ -34,7 +34,7 @@ namespace eve
     }
 
     template<typename T, typename I, auto V>
-    EVE_FORCEINLINE void check( EVE_SUPPORTS(eve::tag::extract_),
+    EVE_FORCEINLINE void check( EVE_MATCH_CALL(eve::tag::extract_),
                                 T const&, std::integral_constant<I, V> const&
                               )
     {

--- a/include/eve/function/definition/shl.hpp
+++ b/include/eve/function/definition/shl.hpp
@@ -23,7 +23,7 @@ namespace eve
   namespace detail
   {
     template<typename T, typename S>
-    EVE_FORCEINLINE void check(EVE_SUPPORTS(eve::tag::shl_), T const& v, S const& s)
+    EVE_FORCEINLINE void check(EVE_MATCH_CALL(eve::tag::shl_), T const& v, S const& s)
     {
       EVE_ASSERT( assert_good_shift<T>(s),
                   "[eve::shl] Shifting by " << s

--- a/include/eve/function/definition/shr.hpp
+++ b/include/eve/function/definition/shr.hpp
@@ -23,7 +23,7 @@ namespace eve
   namespace detail
   {
     template<typename T, typename S>
-    EVE_FORCEINLINE void check(EVE_SUPPORTS(eve::tag::shr_), T const& v, S const& s)
+    EVE_FORCEINLINE void check(EVE_MATCH_CALL(eve::tag::shr_), T const& v, S const& s)
     {
       EVE_ASSERT( assert_good_shift<T>(s),
                   "[eve::shr] Shifting by " << s

--- a/include/eve/function/definition/sqr_abs.hpp
+++ b/include/eve/function/definition/sqr_abs.hpp
@@ -22,7 +22,7 @@ namespace eve
   namespace detail
   {
     template<typename T>
-    EVE_FORCEINLINE void check(EVE_SUPPORTS(eve::tag::sqr_abs_), T const&)
+    EVE_FORCEINLINE void check(EVE_MATCH_CALL(eve::tag::sqr_abs_), T const&)
     {
       static_assert ( std::is_floating_point_v<value_type_t<T>>,
                       "[eve::sqr_abs] - No support for integral types"

--- a/include/eve/function/definition/sqrt.hpp
+++ b/include/eve/function/definition/sqrt.hpp
@@ -22,7 +22,7 @@ namespace eve
 
   namespace detail
   {
-    template<typename T> EVE_FORCEINLINE void check(EVE_SUPPORTS(eve::tag::sqrt_), T const& v)
+    template<typename T> EVE_FORCEINLINE void check(EVE_MATCH_CALL(eve::tag::sqrt_), T const& v)
     {
       if constexpr(std::is_integral_v<T> && std::is_signed_v<T>)
       {


### PR DESCRIPTION
BInary functions with optional decorator may have ended up not recognized by the correct check() overload. This patch slightly changes the API for check() so it can't happen.