### PR TITLE
Make as_wide structure aware

### DIFF
--- a/include/eve/ext/as_wide.hpp
+++ b/include/eve/ext/as_wide.hpp
@@ -33,6 +33,12 @@ namespace eve
     using type = wide<Type, Size>;
   };
 
+  template<template<class...> class Type, typename... Ts, typename Size>
+  struct as_wide< Type<Ts...>,Size>
+  {
+    using type = Type< typename as_wide<Ts,Size>::type... >;
+  };
+
   template<typename Type, typename Size>
   using as_wide_t = typename as_wide<Type, Size>::type;
 }

--- a/test/unit/meta/CMakeLists.txt
+++ b/test/unit/meta/CMakeLists.txt
@@ -10,4 +10,5 @@
 ## General meta tests
 add_unit_test( "meta" as_floating_point.cpp )
 add_unit_test( "meta" as_integer.cpp )
+add_unit_test( "meta" as_wide.cpp )
 add_unit_test( "meta" sign_of.cpp )

--- a/test/unit/meta/as_wide.cpp
+++ b/test/unit/meta/as_wide.cpp
@@ -1,0 +1,60 @@
+//==================================================================================================
+/**
+  EVE - Expressive Vector Engine
+  Copyright 2019 Joel FALCOU
+  Copyright 2019 Jean-Thierry LAPRESTE
+
+  Licensed under the MIT License <http://opensource.org/licenses/MIT>.
+  SPDX-License-Identifier: MIT
+**/
+//==================================================================================================
+#include "test.hpp"
+#include <eve/logical.hpp>
+#include <eve/wide.hpp>
+#include <tts/tests/types.hpp>
+#include <tuple>
+#include <vector>
+
+TTS_CASE_TPL("Check as_wide on scalar", TTS_NUMERIC_TYPES)
+{
+  using eve::as_wide_t;
+  using eve::logical;
+  using eve::fixed;
+  using eve::wide;
+
+  TTS_TYPE_IS((as_wide_t<T, fixed<4>>)          , (wide<T,fixed<4>>          ) );
+  TTS_TYPE_IS((as_wide_t<logical<T>, fixed<4>>) , (logical<wide<T,fixed<4>>> ) );
+}
+
+TTS_CASE_TPL("Check as_wide on wide", TTS_NUMERIC_TYPES)
+{
+  using eve::as_wide_t;
+  using eve::logical;
+  using eve::fixed;
+  using eve::wide;
+
+  TTS_TYPE_IS((as_wide_t<wide<T,fixed<8>>, fixed<4>>)          , (wide<T,fixed<4>>          ) );
+  TTS_TYPE_IS((as_wide_t<logical<wide<T,fixed<8>>>, fixed<4>>) , (logical<wide<T,fixed<4>>> ) );
+}
+
+TTS_CASE("Check as_wide on third party types")
+{
+  using eve::as_wide_t;
+  using eve::logical;
+  using eve::fixed;
+  using eve::wide;
+
+  TTS_TYPE_IS(  (as_wide_t<std::vector<std::uint8_t>, fixed<4>>)
+              , (std::vector<wide<std::uint8_t,fixed<4>>>)
+              );
+
+  TTS_TYPE_IS(  (as_wide_t<std::pair<int,float>, fixed<4>>)
+              , (std::pair<wide<int,fixed<4>>,wide<float,fixed<4>>>)
+              );
+
+  TTS_TYPE_IS(  (as_wide_t<std::tuple<int,logical<double>, float>, fixed<4>>)
+              , (std::tuple<wide<int,fixed<4>>,logical<wide<double,fixed<4>>>, wide<float,fixed<4>>>)
+              );
+
+
+}


### PR DESCRIPTION
Passing a template class to as_wide now returns the same template instantiated with the result of as_wide on each of its template parameters.