### PR TITLE
Add optional support for Boost in tests

### DIFF
--- a/cmake/benchmark.cmake
+++ b/cmake/benchmark.cmake
@@ -50,6 +50,7 @@ function(add_bench root)
                                   ${googlebenchmark_SOURCE_DIR}/src
                                   ${PROJECT_SOURCE_DIR}/benchmark
                                   ${PROJECT_SOURCE_DIR}/include
+                                  ${Boost_INCLUDE_DIRS}
                               )
 
     target_link_libraries(${bench} benchmark)

--- a/cmake/generate_test.cmake
+++ b/cmake/generate_test.cmake
@@ -66,6 +66,7 @@ function(generate_test root rootpath dep file)
                                 ${tts_SOURCE_DIR}/include
                                 ${PROJECT_SOURCE_DIR}/test
                                 ${PROJECT_SOURCE_DIR}/include
+                                ${Boost_INCLUDE_DIRS}
                             )
 
   # No OpenMP 3.1 on MSVC

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,6 +6,18 @@
 ##  SPDX-License-Identifier: MIT
 ##==================================================================================================
 
+##==================================================================================================
+## Find Boost
+##==================================================================================================
+find_package(Boost 1.71.0 QUIET)
+
+if(Boost_FOUND)
+  set(EVE_USE_BOOST 1)
+  message( STATUS "[eve] Boost found in ${Boost_INCLUDE_DIRS} - Boost dependent tests activated")
+else()
+  set(Boost_INCLUDE_DIRS "")
+endif()
+
 add_subdirectory(doc)
 add_subdirectory(exhaustive)
 add_subdirectory(random)


### PR DESCRIPTION
Some unit/exhaustive or random tests require comparison to some boost functions.
This patch allow using Boost directly from test sources.