### PR TITLE
Upgrade to aggregate storage

### DIFF
--- a/include/eve/detail/function/fill.hpp
+++ b/include/eve/detail/function/fill.hpp
@@ -23,22 +23,28 @@ namespace eve::detail
   {
     if constexpr( is_aggregated_v<ABI> )
     {
-      using str_t = typename Pack::storage_type;
-      using sub_t = typename str_t::value_type;
       Pack that;
 
-      that.storage().apply([&](auto &... v) {
-        int k = 0;
-        (((v = sub_t([&](auto i, auto) { return g(i + k, Pack::static_size); }),
-           k += str_t::small_size),
-          ...));
-      });
+      that.storage().apply
+      (
+        [&]<typename... Sub>(Sub&... v)
+        {
+          int k = 0;
+
+          ( ( v = Sub([&](auto i, auto) { return g(i + k, Pack::static_size); })
+            , k += Sub::static_size
+            )
+          , ...
+          );
+        }
+      );
+
       return that;
     }
     else
     {
       static constexpr typename Pack::size_type sz = cardinal_v<Pack>;
-      Pack                                      that;
+      Pack  that;
 
       for( typename Pack::size_type i = 0; i < sz; ++i ) that[i] = g(i, sz);
 

--- a/include/eve/detail/function/simd/common/arithmetic_compounds.hpp
+++ b/include/eve/detail/function/simd/common/arithmetic_compounds.hpp
@@ -42,10 +42,7 @@ namespace eve::detail
       }
       else if constexpr( is_aggregated_v<ABI> )
       {
-        using st_t = typename type::storage_type;
-        st_t::for_each([&](auto const &... I) {
-          ((self.storage().segments[I] += other.storage().segments[I]), ...);
-        });
+        self.storage().for_each( [&](auto& s, auto const& o)  { s += o; }, other );
         return self;
       }
     }
@@ -72,10 +69,7 @@ namespace eve::detail
       }
       else if constexpr( is_aggregated_v<ABI> )
       {
-        using st_t = typename type::storage_type;
-        st_t::for_each([&](auto const &... I) {
-          ((self.storage().segments[I] -= other.storage().segments[I]), ...);
-        });
+        self.storage().for_each( [&](auto& s, auto const& o)  { s -= o; }, other );
         return self;
       }
     }
@@ -102,10 +96,7 @@ namespace eve::detail
       }
       else if constexpr( is_aggregated_v<ABI> )
       {
-        using st_t = typename type::storage_type;
-        st_t::for_each([&](auto const &... I) {
-          ((self.storage().segments[I] *= other.storage().segments[I]), ...);
-        });
+        self.storage().for_each( [&](auto& s, auto const& o)  { s *= o; }, other );
         return self;
       }
     }
@@ -132,17 +123,14 @@ namespace eve::detail
       }
       else if constexpr( is_aggregated_v<ABI> )
       {
-        using st_t = typename type::storage_type;
-        st_t::for_each([&](auto const &... I) {
-          ((self.storage().segments[I] /= other.storage().segments[I]), ...);
-        });
+        self.storage().for_each( [&](auto& s, auto const& o)  { s /= o; }, other );
         return self;
       }
     }
   }
 
   //================================================================================================
-  // /=
+  // %=
   //================================================================================================
   template<integral_scalar_value T, value U, typename N, typename ABI>
   EVE_FORCEINLINE decltype(auto)
@@ -159,10 +147,7 @@ namespace eve::detail
     {
       if constexpr( is_aggregated_v<ABI> )
       {
-        using st_t = typename type::storage_type;
-        st_t::for_each([&](auto const &... I) {
-          ((self.storage().segments[I] %= other.storage().segments[I]), ...);
-        });
+        self.storage().for_each( [&](auto& s, auto const& o)  { s %= o; }, other );
         return self;
       }
       else

--- a/include/eve/detail/function/simd/common/bit_compounds.hpp
+++ b/include/eve/detail/function/simd/common/bit_compounds.hpp
@@ -47,10 +47,7 @@ namespace eve::detail
       }
       else if constexpr( is_aggregated_v<ABI> )
       {
-        using st_t = typename type::storage_type;
-        st_t::for_each([&](auto const &... I) {
-          ((self.storage().segments[I] &= other.storage().segments[I]), ...);
-        });
+        self.storage().for_each( [&](auto& s, auto const& o)  { s &= o; }, other );
         return self;
       }
     }
@@ -82,10 +79,7 @@ namespace eve::detail
       }
       else if constexpr( is_aggregated_v<ABI> )
       {
-        using st_t = typename type::storage_type;
-        st_t::for_each([&](auto const &... I) {
-          ((self.storage().segments[I] |= other.storage().segments[I]), ...);
-        });
+        self.storage().for_each( [&](auto& s, auto const& o)  { s |= o; }, other );
         return self;
       }
     }
@@ -117,10 +111,7 @@ namespace eve::detail
       }
       else if constexpr( is_aggregated_v<ABI> )
       {
-        using st_t = typename type::storage_type;
-        st_t::for_each([&](auto const &... I) {
-          ((self.storage().segments[I] ^= other.storage().segments[I]), ...);
-        });
+        self.storage().for_each( [&](auto& s, auto const& o)  { s ^= o; }, other );
         return self;
       }
     }

--- a/include/eve/detail/function/simd/common/combine.hpp
+++ b/include/eve/detail/function/simd/common/combine.hpp
@@ -11,12 +11,9 @@
 #pragma once
 
 #include <eve/detail/abi.hpp>
-#include <eve/detail/alias.hpp>
 #include <eve/detail/is_native.hpp>
 #include <eve/detail/meta.hpp>
 #include <eve/forward.hpp>
-
-#include <cstring>
 
 namespace eve::detail
 {
@@ -34,13 +31,8 @@ namespace eve::detail
     {
       that_t that;
 
-      // TODO: use std::bit_cast when available
-      auto const *srcl = reinterpret_cast<detail::alias_t<std::byte const> *>(&l);
-      auto const *srch = reinterpret_cast<detail::alias_t<std::byte const> *>(&h);
-      auto *      dst  = reinterpret_cast<detail::alias_t<std::byte> *>(&that);
-
-      std::memcpy(dst, srcl, sizeof(l));
-      std::memcpy(dst + sizeof(l), srch, sizeof(h));
+      that.storage().segments[0] = l;
+      that.storage().segments[1] = h;
 
       return that;
     }

--- a/include/eve/detail/function/simd/common/load.hpp
+++ b/include/eve/detail/function/simd/common/load.hpp
@@ -63,14 +63,17 @@ namespace eve::detail
   template<typename Pack, typename Pointer>
   EVE_FORCEINLINE Pack load(as_<Pack> const &, eve::aggregated_ const &, Pointer ptr) noexcept
   {
-    using str_t = typename Pack::storage_type;
-    using sub_t = typename str_t::value_type;
     Pack that;
 
-    that.storage().apply([&](auto &... v) {
-      int offset = 0;
-      (((v = sub_t(ptr + offset), offset += str_t::small_size), ...));
-    });
+    that.storage().apply
+    (
+      [&]<typename... Sub>(Sub&... v)
+      {
+        int offset = 0;
+        (((v = Sub(ptr + offset), offset += Sub::static_size), ...));
+      }
+    );
+
     return that.storage();
   }
 }

--- a/include/eve/detail/function/simd/common/make.hpp
+++ b/include/eve/detail/function/simd/common/make.hpp
@@ -56,10 +56,11 @@ namespace eve::detail
   template<typename Pack, typename Value>
   EVE_FORCEINLINE Pack make(as_<Pack> const &, eve::aggregated_ const &, Value vs) noexcept
   {
-    typename Pack::storage_type::value_type sub_value(vs);
-    Pack                                    that;
+    using sub_t = typename Pack::storage_type::value_type;
+    Pack  that;
 
-    that.storage().apply([&sub_value](auto &... v) { ((v = sub_value), ...); });
+    that.storage().for_each( [sub_value = sub_t(vs)](auto& s) { s = sub_value; } );
+
     return that;
   }
 }

--- a/include/eve/detail/function/simd/common/slice.hpp
+++ b/include/eve/detail/function/simd/common/slice.hpp
@@ -55,8 +55,7 @@ namespace eve::detail
     }
     else if constexpr( is_aggregated_v<abi_t> )
     {
-      std::array<sub_t, 2> that {a.slice(lower_), a.slice(upper_)};
-      return that;
+      return a.storage().segments;
     }
   }
 
@@ -80,24 +79,7 @@ namespace eve::detail
     }
     else if constexpr( is_aggregated_v<abi_t> )
     {
-      static constexpr auto reps = P::storage_type::replication;
-
-      if constexpr( reps == 2 )
-      {
-        return a.storage().segments[Slice::value];
-      }
-      else
-      {
-        sub_t                 that;
-        static constexpr auto subreps = sub_t::storage_type::replication;
-        static constexpr auto offset  = Slice::value * subreps;
-
-        auto const &out = a.storage().segments;
-        detail::apply<subreps>(
-            [&](auto const &... I) { that.storage().segments = {out[I + offset]...}; });
-
-        return that;
-      }
+      return a.storage().segments[Slice::value];
     }
   }
 

--- a/include/eve/module/core/function/generic/store.hpp
+++ b/include/eve/module/core/function/generic/store.hpp
@@ -46,11 +46,13 @@ namespace eve::detail
   EVE_FORCEINLINE void
   store_(EVE_SUPPORTS(cpu_), wide<T, N, aggregated_> const &value, T *ptr) noexcept
   {
-    using str_t = typename wide<T, N, aggregated_>::storage_type;
-    value.storage().apply([&](auto &... v) {
-      int k = 0;
-      ((store(v, ptr + k), k += str_t::small_size), ...);
-    });
+    value.storage().apply
+    ( [&]<typename... Sub>(Sub&... v)
+      {
+        int k = 0;
+        ((store(v, ptr + k), k += Sub::static_size), ...);
+      }
+    );
   }
 
   template<real_scalar_value T, typename N, typename ABI>
@@ -76,11 +78,13 @@ namespace eve::detail
   store_(EVE_SUPPORTS(cpu_), wide<T, S, aggregated_> const &value, aligned_ptr<T, N> ptr) noexcept
       requires(wide<T, S, aggregated_>::static_alignment <= N)
   {
-    using str_t = typename wide<T, S, aggregated_>::storage_type;
-    value.storage().apply([&](auto &... v) {
-      int k = 0;
-      ((store(v, ptr + k), k += str_t::small_size), ...);
-    });
+    value.storage().apply
+    ( [&]<typename... Sub>(Sub&... v)
+      {
+        int k = 0;
+        ((store(v, ptr + k), k += Sub::static_size), ...);
+      }
+    );
   }
 
   template<real_scalar_value T, typename S, std::size_t N, typename ABI>


### PR DESCRIPTION
+ Go back to a recursive power of 2 slicing
+ Provide small scale algortihms to keep running operations on
  only the smallest type possbile

Those changes don't impact compule time that much, simplify
some code path and remove the need of some raw ass memcpy.