### PR TITLE
Fix check() API to work with decorated functions

### DIFF
--- a/include/eve/function/numeric.hpp
+++ b/include/eve/function/numeric.hpp
@@ -11,26 +11,28 @@
 #ifndef EVE_FUNCTION_NUMERIC_HPP_INCLUDED
 #define EVE_FUNCTION_NUMERIC_HPP_INCLUDED
 
-#include <type_traits>
+#include <eve/detail/overload.hpp>
 #include <eve/detail/abi.hpp>
 
 namespace eve
 {
   //================================================================================================
   // Function decorators mark-up used in function overloads
-  struct numeric_type
+  struct numeric_type : decorator_
   {
     template<typename Function>
-    constexpr EVE_FORCEINLINE auto operator()(Function f) noexcept
+    constexpr EVE_FORCEINLINE auto operator()(Function f) const noexcept
     {
-      return [f](auto const &... args) { return f(numeric_type{}, args...); };
+      return  [f](auto&&... args)
+              {
+                return f(numeric_type{}, std::forward<decltype(args)>(args)...);
+              };
     }
   };
-  
+
   //================================================================================================
   // Function decorator - numeric mode
-  template<typename Function>
-  constexpr EVE_FORCEINLINE auto numeric_(Function f) noexcept
+  template<typename Function> constexpr EVE_FORCEINLINE auto numeric_(Function f) noexcept
   {
     return numeric_type{}(f);
   }

--- a/include/eve/function/pedantic.hpp
+++ b/include/eve/function/pedantic.hpp
@@ -11,26 +11,28 @@
 #ifndef EVE_FUNCTION_PEDANTIC_HPP_INCLUDED
 #define EVE_FUNCTION_PEDANTIC_HPP_INCLUDED
 
-#include <type_traits>
+#include <eve/detail/overload.hpp>
 #include <eve/detail/abi.hpp>
 
 namespace eve
 {
   //================================================================================================
   // Function decorators mark-up used in function overloads
-  struct pedantic_type
+  struct pedantic_type : decorator_
   {
     template<typename Function>
-    constexpr EVE_FORCEINLINE auto operator()(Function f) noexcept
+    constexpr EVE_FORCEINLINE auto operator()(Function f) const noexcept
     {
-      return [f](auto const &... args) { return f(pedantic_type{}, args...); };
+      return  [f](auto&&... args)
+              {
+                return f(pedantic_type{}, std::forward<decltype(args)>(args)...);
+              };
     }
   };
-  
+
   //================================================================================================
   // Function decorator - pedantic mode
-  template<typename Function>
-  constexpr EVE_FORCEINLINE auto pedantic_(Function f) noexcept
+  template<typename Function> constexpr EVE_FORCEINLINE auto pedantic_(Function f) noexcept
   {
     return pedantic_type{}(f);
   }

--- a/include/eve/function/raw.hpp
+++ b/include/eve/function/raw.hpp
@@ -11,26 +11,28 @@
 #ifndef EVE_FUNCTION_RAW_HPP_INCLUDED
 #define EVE_FUNCTION_RAW_HPP_INCLUDED
 
-#include <type_traits>
+#include <eve/detail/overload.hpp>
 #include <eve/detail/abi.hpp>
 
 namespace eve
 {
   //================================================================================================
   // Function decorators mark-up used in function overloads
-  struct raw_type
+  struct raw_type : decorator_
   {
     template<typename Function>
-    constexpr EVE_FORCEINLINE auto operator()(Function f) noexcept
+    constexpr EVE_FORCEINLINE auto operator()(Function f) const noexcept
     {
-      return [f](auto const &... args) { return f(raw_type{}, args...); };
+      return  [f](auto&&... args)
+              {
+                return f(raw_type{}, std::forward<decltype(args)>(args)...);
+              };
     }
   };
-  
+
   //================================================================================================
   // Function decorator - raw mode
-  template<typename Function>
-  constexpr EVE_FORCEINLINE auto raw_(Function f) noexcept
+  template<typename Function> constexpr EVE_FORCEINLINE auto raw_(Function f) noexcept
   {
     return raw_type{}(f);
   }

--- a/include/eve/function/regular.hpp
+++ b/include/eve/function/regular.hpp
@@ -11,26 +11,28 @@
 #ifndef EVE_FUNCTION_REGULAR_HPP_INCLUDED
 #define EVE_FUNCTION_REGULAR_HPP_INCLUDED
 
-#include <type_traits>
+#include <eve/detail/overload.hpp>
 #include <eve/detail/abi.hpp>
 
 namespace eve
 {
   //================================================================================================
   // Function decorators mark-up used in function overloads
-  struct regular_type
+  struct regular_type : decorator_
   {
     template<typename Function>
-    constexpr EVE_FORCEINLINE auto operator()(Function f) noexcept
+    constexpr EVE_FORCEINLINE auto operator()(Function f) const noexcept
     {
-      return [f](auto const &... args) { return f(args...); };
+      return  [f](auto&&... args)
+              {
+                return f(std::forward<decltype(args)>(args)...);
+              };
     }
   };
-  
+
   //================================================================================================
   // Function decorator - regular mode
-  template<typename Function>
-  constexpr EVE_FORCEINLINE auto regular_(Function f) noexcept
+  template<typename Function> constexpr EVE_FORCEINLINE auto regular_(Function f) noexcept
   {
     return regular_type{}(f);
   }

--- a/include/eve/function/saturated.hpp
+++ b/include/eve/function/saturated.hpp
@@ -11,26 +11,28 @@
 #ifndef EVE_FUNCTION_SATURATED_HPP_INCLUDED
 #define EVE_FUNCTION_SATURATED_HPP_INCLUDED
 
-#include <type_traits>
+#include <eve/detail/overload.hpp>
 #include <eve/detail/abi.hpp>
 
 namespace eve
 {
   //================================================================================================
   // Function decorators mark-up used in function overloads
-  struct saturated_type
+  struct saturated_type : decorator_
   {
     template<typename Function>
-    constexpr EVE_FORCEINLINE auto operator()(Function f) noexcept
+    constexpr EVE_FORCEINLINE auto operator()(Function f) const noexcept
     {
-      return [f](auto const &... args) { return f(saturated_type{}, args...); };
+      return  [f](auto&&... args)
+              {
+                return f(saturated_type{}, std::forward<decltype(args)>(args)...);
+              };
     }
   };
 
   //================================================================================================
   // Function decorator - saturated mode
-  template<typename Function>
-  constexpr EVE_FORCEINLINE auto saturated_(Function f) noexcept
+  template<typename Function> constexpr EVE_FORCEINLINE auto saturated_(Function f) noexcept
   {
     return saturated_type{}(f);
   }


### PR DESCRIPTION
Unary function with decoration were failing to call the proper check() overload. The callable_object macro has been amended to handle this properly without other code changes.