### PR TITLE
Fix #342 - Renamed ABI types to not be confused with API types

### DIFF
--- a/include/eve/arch/abi_of.hpp
+++ b/include/eve/arch/abi_of.hpp
@@ -30,8 +30,8 @@ namespace eve
 
         if constexpr( spy::simd_instruction_set == spy::x86_simd_ )
         {
-               if constexpr( width <= 16) return sse_{};
-          else if constexpr( width == 32) return avx_{};
+               if constexpr( width <= 16) return x86_128_{};
+          else if constexpr( width == 32) return x86_256_{};
           else                            return aggregated_{};
         }
         else if constexpr( spy::simd_instruction_set == spy::vmx_ )
@@ -48,14 +48,14 @@ namespace eve
         {
           if constexpr( spy::supports::aarch64_ )
           {
-            if constexpr(width <= 8)       return neon64_{};
-            else if constexpr(width == 16) return neon128_{};
+            if constexpr(width <= 8)       return arm_64_{};
+            else if constexpr(width == 16) return arm_128_{};
             else                           return emulated_{};
           }
           else
           {
-            if constexpr(!f64 && width <= 8)       return neon64_{};
-            else if constexpr(!f64 && width == 16) return neon128_{};
+            if constexpr(!f64 && width <= 8)       return arm_64_{};
+            else if constexpr(!f64 && width == 16) return arm_128_{};
             else                                   return emulated_{};
           }
         }

--- a/include/eve/arch/arm/as_register.hpp
+++ b/include/eve/arch/arm/as_register.hpp
@@ -27,7 +27,7 @@ namespace eve
 {
   // ---------------------------------------------------------------------------------------------
   // NEON 64
-  template<typename T, typename Size> struct as_register<T, Size, eve::neon64_>
+  template<typename T, typename Size> struct as_register<T, Size, eve::arm_64_>
   {
     static constexpr auto find()
     {
@@ -62,7 +62,7 @@ namespace eve
   // ---------------------------------------------------------------------------------------------
   // NEON 128
   template<typename T, typename Size>
-  struct as_register<T, Size, eve::neon128_>
+  struct as_register<T, Size, eve::arm_128_>
   {
     static constexpr auto find()
     {
@@ -96,13 +96,13 @@ namespace eve
   // ---------------------------------------------------------------------------------------------
   // logical cases
   template<typename T, typename Size>
-  struct as_register<logical<T>, Size, eve::neon128_>
-      : as_register<detail::as_integer_t<T, unsigned>, Size, eve::neon128_>
+  struct as_register<logical<T>, Size, eve::arm_128_>
+      : as_register<detail::as_integer_t<T, unsigned>, Size, eve::arm_128_>
   {};
 
   template<typename T, typename Size>
-  struct as_register<logical<T>, Size, eve::neon64_>
-      : as_register<detail::as_integer_t<T, unsigned>, Size, eve::neon64_>
+  struct as_register<logical<T>, Size, eve::arm_64_>
+      : as_register<detail::as_integer_t<T, unsigned>, Size, eve::arm_64_>
   {};
 }
 #endif

--- a/include/eve/arch/arm/spec.hpp
+++ b/include/eve/arch/arm/spec.hpp
@@ -31,7 +31,7 @@ namespace eve
 # if !defined(EVE_CURRENT_API) && defined(SPY_SIMD_IS_ARM)
 #  include <arm_neon.h>
 #  if !defined(EVE_CURRENT_ABI) && defined(SPY_SIMD_IS_ARM_NEON)
-#   define EVE_CURRENT_ABI ::eve::neon128_
+#   define EVE_CURRENT_ABI ::eve::arm_128_
 #   define EVE_CURRENT_API ::eve::neon128_
 #  endif
 # endif

--- a/include/eve/arch/arm/tags.hpp
+++ b/include/eve/arch/arm/tags.hpp
@@ -25,27 +25,26 @@ namespace eve
 {
   // clang-format off
   //================================================================================================
-  // Dispatching tag for VMX SIMD implementation
+  // ABI tags for all ARM bits SIMD registers
   //================================================================================================
-  struct neon64_  : simd_
+  template<std::size_t Size, bool Logical> struct arm_abi_
   {
-    static constexpr std::size_t bits           = 64;
-    static constexpr std::size_t bytes          = 8;
-    static constexpr bool        is_bit_logical = true;
+    static constexpr std::size_t bits           = Size;
+    static constexpr std::size_t bytes          = Size/8;
+    static constexpr bool        is_bit_logical = Logical;
 
     template<typename Type>
     static constexpr std::size_t expected_cardinal = bytes / sizeof(Type);
   };
 
-  struct neon128_ : simd_
-  {
-    static constexpr std::size_t bits           = 128;
-    static constexpr std::size_t bytes          = 16;
-    static constexpr bool        is_bit_logical = true;
+  struct arm_64_  : arm_abi_<64,true> {};
+  struct arm_128_ : arm_abi_<128,true> {};
 
-    template<typename Type>
-    static constexpr std::size_t expected_cardinal = bytes / sizeof(Type);
-  };
+  //================================================================================================
+  // Dispatching tag for ARM SIMD implementation
+  //================================================================================================
+  struct neon64_  : simd_ {};
+  struct neon128_ : simd_ {};
 
   //================================================================================================
   // NEON extension tag objects
@@ -81,6 +80,5 @@ namespace eve
   //================================================================================================
   // ARM ABI concept
   //================================================================================================
-  template<typename T> concept arm_abi = detail::is_one_of<T>(detail::types<neon128_, neon64_> {});
+  template<typename T> concept arm_abi = detail::is_one_of<T>(detail::types<arm_64_,arm_128_> {});
 }
-

--- a/include/eve/arch/x86/as_register.hpp
+++ b/include/eve/arch/x86/as_register.hpp
@@ -17,8 +17,8 @@ namespace eve
 {
   template<typename T>
   struct logical;
-  struct sse_;
-  struct avx_;
+  struct x86_128_;
+  struct x86_256_;
 }
 
 #if defined(EVE_HW_X86)
@@ -26,7 +26,7 @@ namespace eve
 namespace eve
 {
   template<typename Type, typename Size>
-  struct as_register<Type, Size, eve::sse_>
+  struct as_register<Type, Size, eve::x86_128_>
   {
     static constexpr auto find()
     {
@@ -44,7 +44,7 @@ namespace eve
   };
 
   template<typename Type, typename Size>
-  struct as_register<Type, Size, eve::avx_>
+  struct as_register<Type, Size, eve::x86_256_>
   {
     static constexpr auto find()
     {
@@ -63,12 +63,12 @@ namespace eve
 
   // logical uses same registers
   template<typename T, typename Size>
-  struct as_register<logical<T>, Size, eve::sse_> : as_register<T, Size, eve::sse_>
+  struct as_register<logical<T>, Size, eve::x86_128_> : as_register<T, Size, eve::x86_128_>
   {
   };
 
   template<typename T, typename Size>
-  struct as_register<logical<T>, Size, eve::avx_> : as_register<T, Size, eve::avx_>
+  struct as_register<logical<T>, Size, eve::x86_256_> : as_register<T, Size, eve::x86_256_>
   {
   };
 }

--- a/include/eve/arch/x86/spec.hpp
+++ b/include/eve/arch/x86/spec.hpp
@@ -33,31 +33,31 @@ namespace eve
 # if !defined(EVE_CURRENT_API) && defined(SPY_SIMD_IS_X86)
 #  include <immintrin.h>
 #  if !defined(EVE_CURRENT_ABI) && defined(SPY_SIMD_IS_X86_AVX2)
-#    define EVE_CURRENT_ABI ::eve::avx_
+#    define EVE_CURRENT_ABI ::eve::x86_256_
 #    define EVE_CURRENT_API ::eve::avx2_
 #  endif
 #  if !defined(EVE_CURRENT_ABI) && defined(SPY_SIMD_IS_X86_AVX)
-#    define EVE_CURRENT_ABI ::eve::avx_
+#    define EVE_CURRENT_ABI ::eve::x86_256_
 #    define EVE_CURRENT_API ::eve::avx_
 #  endif
 #  if !defined(EVE_CURRENT_ABI) && defined(SPY_SIMD_IS_X86_SSE4_2)
-#    define EVE_CURRENT_ABI ::eve::sse_
+#    define EVE_CURRENT_ABI ::eve::x86_128_
 #    define EVE_CURRENT_API ::eve::sse4_2_
 #  endif
 #  if !defined(EVE_CURRENT_ABI) && defined(SPY_SIMD_IS_X86_SSE4_1)
-#    define EVE_CURRENT_ABI ::eve::sse_
+#    define EVE_CURRENT_ABI ::eve::x86_128_
 #    define EVE_CURRENT_API ::eve::sse4_1_
 #  endif
 #  if !defined(EVE_CURRENT_ABI) && defined(SPY_SIMD_IS_X86_SSSE3)
-#    define EVE_CURRENT_ABI ::eve::sse_
+#    define EVE_CURRENT_ABI ::eve::x86_128_
 #    define EVE_CURRENT_API ::eve::ssse3_
 #  endif
 #  if !defined(EVE_CURRENT_ABI) && defined(SPY_SIMD_IS_X86_SSE3)
-#    define EVE_CURRENT_ABI ::eve::sse_
+#    define EVE_CURRENT_ABI ::eve::x86_128_
 #    define EVE_CURRENT_API ::eve::sse3_
 #  endif
 #  if !defined(EVE_CURRENT_ABI) && defined(SPY_SIMD_IS_X86_SSE2)
-#    define EVE_CURRENT_ABI ::eve::sse_
+#    define EVE_CURRENT_ABI ::eve::x86_128_
 #    define EVE_CURRENT_API ::eve::sse2_
 #  endif
 # endif

--- a/include/eve/arch/x86/tags.hpp
+++ b/include/eve/arch/x86/tags.hpp
@@ -19,17 +19,20 @@ namespace eve
 {
   // clang-format off
   //================================================================================================
-  // ABI tag for all X86 128 bits SIMD registers
+  // ABI tags for all X86 bits SIMD registers
   //================================================================================================
-  struct sse_
+  template<std::size_t Size, bool Logical> struct x86_abi_
   {
-    static constexpr std::size_t bits           = 128;
-    static constexpr std::size_t bytes          = 16;
-    static constexpr bool        is_bit_logical = true;
+    static constexpr std::size_t bits           = Size;
+    static constexpr std::size_t bytes          = Size/8;
+    static constexpr bool        is_bit_logical = Logical;
 
     template<typename Type>
     static constexpr std::size_t expected_cardinal = bytes / sizeof(Type);
   };
+
+  struct x86_128_ : x86_abi_<128, true> {};
+  struct x86_256_ : x86_abi_<256, true> {};
 
   //================================================================================================
   // Dispatching tag for SSE* SIMD implementation
@@ -39,18 +42,8 @@ namespace eve
   struct ssse3_   : sse3_   {};
   struct sse4_1_  : ssse3_  {};
   struct sse4_2_  : sse4_1_ {};
-
-  struct avx_     : sse4_2_
-  {
-    static constexpr std::size_t bits           = 256;
-    static constexpr std::size_t bytes          = 32;
-    static constexpr bool        is_bit_logical = true;
-
-    template<typename Type>
-    static constexpr std::size_t expected_cardinal = bytes / sizeof(Type);
-  };
-
-  struct avx2_    : avx_ {};
+  struct avx_     : sse4_2_ {};
+  struct avx2_    : avx_    {};
 
   //================================================================================================
   // SSE* extension tag objects - Forwarded from SPY
@@ -97,6 +90,6 @@ namespace eve
   // x86 ABI concept
   //================================================================================================
   template<typename T>
-  concept x86_abi = detail::is_one_of<T>(detail::types<sse_, avx_> {});
+  concept x86_abi = detail::is_one_of<T>(detail::types<x86_128_, x86_256_> {});
 }
 

--- a/include/eve/detail/function/simd/arm/neon/arithmetic_compounds.hpp
+++ b/include/eve/detail/function/simd/arm/neon/arithmetic_compounds.hpp
@@ -23,10 +23,10 @@ namespace eve::detail
   // +=
   //================================================================================================
   template<real_scalar_value T, value U, typename N>
-  EVE_FORCEINLINE decltype(auto) self_add(wide<T, N, neon64_> &self, U const &other) noexcept
-      requires(scalar_value<U> || std::same_as<wide<T, N, neon64_>, U>)
+  EVE_FORCEINLINE decltype(auto) self_add(wide<T, N, arm_64_> &self, U const &other) noexcept
+      requires(scalar_value<U> || std::same_as<wide<T, N, arm_64_>, U>)
   {
-    using type = wide<T, N, neon64_>;
+    using type = wide<T, N, arm_64_>;
 
     if constexpr( scalar_value<U> )
     {
@@ -88,10 +88,10 @@ namespace eve::detail
   }
 
   template<real_scalar_value T, value U, typename N>
-  EVE_FORCEINLINE decltype(auto) self_add(wide<T, N, neon128_> &self, U const &other) noexcept
-      requires(scalar_value<U> || std::same_as<wide<T, N, neon128_>, U>)
+  EVE_FORCEINLINE decltype(auto) self_add(wide<T, N, arm_128_> &self, U const &other) noexcept
+      requires(scalar_value<U> || std::same_as<wide<T, N, arm_128_>, U>)
   {
-    using type = wide<T, N, neon128_>;
+    using type = wide<T, N, arm_128_>;
 
     if constexpr( scalar_value<U> )
     {
@@ -156,10 +156,10 @@ namespace eve::detail
   // -=
   //================================================================================================
   template<real_scalar_value T, value U, typename N>
-  EVE_FORCEINLINE decltype(auto) self_sub(wide<T, N, neon64_> &self, U const &other) noexcept
-      requires(scalar_value<U> || std::same_as<wide<T, N, neon64_>, U>)
+  EVE_FORCEINLINE decltype(auto) self_sub(wide<T, N, arm_64_> &self, U const &other) noexcept
+      requires(scalar_value<U> || std::same_as<wide<T, N, arm_64_>, U>)
   {
-    using type = wide<T, N, neon64_>;
+    using type = wide<T, N, arm_64_>;
 
     if constexpr( scalar_value<U> )
     {
@@ -221,10 +221,10 @@ namespace eve::detail
   }
 
   template<real_scalar_value T, value U, typename N>
-  EVE_FORCEINLINE decltype(auto) self_sub(wide<T, N, neon128_> &self, U const &other) noexcept
-      requires(scalar_value<U> || std::same_as<wide<T, N, neon128_>, U>)
+  EVE_FORCEINLINE decltype(auto) self_sub(wide<T, N, arm_128_> &self, U const &other) noexcept
+      requires(scalar_value<U> || std::same_as<wide<T, N, arm_128_>, U>)
   {
-    using type = wide<T, N, neon128_>;
+    using type = wide<T, N, arm_128_>;
 
     if constexpr( scalar_value<U> )
     {
@@ -289,10 +289,10 @@ namespace eve::detail
   // *=
   //================================================================================================
   template<real_scalar_value T, value U, typename N>
-  EVE_FORCEINLINE decltype(auto) self_mul(wide<T, N, neon64_> &self, U const &other) noexcept
-      requires(scalar_value<U> || std::same_as<wide<T, N, neon64_>, U>)
+  EVE_FORCEINLINE decltype(auto) self_mul(wide<T, N, arm_64_> &self, U const &other) noexcept
+      requires(scalar_value<U> || std::same_as<wide<T, N, arm_64_>, U>)
   {
-    using type = wide<T, N, neon64_>;
+    using type = wide<T, N, arm_64_>;
 
     if constexpr( scalar_value<U> )
     {
@@ -405,10 +405,10 @@ namespace eve::detail
   }
 
   template<real_scalar_value T, value U, typename N>
-  EVE_FORCEINLINE decltype(auto) self_mul(wide<T, N, neon128_> &self, U const &other) noexcept
-      requires(scalar_value<U> || std::same_as<wide<T, N, neon128_>, U>)
+  EVE_FORCEINLINE decltype(auto) self_mul(wide<T, N, arm_128_> &self, U const &other) noexcept
+      requires(scalar_value<U> || std::same_as<wide<T, N, arm_128_>, U>)
   {
-    using type = wide<T, N, neon128_>;
+    using type = wide<T, N, arm_128_>;
 
     if constexpr( scalar_value<U> )
     {
@@ -520,10 +520,10 @@ namespace eve::detail
   // /=
   //================================================================================================
   template<real_scalar_value T, value U, typename N>
-  EVE_FORCEINLINE decltype(auto) self_div(wide<T, N, neon64_> &self, U const &other) noexcept
-      requires(scalar_value<U> || std::same_as<wide<T, N, neon64_>, U>)
+  EVE_FORCEINLINE decltype(auto) self_div(wide<T, N, arm_64_> &self, U const &other) noexcept
+      requires(scalar_value<U> || std::same_as<wide<T, N, arm_64_>, U>)
   {
-    using type = wide<T, N, neon64_>;
+    using type = wide<T, N, arm_64_>;
 
     if constexpr( scalar_value<U> )
     {
@@ -558,10 +558,10 @@ namespace eve::detail
   }
 
   template<real_scalar_value T, value U, typename N>
-  EVE_FORCEINLINE decltype(auto) self_div(wide<T, N, neon128_> &self, U const &other) noexcept
-      requires(scalar_value<U> || std::same_as<wide<T, N, neon128_>, U>)
+  EVE_FORCEINLINE decltype(auto) self_div(wide<T, N, arm_128_> &self, U const &other) noexcept
+      requires(scalar_value<U> || std::same_as<wide<T, N, arm_128_>, U>)
   {
-    using type = wide<T, N, neon128_>;
+    using type = wide<T, N, arm_128_>;
 
     if constexpr( scalar_value<U> )
     {

--- a/include/eve/detail/function/simd/arm/neon/bit_compounds.hpp
+++ b/include/eve/detail/function/simd/arm/neon/bit_compounds.hpp
@@ -22,10 +22,10 @@ namespace eve::detail
   // &=
   //================================================================================================
   template<scalar_value T, value U, typename N>
-  EVE_FORCEINLINE decltype(auto) self_bitand(wide<T, N, neon64_> &self, U const &other) noexcept
-      requires((sizeof(wide<T, N, neon64_>) == sizeof(U)) || (sizeof(T) == sizeof(U)))
+  EVE_FORCEINLINE decltype(auto) self_bitand(wide<T, N, arm_64_> &self, U const &other) noexcept
+      requires((sizeof(wide<T, N, arm_64_>) == sizeof(U)) || (sizeof(T) == sizeof(U)))
   {
-    using type = wide<T, N, neon64_>;
+    using type = wide<T, N, arm_64_>;
 
     if constexpr( element_bit_compatible_to<U, type> )
     {
@@ -92,10 +92,10 @@ namespace eve::detail
   }
 
   template<scalar_value T, value U, typename N>
-  EVE_FORCEINLINE decltype(auto) self_bitand(wide<T, N, neon128_> &self, U const &other) noexcept
-      requires((sizeof(wide<T, N, neon128_>) == sizeof(U)) || (sizeof(T) == sizeof(U)))
+  EVE_FORCEINLINE decltype(auto) self_bitand(wide<T, N, arm_128_> &self, U const &other) noexcept
+      requires((sizeof(wide<T, N, arm_128_>) == sizeof(U)) || (sizeof(T) == sizeof(U)))
   {
-    using type = wide<T, N, neon128_>;
+    using type = wide<T, N, arm_128_>;
 
     if constexpr( element_bit_compatible_to<U, type> )
     {
@@ -165,10 +165,10 @@ namespace eve::detail
   // |=
   //================================================================================================
   template<scalar_value T, value U, typename N>
-  EVE_FORCEINLINE decltype(auto) self_bitor(wide<T, N, neon64_> &self, U const &other) noexcept
-      requires((sizeof(wide<T, N, neon64_>) == sizeof(U)) || (sizeof(T) == sizeof(U)))
+  EVE_FORCEINLINE decltype(auto) self_bitor(wide<T, N, arm_64_> &self, U const &other) noexcept
+      requires((sizeof(wide<T, N, arm_64_>) == sizeof(U)) || (sizeof(T) == sizeof(U)))
   {
-    using type = wide<T, N, neon64_>;
+    using type = wide<T, N, arm_64_>;
 
     if constexpr( element_bit_compatible_to<U, type> )
     {
@@ -235,10 +235,10 @@ namespace eve::detail
   }
 
   template<scalar_value T, value U, typename N>
-  EVE_FORCEINLINE decltype(auto) self_bitor(wide<T, N, neon128_> &self, U const &other) noexcept
-      requires((sizeof(wide<T, N, neon128_>) == sizeof(U)) || (sizeof(T) == sizeof(U)))
+  EVE_FORCEINLINE decltype(auto) self_bitor(wide<T, N, arm_128_> &self, U const &other) noexcept
+      requires((sizeof(wide<T, N, arm_128_>) == sizeof(U)) || (sizeof(T) == sizeof(U)))
   {
-    using type = wide<T, N, neon128_>;
+    using type = wide<T, N, arm_128_>;
 
     if constexpr( element_bit_compatible_to<U, type> )
     {
@@ -308,10 +308,10 @@ namespace eve::detail
   // ^=
   //================================================================================================
   template<scalar_value T, value U, typename N>
-  EVE_FORCEINLINE decltype(auto) self_bitxor(wide<T, N, neon64_> &self, U const &other) noexcept
-      requires((sizeof(wide<T, N, neon64_>) == sizeof(U)) || (sizeof(T) == sizeof(U)))
+  EVE_FORCEINLINE decltype(auto) self_bitxor(wide<T, N, arm_64_> &self, U const &other) noexcept
+      requires((sizeof(wide<T, N, arm_64_>) == sizeof(U)) || (sizeof(T) == sizeof(U)))
   {
-    using type = wide<T, N, neon64_>;
+    using type = wide<T, N, arm_64_>;
 
     if constexpr( element_bit_compatible_to<U, type> )
     {
@@ -378,10 +378,10 @@ namespace eve::detail
   }
 
   template<scalar_value T, value U, typename N>
-  EVE_FORCEINLINE decltype(auto) self_bitxor(wide<T, N, neon128_> &self, U const &other) noexcept
-      requires((sizeof(wide<T, N, neon128_>) == sizeof(U)) || (sizeof(T) == sizeof(U)))
+  EVE_FORCEINLINE decltype(auto) self_bitxor(wide<T, N, arm_128_> &self, U const &other) noexcept
+      requires((sizeof(wide<T, N, arm_128_>) == sizeof(U)) || (sizeof(T) == sizeof(U)))
   {
-    using type = wide<T, N, neon128_>;
+    using type = wide<T, N, arm_128_>;
 
     if constexpr( element_bit_compatible_to<U, type> )
     {

--- a/include/eve/detail/function/simd/arm/neon/combine.hpp
+++ b/include/eve/detail/function/simd/arm/neon/combine.hpp
@@ -16,7 +16,7 @@ namespace eve::detail
 {
   template<typename T, typename N>
   EVE_FORCEINLINE auto
-  combine(neon128_ const &, wide<T, N, neon128_> const &l, wide<T, N, neon128_> const &h) noexcept
+  combine(neon128_ const &, wide<T, N, arm_128_> const &l, wide<T, N, arm_128_> const &h) noexcept
   {
     using that_t = wide<T, typename N::combined_type>;
     return that_t(typename that_t::storage_type {l, h});
@@ -24,11 +24,11 @@ namespace eve::detail
 
   template<typename T, typename N>
   EVE_FORCEINLINE auto
-  combine(neon128_ const &, wide<T, N, neon64_> const &l, wide<T, N, neon64_> const &h) noexcept
+  combine(neon128_ const &, wide<T, N, arm_64_> const &l, wide<T, N, arm_64_> const &h) noexcept
   {
     using that_t = wide<T, typename N::combined_type>;
 
-    if constexpr( N::value * sizeof(T) == eve::neon64_::bytes )
+    if constexpr( N::value * sizeof(T) == eve::arm_64_::bytes )
     {
       if constexpr( std::is_same_v<T, float> )
       {
@@ -83,7 +83,7 @@ namespace eve::detail
     {
       auto mask = [&](auto... I) {
         uint8x8_t m = {static_cast<std::uint8_t>(I)...,
-                       static_cast<std::uint8_t>(I + eve::neon64_::bytes)...};
+                       static_cast<std::uint8_t>(I + eve::arm_64_::bytes)...};
         return m;
       };
 

--- a/include/eve/detail/function/simd/arm/neon/load.hpp
+++ b/include/eve/detail/function/simd/arm/neon/load.hpp
@@ -27,26 +27,26 @@ namespace eve::detail
     {
       if constexpr( std::is_same_v<T, float> )
       {
-              if constexpr( std::is_same_v<Arch, eve::neon128_> ) return vld1q_f32(ptr);
-        else  if constexpr( std::is_same_v<Arch, eve::neon64_>  ) return vld1_f32(ptr);
+              if constexpr( std::is_same_v<Arch, eve::arm_128_> ) return vld1q_f32(ptr);
+        else  if constexpr( std::is_same_v<Arch, eve::arm_64_>  ) return vld1_f32(ptr);
       }
   #if defined(__aarch64__)
       else if constexpr( std::is_same_v<T, double> )
       {
-              if constexpr( std::is_same_v<Arch, eve::neon128_> ) return vld1q_f64(ptr);
-        else  if constexpr( std::is_same_v<Arch, eve::neon64_>  ) return vld1_f64(ptr);
+              if constexpr( std::is_same_v<Arch, eve::arm_128_> ) return vld1q_f64(ptr);
+        else  if constexpr( std::is_same_v<Arch, eve::arm_64_>  ) return vld1_f64(ptr);
       }
   #endif
       else if constexpr( std::signed_integral<T> )
       {
-        if constexpr( std::is_same_v<Arch, eve::neon128_> )
+        if constexpr( std::is_same_v<Arch, eve::arm_128_> )
         {
           if constexpr( sizeof(T) == 8 )  return vld1q_s64(ptr);
           if constexpr( sizeof(T) == 4 )  return vld1q_s32(ptr);
           if constexpr( sizeof(T) == 2 )  return vld1q_s16(ptr);
           if constexpr( sizeof(T) == 1 )  return vld1q_s8(ptr);
         }
-        else if constexpr( std::is_same_v<Arch, eve::neon64_>  )
+        else if constexpr( std::is_same_v<Arch, eve::arm_64_>  )
         {
           if constexpr( sizeof(T) == 8 ) return vld1_s64(ptr);
           if constexpr( sizeof(T) == 4 ) return vld1_s32(ptr);
@@ -56,14 +56,14 @@ namespace eve::detail
       }
       else
       {
-        if constexpr( std::is_same_v<Arch, eve::neon128_> )
+        if constexpr( std::is_same_v<Arch, eve::arm_128_> )
         {
           if constexpr( sizeof(T) == 8 )  return vld1q_u64(ptr);
           if constexpr( sizeof(T) == 4 )  return vld1q_u32(ptr);
           if constexpr( sizeof(T) == 2 )  return vld1q_u16(ptr);
           if constexpr( sizeof(T) == 1 )  return vld1q_u8(ptr);
         }
-        else if constexpr( std::is_same_v<Arch, eve::neon64_>  )
+        else if constexpr( std::is_same_v<Arch, eve::arm_64_>  )
         {
           if constexpr( sizeof(T) == 8 ) return vld1_u64(ptr);
           if constexpr( sizeof(T) == 4 ) return vld1_u32(ptr);
@@ -98,26 +98,26 @@ namespace eve::detail
       {
         if constexpr( std::is_same_v<T, float> )
         {
-                if constexpr( std::is_same_v<Arch, eve::neon128_> ) return vld1q_f32_ex(ptr, 128);
-          else  if constexpr( std::is_same_v<Arch, eve::neon64_>  ) return vld1_f32_ex(ptr, 64);
+                if constexpr( std::is_same_v<Arch, eve::arm_128_> ) return vld1q_f32_ex(ptr, 128);
+          else  if constexpr( std::is_same_v<Arch, eve::arm_64_>  ) return vld1_f32_ex(ptr, 64);
         }
     #if defined(__aarch64__)
         else if constexpr( std::is_same_v<T, double> )
         {
-                if constexpr( std::is_same_v<Arch, eve::neon128_> ) return vld1q_f64_ex(ptr, 128);
-          else  if constexpr( std::is_same_v<Arch, eve::neon64_>  ) return vld1_f64_ex(ptr, 64);
+                if constexpr( std::is_same_v<Arch, eve::arm_128_> ) return vld1q_f64_ex(ptr, 128);
+          else  if constexpr( std::is_same_v<Arch, eve::arm_64_>  ) return vld1_f64_ex(ptr, 64);
         }
     #endif
         else if constexpr( std::signed_integral<T> )
         {
-          if constexpr( std::is_same_v<Arch, eve::neon128_> )
+          if constexpr( std::is_same_v<Arch, eve::arm_128_> )
           {
             if constexpr( sizeof(T) == 8 )  return vld1q_s64_ex(ptr, 128);
             if constexpr( sizeof(T) == 4 )  return vld1q_s32_ex(ptr, 128);
             if constexpr( sizeof(T) == 2 )  return vld1q_s16_ex(ptr, 128);
             if constexpr( sizeof(T) == 1 )  return vld1q_s8_ex(ptr, 128);
           }
-          else if constexpr( std::is_same_v<Arch, eve::neon64_>  )
+          else if constexpr( std::is_same_v<Arch, eve::arm_64_>  )
           {
             if constexpr( sizeof(T) == 8 ) return vld1_s64_ex(ptr, 64);
             if constexpr( sizeof(T) == 4 ) return vld1_s32_ex(ptr, 64);
@@ -127,14 +127,14 @@ namespace eve::detail
         }
         else
         {
-          if constexpr( std::is_same_v<Arch, eve::neon128_> )
+          if constexpr( std::is_same_v<Arch, eve::arm_128_> )
           {
             if constexpr( sizeof(T) == 8 )  return vld1q_u64_ex(ptr, 128);
             if constexpr( sizeof(T) == 4 )  return vld1q_u32_ex(ptr, 128);
             if constexpr( sizeof(T) == 2 )  return vld1q_u16_ex(ptr, 128);
             if constexpr( sizeof(T) == 1 )  return vld1q_u8_ex(ptr, 128);
           }
-          else if constexpr( std::is_same_v<Arch, eve::neon64_>  )
+          else if constexpr( std::is_same_v<Arch, eve::arm_64_>  )
           {
             if constexpr( sizeof(T) == 8 ) return vld1_u64_ex(ptr, 64);
             if constexpr( sizeof(T) == 4 ) return vld1_u32_ex(ptr, 64);

--- a/include/eve/detail/function/simd/arm/neon/load.hpp
+++ b/include/eve/detail/function/simd/arm/neon/load.hpp
@@ -23,7 +23,7 @@ namespace eve::detail
   template<real_scalar_value T, typename N, arm_abi ABI, typename Arch>
   EVE_FORCEINLINE auto load(eve::as_<wide<T, N, ABI>> const &, Arch const &, T const* ptr) noexcept
   {
-    if constexpr( N::value * sizeof(T) >= neon64_::bytes )
+    if constexpr( N::value * sizeof(T) >= arm_64_::bytes )
     {
       if constexpr( std::is_same_v<T, float> )
       {
@@ -94,7 +94,7 @@ namespace eve::detail
     }
     else
     {
-      if constexpr( N::value * sizeof(T) >= eve::neon64_::bytes )
+      if constexpr( N::value * sizeof(T) >= eve::arm_64_::bytes )
       {
         if constexpr( std::is_same_v<T, float> )
         {

--- a/include/eve/detail/function/simd/arm/neon/lookup.hpp
+++ b/include/eve/detail/function/simd/arm/neon/lookup.hpp
@@ -23,7 +23,7 @@ namespace eve::detail
 {
   template<typename T, typename I, typename N>
   EVE_FORCEINLINE auto
-  lookup_(EVE_SUPPORTS(neon128_), wide<T, N, neon64_> a, wide<I, N, neon64_> idx) noexcept
+  lookup_(EVE_SUPPORTS(neon128_), wide<T, N, arm_64_> a, wide<I, N, arm_64_> idx) noexcept
   {
     if constexpr( std::is_signed_v<I> )
     {
@@ -32,7 +32,7 @@ namespace eve::detail
     }
     else
     {
-      using t8_t = typename wide<T, N, neon64_>::template rebind<std::uint8_t, fixed<8>>;
+      using t8_t = typename wide<T, N, arm_64_>::template rebind<std::uint8_t, fixed<8>>;
 
       if constexpr( sizeof(I) == 1 )
       {
@@ -41,7 +41,7 @@ namespace eve::detail
       else
       {
         t8_t i1 = lookup(bit_cast( eve::shl(idx, shift<I>), as(i1)), t8_t {repeater<I>});
-        i1      = bit_cast(bit_cast(i1, as<wide<I, N, neon64_>>()) + offset<I>, as<t8_t>());
+        i1      = bit_cast(bit_cast(i1, as<wide<I, N, arm_64_>>()) + offset<I>, as<t8_t>());
         return bit_cast(lookup(bit_cast(a, as<t8_t>()), i1), as(a));
       }
     }
@@ -49,7 +49,7 @@ namespace eve::detail
 
   template<typename T, typename I, typename N>
   EVE_FORCEINLINE auto
-  lookup_(EVE_SUPPORTS(neon128_), wide<T, N, neon128_> a, wide<I, N, neon128_> idx) noexcept
+  lookup_(EVE_SUPPORTS(neon128_), wide<T, N, arm_128_> a, wide<I, N, arm_128_> idx) noexcept
   {
     if constexpr( std::is_signed_v<I> )
     {
@@ -58,11 +58,11 @@ namespace eve::detail
     }
     else
     {
-      using t8_t = typename wide<T, N, neon128_>::template rebind<std::uint8_t, fixed<16>>;
+      using t8_t = typename wide<T, N, arm_128_>::template rebind<std::uint8_t, fixed<16>>;
 
       if constexpr( sizeof(I) == 1 )
       {
-        using t8h_t = typename wide<T, N, neon128_>::template rebind<std::uint8_t, fixed<8>>;
+        using t8h_t = typename wide<T, N, arm_128_>::template rebind<std::uint8_t, fixed<8>>;
 
         auto        pieces = bit_cast(a, as<t8_t>());
         uint8x8x2_t tbl    = {{pieces.slice(lower_), pieces.slice(upper_)}};
@@ -73,7 +73,7 @@ namespace eve::detail
       else
       {
         t8_t i1 = lookup(bit_cast( eve::shl(idx, shift<I>), as(i1)), t8_t {repeater<I>});
-        i1      = bit_cast(bit_cast(i1, as<wide<I, N, neon128_>>()) + offset<I>, as<t8_t>());
+        i1      = bit_cast(bit_cast(i1, as<wide<I, N, arm_128_>>()) + offset<I>, as<t8_t>());
         return bit_cast(lookup(bit_cast(a, as<t8_t>()), i1), as(a));
       }
     }

--- a/include/eve/detail/function/simd/arm/neon/make.hpp
+++ b/include/eve/detail/function/simd/arm/neon/make.hpp
@@ -42,15 +42,15 @@ namespace eve::detail
   };
 
   template<real_scalar_value T, typename... Vs>
-  EVE_FORCEINLINE auto make(eve::as_<T> const &, eve::neon64_ const &, Vs... vs) noexcept
+  EVE_FORCEINLINE auto make(eve::as_<T> const &, eve::arm_64_ const &, Vs... vs) noexcept
   {
-    return neon_maker<T, eve::neon64_> {}(vs...);
+    return neon_maker<T, eve::arm_64_> {}(vs...);
   }
 
   template<real_scalar_value T, typename... Vs>
-  EVE_FORCEINLINE auto make(eve::as_<T> const &, eve::neon128_ const &, Vs... vs) noexcept
+  EVE_FORCEINLINE auto make(eve::as_<T> const &, eve::arm_128_ const &, Vs... vs) noexcept
   {
-    return neon_maker<T, eve::neon128_> {}(vs...);
+    return neon_maker<T, eve::arm_128_> {}(vs...);
   }
 
   //================================================================================================
@@ -83,15 +83,15 @@ namespace eve::detail
   };
 
   template<real_scalar_value T, typename... Vs>
-  EVE_FORCEINLINE auto make(eve::as_<logical<T>> const &, eve::neon64_ const &, Vs... vs) noexcept
+  EVE_FORCEINLINE auto make(eve::as_<logical<T>> const &, eve::arm_64_ const &, Vs... vs) noexcept
   {
-    return neon_maker<logical<T>, eve::neon64_> {}(vs...);
+    return neon_maker<logical<T>, eve::arm_64_> {}(vs...);
   }
 
   template<real_scalar_value T, typename... Vs>
-  EVE_FORCEINLINE auto make(eve::as_<logical<T>> const &, eve::neon128_ const &, Vs... vs) noexcept
+  EVE_FORCEINLINE auto make(eve::as_<logical<T>> const &, eve::arm_128_ const &, Vs... vs) noexcept
   {
-    return neon_maker<logical<T>, eve::neon128_> {}(vs...);
+    return neon_maker<logical<T>, eve::arm_128_> {}(vs...);
   }
 }
 

--- a/include/eve/detail/function/simd/arm/neon/slice.hpp
+++ b/include/eve/detail/function/simd/arm/neon/slice.hpp
@@ -19,7 +19,7 @@
 namespace eve::detail
 {
   template<typename T, typename N, typename Slice>
-  EVE_FORCEINLINE auto slice(wide<T, N, neon128_> const &a, Slice const &) noexcept
+  EVE_FORCEINLINE auto slice(wide<T, N, arm_128_> const &a, Slice const &) noexcept
       requires(N::value > 1)
   {
     using type = wide<T, typename N::split_type>;
@@ -129,7 +129,7 @@ namespace eve::detail
   }
 
   template<typename T, typename N, typename Slice>
-  EVE_FORCEINLINE auto slice(wide<T, N, neon64_> const &a, Slice const &) noexcept
+  EVE_FORCEINLINE auto slice(wide<T, N, arm_64_> const &a, Slice const &) noexcept
       requires(N::value > 1)
   {
     using type = wide<T, typename N::split_type>;
@@ -154,14 +154,14 @@ namespace eve::detail
   }
 
   template<typename T, typename N>
-  EVE_FORCEINLINE auto slice(wide<T, N, neon128_> const &a) noexcept requires(N::value > 1)
+  EVE_FORCEINLINE auto slice(wide<T, N, arm_128_> const &a) noexcept requires(N::value > 1)
   {
     std::array<wide<T, typename N::split_type>, 2> that {slice(a, lower_), slice(a, upper_)};
     return that;
   }
 
   template<typename T, typename N>
-  EVE_FORCEINLINE auto slice(wide<T, N, neon64_> const &a) noexcept requires(N::value > 1)
+  EVE_FORCEINLINE auto slice(wide<T, N, arm_64_> const &a) noexcept requires(N::value > 1)
   {
     std::array<wide<T, typename N::split_type>, 2> that {slice(a, lower_), slice(a, upper_)};
     return that;

--- a/include/eve/detail/function/simd/x86/arithmetic_compounds.hpp
+++ b/include/eve/detail/function/simd/x86/arithmetic_compounds.hpp
@@ -23,10 +23,10 @@ namespace eve::detail
   // +=
   //================================================================================================
   template<scalar_value T, value U, typename N>
-  EVE_FORCEINLINE decltype(auto) self_add(wide<T, N, sse_> &self, U const &other) noexcept
-      requires(scalar_value<U> || std::same_as<wide<T, N, sse_>, U>)
+  EVE_FORCEINLINE decltype(auto) self_add(wide<T, N, x86_128_> &self, U const &other) noexcept
+      requires(scalar_value<U> || std::same_as<wide<T, N, x86_128_>, U>)
   {
-    using type = wide<T, N, sse_>;
+    using type = wide<T, N, x86_128_>;
 
     if constexpr( scalar_value<U> )
     {
@@ -66,10 +66,10 @@ namespace eve::detail
   }
 
   template<scalar_value T, value U, typename N>
-  EVE_FORCEINLINE decltype(auto) self_add(wide<T, N, avx_> &self, U const &other) noexcept
-      requires(scalar_value<U> || std::same_as<wide<T, N, avx_>, U>)
+  EVE_FORCEINLINE decltype(auto) self_add(wide<T, N, x86_256_> &self, U const &other) noexcept
+      requires(scalar_value<U> || std::same_as<wide<T, N, x86_256_>, U>)
   {
-    using type = wide<T, N, avx_>;
+    using type = wide<T, N, x86_256_>;
 
     if constexpr( scalar_value<U> )
     {
@@ -123,10 +123,10 @@ namespace eve::detail
   // -=
   //================================================================================================
   template<scalar_value T, value U, typename N>
-  EVE_FORCEINLINE decltype(auto) self_sub(wide<T, N, sse_> &self, U const &other) noexcept
-      requires(scalar_value<U> || std::same_as<wide<T, N, sse_>, U>)
+  EVE_FORCEINLINE decltype(auto) self_sub(wide<T, N, x86_128_> &self, U const &other) noexcept
+      requires(scalar_value<U> || std::same_as<wide<T, N, x86_128_>, U>)
   {
-    using type = wide<T, N, sse_>;
+    using type = wide<T, N, x86_128_>;
 
     if constexpr( scalar_value<U> )
     {
@@ -166,10 +166,10 @@ namespace eve::detail
   }
 
   template<scalar_value T, value U, typename N>
-  EVE_FORCEINLINE decltype(auto) self_sub(wide<T, N, avx_> &self, U const &other) noexcept
-      requires(scalar_value<U> || std::same_as<wide<T, N, avx_>, U>)
+  EVE_FORCEINLINE decltype(auto) self_sub(wide<T, N, x86_256_> &self, U const &other) noexcept
+      requires(scalar_value<U> || std::same_as<wide<T, N, x86_256_>, U>)
   {
-    using type = wide<T, N, avx_>;
+    using type = wide<T, N, x86_256_>;
 
     if constexpr( scalar_value<U> )
     {
@@ -223,10 +223,10 @@ namespace eve::detail
   // *=
   //================================================================================================
   template<scalar_value T, value U, typename N>
-  EVE_FORCEINLINE decltype(auto) self_mul(wide<T, N, sse_> &self, U const &other) noexcept
-      requires(scalar_value<U> || std::same_as<wide<T, N, sse_>, U>)
+  EVE_FORCEINLINE decltype(auto) self_mul(wide<T, N, x86_128_> &self, U const &other) noexcept
+      requires(scalar_value<U> || std::same_as<wide<T, N, x86_128_>, U>)
   {
-    using type = wide<T, N, sse_>;
+    using type = wide<T, N, x86_128_>;
 
     if constexpr( scalar_value<U> )
     {
@@ -292,10 +292,10 @@ namespace eve::detail
   }
 
   template<scalar_value T, value U, typename N>
-  EVE_FORCEINLINE decltype(auto) self_mul(wide<T, N, avx_> &self, U const &other) noexcept
-      requires(scalar_value<U> || std::same_as<wide<T, N, avx_>, U>)
+  EVE_FORCEINLINE decltype(auto) self_mul(wide<T, N, x86_256_> &self, U const &other) noexcept
+      requires(scalar_value<U> || std::same_as<wide<T, N, x86_256_>, U>)
   {
-    using type = wide<T, N, avx_>;
+    using type = wide<T, N, x86_256_>;
 
     if constexpr( scalar_value<U> )
     {
@@ -340,10 +340,10 @@ namespace eve::detail
   // /=
   //================================================================================================
   template<scalar_value T, value U, typename N>
-  EVE_FORCEINLINE decltype(auto) self_div(wide<T, N, sse_> &self, U const &other) noexcept
-      requires(scalar_value<U> || std::same_as<wide<T, N, sse_>, U>)
+  EVE_FORCEINLINE decltype(auto) self_div(wide<T, N, x86_128_> &self, U const &other) noexcept
+      requires(scalar_value<U> || std::same_as<wide<T, N, x86_128_>, U>)
   {
-    using type = wide<T, N, sse_>;
+    using type = wide<T, N, x86_128_>;
 
     if constexpr( scalar_value<U> )
     {
@@ -380,10 +380,10 @@ namespace eve::detail
   }
 
   template<scalar_value T, value U, typename N>
-  EVE_FORCEINLINE decltype(auto) self_div(wide<T, N, avx_> &self, U const &other) noexcept
-      requires(scalar_value<U> || std::same_as<wide<T, N, avx_>, U>)
+  EVE_FORCEINLINE decltype(auto) self_div(wide<T, N, x86_256_> &self, U const &other) noexcept
+      requires(scalar_value<U> || std::same_as<wide<T, N, x86_256_>, U>)
   {
-    using type = wide<T, N, avx_>;
+    using type = wide<T, N, x86_256_>;
 
     if constexpr( scalar_value<U> )
     {

--- a/include/eve/detail/function/simd/x86/bit_compounds.hpp
+++ b/include/eve/detail/function/simd/x86/bit_compounds.hpp
@@ -22,10 +22,10 @@ namespace eve::detail
   // &=
   //================================================================================================
   template<scalar_value T, value U, typename N>
-  EVE_FORCEINLINE decltype(auto) self_bitand(wide<T, N, sse_> &self, U const &other) noexcept
-      requires((sizeof(wide<T, N, sse_>) == sizeof(U)) || (sizeof(T) == sizeof(U)))
+  EVE_FORCEINLINE decltype(auto) self_bitand(wide<T, N, x86_128_> &self, U const &other) noexcept
+      requires((sizeof(wide<T, N, x86_128_>) == sizeof(U)) || (sizeof(T) == sizeof(U)))
   {
-    using type = wide<T, N, sse_>;
+    using type = wide<T, N, x86_128_>;
 
     if constexpr( scalar_value<U> )
     {
@@ -53,10 +53,10 @@ namespace eve::detail
   }
 
   template<scalar_value T, value U, typename N>
-  EVE_FORCEINLINE decltype(auto) self_bitand(wide<T, N, avx_> &self, U const &other) noexcept
-      requires((sizeof(wide<T, N, avx_>) == sizeof(U)) || (sizeof(T) == sizeof(U)))
+  EVE_FORCEINLINE decltype(auto) self_bitand(wide<T, N, x86_256_> &self, U const &other) noexcept
+      requires((sizeof(wide<T, N, x86_256_>) == sizeof(U)) || (sizeof(T) == sizeof(U)))
   {
-    using type = wide<T, N, avx_>;
+    using type = wide<T, N, x86_256_>;
 
     if constexpr( scalar_value<U> )
     {
@@ -95,10 +95,10 @@ namespace eve::detail
   // |=
   //================================================================================================
   template<scalar_value T, value U, typename N>
-  EVE_FORCEINLINE decltype(auto) self_bitor(wide<T, N, sse_> &self, U const &other) noexcept
-      requires((sizeof(wide<T, N, sse_>) == sizeof(U)) || (sizeof(T) == sizeof(U)))
+  EVE_FORCEINLINE decltype(auto) self_bitor(wide<T, N, x86_128_> &self, U const &other) noexcept
+      requires((sizeof(wide<T, N, x86_128_>) == sizeof(U)) || (sizeof(T) == sizeof(U)))
   {
-    using type = wide<T, N, sse_>;
+    using type = wide<T, N, x86_128_>;
 
     if constexpr( scalar_value<U> )
     {
@@ -126,10 +126,10 @@ namespace eve::detail
   }
 
   template<scalar_value T, value U, typename N>
-  EVE_FORCEINLINE decltype(auto) self_bitor(wide<T, N, avx_> &self, U const &other) noexcept
-      requires((sizeof(wide<T, N, avx_>) == sizeof(U)) || (sizeof(T) == sizeof(U)))
+  EVE_FORCEINLINE decltype(auto) self_bitor(wide<T, N, x86_256_> &self, U const &other) noexcept
+      requires((sizeof(wide<T, N, x86_256_>) == sizeof(U)) || (sizeof(T) == sizeof(U)))
   {
-    using type = wide<T, N, avx_>;
+    using type = wide<T, N, x86_256_>;
 
     if constexpr( scalar_value<U> )
     {
@@ -169,10 +169,10 @@ namespace eve::detail
   // ^=
   //================================================================================================
   template<scalar_value T, value U, typename N>
-  EVE_FORCEINLINE decltype(auto) self_bitxor(wide<T, N, sse_> &self, U const &other) noexcept
-      requires((sizeof(wide<T, N, sse_>) == sizeof(U)) || (sizeof(T) == sizeof(U)))
+  EVE_FORCEINLINE decltype(auto) self_bitxor(wide<T, N, x86_128_> &self, U const &other) noexcept
+      requires((sizeof(wide<T, N, x86_128_>) == sizeof(U)) || (sizeof(T) == sizeof(U)))
   {
-    using type = wide<T, N, sse_>;
+    using type = wide<T, N, x86_128_>;
 
     if constexpr( scalar_value<U> )
     {
@@ -200,10 +200,10 @@ namespace eve::detail
   }
 
   template<scalar_value T, value U, typename N>
-  EVE_FORCEINLINE decltype(auto) self_bitxor(wide<T, N, avx_> &self, U const &other) noexcept
-      requires((sizeof(wide<T, N, avx_>) == sizeof(U)) || (sizeof(T) == sizeof(U)))
+  EVE_FORCEINLINE decltype(auto) self_bitxor(wide<T, N, x86_256_> &self, U const &other) noexcept
+      requires((sizeof(wide<T, N, x86_256_>) == sizeof(U)) || (sizeof(T) == sizeof(U)))
   {
-    using type = wide<T, N, avx_>;
+    using type = wide<T, N, x86_256_>;
 
     if constexpr( scalar_value<U> )
     {

--- a/include/eve/detail/function/simd/x86/bitmask.hpp
+++ b/include/eve/detail/function/simd/x86/bitmask.hpp
@@ -25,7 +25,7 @@ namespace eve::detail
   {
     using type = std::bitset<N::value>;
 
-    if constexpr( std::is_same_v<ABI, sse_>)
+    if constexpr( std::is_same_v<ABI, x86_128_>)
     {
             if constexpr( std::is_same_v<T, float > ) return type(_mm_movemask_ps(p.mask()));
       else  if constexpr( std::is_same_v<T, double> ) return type(_mm_movemask_pd(p.mask()));
@@ -55,7 +55,7 @@ namespace eve::detail
         }
       }
     }
-    else if constexpr( std::is_same_v<ABI, avx_>)
+    else if constexpr( std::is_same_v<ABI, x86_256_>)
     {
             if constexpr( std::is_same_v<T, float > ) return type(_mm256_movemask_ps(p.mask()));
       else  if constexpr( std::is_same_v<T, double> ) return type(_mm256_movemask_pd(p.mask()));

--- a/include/eve/detail/function/simd/x86/combine.hpp
+++ b/include/eve/detail/function/simd/x86/combine.hpp
@@ -20,21 +20,21 @@ namespace eve::detail
   //================================================================================================
   template<typename T, typename N>
   EVE_FORCEINLINE auto
-  combine(sse2_ const &, wide<T, N, sse_> const &l, wide<T, N, sse_> const &h) noexcept
+  combine(sse2_ const &, wide<T, N, x86_128_> const &l, wide<T, N, x86_128_> const &h) noexcept
   {
     using t_t = wide<T, typename N::combined_type>;
     using s_t = typename t_t::storage_type;
 
     //==============================================================================================
     // If we aggregate two fully sized wide, just coalesce inside new storage
-    if constexpr( N::value * sizeof(T) == eve::sse_::bytes )
+    if constexpr( N::value * sizeof(T) == eve::x86_128_::bytes )
     {
       return s_t {l, h};
     }
     //==============================================================================================
     // Handle half-storage
     //==============================================================================================
-    else if constexpr( 2 * N::value * sizeof(T) == eve::sse_::bytes )
+    else if constexpr( 2 * N::value * sizeof(T) == eve::x86_128_::bytes )
     {
       if constexpr( std::is_same_v<T, double> )
       {
@@ -53,7 +53,7 @@ namespace eve::detail
     //==============================================================================================
     // Handle quarter-storage
     //==============================================================================================
-    else if constexpr( 4 * N::value * sizeof(T) == eve::sse_::bytes )
+    else if constexpr( 4 * N::value * sizeof(T) == eve::x86_128_::bytes )
     {
       if constexpr( std::is_same_v<T, float> )
       {
@@ -75,11 +75,11 @@ namespace eve::detail
     //==============================================================================================
     else if constexpr( std::is_integral_v<T> && ((sizeof(T) != 8) && (N::value == 2)) )
     {
-      return make(eve::as_<T> {}, eve::sse_ {}, l[0], l[1], h[0], h[1]);
+      return make(eve::as_<T> {}, eve::x86_128_ {}, l[0], l[1], h[0], h[1]);
     }
     else if constexpr( std::is_integral_v<T> && (sizeof(T) != 8) && (N::value == 1) )
     {
-      return make(eve::as_<T> {}, eve::sse_ {}, l[0], h[0]);
+      return make(eve::as_<T> {}, eve::x86_128_ {}, l[0], h[0]);
     }
   }
 
@@ -88,7 +88,7 @@ namespace eve::detail
   //================================================================================================
   template<typename T, typename N>
   EVE_FORCEINLINE auto
-  combine(avx_ const &, wide<T, N, avx_> const &l, wide<T, N, avx_> const &h) noexcept
+  combine(avx_ const &, wide<T, N, x86_256_> const &l, wide<T, N, x86_256_> const &h) noexcept
   {
     using that_t = typename wide<T, typename N::combined_type>::storage_type;
     return that_t {l, h};
@@ -99,9 +99,9 @@ namespace eve::detail
   //================================================================================================
   template<typename T, typename N>
   EVE_FORCEINLINE auto
-  combine(avx_ const &, wide<T, N, sse_> const &l, wide<T, N, sse_> const &h) noexcept
+  combine(avx_ const &, wide<T, N, x86_128_> const &l, wide<T, N, x86_128_> const &h) noexcept
   {
-    if constexpr( N::value * sizeof(T) == eve::sse_::bytes )
+    if constexpr( N::value * sizeof(T) == eve::x86_128_::bytes )
     {
       if constexpr( std::is_same_v<T, double> )
       {

--- a/include/eve/detail/function/simd/x86/load.hpp
+++ b/include/eve/detail/function/simd/x86/load.hpp
@@ -22,9 +22,9 @@ namespace eve::detail
   // 128 bits loads
   //================================================================================================
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE auto load(eve::as_<wide<T, N>> const &, eve::sse_ const &, T const* p)
+  EVE_FORCEINLINE auto load(eve::as_<wide<T, N>> const &, eve::x86_128_ const &, T const* p)
   {
-    if constexpr( N::value * sizeof(T) == sse_::bytes )
+    if constexpr( N::value * sizeof(T) == x86_128_::bytes )
     {
       if constexpr( std::is_same_v<T, double> )
       {
@@ -49,9 +49,9 @@ namespace eve::detail
 
   template<real_scalar_value T, typename N, std::size_t A>
   EVE_FORCEINLINE auto
-  load(eve::as_<wide<T, N>> const &tgt, eve::sse_ const &mode, aligned_ptr<T const, A> p) noexcept
+  load(eve::as_<wide<T, N>> const &tgt, eve::x86_128_ const &mode, aligned_ptr<T const, A> p) noexcept
   {
-    if constexpr( A >= 16 && N::value * sizeof(T) == sse_::bytes )
+    if constexpr( A >= 16 && N::value * sizeof(T) == x86_128_::bytes )
     {
       if constexpr( std::is_same_v<T, double> )
       {
@@ -74,18 +74,16 @@ namespace eve::detail
 
   template<real_scalar_value T, typename N, std::size_t A>
   EVE_FORCEINLINE auto
-  load(eve::as_<wide<T, N>> const &tgt, eve::sse_ const & mode, aligned_ptr<T, A> p) noexcept
+  load(eve::as_<wide<T, N>> const &tgt, eve::x86_128_ const & mode, aligned_ptr<T, A> p) noexcept
   {
     return load(tgt,mode, aligned_ptr<T const, A>(p));
   }
 
-  //------------------------------------------------------------------------------------------------
-  // 256 bits loads
   //================================================================================================
   // 256 bits loads
   //================================================================================================
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE auto load(eve::as_<wide<T, N>> const &, eve::avx_ const &, T const* p) noexcept
+  EVE_FORCEINLINE auto load(eve::as_<wide<T, N>> const &, eve::x86_256_ const &, T const* p) noexcept
   {
     if constexpr( std::is_same_v<T, double> )
     {
@@ -103,7 +101,7 @@ namespace eve::detail
 
   template<real_scalar_value T, typename N, std::size_t A>
   EVE_FORCEINLINE auto
-  load(eve::as_<wide<T, N>> const &tgt, eve::avx_ const &mode, aligned_ptr<T const, A> p) noexcept
+  load(eve::as_<wide<T, N>> const &tgt, eve::x86_256_ const &mode, aligned_ptr<T const, A> p) noexcept
   {
     if constexpr( A >= 32 )
     {
@@ -128,7 +126,7 @@ namespace eve::detail
 
   template<real_scalar_value T, typename N, std::size_t A>
   EVE_FORCEINLINE auto
-  load(eve::as_<wide<T, N>> const &tgt, eve::avx_ const & mode, aligned_ptr<T, A> p) noexcept
+  load(eve::as_<wide<T, N>> const &tgt, eve::x86_256_ const & mode, aligned_ptr<T, A> p) noexcept
   {
     return load(tgt, mode, aligned_ptr<T const, A>(p));
   }

--- a/include/eve/detail/function/simd/x86/lookup.hpp
+++ b/include/eve/detail/function/simd/x86/lookup.hpp
@@ -20,8 +20,8 @@
 namespace eve::detail
 {
   template<typename T, typename I, typename N>
-  EVE_FORCEINLINE wide<T, N, sse_>
-                  lookup_(EVE_SUPPORTS(ssse3_), wide<T, N, sse_> a, wide<I, N, sse_> idx) noexcept
+  EVE_FORCEINLINE wide<T, N, x86_128_>
+                  lookup_(EVE_SUPPORTS(ssse3_), wide<T, N, x86_128_> a, wide<I, N, x86_128_> idx) noexcept
   {
     // TODO: We use sizeof as a discriminant but we could actually use shuffle
     // to extract the one byte for the lookup form bigger integer and put them inside
@@ -33,10 +33,10 @@ namespace eve::detail
     }
     else
     {
-      using t8_t = typename wide<T, N, sse_>::template rebind<std::uint8_t, fixed<16>>;
+      using t8_t = typename wide<T, N, x86_128_>::template rebind<std::uint8_t, fixed<16>>;
 
       t8_t i1 = _mm_shuffle_epi8(shl(idx, shift<I>), t8_t {repeater<I>});
-      i1      = bit_cast(bit_cast(i1, as<wide<I, N, sse_>>()) + offset<I>, as<t8_t>());
+      i1      = bit_cast(bit_cast(i1, as<wide<I, N, x86_128_>>()) + offset<I>, as<t8_t>());
 
       t8_t const blocks = _mm_shuffle_epi8(bit_cast(a, as<t8_t>()), i1);
       return bit_cast(blocks, as(a));

--- a/include/eve/detail/function/simd/x86/make.hpp
+++ b/include/eve/detail/function/simd/x86/make.hpp
@@ -21,9 +21,9 @@ namespace eve::detail
   // 128 bits make
   //================================================================================================
   template<real_scalar_value T, typename... Vs>
-  EVE_FORCEINLINE auto make(eve::as_<T> const &, eve::sse_ const &, Vs... vs) noexcept
+  EVE_FORCEINLINE auto make(eve::as_<T> const &, eve::x86_128_ const &, Vs... vs) noexcept
   {
-    static_assert(sizeof...(Vs) <= sse_::bytes / sizeof(T),
+    static_assert(sizeof...(Vs) <= x86_128_::bytes / sizeof(T),
                   "[eve::make sse] - Invalid number of arguments");
 
     if constexpr( std::is_same_v<T, double> )
@@ -95,7 +95,7 @@ namespace eve::detail
   }
 
   template<real_scalar_value T, typename V>
-  EVE_FORCEINLINE auto make(eve::as_<T> const &, eve::sse_ const &, V v) noexcept
+  EVE_FORCEINLINE auto make(eve::as_<T> const &, eve::x86_128_ const &, V v) noexcept
   {
     if constexpr( std::is_same_v<T, double> )
     {
@@ -135,9 +135,9 @@ namespace eve::detail
   // 256 bits make
   //================================================================================================
   template<real_scalar_value T, typename... Vs>
-  EVE_FORCEINLINE auto make(eve::as_<T> const &, eve::avx_ const &, Vs... vs) noexcept
+  EVE_FORCEINLINE auto make(eve::as_<T> const &, eve::x86_256_ const &, Vs... vs) noexcept
   {
-    static_assert(sizeof...(Vs) <= avx_::bytes / sizeof(T),
+    static_assert(sizeof...(Vs) <= x86_256_::bytes / sizeof(T),
                   "[eve::make avx] - Invalid number of arguments");
 
     if constexpr( std::is_same_v<T, double> )
@@ -170,7 +170,7 @@ namespace eve::detail
   }
 
   template<real_scalar_value T, typename V>
-  EVE_FORCEINLINE auto make(eve::as_<T> const &, eve::avx_ const &, V v) noexcept
+  EVE_FORCEINLINE auto make(eve::as_<T> const &, eve::x86_256_ const &, V v) noexcept
   {
     if constexpr( std::is_same_v<T, double> )
     {
@@ -205,15 +205,15 @@ namespace eve::detail
   // logical cases
   //================================================================================================
   template<real_scalar_value T, typename... Vs>
-  EVE_FORCEINLINE auto make(eve::as_<logical<T>> const &, eve::sse_ const &, Vs... vs) noexcept
+  EVE_FORCEINLINE auto make(eve::as_<logical<T>> const &, eve::x86_128_ const &, Vs... vs) noexcept
   {
-    return make(eve::as_<T> {}, eve::sse_ {}, logical<T>(vs).mask()...);
+    return make(eve::as_<T> {}, eve::x86_128_ {}, logical<T>(vs).mask()...);
   }
 
   template<real_scalar_value T, typename... Vs>
-  EVE_FORCEINLINE auto make(eve::as_<logical<T>> const &, eve::avx_ const &, Vs... vs) noexcept
+  EVE_FORCEINLINE auto make(eve::as_<logical<T>> const &, eve::x86_256_ const &, Vs... vs) noexcept
   {
-    return make(eve::as_<T> {}, eve::avx_ {}, logical<T>(vs).mask()...);
+    return make(eve::as_<T> {}, eve::x86_256_ {}, logical<T>(vs).mask()...);
   }
 }
 

--- a/include/eve/detail/function/simd/x86/slice.hpp
+++ b/include/eve/detail/function/simd/x86/slice.hpp
@@ -23,7 +23,7 @@ namespace eve::detail
   // Single slice
   //================================================================================================
   template<typename T, typename N, typename Slice>
-  EVE_FORCEINLINE auto slice(wide<T, N, sse_> const &a, Slice const &) noexcept
+  EVE_FORCEINLINE auto slice(wide<T, N, x86_128_> const &a, Slice const &) noexcept
       requires(N::value > 1)
   {
     using that_t = wide<T, typename N::split_type>;
@@ -53,11 +53,11 @@ namespace eve::detail
         {
           return that_t(a[1]);
         }
-        if constexpr( bytes_size == eve::sse_::bytes )
+        if constexpr( bytes_size == eve::x86_128_::bytes )
         {
           return that_t(_mm_shuffle_epi32(a, 0xEE));
         }
-        if constexpr( 2 * bytes_size == eve::sse_::bytes )
+        if constexpr( 2 * bytes_size == eve::x86_128_::bytes )
         {
           return that_t(_mm_shuffle_epi32(a, 0x01));
         }
@@ -70,7 +70,7 @@ namespace eve::detail
   }
 
   template<typename T, typename N, typename Slice>
-  EVE_FORCEINLINE auto slice(wide<T, N, avx_> const &a, Slice const &) noexcept
+  EVE_FORCEINLINE auto slice(wide<T, N, x86_256_> const &a, Slice const &) noexcept
       requires(N::value > 1)
   {
     using that_t = wide<T, typename N::split_type>;
@@ -93,14 +93,14 @@ namespace eve::detail
   // Both slice
   //================================================================================================
   template<typename T, typename N>
-  EVE_FORCEINLINE auto slice(wide<T, N, sse_> const &a) noexcept requires(N::value > 1)
+  EVE_FORCEINLINE auto slice(wide<T, N, x86_128_> const &a) noexcept requires(N::value > 1)
   {
     std::array<wide<T, typename N::split_type>, 2> that {slice(a, lower_), slice(a, upper_)};
     return that;
   }
 
   template<typename T, typename N>
-  EVE_FORCEINLINE auto slice(wide<T, N, avx_> const &a) noexcept requires(N::value > 1)
+  EVE_FORCEINLINE auto slice(wide<T, N, x86_256_> const &a) noexcept requires(N::value > 1)
   {
     std::array<wide<T, typename N::split_type>, 2> that {slice(a, lower_), slice(a, upper_)};
     return that;

--- a/include/eve/module/algorithm/function/simd/arm/neon/all.hpp
+++ b/include/eve/module/algorithm/function/simd/arm/neon/all.hpp
@@ -16,7 +16,7 @@
 namespace eve::detail
 {
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE bool all_(EVE_SUPPORTS(neon128_), logical<wide<T, N, neon64_>> const &v0) noexcept
+  EVE_FORCEINLINE bool all_(EVE_SUPPORTS(neon128_), logical<wide<T, N, arm_64_>> const &v0) noexcept
   {
     auto m = v0.bits();
 
@@ -56,7 +56,7 @@ namespace eve::detail
 
   template<real_scalar_value T, typename N>
   EVE_FORCEINLINE bool all_(EVE_SUPPORTS(neon128_),
-                            logical<wide<T, N, neon128_>> const &v0) noexcept
+                            logical<wide<T, N, arm_128_>> const &v0) noexcept
   {
     auto [l, h] = v0.mask().slice();
     return all(l) && all(h);

--- a/include/eve/module/algorithm/function/simd/arm/neon/any.hpp
+++ b/include/eve/module/algorithm/function/simd/arm/neon/any.hpp
@@ -16,7 +16,7 @@
 namespace eve::detail
 {
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE bool any_(EVE_SUPPORTS(neon128_), logical<wide<T,N,neon64_>> const &v0) noexcept
+  EVE_FORCEINLINE bool any_(EVE_SUPPORTS(neon128_), logical<wide<T,N,arm_64_>> const &v0) noexcept
   {
     auto m = v0.bits();
 
@@ -45,7 +45,7 @@ namespace eve::detail
   }
 
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE bool any_(EVE_SUPPORTS(neon128_), logical<wide<T,N,neon128_>> const &v0) noexcept
+  EVE_FORCEINLINE bool any_(EVE_SUPPORTS(neon128_), logical<wide<T,N,arm_128_>> const &v0) noexcept
   {
     auto[l,h] = v0.mask().slice();
     return any(l) || any(h);

--- a/include/eve/module/core/function/simd/arm/neon/average.hpp
+++ b/include/eve/module/core/function/simd/arm/neon/average.hpp
@@ -22,13 +22,13 @@
 namespace eve::detail
 {
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, neon64_> average_(EVE_SUPPORTS(neon128_),
-                                               wide<T, N, neon64_> const &v0,
-                                               wide<T, N, neon64_> const &v1) noexcept
+  EVE_FORCEINLINE wide<T, N, arm_64_> average_(EVE_SUPPORTS(neon128_),
+                                               wide<T, N, arm_64_> const &v0,
+                                               wide<T, N, arm_64_> const &v1) noexcept
   {
-    using in_t = typename wide<T, N, neon64_>::storage_type;
+    using in_t = typename wide<T, N, arm_64_>::storage_type;
 
-    if constexpr(std::is_floating_point_v<T>) return fma(v0, half(eve::as(v0)), v1 * half(eve::as(v1))); 
+    if constexpr(std::is_floating_point_v<T>) return fma(v0, half(eve::as(v0)), v1 * half(eve::as(v1)));
     else
     {
            if constexpr(sizeof(T) == 8)                   return map(average, v0, v1);
@@ -40,15 +40,15 @@ namespace eve::detail
       else if constexpr(std::is_same_v<in_t, uint8x8_t>)  return vhadd_u8(v0, v1);
     }
   }
-  
-  template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, neon128_> average_(EVE_SUPPORTS(neon128_),
-                                                wide<T, N, neon128_> const &v0,
-                                                wide<T, N, neon128_> const &v1) noexcept
-  {
-    using in_t = typename wide<T, N, neon128_>::storage_type;
 
-    if constexpr(std::is_floating_point_v<T>) return fma(v0, half(eve::as(v0)), v1 * half(eve::as(v1))); 
+  template<real_scalar_value T, typename N>
+  EVE_FORCEINLINE wide<T, N, arm_128_> average_(EVE_SUPPORTS(neon128_),
+                                                wide<T, N, arm_128_> const &v0,
+                                                wide<T, N, arm_128_> const &v1) noexcept
+  {
+    using in_t = typename wide<T, N, arm_128_>::storage_type;
+
+    if constexpr(std::is_floating_point_v<T>) return fma(v0, half(eve::as(v0)), v1 * half(eve::as(v1)));
     else
     {
            if constexpr(sizeof(T) == 8)                   return map(average, v0, v1);

--- a/include/eve/module/core/function/simd/arm/neon/bit_andnot.hpp
+++ b/include/eve/module/core/function/simd/arm/neon/bit_andnot.hpp
@@ -19,11 +19,11 @@
 namespace eve::detail
 {
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, neon64_> bit_andnot_(EVE_SUPPORTS(neon128_),
-                                                      wide<T, N, neon64_> const &v0,
-                                                      wide<T, N, neon64_> const &v1) noexcept
+  EVE_FORCEINLINE wide<T, N, arm_64_> bit_andnot_(EVE_SUPPORTS(neon128_),
+                                                      wide<T, N, arm_64_> const &v0,
+                                                      wide<T, N, arm_64_> const &v1) noexcept
   {
-    using in_t = typename wide<T, N, neon64_>::storage_type;
+    using in_t = typename wide<T, N, arm_64_>::storage_type;
 
 // Dispatch to sub-functions
          if constexpr(std::is_same_v<in_t, float32x2_t>)
@@ -43,11 +43,11 @@ namespace eve::detail
   }
 
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, neon128_> bit_andnot_(EVE_SUPPORTS(neon128_),
-                                                       wide<T, N, neon128_> const &v0,
-                                                       wide<T, N, neon128_> const &v1) noexcept
+  EVE_FORCEINLINE wide<T, N, arm_128_> bit_andnot_(EVE_SUPPORTS(neon128_),
+                                                       wide<T, N, arm_128_> const &v0,
+                                                       wide<T, N, arm_128_> const &v1) noexcept
   {
-    using in_t = typename wide<T, N, neon128_>::storage_type;
+    using in_t = typename wide<T, N, arm_128_>::storage_type;
 
 // Dispatch to sub-functions
          if constexpr(std::is_same_v<in_t, float32x4_t>)

--- a/include/eve/module/core/function/simd/arm/neon/bit_not.hpp
+++ b/include/eve/module/core/function/simd/arm/neon/bit_not.hpp
@@ -19,11 +19,11 @@
 namespace eve::detail
 {
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, neon64_> bit_not_(EVE_SUPPORTS(neon128_),
-                                                   wide<T, N, neon64_> const &v0) noexcept
+  EVE_FORCEINLINE wide<T, N, arm_64_> bit_not_(EVE_SUPPORTS(neon128_),
+                                                   wide<T, N, arm_64_> const &v0) noexcept
   {
     using i_t  = wide<as_integer_t<T, unsigned>, N>;
-    using in_t = typename wide<T, N, neon64_>::storage_type;
+    using in_t = typename wide<T, N, arm_64_>::storage_type;
 
          if constexpr(std::is_floating_point_v<T>)
             return bit_cast(bit_not(bit_cast(v0,as_<i_t>{})), as(v0));
@@ -40,11 +40,11 @@ namespace eve::detail
   }
 
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, neon128_> bit_not_(EVE_SUPPORTS(neon128_),
-                                                    wide<T, N, neon128_> const &v0) noexcept
+  EVE_FORCEINLINE wide<T, N, arm_128_> bit_not_(EVE_SUPPORTS(neon128_),
+                                                    wide<T, N, arm_128_> const &v0) noexcept
   {
     using i_t  = wide<as_integer_t<T, unsigned>, N>;
-    using in_t = typename wide<T, N, neon128_>::storage_type;
+    using in_t = typename wide<T, N, arm_128_>::storage_type;
 
          if constexpr(std::is_floating_point_v<T>)
             return bit_cast(bit_not(bit_cast(v0,as_<i_t>{})),as(v0));

--- a/include/eve/module/core/function/simd/arm/neon/bit_notand.hpp
+++ b/include/eve/module/core/function/simd/arm/neon/bit_notand.hpp
@@ -18,11 +18,11 @@
 namespace eve::detail
 {
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, neon64_> bit_notand_(EVE_SUPPORTS(neon128_),
-                                                      wide<T, N, neon64_> const &v0,
-                                                      wide<T, N, neon64_> const &v1) noexcept
+  EVE_FORCEINLINE wide<T, N, arm_64_> bit_notand_(EVE_SUPPORTS(neon128_),
+                                                      wide<T, N, arm_64_> const &v0,
+                                                      wide<T, N, arm_64_> const &v1) noexcept
   {
-    using in_t = typename wide<T, N, neon64_>::storage_type;
+    using in_t = typename wide<T, N, arm_64_>::storage_type;
 
 // Dispatch to sub-functions
          if constexpr(std::is_same_v<in_t, float32x2_t>)
@@ -42,11 +42,11 @@ namespace eve::detail
   }
 
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, neon128_> bit_notand_(EVE_SUPPORTS(neon128_),
-                                                       wide<T, N, neon128_> const &v0,
-                                                       wide<T, N, neon128_> const &v1) noexcept
+  EVE_FORCEINLINE wide<T, N, arm_128_> bit_notand_(EVE_SUPPORTS(neon128_),
+                                                       wide<T, N, arm_128_> const &v0,
+                                                       wide<T, N, arm_128_> const &v1) noexcept
   {
-    using in_t = typename wide<T, N, neon128_>::storage_type;
+    using in_t = typename wide<T, N, arm_128_>::storage_type;
 
 // Dispatch to sub-functions
          if constexpr(std::is_same_v<in_t, float32x4_t>)

--- a/include/eve/module/core/function/simd/arm/neon/bit_notor.hpp
+++ b/include/eve/module/core/function/simd/arm/neon/bit_notor.hpp
@@ -19,11 +19,11 @@
 namespace eve::detail
 {
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, neon64_> bit_notor_(EVE_SUPPORTS(neon128_),
-                                                 wide<T, N, neon64_> const &v0,
-                                                 wide<T, N, neon64_> const &v1) noexcept
+  EVE_FORCEINLINE wide<T, N, arm_64_> bit_notor_(EVE_SUPPORTS(neon128_),
+                                                 wide<T, N, arm_64_> const &v0,
+                                                 wide<T, N, arm_64_> const &v1) noexcept
   {
-    using in_t = typename wide<T, N, neon64_>::storage_type;
+    using in_t = typename wide<T, N, arm_64_>::storage_type;
 
 // Dispatch to sub-functions
          if constexpr(std::is_same_v<in_t, float32x2_t>)
@@ -43,11 +43,11 @@ namespace eve::detail
   }
 
   template<typename T, typename N>
-  EVE_FORCEINLINE wide<T, N, neon128_> bit_notor_(EVE_SUPPORTS(neon128_),
-                                                      wide<T, N, neon128_> const &v0,
-                                                      wide<T, N, neon128_> const &v1) noexcept
+  EVE_FORCEINLINE wide<T, N, arm_128_> bit_notor_(EVE_SUPPORTS(neon128_),
+                                                      wide<T, N, arm_128_> const &v0,
+                                                      wide<T, N, arm_128_> const &v1) noexcept
   {
-    using in_t = typename wide<T, N, neon128_>::storage_type;
+    using in_t = typename wide<T, N, arm_128_>::storage_type;
 
 // Dispatch to sub-functions
          if constexpr(std::is_same_v<in_t, float32x4_t>)

--- a/include/eve/module/core/function/simd/arm/neon/bit_ornot.hpp
+++ b/include/eve/module/core/function/simd/arm/neon/bit_ornot.hpp
@@ -19,11 +19,11 @@
 namespace eve::detail
 {
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, neon64_> bit_ornot_(EVE_SUPPORTS(neon128_),
-                                                     wide<T, N, neon64_> const &v0,
-                                                     wide<T, N, neon64_> const &v1) noexcept
+  EVE_FORCEINLINE wide<T, N, arm_64_> bit_ornot_(EVE_SUPPORTS(neon128_),
+                                                     wide<T, N, arm_64_> const &v0,
+                                                     wide<T, N, arm_64_> const &v1) noexcept
   {
-    using in_t = typename wide<T, N, neon64_>::storage_type;
+    using in_t = typename wide<T, N, arm_64_>::storage_type;
 
 // Dispatch to sub-functions
 
@@ -45,11 +45,11 @@ namespace eve::detail
   }
 
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, neon128_> bit_ornot_(EVE_SUPPORTS(neon128_),
-                                                      wide<T, N, neon128_> const &v0,
-                                                      wide<T, N, neon128_> const &v1) noexcept
+  EVE_FORCEINLINE wide<T, N, arm_128_> bit_ornot_(EVE_SUPPORTS(neon128_),
+                                                      wide<T, N, arm_128_> const &v0,
+                                                      wide<T, N, arm_128_> const &v1) noexcept
   {
-    using in_t = typename wide<T, N, neon128_>::storage_type;
+    using in_t = typename wide<T, N, arm_128_>::storage_type;
 
 // Dispatch to sub-functions
          if constexpr(std::is_same_v<in_t, float32x4_t>)

--- a/include/eve/module/core/function/simd/arm/neon/bit_select.hpp
+++ b/include/eve/module/core/function/simd/arm/neon/bit_select.hpp
@@ -18,12 +18,12 @@
 namespace eve::detail
 {
   template<typename T, typename N>
-  EVE_FORCEINLINE wide<T, N, neon64_> bit_select_(EVE_SUPPORTS(neon128_),
-                                                      wide<T, N, neon64_> const &m,
-                                                      wide<T, N, neon64_> const &v0,
-                                                      wide<T, N, neon64_> const &v1) noexcept
+  EVE_FORCEINLINE wide<T, N, arm_64_> bit_select_(EVE_SUPPORTS(neon128_),
+                                                      wide<T, N, arm_64_> const &m,
+                                                      wide<T, N, arm_64_> const &v0,
+                                                      wide<T, N, arm_64_> const &v1) noexcept
   {
-    using in_t = typename wide<T, N, neon64_>::storage_type;
+    using in_t = typename wide<T, N, arm_64_>::storage_type;
 
 // Dispatch to sub-functions
 #if defined(__aarch64__)
@@ -49,12 +49,12 @@ namespace eve::detail
   }
 
   template<typename T, typename N>
-  EVE_FORCEINLINE wide<T, N, neon128_> bit_select_(EVE_SUPPORTS(neon128_),
-                                                       wide<T, N, neon128_> const &m,
-                                                       wide<T, N, neon128_> const &v0,
-                                                       wide<T, N, neon128_> const &v1) noexcept
+  EVE_FORCEINLINE wide<T, N, arm_128_> bit_select_(EVE_SUPPORTS(neon128_),
+                                                       wide<T, N, arm_128_> const &m,
+                                                       wide<T, N, arm_128_> const &v0,
+                                                       wide<T, N, arm_128_> const &v1) noexcept
   {
-    using in_t = typename wide<T, N, neon128_>::storage_type;
+    using in_t = typename wide<T, N, arm_128_>::storage_type;
 
 // Dispatch to sub-functions
 #if defined(__aarch64__)

--- a/include/eve/module/core/function/simd/arm/neon/ceil.hpp
+++ b/include/eve/module/core/function/simd/arm/neon/ceil.hpp
@@ -19,8 +19,8 @@
 namespace eve::detail
 {
   template<floating_real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, neon64_> ceil_(EVE_SUPPORTS(neon128_),
-                                            wide<T, N, neon64_> const &v0) noexcept
+  EVE_FORCEINLINE wide<T, N, arm_64_> ceil_(EVE_SUPPORTS(neon128_),
+                                            wide<T, N, arm_64_> const &v0) noexcept
   {
 #if __ARM_ARCH >= 8
     if constexpr(std::is_same_v<T, double>)
@@ -36,8 +36,8 @@ namespace eve::detail
   }
 
   template<floating_real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, neon128_> ceil_(EVE_SUPPORTS(neon128_),
-                                             wide<T, N, neon128_> const &v0) noexcept
+  EVE_FORCEINLINE wide<T, N, arm_128_> ceil_(EVE_SUPPORTS(neon128_),
+                                             wide<T, N, arm_128_> const &v0) noexcept
   {
 #if __ARM_ARCH >= 8
     if constexpr(std::is_same_v<T, double>)

--- a/include/eve/module/core/function/simd/arm/neon/convert.hpp
+++ b/include/eve/module/core/function/simd/arm/neon/convert.hpp
@@ -20,9 +20,9 @@ namespace eve::detail
 {
   template<real_scalar_value T, typename N, real_scalar_value U>
   EVE_FORCEINLINE wide<U, N>
-                  convert_(EVE_SUPPORTS(neon128_), wide<T, N, neon64_> const &v0, as_<U> const &tgt) noexcept
+                  convert_(EVE_SUPPORTS(neon128_), wide<T, N, arm_64_> const &v0, as_<U> const &tgt) noexcept
   {
-    using in_t  = typename wide<T, N, neon64_>::storage_type;
+    using in_t  = typename wide<T, N, arm_64_>::storage_type;
     using tgt_t = typename wide<U, N>::storage_type;
 
     // Idempotent call
@@ -179,9 +179,9 @@ namespace eve::detail
 
   template<real_scalar_value T, typename N, real_scalar_value U>
   EVE_FORCEINLINE wide<U, N>
-                  convert_(EVE_SUPPORTS(neon128_), wide<T, N, neon128_> const &v0, as_<U> const &tgt) noexcept
+                  convert_(EVE_SUPPORTS(neon128_), wide<T, N, arm_128_> const &v0, as_<U> const &tgt) noexcept
   {
-    using in_t  = typename wide<T, N, neon128_>::storage_type;
+    using in_t  = typename wide<T, N, arm_128_>::storage_type;
     using tgt_t = typename wide<U, N>::storage_type;
 
     // Idempotent call

--- a/include/eve/module/core/function/simd/arm/neon/detail/shift.hpp
+++ b/include/eve/module/core/function/simd/arm/neon/detail/shift.hpp
@@ -19,10 +19,10 @@
 namespace eve::detail
 {
   template<typename T, typename N, typename I>
-  EVE_FORCEINLINE auto neon_shifter(wide<T, N, neon64_> const &v0,
-                                    wide<I, N, neon64_> const &v1) noexcept
+  EVE_FORCEINLINE auto neon_shifter(wide<T, N, arm_64_> const &v0,
+                                    wide<I, N, arm_64_> const &v1) noexcept
   {
-    using t_t                      = wide<T, N, neon64_>;
+    using t_t                      = wide<T, N, arm_64_>;
     constexpr bool is_signed_int   = std::is_integral_v<T> && std::is_signed_v<T>;
     constexpr bool is_unsigned_int = std::is_integral_v<T> && std::is_unsigned_v<T>;
 
@@ -40,10 +40,10 @@ namespace eve::detail
   }
 
   template<typename T, typename N, typename I>
-  EVE_FORCEINLINE auto neon_shifter(wide<T, N, neon128_> const &v0,
-                                    wide<I, N, neon128_> const &v1) noexcept
+  EVE_FORCEINLINE auto neon_shifter(wide<T, N, arm_128_> const &v0,
+                                    wide<I, N, arm_128_> const &v1) noexcept
   {
-    using t_t                      = wide<T, N, neon128_>;
+    using t_t                      = wide<T, N, arm_128_>;
     constexpr bool is_signed_int   = std::is_integral_v<T> && std::is_signed_v<T>;
     constexpr bool is_unsigned_int = std::is_integral_v<T> && std::is_unsigned_v<T>;
 

--- a/include/eve/module/core/function/simd/arm/neon/div.hpp
+++ b/include/eve/module/core/function/simd/arm/neon/div.hpp
@@ -16,15 +16,15 @@
 namespace eve::detail
 {
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, neon64_>
-                  div_(EVE_SUPPORTS(neon128_), wide<T, N, neon64_> v0, wide<T, N, neon64_> const &v1) noexcept
+  EVE_FORCEINLINE wide<T, N, arm_64_>
+                  div_(EVE_SUPPORTS(neon128_), wide<T, N, arm_64_> v0, wide<T, N, arm_64_> const &v1) noexcept
   {
     return v0 /= v1;
   }
 
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, neon128_>
-                  div_(EVE_SUPPORTS(neon128_), wide<T, N, neon128_> v0, wide<T, N, neon128_> const &v1) noexcept
+  EVE_FORCEINLINE wide<T, N, arm_128_>
+                  div_(EVE_SUPPORTS(neon128_), wide<T, N, arm_128_> v0, wide<T, N, arm_128_> const &v1) noexcept
   {
     return v0 /= v1;
   }

--- a/include/eve/module/core/function/simd/arm/neon/extract.hpp
+++ b/include/eve/module/core/function/simd/arm/neon/extract.hpp
@@ -19,7 +19,7 @@ namespace eve::detail
 {
   template<typename T, typename N, typename I, auto V>
   EVE_FORCEINLINE logical<T> extract_(EVE_SUPPORTS(neon128_),
-                                      logical<wide<T, N, neon64_>> const &v0,
+                                      logical<wide<T, N, arm_64_>> const &v0,
                                       std::integral_constant<I, V> const &u) noexcept
   {
     return logical<T>(extract(v0.bits(), u));
@@ -27,7 +27,7 @@ namespace eve::detail
 
   template<typename T, typename N, typename I, auto V>
   EVE_FORCEINLINE T extract_(EVE_SUPPORTS(neon128_),
-                             wide<T, N, neon64_> const &v0,
+                             wide<T, N, arm_64_> const &v0,
                              std::integral_constant<I, V> const &) noexcept
   {
     constexpr bool is_signed_int   = std::is_integral_v<T> && std::is_signed_v<T>;
@@ -47,7 +47,7 @@ namespace eve::detail
 
   template<typename T, typename N, typename I, auto V>
   EVE_FORCEINLINE logical<T> extract_(EVE_SUPPORTS(neon128_),
-                                      logical<wide<T, N, neon128_>> const &v0,
+                                      logical<wide<T, N, arm_128_>> const &v0,
                                       std::integral_constant<I, V> const & u) noexcept
   {
     return logical<T>(extract(v0.bits(), u));
@@ -55,7 +55,7 @@ namespace eve::detail
 
   template<typename T, typename N, typename I, auto V>
   EVE_FORCEINLINE T extract_(EVE_SUPPORTS(neon128_),
-                             wide<T, N, neon128_> const &v0,
+                             wide<T, N, arm_128_> const &v0,
                              std::integral_constant<I, V> const &) noexcept
   {
     constexpr bool is_signed_int   = std::is_integral_v<T> && std::is_signed_v<T>;

--- a/include/eve/module/core/function/simd/arm/neon/floor.hpp
+++ b/include/eve/module/core/function/simd/arm/neon/floor.hpp
@@ -19,8 +19,8 @@
 namespace eve::detail
 {
   template<typename floating_scalar_value, typename N>
-  EVE_FORCEINLINE wide<T, N, neon64_> floor_(EVE_SUPPORTS(neon128_),
-                                             wide<T, N, neon64_> const &v0) noexcept
+  EVE_FORCEINLINE wide<T, N, arm_64_> floor_(EVE_SUPPORTS(neon128_),
+                                             wide<T, N, arm_64_> const &v0) noexcept
   {
 #if __ARM_ARCH >= 8
     if constexpr(std::is_same_v<T, double>)
@@ -36,8 +36,8 @@ namespace eve::detail
   }
 
   template<typename floating_scalar_value, typename N>
-  EVE_FORCEINLINE wide<T, N, neon128_> floor_(EVE_SUPPORTS(neon128_),
-                                              wide<T, N, neon128_> const &v0) noexcept
+  EVE_FORCEINLINE wide<T, N, arm_128_> floor_(EVE_SUPPORTS(neon128_),
+                                              wide<T, N, arm_128_> const &v0) noexcept
   {
 #if __ARM_ARCH >= 8
     if constexpr(std::is_same_v<T, double>)

--- a/include/eve/module/core/function/simd/arm/neon/fma.hpp
+++ b/include/eve/module/core/function/simd/arm/neon/fma.hpp
@@ -18,10 +18,10 @@
 namespace eve::detail
 {
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, neon64_> fma_(EVE_SUPPORTS(neon128_),
-                                           wide<T, N, neon64_> const &v0,
-                                           wide<T, N, neon64_> const &v1,
-                                           wide<T, N, neon64_> const &v2) noexcept
+  EVE_FORCEINLINE wide<T, N, arm_64_> fma_(EVE_SUPPORTS(neon128_),
+                                           wide<T, N, arm_64_> const &v0,
+                                           wide<T, N, arm_64_> const &v1,
+                                           wide<T, N, arm_64_> const &v2) noexcept
   {
     constexpr bool is_signed_int   = std::is_integral_v<T> && std::is_signed_v<T>;
     constexpr bool is_unsigned_int = std::is_integral_v<T> && std::is_unsigned_v<T>;
@@ -52,20 +52,20 @@ namespace eve::detail
   }
 
   template<decorator D, real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, neon64_> fma_(EVE_SUPPORTS(neon128_),
+  EVE_FORCEINLINE wide<T, N, arm_64_> fma_(EVE_SUPPORTS(neon128_),
                                            D const &,
-                                           wide<T, N, neon64_> const &v0,
-                                           wide<T, N, neon64_> const &v1,
-                                           wide<T, N, neon64_> const &v2) noexcept
+                                           wide<T, N, arm_64_> const &v0,
+                                           wide<T, N, arm_64_> const &v1,
+                                           wide<T, N, arm_64_> const &v2) noexcept
   {
     return fma(v0, v1, v2);
   }
 
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, neon128_> fma_(EVE_SUPPORTS(neon128_),
-                                            wide<T, N, neon128_> const &v0,
-                                            wide<T, N, neon128_> const &v1,
-                                            wide<T, N, neon128_> const &v2) noexcept
+  EVE_FORCEINLINE wide<T, N, arm_128_> fma_(EVE_SUPPORTS(neon128_),
+                                            wide<T, N, arm_128_> const &v0,
+                                            wide<T, N, arm_128_> const &v1,
+                                            wide<T, N, arm_128_> const &v2) noexcept
   {
     constexpr bool is_signed_int   = std::is_integral_v<T> && std::is_signed_v<T>;
     constexpr bool is_unsigned_int = std::is_integral_v<T> && std::is_unsigned_v<T>;
@@ -95,11 +95,11 @@ namespace eve::detail
   }
 
   template<decorator D, real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, neon128_> fma_(EVE_SUPPORTS(neon128_),
+  EVE_FORCEINLINE wide<T, N, arm_128_> fma_(EVE_SUPPORTS(neon128_),
                                             D const &,
-                                            wide<T, N, neon128_> const &v0,
-                                            wide<T, N, neon128_> const &v1,
-                                            wide<T, N, neon128_> const &v2) noexcept
+                                            wide<T, N, arm_128_> const &v0,
+                                            wide<T, N, arm_128_> const &v1,
+                                            wide<T, N, arm_128_> const &v2) noexcept
   {
     return fma(v0, v1, v2);
   }

--- a/include/eve/module/core/function/simd/arm/neon/fms.hpp
+++ b/include/eve/module/core/function/simd/arm/neon/fms.hpp
@@ -19,39 +19,39 @@
 namespace eve::detail
 {
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, neon64_> fms_(EVE_SUPPORTS(neon128_),
-                                           wide<T, N, neon64_> const &v0,
-                                           wide<T, N, neon64_> const &v1,
-                                           wide<T, N, neon64_> const &v2) noexcept
+  EVE_FORCEINLINE wide<T, N, arm_64_> fms_(EVE_SUPPORTS(neon128_),
+                                           wide<T, N, arm_64_> const &v0,
+                                           wide<T, N, arm_64_> const &v1,
+                                           wide<T, N, arm_64_> const &v2) noexcept
   {
     return fma(v0, v1, -v2);
   }
 
   template<decorator D, real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, neon64_> fms_(EVE_SUPPORTS(neon128_),
+  EVE_FORCEINLINE wide<T, N, arm_64_> fms_(EVE_SUPPORTS(neon128_),
                                            D const &,
-                                           wide<T, N, neon64_> const &v0,
-                                           wide<T, N, neon64_> const &v1,
-                                           wide<T, N, neon64_> const &v2) noexcept
+                                           wide<T, N, arm_64_> const &v0,
+                                           wide<T, N, arm_64_> const &v1,
+                                           wide<T, N, arm_64_> const &v2) noexcept
   {
     return fma(v0, v1, -v2);
   }
 
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, neon128_> fms_(EVE_SUPPORTS(neon128_),
-                                            wide<T, N, neon128_> const &v0,
-                                            wide<T, N, neon128_> const &v1,
-                                            wide<T, N, neon128_> const &v2) noexcept
+  EVE_FORCEINLINE wide<T, N, arm_128_> fms_(EVE_SUPPORTS(neon128_),
+                                            wide<T, N, arm_128_> const &v0,
+                                            wide<T, N, arm_128_> const &v1,
+                                            wide<T, N, arm_128_> const &v2) noexcept
   {
     return fma(v0, v1, -v2);
   }
 
   template<decorator D, real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, neon128_> fms_(EVE_SUPPORTS(neon128_),
+  EVE_FORCEINLINE wide<T, N, arm_128_> fms_(EVE_SUPPORTS(neon128_),
                                             D const &,
-                                            wide<T, N, neon128_> const &v0,
-                                            wide<T, N, neon128_> const &v1,
-                                            wide<T, N, neon128_> const &v2) noexcept
+                                            wide<T, N, arm_128_> const &v0,
+                                            wide<T, N, arm_128_> const &v1,
+                                            wide<T, N, arm_128_> const &v2) noexcept
   {
     return fma(v0, v1, -v2);
   }

--- a/include/eve/module/core/function/simd/arm/neon/fnma.hpp
+++ b/include/eve/module/core/function/simd/arm/neon/fnma.hpp
@@ -18,10 +18,10 @@
 namespace eve::detail
 {
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, neon64_> fnma_(EVE_SUPPORTS(neon128_),
-                                            wide<T, N, neon64_> const &v0,
-                                            wide<T, N, neon64_> const &v1,
-                                            wide<T, N, neon64_> const &v2) noexcept
+  EVE_FORCEINLINE wide<T, N, arm_64_> fnma_(EVE_SUPPORTS(neon128_),
+                                            wide<T, N, arm_64_> const &v0,
+                                            wide<T, N, arm_64_> const &v1,
+                                            wide<T, N, arm_64_> const &v2) noexcept
   {
     if constexpr( std::is_same_v<T, float> )
       return vfms_f32(v2, v1, v0);
@@ -34,20 +34,20 @@ namespace eve::detail
   }
 
   template<decorator D, real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, neon64_> fnma_(EVE_SUPPORTS(neon128_),
+  EVE_FORCEINLINE wide<T, N, arm_64_> fnma_(EVE_SUPPORTS(neon128_),
                                             D const &,
-                                            wide<T, N, neon64_> const &v0,
-                                            wide<T, N, neon64_> const &v1,
-                                            wide<T, N, neon64_> const &v2) noexcept
+                                            wide<T, N, arm_64_> const &v0,
+                                            wide<T, N, arm_64_> const &v1,
+                                            wide<T, N, arm_64_> const &v2) noexcept
   {
     return fnma(v0, v1, v2);
   }
 
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, neon128_> fnma_(EVE_SUPPORTS(neon128_),
-                                             wide<T, N, neon128_> const &v0,
-                                             wide<T, N, neon128_> const &v1,
-                                             wide<T, N, neon128_> const &v2) noexcept
+  EVE_FORCEINLINE wide<T, N, arm_128_> fnma_(EVE_SUPPORTS(neon128_),
+                                             wide<T, N, arm_128_> const &v0,
+                                             wide<T, N, arm_128_> const &v1,
+                                             wide<T, N, arm_128_> const &v2) noexcept
   {
     if constexpr( std::is_same_v<T, float> )
       return vfmsq_f32(v2, v1, v0);
@@ -60,11 +60,11 @@ namespace eve::detail
   }
 
   template<decorator D, real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, neon128_> fnma_(EVE_SUPPORTS(neon128_),
+  EVE_FORCEINLINE wide<T, N, arm_128_> fnma_(EVE_SUPPORTS(neon128_),
                                              D const &,
-                                             wide<T, N, neon128_> const &v0,
-                                             wide<T, N, neon128_> const &v1,
-                                             wide<T, N, neon128_> const &v2) noexcept
+                                             wide<T, N, arm_128_> const &v0,
+                                             wide<T, N, arm_128_> const &v1,
+                                             wide<T, N, arm_128_> const &v2) noexcept
   {
     return fnma(v0, v1, v2);
   }

--- a/include/eve/module/core/function/simd/arm/neon/fnms.hpp
+++ b/include/eve/module/core/function/simd/arm/neon/fnms.hpp
@@ -18,39 +18,39 @@
 namespace eve::detail
 {
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, neon64_> fnms_(EVE_SUPPORTS(neon128_),
-                                            wide<T, N, neon64_> const &v0,
-                                            wide<T, N, neon64_> const &v1,
-                                            wide<T, N, neon64_> const &v2) noexcept
+  EVE_FORCEINLINE wide<T, N, arm_64_> fnms_(EVE_SUPPORTS(neon128_),
+                                            wide<T, N, arm_64_> const &v0,
+                                            wide<T, N, arm_64_> const &v1,
+                                            wide<T, N, arm_64_> const &v2) noexcept
   {
     return -fma(v0, v1, v2);
   }
 
   template<decorator D, real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, neon64_> fnms_(EVE_SUPPORTS(neon128_),
+  EVE_FORCEINLINE wide<T, N, arm_64_> fnms_(EVE_SUPPORTS(neon128_),
                                             D const &,
-                                            wide<T, N, neon64_> const &v0,
-                                            wide<T, N, neon64_> const &v1,
-                                            wide<T, N, neon64_> const &v2) noexcept
+                                            wide<T, N, arm_64_> const &v0,
+                                            wide<T, N, arm_64_> const &v1,
+                                            wide<T, N, arm_64_> const &v2) noexcept
   {
     return -fma(v0, v1, v2);
   }
 
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, neon128_> fnms_(EVE_SUPPORTS(neon128_),
-                                             wide<T, N, neon128_> const &v0,
-                                             wide<T, N, neon128_> const &v1,
-                                             wide<T, N, neon128_> const &v2) noexcept
+  EVE_FORCEINLINE wide<T, N, arm_128_> fnms_(EVE_SUPPORTS(neon128_),
+                                             wide<T, N, arm_128_> const &v0,
+                                             wide<T, N, arm_128_> const &v1,
+                                             wide<T, N, arm_128_> const &v2) noexcept
   {
     return -fma(v0, v1, v2);
   }
 
   template<decorator D, real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, neon128_> fnms_(EVE_SUPPORTS(neon128_),
+  EVE_FORCEINLINE wide<T, N, arm_128_> fnms_(EVE_SUPPORTS(neon128_),
                                              D const &,
-                                             wide<T, N, neon128_> const &v0,
-                                             wide<T, N, neon128_> const &v1,
-                                             wide<T, N, neon128_> const &v2) noexcept
+                                             wide<T, N, arm_128_> const &v0,
+                                             wide<T, N, arm_128_> const &v1,
+                                             wide<T, N, arm_128_> const &v2) noexcept
   {
     return -fma(v0, v1, v2);
   }

--- a/include/eve/module/core/function/simd/arm/neon/is_equal.hpp
+++ b/include/eve/module/core/function/simd/arm/neon/is_equal.hpp
@@ -19,8 +19,8 @@ namespace eve::detail
 {
   template<typename T, typename N>
   EVE_FORCEINLINE as_logical_t<wide<T, N>> is_equal_(EVE_SUPPORTS(neon128_),
-                                                     wide<T, N, neon64_> const &v0,
-                                                     wide<T, N, neon64_> const &v1) noexcept
+                                                     wide<T, N, arm_64_> const &v0,
+                                                     wide<T, N, arm_64_> const &v1) noexcept
   {
     constexpr bool is_signed_int   = std::is_integral_v<T> && std::is_signed_v<T>;
     constexpr bool is_unsigned_int = std::is_integral_v<T> && std::is_unsigned_v<T>;
@@ -45,8 +45,8 @@ namespace eve::detail
 
   template<typename T, typename N>
   EVE_FORCEINLINE as_logical_t<wide<T, N>> is_equal_(EVE_SUPPORTS(neon128_),
-                                                     wide<T, N, neon128_> const &v0,
-                                                     wide<T, N, neon128_> const &v1) noexcept
+                                                     wide<T, N, arm_128_> const &v0,
+                                                     wide<T, N, arm_128_> const &v1) noexcept
   {
     constexpr bool is_signed_int   = std::is_integral_v<T> && std::is_signed_v<T>;
     constexpr bool is_unsigned_int = std::is_integral_v<T> && std::is_unsigned_v<T>;

--- a/include/eve/module/core/function/simd/arm/neon/is_greater.hpp
+++ b/include/eve/module/core/function/simd/arm/neon/is_greater.hpp
@@ -20,8 +20,8 @@ namespace eve::detail
 {
   template<real_scalar_value T, typename N>
   EVE_FORCEINLINE as_logical_t<wide<T, N>> is_greater_(EVE_SUPPORTS(neon128_),
-                                                       wide<T, N, neon64_> const &v0,
-                                                       wide<T, N, neon64_> const &v1) noexcept
+                                                       wide<T, N, arm_64_> const &v0,
+                                                       wide<T, N, arm_64_> const &v1) noexcept
   {
     constexpr bool is_signed_int   = std::is_integral_v<T> && std::is_signed_v<T>;
     constexpr bool is_unsigned_int = std::is_integral_v<T> && std::is_unsigned_v<T>;
@@ -46,8 +46,8 @@ namespace eve::detail
 
   template<real_scalar_value T, typename N>
   EVE_FORCEINLINE as_logical_t<wide<T, N>> is_greater_(EVE_SUPPORTS(neon128_),
-                                                       wide<T, N, neon128_> const &v0,
-                                                       wide<T, N, neon128_> const &v1) noexcept
+                                                       wide<T, N, arm_128_> const &v0,
+                                                       wide<T, N, arm_128_> const &v1) noexcept
   {
     constexpr bool is_signed_int   = std::is_integral_v<T> && std::is_signed_v<T>;
     constexpr bool is_unsigned_int = std::is_integral_v<T> && std::is_unsigned_v<T>;

--- a/include/eve/module/core/function/simd/arm/neon/is_greater_equal.hpp
+++ b/include/eve/module/core/function/simd/arm/neon/is_greater_equal.hpp
@@ -20,8 +20,8 @@ namespace eve::detail
 {
   template<real_scalar_value T, typename N>
   EVE_FORCEINLINE as_logical_t<wide<T, N>> is_greater_equal_(EVE_SUPPORTS(neon128_),
-                                                             wide<T, N, neon64_> const &v0,
-                                                             wide<T, N, neon64_> const &v1) noexcept
+                                                             wide<T, N, arm_64_> const &v0,
+                                                             wide<T, N, arm_64_> const &v1) noexcept
   {
     constexpr bool is_signed_int   = std::is_integral_v<T> && std::is_signed_v<T>;
     constexpr bool is_unsigned_int = std::is_integral_v<T> && std::is_unsigned_v<T>;
@@ -47,8 +47,8 @@ namespace eve::detail
   template<real_scalar_value T, typename N>
   EVE_FORCEINLINE as_logical_t<wide<T, N>>
                   is_greater_equal_(EVE_SUPPORTS(neon128_),
-                                    wide<T, N, neon128_> const &v0,
-                                    wide<T, N, neon128_> const &v1) noexcept
+                                    wide<T, N, arm_128_> const &v0,
+                                    wide<T, N, arm_128_> const &v1) noexcept
   {
     constexpr bool is_signed_int   = std::is_integral_v<T> && std::is_signed_v<T>;
     constexpr bool is_unsigned_int = std::is_integral_v<T> && std::is_unsigned_v<T>;

--- a/include/eve/module/core/function/simd/arm/neon/is_less.hpp
+++ b/include/eve/module/core/function/simd/arm/neon/is_less.hpp
@@ -20,8 +20,8 @@ namespace eve::detail
 {
   template<real_scalar_value T, typename N>
   EVE_FORCEINLINE as_logical_t<wide<T, N>> is_less_(EVE_SUPPORTS(neon128_),
-                                                    wide<T, N, neon64_> const &v0,
-                                                    wide<T, N, neon64_> const &v1) noexcept
+                                                    wide<T, N, arm_64_> const &v0,
+                                                    wide<T, N, arm_64_> const &v1) noexcept
   {
     constexpr bool is_signed_int   = std::is_integral_v<T> && std::is_signed_v<T>;
     constexpr bool is_unsigned_int = std::is_integral_v<T> && std::is_unsigned_v<T>;
@@ -46,8 +46,8 @@ namespace eve::detail
 
   template<real_scalar_value T, typename N>
   EVE_FORCEINLINE as_logical_t<wide<T, N>> is_less_(EVE_SUPPORTS(neon128_),
-                                                    wide<T, N, neon128_> const &v0,
-                                                    wide<T, N, neon128_> const &v1) noexcept
+                                                    wide<T, N, arm_128_> const &v0,
+                                                    wide<T, N, arm_128_> const &v1) noexcept
   {
     constexpr bool is_signed_int   = std::is_integral_v<T> && std::is_signed_v<T>;
     constexpr bool is_unsigned_int = std::is_integral_v<T> && std::is_unsigned_v<T>;

--- a/include/eve/module/core/function/simd/arm/neon/is_less_equal.hpp
+++ b/include/eve/module/core/function/simd/arm/neon/is_less_equal.hpp
@@ -19,8 +19,8 @@ namespace eve::detail
 {
   template<real_scalar_value T, typename N>
   EVE_FORCEINLINE as_logical_t<wide<T, N>> is_less_equal_(EVE_SUPPORTS(neon128_),
-                                                          wide<T, N, neon64_> const &v0,
-                                                          wide<T, N, neon64_> const &v1) noexcept
+                                                          wide<T, N, arm_64_> const &v0,
+                                                          wide<T, N, arm_64_> const &v1) noexcept
   {
     constexpr bool is_signed_int   = std::is_integral_v<T> && std::is_signed_v<T>;
     constexpr bool is_unsigned_int = std::is_integral_v<T> && std::is_unsigned_v<T>;
@@ -45,8 +45,8 @@ namespace eve::detail
 
   template<real_scalar_value T, typename N>
   EVE_FORCEINLINE as_logical_t<wide<T, N>> is_less_equal_(EVE_SUPPORTS(neon128_),
-                                                          wide<T, N, neon128_> const &v0,
-                                                          wide<T, N, neon128_> const &v1) noexcept
+                                                          wide<T, N, arm_128_> const &v0,
+                                                          wide<T, N, arm_128_> const &v1) noexcept
   {
     constexpr bool is_signed_int   = std::is_integral_v<T> && std::is_signed_v<T>;
     constexpr bool is_unsigned_int = std::is_integral_v<T> && std::is_unsigned_v<T>;

--- a/include/eve/module/core/function/simd/arm/neon/max.hpp
+++ b/include/eve/module/core/function/simd/arm/neon/max.hpp
@@ -22,9 +22,9 @@
 namespace eve::detail
 {
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, neon64_> max_(EVE_SUPPORTS(neon128_),
-                                           wide<T, N, neon64_> const &v0,
-                                           wide<T, N, neon64_> const &v1) noexcept
+  EVE_FORCEINLINE wide<T, N, arm_64_> max_(EVE_SUPPORTS(neon128_),
+                                           wide<T, N, arm_64_> const &v0,
+                                           wide<T, N, arm_64_> const &v1) noexcept
   {
     constexpr bool is_signed_int   = std::is_integral_v<T> && std::is_signed_v<T>;
     constexpr bool is_unsigned_int = std::is_integral_v<T> && std::is_unsigned_v<T>;
@@ -44,9 +44,9 @@ namespace eve::detail
   }
 
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, neon128_> max_(EVE_SUPPORTS(neon128_),
-                                            wide<T, N, neon128_> const &v0,
-                                            wide<T, N, neon128_> const &v1) noexcept
+  EVE_FORCEINLINE wide<T, N, arm_128_> max_(EVE_SUPPORTS(neon128_),
+                                            wide<T, N, arm_128_> const &v0,
+                                            wide<T, N, arm_128_> const &v1) noexcept
   {
     constexpr bool is_signed_int   = std::is_integral_v<T> && std::is_signed_v<T>;
     constexpr bool is_unsigned_int = std::is_integral_v<T> && std::is_unsigned_v<T>;
@@ -66,25 +66,25 @@ namespace eve::detail
   }
 
   template<typename T, typename N>
-  EVE_FORCEINLINE wide<T, N, neon64_> max_(EVE_SUPPORTS(neon128_),
+  EVE_FORCEINLINE wide<T, N, arm_64_> max_(EVE_SUPPORTS(neon128_),
                                            pedantic_type const &,
-                                           wide<T, N, neon64_> const &a0,
-                                           wide<T, N, neon64_> const &a1) noexcept
+                                           wide<T, N, arm_64_> const &a0,
+                                           wide<T, N, arm_64_> const &a1) noexcept
   {
     auto tmp = eve::max(a0, a1);
     if constexpr(eve::platform::supports_invalids) tmp = if_else(is_nan(a1), a0, tmp);
-    return if_else(is_eqz(a0) && is_eqz(a1), bit_and(a0, a1), tmp); 
+    return if_else(is_eqz(a0) && is_eqz(a1), bit_and(a0, a1), tmp);
   }
 
   template<typename T, typename N>
-  EVE_FORCEINLINE wide<T, N, neon128_> max_(EVE_SUPPORTS(neon128_),
+  EVE_FORCEINLINE wide<T, N, arm_128_> max_(EVE_SUPPORTS(neon128_),
                                             pedantic_type const &,
-                                            wide<T, N, neon128_> const &a0,
-                                            wide<T, N, neon128_> const &a1) noexcept
+                                            wide<T, N, arm_128_> const &a0,
+                                            wide<T, N, arm_128_> const &a1) noexcept
   {
     auto tmp = eve::max(a0, a1);
     if constexpr(eve::platform::supports_invalids) tmp = if_else(is_nan(a1), a0, tmp);
-    return if_else(is_eqz(a0) && is_eqz(a1), bit_and(a0, a1), tmp); 
+    return if_else(is_eqz(a0) && is_eqz(a1), bit_and(a0, a1), tmp);
   }
 
 }

--- a/include/eve/module/core/function/simd/arm/neon/min.hpp
+++ b/include/eve/module/core/function/simd/arm/neon/min.hpp
@@ -23,9 +23,9 @@
 namespace eve::detail
 {
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, neon64_> min_(EVE_SUPPORTS(neon128_),
-                                           wide<T, N, neon64_> const &v0,
-                                           wide<T, N, neon64_> const &v1) noexcept
+  EVE_FORCEINLINE wide<T, N, arm_64_> min_(EVE_SUPPORTS(neon128_),
+                                           wide<T, N, arm_64_> const &v0,
+                                           wide<T, N, arm_64_> const &v1) noexcept
   {
     constexpr bool is_signed_int   = std::is_integral_v<T> && std::is_signed_v<T>;
     constexpr bool is_unsigned_int = std::is_integral_v<T> && std::is_unsigned_v<T>;
@@ -45,9 +45,9 @@ namespace eve::detail
   }
 
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, neon128_> min_(EVE_SUPPORTS(neon128_),
-                                            wide<T, N, neon128_> const &v0,
-                                            wide<T, N, neon128_> const &v1) noexcept
+  EVE_FORCEINLINE wide<T, N, arm_128_> min_(EVE_SUPPORTS(neon128_),
+                                            wide<T, N, arm_128_> const &v0,
+                                            wide<T, N, arm_128_> const &v1) noexcept
   {
     constexpr bool is_signed_int   = std::is_integral_v<T> && std::is_signed_v<T>;
     constexpr bool is_unsigned_int = std::is_integral_v<T> && std::is_unsigned_v<T>;
@@ -67,10 +67,10 @@ namespace eve::detail
   }
 
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, neon64_> max_(EVE_SUPPORTS(neon128_),
+  EVE_FORCEINLINE wide<T, N, arm_64_> max_(EVE_SUPPORTS(neon128_),
                                            pedantic_type const &,
-                                           wide<T, N, neon64_> const &a0,
-                                           wide<T, N, neon64_> const &a1) noexcept
+                                           wide<T, N, arm_64_> const &a0,
+                                           wide<T, N, arm_64_> const &a1) noexcept
   {
     auto tmp = eve::min(a0, a1);
     if constexpr(eve::platform::supports_invalids) tmp = if_else(is_nan(a1), a0, tmp);
@@ -78,10 +78,10 @@ namespace eve::detail
   }
 
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, neon128_> max_(EVE_SUPPORTS(neon128_),
+  EVE_FORCEINLINE wide<T, N, arm_128_> max_(EVE_SUPPORTS(neon128_),
                                             pedantic_type const &,
-                                            wide<T, N, neon128_> const &a0,
-                                            wide<T, N, neon128_> const &a1) noexcept
+                                            wide<T, N, arm_128_> const &a0,
+                                            wide<T, N, arm_128_> const &a1) noexcept
   {
     auto tmp = eve::min(a0, a1);
     if constexpr(eve::platform::supports_invalids) tmp = if_else(is_nan(a1), a0, tmp);

--- a/include/eve/module/core/function/simd/arm/neon/minus.hpp
+++ b/include/eve/module/core/function/simd/arm/neon/minus.hpp
@@ -19,8 +19,8 @@
 namespace eve::detail
 {
   template<typename T, typename N>
-  EVE_FORCEINLINE wide<T, N, neon64_> minus_(EVE_SUPPORTS(neon128_),
-                                                   wide<T, N, neon64_> const &v0) noexcept
+  EVE_FORCEINLINE wide<T, N, arm_64_> minus_(EVE_SUPPORTS(neon128_),
+                                                   wide<T, N, arm_64_> const &v0) noexcept
   {
     constexpr bool is_signed_int   = std::is_integral_v<T> && std::is_signed_v<T>;
     constexpr bool is_unsigned_int = std::is_integral_v<T> && std::is_unsigned_v<T>;
@@ -44,8 +44,8 @@ namespace eve::detail
   }
 
   template<typename T, typename N>
-  EVE_FORCEINLINE wide<T, N, neon128_> minus_(EVE_SUPPORTS(neon128_),
-                                                    wide<T, N, neon128_> const &v0) noexcept
+  EVE_FORCEINLINE wide<T, N, arm_128_> minus_(EVE_SUPPORTS(neon128_),
+                                                    wide<T, N, arm_128_> const &v0) noexcept
   {
     constexpr bool is_signed_int   = std::is_integral_v<T> && std::is_signed_v<T>;
     constexpr bool is_unsigned_int = std::is_integral_v<T> && std::is_unsigned_v<T>;

--- a/include/eve/module/core/function/simd/arm/neon/mul.hpp
+++ b/include/eve/module/core/function/simd/arm/neon/mul.hpp
@@ -16,39 +16,39 @@
 namespace eve::detail
 {
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, neon64_>
-                  mul_(EVE_SUPPORTS(neon128_), wide<T, N, neon64_> v0, wide<T, N, neon64_> const &v1) noexcept
+  EVE_FORCEINLINE wide<T, N, arm_64_>
+                  mul_(EVE_SUPPORTS(neon128_), wide<T, N, arm_64_> v0, wide<T, N, arm_64_> const &v1) noexcept
   {
     return v0 *= v1;
   }
 
   template<real_scalar_value T, typename N, real_scalar_value U>
-  EVE_FORCEINLINE auto mul_(EVE_SUPPORTS(neon128_), U const &v0, wide<T, N, neon64_> v1)
+  EVE_FORCEINLINE auto mul_(EVE_SUPPORTS(neon128_), U const &v0, wide<T, N, arm_64_> v1)
   {
     return v1 *= v0;
   }
 
   template<real_scalar_value T, typename N, real_scalar_value U>
-  EVE_FORCEINLINE auto mul_(EVE_SUPPORTS(neon128_), wide<T, N, neon64_> v0, U const &v1) noexcept
+  EVE_FORCEINLINE auto mul_(EVE_SUPPORTS(neon128_), wide<T, N, arm_64_> v0, U const &v1) noexcept
   {
     return v0 *= v1;
   }
 
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, neon128_>
-                  mul_(EVE_SUPPORTS(neon128_), wide<T, N, neon128_> v0, wide<T, N, neon128_> const &v1) noexcept
+  EVE_FORCEINLINE wide<T, N, arm_128_>
+                  mul_(EVE_SUPPORTS(neon128_), wide<T, N, arm_128_> v0, wide<T, N, arm_128_> const &v1) noexcept
   {
     return v0 *= v1;
   }
 
   template<real_scalar_value T, typename N, real_scalar_value U>
-  EVE_FORCEINLINE auto mul_(EVE_SUPPORTS(neon128_), U const &v0, wide<T, N, neon128_> v1)
+  EVE_FORCEINLINE auto mul_(EVE_SUPPORTS(neon128_), U const &v0, wide<T, N, arm_128_> v1)
   {
     return v1 *= v0;
   }
 
   template<real_scalar_value T, typename N, real_scalar_value U>
-  EVE_FORCEINLINE auto mul_(EVE_SUPPORTS(neon128_), wide<T, N, neon128_> v0, U const &v1) noexcept
+  EVE_FORCEINLINE auto mul_(EVE_SUPPORTS(neon128_), wide<T, N, arm_128_> v0, U const &v1) noexcept
   {
     return v0 *= v1;
   }

--- a/include/eve/module/core/function/simd/arm/neon/nearest.hpp
+++ b/include/eve/module/core/function/simd/arm/neon/nearest.hpp
@@ -16,8 +16,8 @@
 namespace eve::detail
 {
   template<floating_real_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, neon64_> nearest_(EVE_SUPPORTS(neon128_),
-                                               wide<T, N, neon64_> const &v0) noexcept
+  EVE_FORCEINLINE wide<T, N, arm_64_> nearest_(EVE_SUPPORTS(neon128_),
+                                               wide<T, N, arm_64_> const &v0) noexcept
   {
 #if __ARM_ARCH >= 8
     if constexpr(std::is_same_v<T, double>)
@@ -33,8 +33,8 @@ namespace eve::detail
   }
 
   template<floating_real_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, neon128_> nearest_(EVE_SUPPORTS(neon128_),
-                                                wide<T, N, neon128_> const &v0) noexcept
+  EVE_FORCEINLINE wide<T, N, arm_128_> nearest_(EVE_SUPPORTS(neon128_),
+                                                wide<T, N, arm_128_> const &v0) noexcept
   {
 #if __ARM_ARCH >= 8
     if constexpr(std::is_same_v<T, double>)

--- a/include/eve/module/core/function/simd/arm/neon/rec.hpp
+++ b/include/eve/module/core/function/simd/arm/neon/rec.hpp
@@ -19,8 +19,8 @@
 namespace eve::detail
 {
   template<floating_real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, neon64_>
-                  rec_(EVE_SUPPORTS(neon128_), raw_type const &, wide<T, N, neon64_> const &v0) noexcept
+  EVE_FORCEINLINE wide<T, N, arm_64_>
+                  rec_(EVE_SUPPORTS(neon128_), raw_type const &, wide<T, N, arm_64_> const &v0) noexcept
   {
 #if defined(__aarch64__)
     if constexpr(std::is_same_v<T, double>) { return vrecpe_f64(v0); }
@@ -30,8 +30,8 @@ namespace eve::detail
   }
 
   template<floating_real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, neon128_>
-                  rec_(EVE_SUPPORTS(neon128_), raw_type const &, wide<T, N, neon128_> const &v0) noexcept
+  EVE_FORCEINLINE wide<T, N, arm_128_>
+                  rec_(EVE_SUPPORTS(neon128_), raw_type const &, wide<T, N, arm_128_> const &v0) noexcept
   {
 #if defined(__aarch64__)
     if constexpr(std::is_same_v<T, double>) { return vrecpeq_f64(v0); }
@@ -41,11 +41,11 @@ namespace eve::detail
   }
 
   template<floating_real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, neon64_> rec_(EVE_SUPPORTS(neon128_),
-                                           wide<T, N, neon64_> const &v0) noexcept
+  EVE_FORCEINLINE wide<T, N, arm_64_> rec_(EVE_SUPPORTS(neon128_),
+                                           wide<T, N, arm_64_> const &v0) noexcept
   {
 #if defined(__aarch64__)
-    if constexpr(std::is_same_v<T, double>) { return wide<T, N, neon64_>{T{1} / v0[ 0 ]}; }
+    if constexpr(std::is_same_v<T, double>) { return wide<T, N, arm_64_>{T{1} / v0[ 0 ]}; }
 #endif
 
     if constexpr(std::is_same_v<T, float>)
@@ -57,8 +57,8 @@ namespace eve::detail
   }
 
   template<floating_real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, neon128_> rec_(EVE_SUPPORTS(neon128_),
-                                            wide<T, N, neon128_> const &v0) noexcept
+  EVE_FORCEINLINE wide<T, N, arm_128_> rec_(EVE_SUPPORTS(neon128_),
+                                            wide<T, N, arm_128_> const &v0) noexcept
   {
       // estimate 1/x with an extra NR step for full precision
       auto a = refine_rec(v0, raw(rec)(v0));
@@ -66,15 +66,15 @@ namespace eve::detail
   }
 
   template<floating_real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, neon64_>
-                  rec_(EVE_SUPPORTS(neon128_), pedantic_type const &, wide<T, N, neon64_> const &v0) noexcept
+  EVE_FORCEINLINE wide<T, N, arm_64_>
+                  rec_(EVE_SUPPORTS(neon128_), pedantic_type const &, wide<T, N, arm_64_> const &v0) noexcept
   {
     return rec(v0);
   }
 
   template<floating_real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, neon128_>
-                  rec_(EVE_SUPPORTS(neon128_), pedantic_type const &, wide<T, N, neon128_> const &v0) noexcept
+  EVE_FORCEINLINE wide<T, N, arm_128_>
+                  rec_(EVE_SUPPORTS(neon128_), pedantic_type const &, wide<T, N, arm_128_> const &v0) noexcept
   {
     return rec(v0);
   }

--- a/include/eve/module/core/function/simd/arm/neon/refine_rec.hpp
+++ b/include/eve/module/core/function/simd/arm/neon/refine_rec.hpp
@@ -18,36 +18,36 @@
 namespace eve::detail
 {
   template<typename N>
-  EVE_FORCEINLINE wide<float, N, neon64_> refine_rec_(EVE_SUPPORTS(neon128_),
-                                                      wide<float, N, neon64_> const &a0,
-                                                      wide<float, N, neon64_> const &a1) noexcept
+  EVE_FORCEINLINE wide<float, N, arm_64_> refine_rec_(EVE_SUPPORTS(neon128_),
+                                                      wide<float, N, arm_64_> const &a0,
+                                                      wide<float, N, arm_64_> const &a1) noexcept
   {
     return vmul_f32(vrecps_f32(a0, a1), a1);
   }
 
   template<typename N>
-  EVE_FORCEINLINE wide<float, N, neon128_> refine_rec_(EVE_SUPPORTS(neon128_),
-                                                       wide<float, N, neon128_> const &a0,
-                                                       wide<float, N, neon128_> const &a1) noexcept
+  EVE_FORCEINLINE wide<float, N, arm_128_> refine_rec_(EVE_SUPPORTS(neon128_),
+                                                       wide<float, N, arm_128_> const &a0,
+                                                       wide<float, N, arm_128_> const &a1) noexcept
   {
     return vmulq_f32(vrecpsq_f32(a0, a1), a1);
   }
 
 #if defined(__aarch64__)
   template<typename N>
-  EVE_FORCEINLINE wide<double, N, neon64_> refine_rec_(EVE_SUPPORTS(neon128_),
-                                                       wide<double, N, neon64_> const &a0,
-                                                       wide<double, N, neon64_> const &a1) noexcept
+  EVE_FORCEINLINE wide<double, N, arm_64_> refine_rec_(EVE_SUPPORTS(neon128_),
+                                                       wide<double, N, arm_64_> const &a0,
+                                                       wide<double, N, arm_64_> const &a1) noexcept
   {
     auto x = vmul_f64(vrecps_f64(a0, a1), a1);
     return vmul_f64(vrecps_f64(a0, x), x);
   }
 
   template<typename N>
-  EVE_FORCEINLINE wide<double, N, neon128_>
+  EVE_FORCEINLINE wide<double, N, arm_128_>
                   refine_rec_(EVE_SUPPORTS(neon128_),
-                              wide<double, N, neon128_> const &a0,
-                              wide<double, N, neon128_> const &a1) noexcept
+                              wide<double, N, arm_128_> const &a0,
+                              wide<double, N, arm_128_> const &a1) noexcept
   {
     auto x = vmulq_f64(vrecpsq_f64(a0, a1), a1);
     return vmulq_f64(vrecpsq_f64(a0, x), x);

--- a/include/eve/module/core/function/simd/arm/neon/rshl.hpp
+++ b/include/eve/module/core/function/simd/arm/neon/rshl.hpp
@@ -19,16 +19,16 @@
 namespace eve::detail
 {
   template<integral_real_scalar_value T, typename N, integral_real_scalar_value I>
-  EVE_FORCEINLINE wide<T, N, neon64_> rshl_(EVE_SUPPORTS(neon128_),
-                                            wide<T, N, neon64_> const &v0,
-                                            wide<I, N, neon64_> const &v1) noexcept
+  EVE_FORCEINLINE wide<T, N, arm_64_> rshl_(EVE_SUPPORTS(neon128_),
+                                            wide<T, N, arm_64_> const &v0,
+                                            wide<I, N, arm_64_> const &v1) noexcept
   {
     return neon_shifter(v0, v1);
   }
 
   template<integral_real_scalar_value T, typename N, integral_real_scalar_value I>
-  EVE_FORCEINLINE wide<T, N, neon64_>
-                  rshl_(EVE_SUPPORTS(neon128_), wide<T, N, neon64_> const &v0, I v1) noexcept
+  EVE_FORCEINLINE wide<T, N, arm_64_>
+                  rshl_(EVE_SUPPORTS(neon128_), wide<T, N, arm_64_> const &v0, I v1) noexcept
   {
     using i_t = wide<as_integer_t<T, signed>, N>;
     return eve::rshl(v0, i_t(v1));
@@ -36,14 +36,14 @@ namespace eve::detail
 
   template<integral_real_scalar_value T, typename N, integral_real_scalar_value I>
   EVE_FORCEINLINE auto rshl_(EVE_SUPPORTS(neon128_),
-                             wide<T, N, neon128_> const &v0,
-                             wide<I, N, neon128_> const &v1) noexcept
+                             wide<T, N, arm_128_> const &v0,
+                             wide<I, N, arm_128_> const &v1) noexcept
   {
     return neon_shifter(v0, v1);
   }
 
   template<integral_real_scalar_value T, typename N, integral_real_scalar_value I>
-  EVE_FORCEINLINE auto rshl_(EVE_SUPPORTS(neon128_), wide<T, N, neon128_> const &v0, I v1) noexcept
+  EVE_FORCEINLINE auto rshl_(EVE_SUPPORTS(neon128_), wide<T, N, arm_128_> const &v0, I v1) noexcept
   {
     using i_t = wide<as_integer_t<T, signed>, N>;
     return eve::rshl(v0, i_t(v1));

--- a/include/eve/module/core/function/simd/arm/neon/rshr.hpp
+++ b/include/eve/module/core/function/simd/arm/neon/rshr.hpp
@@ -19,32 +19,32 @@
 namespace eve::detail
 {
   template<integral_real_scalar_value T, typename N, integral_real_scalar_value I>
-  EVE_FORCEINLINE wide<T, N, neon64_> rshr_(EVE_SUPPORTS(neon128_),
-                                            wide<T, N, neon64_> const &v0,
-                                            wide<I, N, neon64_> const &v1) noexcept
+  EVE_FORCEINLINE wide<T, N, arm_64_> rshr_(EVE_SUPPORTS(neon128_),
+                                            wide<T, N, arm_64_> const &v0,
+                                            wide<I, N, arm_64_> const &v1) noexcept
   {
     return neon_shifter(v0, -v1);
   }
 
   template<integral_real_scalar_value T, typename N, integral_real_scalar_value I>
-  EVE_FORCEINLINE wide<T, N, neon64_>
-                  rshr_(EVE_SUPPORTS(neon128_), wide<T, N, neon64_> const &v0, I v1) noexcept
+  EVE_FORCEINLINE wide<T, N, arm_64_>
+                  rshr_(EVE_SUPPORTS(neon128_), wide<T, N, arm_64_> const &v0, I v1) noexcept
   {
     using i_t = wide<as_integer_t<T, signed>, N>;
     return eve::rshr(v0, i_t(v1));
   }
 
   template<integral_real_scalar_value T, typename N, integral_real_scalar_value I>
-  EVE_FORCEINLINE wide<T, N, neon128_> rshr_(EVE_SUPPORTS(neon128_),
-                                             wide<T, N, neon128_> const &v0,
-                                             wide<I, N, neon128_> const &v1) noexcept
+  EVE_FORCEINLINE wide<T, N, arm_128_> rshr_(EVE_SUPPORTS(neon128_),
+                                             wide<T, N, arm_128_> const &v0,
+                                             wide<I, N, arm_128_> const &v1) noexcept
   {
     return neon_shifter(v0, -v1);
   }
 
   template<integral_real_scalar_value T, typename N, integral_real_scalar_value I>
-  EVE_FORCEINLINE wide<T, N, neon128_>
-                  rshr_(EVE_SUPPORTS(neon128_), wide<T, N, neon128_> const &v0, I v1) noexcept
+  EVE_FORCEINLINE wide<T, N, arm_128_>
+                  rshr_(EVE_SUPPORTS(neon128_), wide<T, N, arm_128_> const &v0, I v1) noexcept
   {
     using i_t = wide<as_integer_t<T, signed>, N>;
     return eve::rshr(v0, i_t(v1));

--- a/include/eve/module/core/function/simd/arm/neon/rsqrt.hpp
+++ b/include/eve/module/core/function/simd/arm/neon/rsqrt.hpp
@@ -25,10 +25,10 @@ namespace eve::detail
   //------------------------------------------------------------------------------------------------
   // Raw version
   template<floating_real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, neon64_>
-                  rsqrt_(EVE_SUPPORTS(neon128_), raw_type const &, wide<T, N, neon64_> const &v0) noexcept
+  EVE_FORCEINLINE wide<T, N, arm_64_>
+                  rsqrt_(EVE_SUPPORTS(neon128_), raw_type const &, wide<T, N, arm_64_> const &v0) noexcept
   {
-    using that_t = wide<T, N, neon64_>;
+    using that_t = wide<T, N, arm_64_>;
 
     if constexpr(std::is_same_v<T, double> && supports_aarch64) { return that_t(vrsqrte_f64(v0)); }
     else if constexpr(std::is_same_v<T, float>)
@@ -42,10 +42,10 @@ namespace eve::detail
   }
 
   template<floating_real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, neon128_>
-                  rsqrt_(EVE_SUPPORTS(neon128_), raw_type const &, wide<T, N, neon128_> const &v0) noexcept
+  EVE_FORCEINLINE wide<T, N, arm_128_>
+                  rsqrt_(EVE_SUPPORTS(neon128_), raw_type const &, wide<T, N, arm_128_> const &v0) noexcept
   {
-    using that_t = wide<T, N, neon128_>;
+    using that_t = wide<T, N, arm_128_>;
 
     if constexpr(std::is_same_v<T, double> && supports_aarch64) { return that_t(vrsqrteq_f64(v0)); }
     else if constexpr(std::is_same_v<T, float>)
@@ -61,10 +61,10 @@ namespace eve::detail
   //------------------------------------------------------------------------------------------------
   // Basic version
   template<floating_real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, neon64_> rsqrt_(EVE_SUPPORTS(neon128_),
-                                             wide<T, N, neon64_> const &v0) noexcept
+  EVE_FORCEINLINE wide<T, N, arm_64_> rsqrt_(EVE_SUPPORTS(neon128_),
+                                             wide<T, N, arm_64_> const &v0) noexcept
   {
-    using that_t = wide<T, N, neon64_>;
+    using that_t = wide<T, N, arm_64_>;
 
     if constexpr(std::is_same_v<T, double> && supports_aarch64)
     {
@@ -86,10 +86,10 @@ namespace eve::detail
   }
 
   template<floating_real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, neon128_> rsqrt_(EVE_SUPPORTS(neon128_),
-                                             wide<T, N, neon128_> const &v0) noexcept
+  EVE_FORCEINLINE wide<T, N, arm_128_> rsqrt_(EVE_SUPPORTS(neon128_),
+                                             wide<T, N, arm_128_> const &v0) noexcept
   {
-    using that_t = wide<T, N, neon128_>;
+    using that_t = wide<T, N, arm_128_>;
 
     if constexpr(std::is_same_v<T, double> && supports_aarch64)
     {
@@ -114,13 +114,13 @@ namespace eve::detail
   //------------------------------------------------------------------------------------------------
   // Pedantic version
   template<floating_real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, neon64_> rsqrt_(EVE_SUPPORTS(neon128_),
+  EVE_FORCEINLINE wide<T, N, arm_64_> rsqrt_(EVE_SUPPORTS(neon128_),
                                              pedantic_type const &,
-                                             wide<T, N, neon64_> const &v00) noexcept
+                                             wide<T, N, arm_64_> const &v00) noexcept
   {
     if (any(is_denormal(v00)))
     {
-      using that_t = wide<T, N, neon64_>;
+      using that_t = wide<T, N, arm_64_>;
       auto[v0, nn] =  pedantic(eve::ifrexp)(v00);
       auto tst = is_odd(nn);
       nn  = dec[tst](nn);
@@ -133,13 +133,13 @@ namespace eve::detail
 
 
   template<floating_real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, neon128_> rsqrt_(EVE_SUPPORTS(neon128_),
+  EVE_FORCEINLINE wide<T, N, arm_128_> rsqrt_(EVE_SUPPORTS(neon128_),
                                              pedantic_type const &,
-                                             wide<T, N, neon128_> const &v00) noexcept
+                                             wide<T, N, arm_128_> const &v00) noexcept
   {
     if (any(is_denormal(v00)))
     {
-      using that_t = wide<T, N, neon128_>;
+      using that_t = wide<T, N, arm_128_>;
       auto[v0, nn] =  pedantic(eve::ifrexp)(v00);
       auto tst = is_odd(nn);
       nn  = dec[tst](nn);

--- a/include/eve/module/core/function/simd/arm/neon/shl.hpp
+++ b/include/eve/module/core/function/simd/arm/neon/shl.hpp
@@ -18,16 +18,16 @@
 namespace eve::detail
 {
   template<integral_real_scalar_value T, typename N, integral_real_scalar_value I>
-  EVE_FORCEINLINE wide<T, N, neon64_> shl_(EVE_SUPPORTS(neon128_),
-                            wide<T, N, neon64_> const &v0,
-                            wide<I, N, neon64_> const &v1) noexcept
+  EVE_FORCEINLINE wide<T, N, arm_64_> shl_(EVE_SUPPORTS(neon128_),
+                            wide<T, N, arm_64_> const &v0,
+                            wide<I, N, arm_64_> const &v1) noexcept
   {
     return neon_shifter(v0, v1);
   }
 
   template<integral_real_scalar_value T, typename N, integral_real_scalar_value I>
-  EVE_FORCEINLINE wide<T, N, neon64_> shl_(EVE_SUPPORTS(neon128_),
-                            wide<T, N, neon64_> const &v0,
+  EVE_FORCEINLINE wide<T, N, arm_64_> shl_(EVE_SUPPORTS(neon128_),
+                            wide<T, N, arm_64_> const &v0,
                             I v1) noexcept
   {
     using i_t = wide<as_integer_t<T, signed>, N>;
@@ -35,16 +35,16 @@ namespace eve::detail
   }
 
   template<integral_real_scalar_value T, typename N, integral_real_scalar_value I>
-  EVE_FORCEINLINE wide<T, N, neon128_> shl_(EVE_SUPPORTS(neon128_),
-                            wide<T, N, neon128_> const &v0,
-                            wide<I, N, neon128_> const &v1) noexcept
+  EVE_FORCEINLINE wide<T, N, arm_128_> shl_(EVE_SUPPORTS(neon128_),
+                            wide<T, N, arm_128_> const &v0,
+                            wide<I, N, arm_128_> const &v1) noexcept
   {
     return neon_shifter(v0, v1);
   }
 
   template<integral_real_scalar_value T, typename N, integral_real_scalar_value I>
-  EVE_FORCEINLINE wide<T, N, neon128_> shl_(EVE_SUPPORTS(neon128_),
-                            wide<T, N, neon128_> const &v0,
+  EVE_FORCEINLINE wide<T, N, arm_128_> shl_(EVE_SUPPORTS(neon128_),
+                            wide<T, N, arm_128_> const &v0,
                             I v1) noexcept
   {
     using i_t = wide<as_integer_t<T, signed>, N>;

--- a/include/eve/module/core/function/simd/arm/neon/shr.hpp
+++ b/include/eve/module/core/function/simd/arm/neon/shr.hpp
@@ -19,16 +19,16 @@
 namespace eve::detail
 {
   template<integral_real_scalar_value T, typename N, integral_real_scalar_value I>
-  EVE_FORCEINLINE wide<T, N, neon64_> shr_(EVE_SUPPORTS(neon128_),
-                                           wide<T, N, neon64_> const &v0,
-                                           wide<I, N, neon64_> const &v1) noexcept
+  EVE_FORCEINLINE wide<T, N, arm_64_> shr_(EVE_SUPPORTS(neon128_),
+                                           wide<T, N, arm_64_> const &v0,
+                                           wide<I, N, arm_64_> const &v1) noexcept
   {
     return neon_shifter(v0, -v1);
   }
 
   template<integral_real_scalar_value T, typename N, integral_real_scalar_value I>
-  EVE_FORCEINLINE wide<T, N, neon64_> shr_(EVE_SUPPORTS(neon128_),
-                                           wide<T, N, neon64_> const &v0,
+  EVE_FORCEINLINE wide<T, N, arm_64_> shr_(EVE_SUPPORTS(neon128_),
+                                           wide<T, N, arm_64_> const &v0,
                                            I v1) noexcept
   {
     using i_t = wide<as_integer_t<T, signed>, N>;
@@ -36,16 +36,16 @@ namespace eve::detail
   }
 
   template<integral_real_scalar_value T, typename N, integral_real_scalar_value I>
-  EVE_FORCEINLINE wide<T, N, neon128_> shr_(EVE_SUPPORTS(neon128_),
-                                            wide<T, N, neon128_> const &v0,
-                                            wide<I, N, neon128_> const &v1) noexcept
+  EVE_FORCEINLINE wide<T, N, arm_128_> shr_(EVE_SUPPORTS(neon128_),
+                                            wide<T, N, arm_128_> const &v0,
+                                            wide<I, N, arm_128_> const &v1) noexcept
   {
     return neon_shifter(v0, -v1);
   }
 
   template<integral_real_scalar_value T, typename N, integral_real_scalar_value I>
-  EVE_FORCEINLINE wide<T, N, neon128_> shr_(EVE_SUPPORTS(neon128_),
-                                            wide<T, N, neon128_> const &v0,
+  EVE_FORCEINLINE wide<T, N, arm_128_> shr_(EVE_SUPPORTS(neon128_),
+                                            wide<T, N, arm_128_> const &v0,
                                             I v1) noexcept
   {
     using i_t = wide<as_integer_t<T, signed>, N>;

--- a/include/eve/module/core/function/simd/arm/neon/sqrt.hpp
+++ b/include/eve/module/core/function/simd/arm/neon/sqrt.hpp
@@ -21,8 +21,8 @@ namespace eve::detail
   //------------------------------------------------------------------------------------------------
   // Raw version
   template<floating_real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, neon64_>
-                  sqrt_(EVE_SUPPORTS(neon128_), raw_type const &, wide<T, N, neon64_> const &v0) noexcept
+  EVE_FORCEINLINE wide<T, N, arm_64_>
+                  sqrt_(EVE_SUPPORTS(neon128_), raw_type const &, wide<T, N, arm_64_> const &v0) noexcept
   {
     if constexpr(std::is_same_v<T, double> && supports_aarch64) { return vsqrt_f64(v0); }
     else if constexpr(std::is_same_v<T, float>)
@@ -36,8 +36,8 @@ namespace eve::detail
   }
 
   template<floating_real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, neon128_>
-                  sqrt_(EVE_SUPPORTS(neon128_), raw_type const &, wide<T, N, neon128_> const &v0) noexcept
+  EVE_FORCEINLINE wide<T, N, arm_128_>
+                  sqrt_(EVE_SUPPORTS(neon128_), raw_type const &, wide<T, N, arm_128_> const &v0) noexcept
   {
     if constexpr(std::is_same_v<T, double> && supports_aarch64) { return vsqrtq_f64(v0); }
     else if constexpr(std::is_same_v<T, float>)
@@ -53,8 +53,8 @@ namespace eve::detail
   //------------------------------------------------------------------------------------------------
   // Basic version
   template<floating_real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, neon64_> sqrt_(EVE_SUPPORTS(neon128_),
-                                            wide<T, N, neon64_> const &v0) noexcept
+  EVE_FORCEINLINE wide<T, N, arm_64_> sqrt_(EVE_SUPPORTS(neon128_),
+                                            wide<T, N, arm_64_> const &v0) noexcept
   {
     if constexpr(std::is_same_v<T, double> && supports_aarch64) { return vsqrt_f64(v0); }
     else if constexpr(std::is_same_v<T, float>)
@@ -73,8 +73,8 @@ namespace eve::detail
   }
 
   template<floating_real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, neon128_> sqrt_(EVE_SUPPORTS(neon128_),
-                                             wide<T, N, neon128_> const &v0) noexcept
+  EVE_FORCEINLINE wide<T, N, arm_128_> sqrt_(EVE_SUPPORTS(neon128_),
+                                             wide<T, N, arm_128_> const &v0) noexcept
   {
     if constexpr(std::is_same_v<T, double> && supports_aarch64) { return vsqrtq_f64(v0); }
     else if constexpr(std::is_same_v<T, float>)

--- a/include/eve/module/core/function/simd/arm/neon/store.hpp
+++ b/include/eve/module/core/function/simd/arm/neon/store.hpp
@@ -209,7 +209,7 @@ namespace eve::detail
   EVE_FORCEINLINE void
   store_(EVE_SUPPORTS(neon128_), wide<T, S, neon128_> const &value, aligned_ptr<T, N> ptr) noexcept
   {
-    if constexpr( N >= arm_128_::bytes )
+    if constexpr( N >= neon128_::bytes )
     {
       if constexpr( std::is_same_v<T, float> )
       {
@@ -271,14 +271,14 @@ namespace eve::detail
 #else
   template<real_scalar_value T, typename S, std::size_t N>
   EVE_FORCEINLINE void
-  store_(EVE_SUPPORTS(neon128_), wide<T, S, neon64_> const &value, aligned_ptr<T, N> ptr) noexcept
+  store_(EVE_SUPPORTS(neon128_), wide<T, S, arm_64_> const &value, aligned_ptr<T, N> ptr) noexcept
   {
     store(value, ptr.get());
   }
 
   template<real_scalar_value T, typename S, std::size_t N>
   EVE_FORCEINLINE void
-  store_(EVE_SUPPORTS(neon128_), wide<T, S, neon128_> const &value, aligned_ptr<T, N> ptr) noexcept
+  store_(EVE_SUPPORTS(neon128_), wide<T, S, arm_128_> const &value, aligned_ptr<T, N> ptr) noexcept
   {
     store(value, ptr.get());
   }

--- a/include/eve/module/core/function/simd/arm/neon/store.hpp
+++ b/include/eve/module/core/function/simd/arm/neon/store.hpp
@@ -21,9 +21,9 @@ namespace eve::detail
 {
   template<real_scalar_value T, typename N>
   EVE_FORCEINLINE void
-  store_(EVE_SUPPORTS(neon128_), wide<T, N, neon64_> const &value, T *ptr) noexcept
+  store_(EVE_SUPPORTS(neon128_), wide<T, N, arm_64_> const &value, T *ptr) noexcept
   {
-    if constexpr( N::value * sizeof(T) == neon64_::bytes )
+    if constexpr( N::value * sizeof(T) == arm_64_::bytes )
     {
       if constexpr( std::is_same_v<T, float> )
       {
@@ -85,7 +85,7 @@ namespace eve::detail
 
   template<real_scalar_value T, typename N>
   EVE_FORCEINLINE void
-  store_(EVE_SUPPORTS(neon128_), wide<T, N, neon128_> const &value, T *ptr) noexcept
+  store_(EVE_SUPPORTS(neon128_), wide<T, N, arm_128_> const &value, T *ptr) noexcept
   {
     if constexpr( std::is_same_v<T, float> )
     {
@@ -145,7 +145,7 @@ namespace eve::detail
   EVE_FORCEINLINE void
   store_(EVE_SUPPORTS(neon128_), wide<T, S, neon64_> const &value, aligned_ptr<T, N> ptr) noexcept
   {
-    if constexpr( N >= neon64_::bytes )
+    if constexpr( N >= arm_64_::bytes )
     {
       if constexpr( std::is_same_v<T, float> )
       {
@@ -209,7 +209,7 @@ namespace eve::detail
   EVE_FORCEINLINE void
   store_(EVE_SUPPORTS(neon128_), wide<T, S, neon128_> const &value, aligned_ptr<T, N> ptr) noexcept
   {
-    if constexpr( N >= neon128_::bytes )
+    if constexpr( N >= arm_128_::bytes )
     {
       if constexpr( std::is_same_v<T, float> )
       {

--- a/include/eve/module/core/function/simd/arm/neon/sub.hpp
+++ b/include/eve/module/core/function/simd/arm/neon/sub.hpp
@@ -16,15 +16,15 @@
 namespace eve::detail
 {
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, neon64_>
-                  sub_(EVE_SUPPORTS(neon128_), wide<T, N, neon64_> v0, wide<T, N, neon64_> const &v1) noexcept
+  EVE_FORCEINLINE wide<T, N, arm_64_>
+                  sub_(EVE_SUPPORTS(neon128_), wide<T, N, arm_64_> v0, wide<T, N, arm_64_> const &v1) noexcept
   {
     return v0 -= v1;
   }
 
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, neon128_>
-                  sub_(EVE_SUPPORTS(neon128_), wide<T, N, neon128_> v0, wide<T, N, neon128_> const &v1) noexcept
+  EVE_FORCEINLINE wide<T, N, arm_128_>
+                  sub_(EVE_SUPPORTS(neon128_), wide<T, N, arm_128_> v0, wide<T, N, arm_128_> const &v1) noexcept
   {
     return v0 -= v1;
   }

--- a/include/eve/module/core/function/simd/arm/neon/trunc.hpp
+++ b/include/eve/module/core/function/simd/arm/neon/trunc.hpp
@@ -19,8 +19,8 @@
 namespace eve::detail
 {
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, neon64_> trunc_(EVE_SUPPORTS(neon128_),
-                                             wide<T, N, neon64_> const &v0) noexcept
+  EVE_FORCEINLINE wide<T, N, arm_64_> trunc_(EVE_SUPPORTS(neon128_),
+                                             wide<T, N, arm_64_> const &v0) noexcept
   {
     if constexpr(integral_value<T>) return v0;
 #if __ARM_ARCH >= 8
@@ -37,16 +37,16 @@ namespace eve::detail
 }
 
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, neon64_> trunc_(EVE_SUPPORTS(neon128_),
+  EVE_FORCEINLINE wide<T, N, arm_64_> trunc_(EVE_SUPPORTS(neon128_),
                                              raw_type const &,
-                                             wide<T, N, neon64_> const &v0) noexcept
+                                             wide<T, N, arm_64_> const &v0) noexcept
   {
     return trunc(v0);
   }
 
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, neon128_> trunc_(EVE_SUPPORTS(neon128_),
-                                              wide<T, N, neon128_> const &v0) noexcept
+  EVE_FORCEINLINE wide<T, N, arm_128_> trunc_(EVE_SUPPORTS(neon128_),
+                                              wide<T, N, arm_128_> const &v0) noexcept
   {
     if constexpr(integral_value<T>) return v0;
 #if __ARM_ARCH >= 8
@@ -63,9 +63,9 @@ namespace eve::detail
   }
 
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, neon128_> trunc_(EVE_SUPPORTS(neon128_),
+  EVE_FORCEINLINE wide<T, N, arm_128_> trunc_(EVE_SUPPORTS(neon128_),
                                              raw_type const &,
-                                             wide<T, N, neon128_> const &v0) noexcept
+                                             wide<T, N, arm_128_> const &v0) noexcept
   {
     return trunc(v0);
   }

--- a/include/eve/module/core/function/simd/x86/add.hpp
+++ b/include/eve/module/core/function/simd/x86/add.hpp
@@ -30,10 +30,10 @@ namespace eve::detail
   // 128 bits saturated implementation
   //================================================================================================
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, sse_> add_(EVE_SUPPORTS(sse2_),
+  EVE_FORCEINLINE wide<T, N, x86_128_> add_(EVE_SUPPORTS(sse2_),
                                         saturated_type const &  st,
-                                        wide<T, N, sse_> const &v0,
-                                        wide<T, N, sse_> const &v1) noexcept
+                                        wide<T, N, x86_128_> const &v0,
+                                        wide<T, N, x86_128_> const &v1) noexcept
   {
     if constexpr( std::floating_point<T> )
     {
@@ -78,10 +78,10 @@ namespace eve::detail
   // 256 bits saturated implementation
   //================================================================================================
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, avx_> add_(EVE_SUPPORTS(avx2_),
+  EVE_FORCEINLINE wide<T, N, x86_256_> add_(EVE_SUPPORTS(avx2_),
                                         saturated_type const &  st,
-                                        wide<T, N, avx_> const &v0,
-                                        wide<T, N, avx_> const &v1) noexcept
+                                        wide<T, N, x86_256_> const &v0,
+                                        wide<T, N, x86_256_> const &v1) noexcept
   {
     if constexpr( std::floating_point<T> )
     {

--- a/include/eve/module/core/function/simd/x86/average.hpp
+++ b/include/eve/module/core/function/simd/x86/average.hpp
@@ -26,29 +26,29 @@ namespace eve::detail
   // -----------------------------------------------------------------------------------------------
   // 128 bits implementation
   template<unsigned_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, sse_> average_(EVE_SUPPORTS(sse2_)
-                                           , wide<T, N, sse_> const &a
-                                           , wide<T, N, sse_> const &b) noexcept
+  EVE_FORCEINLINE wide<T, N, x86_128_> average_(EVE_SUPPORTS(sse2_)
+                                           , wide<T, N, x86_128_> const &a
+                                           , wide<T, N, x86_128_> const &b) noexcept
   {
          if constexpr(sizeof(T) == 1) return _mm_avg_epu8(a, b);
     else if constexpr(sizeof(T) == 2) return _mm_avg_epu16(a, b);
-    else                              return (a & b) + ((a ^ b) >> 1); 
+    else                              return (a & b) + ((a ^ b) >> 1);
   }
 
   // -----------------------------------------------------------------------------------------------
   // 256 bits implementation
   template<unsigned_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, avx_> average_(EVE_SUPPORTS(avx_)
-                                           , wide<T, N, avx_> const &a
-                                           , wide<T, N, avx_> const &b) noexcept
+  EVE_FORCEINLINE wide<T, N, x86_256_> average_(EVE_SUPPORTS(avx_)
+                                           , wide<T, N, x86_256_> const &a
+                                           , wide<T, N, x86_256_> const &b) noexcept
   {
     if constexpr(current_api >= avx2)
     {
              if constexpr(sizeof(T) == 1) return _mm256_avg_epu8(a, b);
         else if constexpr(sizeof(T) == 2) return _mm256_avg_epu16(a, b);
-        else                              return (a & b) + ((a ^ b) >> 1); 
+        else                              return (a & b) + ((a ^ b) >> 1);
     }
-    else                                   return average_(EVE_RETARGET(cpu_), a, b); 
+    else                                   return average_(EVE_RETARGET(cpu_), a, b);
 
   }
 }

--- a/include/eve/module/core/function/simd/x86/bit_andnot.hpp
+++ b/include/eve/module/core/function/simd/x86/bit_andnot.hpp
@@ -20,9 +20,9 @@ namespace eve ::detail
   // -----------------------------------------------------------------------------------------------
   // 128 bits implementation
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, sse_> bit_andnot_(EVE_SUPPORTS(sse2_),
-                                                   wide<T, N, sse_> const &v0,
-                                                   wide<T, N, sse_> const &v1) noexcept
+  EVE_FORCEINLINE wide<T, N, x86_128_> bit_andnot_(EVE_SUPPORTS(sse2_),
+                                                   wide<T, N, x86_128_> const &v0,
+                                                   wide<T, N, x86_128_> const &v1) noexcept
   {
          if constexpr(std::is_same_v<T, float>)  return _mm_andnot_ps(v1, v0);
     else if constexpr(std::is_same_v<T, double>) return _mm_andnot_pd(v1, v0);
@@ -32,15 +32,15 @@ namespace eve ::detail
   // -----------------------------------------------------------------------------------------------
   // 256 bits implementation
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, avx_> bit_andnot_(EVE_SUPPORTS(avx_),
-                                                   wide<T, N, avx_> const &v0,
-                                                   wide<T, N, avx_> const &v1) noexcept
+  EVE_FORCEINLINE wide<T, N, x86_256_> bit_andnot_(EVE_SUPPORTS(avx_),
+                                                   wide<T, N, x86_256_> const &v0,
+                                                   wide<T, N, x86_256_> const &v1) noexcept
   {
     if constexpr(std::is_same_v<T, float>)       return _mm256_andnot_ps(v1, v0);
     else if constexpr(std::is_same_v<T, double>) return _mm256_andnot_pd(v1, v0);
     else if constexpr(integral_value<T>)
     {
-      if constexpr(current_api >= avx2)          return _mm256_andnot_si256(v1, v0); 
+      if constexpr(current_api >= avx2)          return _mm256_andnot_si256(v1, v0);
       else return _mm256_castps_si256(_mm256_andnot_ps(_mm256_castsi256_ps(v1), _mm256_castsi256_ps(v0)));
     }
   }

--- a/include/eve/module/core/function/simd/x86/bit_notand.hpp
+++ b/include/eve/module/core/function/simd/x86/bit_notand.hpp
@@ -20,9 +20,9 @@ namespace eve ::detail
   // -----------------------------------------------------------------------------------------------
   // 128 bits implementation
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, sse_> bit_notand_(EVE_SUPPORTS(sse2_),
-                                                   wide<T, N, sse_> const &v0,
-                                                   wide<T, N, sse_> const &v1) noexcept
+  EVE_FORCEINLINE wide<T, N, x86_128_> bit_notand_(EVE_SUPPORTS(sse2_),
+                                                   wide<T, N, x86_128_> const &v0,
+                                                   wide<T, N, x86_128_> const &v1) noexcept
   {
     if constexpr(std::is_same_v<T, float>)       return _mm_andnot_ps(v0, v1);
     else if constexpr(std::is_same_v<T, double>) return _mm_andnot_pd(v0, v1);
@@ -32,15 +32,15 @@ namespace eve ::detail
   // -----------------------------------------------------------------------------------------------
   // 256 bits implementation
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, avx_> bit_notand_(EVE_SUPPORTS(avx_),
-                                                   wide<T, N, avx_> const &v0,
-                                                   wide<T, N, avx_> const &v1) noexcept
+  EVE_FORCEINLINE wide<T, N, x86_256_> bit_notand_(EVE_SUPPORTS(avx_),
+                                                   wide<T, N, x86_256_> const &v0,
+                                                   wide<T, N, x86_256_> const &v1) noexcept
   {
     if constexpr(std::is_same_v<T, float>)       return _mm256_andnot_ps(v0, v1);
     else if constexpr(std::is_same_v<T, double>) return _mm256_andnot_pd(v0, v1);
     else if constexpr(std::is_integral_v<T>)
     {
-      if constexpr(current_api >= avx2)           return _mm256_andnot_si256(v0, v1); 
+      if constexpr(current_api >= avx2)           return _mm256_andnot_si256(v0, v1);
       else return _mm256_castps_si256(_mm256_andnot_ps(_mm256_castsi256_ps(v0), _mm256_castsi256_ps(v1)));
     }
   }

--- a/include/eve/module/core/function/simd/x86/bit_select.hpp
+++ b/include/eve/module/core/function/simd/x86/bit_select.hpp
@@ -20,17 +20,17 @@
 namespace eve::detail
 {
   template<typename U, typename T, typename N>
-  EVE_FORCEINLINE wide<T, N, sse_> bit_select_(EVE_SUPPORTS(avx_),
-                                                   wide<U, N, sse_> const &v0,
-                                                   wide<T, N, sse_> const &v1,
-                                                   wide<T, N, sse_> const &v2) noexcept
+  EVE_FORCEINLINE wide<T, N, x86_128_> bit_select_(EVE_SUPPORTS(avx_),
+                                                   wide<U, N, x86_128_> const &v0,
+                                                   wide<T, N, x86_128_> const &v1,
+                                                   wide<T, N, x86_128_> const &v2) noexcept
   {
     if constexpr(supports_xop)
     {
       if constexpr(std::is_floating_point_v<T>)
       {
-        using itype = wide<as_integer_t<T, unsigned>, N, sse_>;
-        using utype = wide<as_integer_t<U, unsigned>, N, sse_>;
+        using itype = wide<as_integer_t<T, unsigned>, N, x86_128_>;
+        using utype = wide<as_integer_t<U, unsigned>, N, x86_128_>;
         itype tmp   = _mm_cmov_si128( bit_cast(v1,as_<itype>()),
                                       bit_cast(v2,as_<itype>()),
                                       bit_cast(v0,as_<utype>())
@@ -51,17 +51,17 @@ namespace eve::detail
 
 #if defined(SPY_COMPILER_IS_MSVC)
   template<typename U, typename T, typename N>
-  EVE_FORCEINLINE wide<T, N, avx_> bit_select_(EVE_SUPPORTS(avx_),
-                                                   wide<U, N, avx_> const &v0,
-                                                   wide<T, N, avx_> const &v1,
-                                                   wide<T, N, avx_> const &v2) noexcept
+  EVE_FORCEINLINE wide<T, N, x86_256_> bit_select_(EVE_SUPPORTS(avx_),
+                                                   wide<U, N, x86_256_> const &v0,
+                                                   wide<T, N, x86_256_> const &v1,
+                                                   wide<T, N, x86_256_> const &v2) noexcept
   {
     if constexpr(supports_xop)
     {
       if constexpr(std::is_floating_point_v<T>)
       {
-        using itype = wide<as_integer_t<T, unsigned>, N, avx_>;
-        using utype = wide<as_integer_t<U, unsigned>, N, avx_>;
+        using itype = wide<as_integer_t<T, unsigned>, N, x86_256_>;
+        using utype = wide<as_integer_t<U, unsigned>, N, x86_256_>;
         itype tmp   =  _mm256_cmov_si256( bit_cast(v1,as_<itype>()),
                                           bit_cast(v2,as_<itype>()),
                                           bit_cast(v0,as_<utype>())

--- a/include/eve/module/core/function/simd/x86/ceil.hpp
+++ b/include/eve/module/core/function/simd/x86/ceil.hpp
@@ -23,8 +23,8 @@ namespace eve::detail
   //-----------------------------------------------------------------------------------------------
   // 128 bits implementation
   template<floating_real_scalar_value T, typename N, typename ABI>
-  EVE_FORCEINLINE wide<T, N, sse_> ceil_(EVE_SUPPORTS(sse4_1_)
-                                        , wide<T, N, sse_> const &a0) noexcept
+  EVE_FORCEINLINE wide<T, N, x86_128_> ceil_(EVE_SUPPORTS(sse4_1_)
+                                        , wide<T, N, x86_128_> const &a0) noexcept
   {
     if constexpr(std::is_same_v<T, double>)     return _mm_ceil_pd(a0);
     else if constexpr(std::is_same_v<T, float>) return _mm_ceil_ps(a0);
@@ -33,8 +33,8 @@ namespace eve::detail
   //-----------------------------------------------------------------------------------------------
   // 256 bits implementation
   template<floating_real_scalar_value T, typename N, typename ABI>
-  EVE_FORCEINLINE wide<T, N, avx_> ceil_(EVE_SUPPORTS(avx_)
-                                        , wide<T, N, avx_> const &a0) noexcept
+  EVE_FORCEINLINE wide<T, N, x86_256_> ceil_(EVE_SUPPORTS(avx_)
+                                        , wide<T, N, x86_256_> const &a0) noexcept
   {
     if constexpr(std::is_same_v<T, double>)     return _mm256_round_pd(a0, _MM_FROUND_CEIL);
     else if constexpr(std::is_same_v<T, float>) return _mm256_round_ps(a0, _MM_FROUND_CEIL);

--- a/include/eve/module/core/function/simd/x86/convert_128.hpp
+++ b/include/eve/module/core/function/simd/x86/convert_128.hpp
@@ -35,7 +35,7 @@ namespace eve::detail
   //================================================================================================
   template<real_scalar_value In, typename N, real_scalar_value Out>
   EVE_FORCEINLINE wide<Out, N>
-  convert_(EVE_SUPPORTS(sse2_), wide<In, N, sse_> const &v0, as_<Out> const &tgt) noexcept
+  convert_(EVE_SUPPORTS(sse2_), wide<In, N, x86_128_> const &v0, as_<Out> const &tgt) noexcept
   {
     //==============================================================================================
     // Idempotent call

--- a/include/eve/module/core/function/simd/x86/convert_256.hpp
+++ b/include/eve/module/core/function/simd/x86/convert_256.hpp
@@ -26,7 +26,7 @@ namespace eve::detail
   //================================================================================================
   template<real_scalar_value In, typename N, real_scalar_value Out>
   EVE_FORCEINLINE wide<Out, N>
-  convert_(EVE_SUPPORTS(avx_), wide<In, N, avx_> const &v0, as_<Out> const &tgt) noexcept
+  convert_(EVE_SUPPORTS(avx_), wide<In, N, x86_256_> const &v0, as_<Out> const &tgt) noexcept
   {
     if constexpr( std::is_same_v<In, Out> )
     {
@@ -51,7 +51,7 @@ namespace eve::detail
   //================================================================================================
   template<real_scalar_value In, typename N, real_scalar_value Out>
   EVE_FORCEINLINE wide<Out, N>
-  convert_(EVE_SUPPORTS(avx_), wide<In, N, sse_> const &v0, as_<Out> const &tgt) noexcept
+  convert_(EVE_SUPPORTS(avx_), wide<In, N, x86_128_> const &v0, as_<Out> const &tgt) noexcept
   {
     //==============================================================================================
     // Idempotent call

--- a/include/eve/module/core/function/simd/x86/div.hpp
+++ b/include/eve/module/core/function/simd/x86/div.hpp
@@ -18,8 +18,8 @@ namespace eve::detail
   // -----------------------------------------------------------------------------------------------
   // 128 bits implementation
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, sse_>
-                  div_(EVE_SUPPORTS(sse2_), wide<T, N, sse_> v0, wide<T, N, sse_> const &v1) noexcept
+  EVE_FORCEINLINE wide<T, N, x86_128_>
+                  div_(EVE_SUPPORTS(sse2_), wide<T, N, x86_128_> v0, wide<T, N, x86_128_> const &v1) noexcept
   {
     return v0 /= v1;
   }
@@ -27,8 +27,8 @@ namespace eve::detail
   // -----------------------------------------------------------------------------------------------
   // 256 bits implementation
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, avx_>
-                  div_(EVE_SUPPORTS(avx_), wide<T, N, avx_> v0, wide<T, N, avx_> const &v1) noexcept
+  EVE_FORCEINLINE wide<T, N, x86_256_>
+                  div_(EVE_SUPPORTS(avx_), wide<T, N, x86_256_> v0, wide<T, N, x86_256_> const &v1) noexcept
   {
     return v0 /= v1;
   }

--- a/include/eve/module/core/function/simd/x86/extract.hpp
+++ b/include/eve/module/core/function/simd/x86/extract.hpp
@@ -23,7 +23,7 @@ namespace eve::detail
   // 128 bits implementation
   template<typename T, typename I, typename N, auto V>
   EVE_FORCEINLINE T extract_(EVE_SUPPORTS(sse2_),
-                             wide<T, N, sse_> const &v0,
+                             wide<T, N, x86_128_> const &v0,
                              std::integral_constant<I, V> const &) noexcept
   {
     if constexpr(std::is_floating_point_v<T>)
@@ -85,7 +85,7 @@ namespace eve::detail
 
   template<typename T, typename N, typename I, auto V>
   EVE_FORCEINLINE logical<T> extract_(EVE_SUPPORTS(sse2_),
-                                      logical<wide<T, N, sse_>> const &   v0,
+                                      logical<wide<T, N, x86_128_>> const &   v0,
                                       std::integral_constant<I, V> const &u) noexcept
   {
     return logical<T>(extract(v0.bits(), u));

--- a/include/eve/module/core/function/simd/x86/floor.hpp
+++ b/include/eve/module/core/function/simd/x86/floor.hpp
@@ -21,8 +21,8 @@
 namespace eve::detail
 {
   template<floating_scalar_value T, typename N, typename ABI>
-  EVE_FORCEINLINE wide<T, N, sse_> floor_(EVE_SUPPORTS(sse4_1_),
-                                          wide<T, N, sse_> const &a0) noexcept
+  EVE_FORCEINLINE wide<T, N, x86_128_> floor_(EVE_SUPPORTS(sse4_1_),
+                                          wide<T, N, x86_128_> const &a0) noexcept
   {
          if constexpr(std::is_same_v<T, double>) return _mm_floor_pd(a0);
     else if constexpr(std::is_same_v<T, float>)  return _mm_floor_ps(a0);
@@ -31,7 +31,7 @@ namespace eve::detail
   //-----------------------------------------------------------------------------------------------
   // 256 bits implementation
   template<floating_scalar_value T, typename N, typename ABI>
-  EVE_FORCEINLINE wide<T, N, avx_> floor_(EVE_SUPPORTS(avx_), wide<T, N, avx_> const &a0) noexcept
+  EVE_FORCEINLINE wide<T, N, x86_256_> floor_(EVE_SUPPORTS(avx_), wide<T, N, x86_256_> const &a0) noexcept
   {
          if constexpr(std::is_same_v<T, double>) return _mm256_round_pd(a0, _MM_FROUND_FLOOR);
     else if constexpr(std::is_same_v<T, float>)  return _mm256_round_ps(a0, _MM_FROUND_FLOOR);

--- a/include/eve/module/core/function/simd/x86/fma.hpp
+++ b/include/eve/module/core/function/simd/x86/fma.hpp
@@ -21,10 +21,10 @@
 namespace eve::detail
 {
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, sse_> fma_(EVE_SUPPORTS(avx2_),
-                                        wide<T, N, sse_> const &a,
-                                        wide<T, N, sse_> const &b,
-                                        wide<T, N, sse_> const &c) noexcept
+  EVE_FORCEINLINE wide<T, N, x86_128_> fma_(EVE_SUPPORTS(avx2_),
+                                        wide<T, N, x86_128_> const &a,
+                                        wide<T, N, x86_128_> const &b,
+                                        wide<T, N, x86_128_> const &c) noexcept
   {
     if constexpr( std::is_floating_point_v<T> )
     {
@@ -62,10 +62,10 @@ namespace eve::detail
   }
 
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, avx_> fma_(EVE_SUPPORTS(avx2_),
-                                        wide<T, N, avx_> const &a,
-                                        wide<T, N, avx_> const &b,
-                                        wide<T, N, avx_> const &c) noexcept
+  EVE_FORCEINLINE wide<T, N, x86_256_> fma_(EVE_SUPPORTS(avx2_),
+                                        wide<T, N, x86_256_> const &a,
+                                        wide<T, N, x86_256_> const &b,
+                                        wide<T, N, x86_256_> const &c) noexcept
   {
     if constexpr( std::is_floating_point_v<T> )
     {
@@ -93,11 +93,11 @@ namespace eve::detail
   /////////////////////////////////////////////////////////////////////////////////
   /// pedantic numeric
   template<decorator D, real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, sse_> fma_(EVE_SUPPORTS(avx2_),
+  EVE_FORCEINLINE wide<T, N, x86_128_> fma_(EVE_SUPPORTS(avx2_),
                                         D const &,
-                                        wide<T, N, sse_> const &a,
-                                        wide<T, N, sse_> const &b,
-                                        wide<T, N, sse_> const &c) noexcept
+                                        wide<T, N, x86_128_> const &a,
+                                        wide<T, N, x86_128_> const &b,
+                                        wide<T, N, x86_128_> const &c) noexcept
   {
     if constexpr( supports_fma3 || supports_fma4  )
     {
@@ -110,11 +110,11 @@ namespace eve::detail
   }
 
   template<decorator D, real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, avx_> fma_(EVE_SUPPORTS(avx2_),
+  EVE_FORCEINLINE wide<T, N, x86_256_> fma_(EVE_SUPPORTS(avx2_),
                                         D const &,
-                                        wide<T, N, avx_> const &a,
-                                        wide<T, N, avx_> const &b,
-                                        wide<T, N, avx_> const &c) noexcept
+                                        wide<T, N, x86_256_> const &a,
+                                        wide<T, N, x86_256_> const &b,
+                                        wide<T, N, x86_256_> const &c) noexcept
   {
     if constexpr( supports_fma3 || supports_fma4  )
     {

--- a/include/eve/module/core/function/simd/x86/fms.hpp
+++ b/include/eve/module/core/function/simd/x86/fms.hpp
@@ -22,10 +22,10 @@
 namespace eve::detail
 {
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, sse_> fms_(EVE_SUPPORTS(avx2_),
-                                        wide<T, N, sse_> const &a,
-                                        wide<T, N, sse_> const &b,
-                                        wide<T, N, sse_> const &c) noexcept
+  EVE_FORCEINLINE wide<T, N, x86_128_> fms_(EVE_SUPPORTS(avx2_),
+                                        wide<T, N, x86_128_> const &a,
+                                        wide<T, N, x86_128_> const &b,
+                                        wide<T, N, x86_128_> const &c) noexcept
   {
     if constexpr( std::is_floating_point_v<T> )
     {
@@ -63,10 +63,10 @@ namespace eve::detail
   }
 
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, avx_> fms_(EVE_SUPPORTS(avx2_),
-                                        wide<T, N, avx_> const &a,
-                                        wide<T, N, avx_> const &b,
-                                        wide<T, N, avx_> const &c) noexcept
+  EVE_FORCEINLINE wide<T, N, x86_256_> fms_(EVE_SUPPORTS(avx2_),
+                                        wide<T, N, x86_256_> const &a,
+                                        wide<T, N, x86_256_> const &b,
+                                        wide<T, N, x86_256_> const &c) noexcept
   {
     if constexpr( std::is_floating_point_v<T> )
     {
@@ -94,11 +94,11 @@ namespace eve::detail
   /////////////////////////////////////////////////////////////////////////////////
   /// pedantic numeric
   template<decorator D, real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, sse_> fms_(EVE_SUPPORTS(avx2_),
+  EVE_FORCEINLINE wide<T, N, x86_128_> fms_(EVE_SUPPORTS(avx2_),
                                         D const &,
-                                        wide<T, N, sse_> const &a,
-                                        wide<T, N, sse_> const &b,
-                                        wide<T, N, sse_> const &c) noexcept
+                                        wide<T, N, x86_128_> const &a,
+                                        wide<T, N, x86_128_> const &b,
+                                        wide<T, N, x86_128_> const &c) noexcept
   {
     if constexpr( std::is_floating_point_v<T> )
     {
@@ -136,11 +136,11 @@ namespace eve::detail
   }
 
   template<decorator D, real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, avx_> fms_(EVE_SUPPORTS(avx2_),
+  EVE_FORCEINLINE wide<T, N, x86_256_> fms_(EVE_SUPPORTS(avx2_),
                                         D const &,
-                                        wide<T, N, avx_> const &a,
-                                        wide<T, N, avx_> const &b,
-                                        wide<T, N, avx_> const &c) noexcept
+                                        wide<T, N, x86_256_> const &a,
+                                        wide<T, N, x86_256_> const &b,
+                                        wide<T, N, x86_256_> const &c) noexcept
   {
     if constexpr( std::is_floating_point_v<T> )
     {

--- a/include/eve/module/core/function/simd/x86/fnma.hpp
+++ b/include/eve/module/core/function/simd/x86/fnma.hpp
@@ -22,10 +22,10 @@
 namespace eve::detail
 {
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, sse_> fnma_(EVE_SUPPORTS(avx2_),
-                                         wide<T, N, sse_> const &a,
-                                         wide<T, N, sse_> const &b,
-                                         wide<T, N, sse_> const &c) noexcept
+  EVE_FORCEINLINE wide<T, N, x86_128_> fnma_(EVE_SUPPORTS(avx2_),
+                                         wide<T, N, x86_128_> const &a,
+                                         wide<T, N, x86_128_> const &b,
+                                         wide<T, N, x86_128_> const &c) noexcept
   {
     if constexpr( std::is_floating_point_v<T> )
     {
@@ -44,10 +44,10 @@ namespace eve::detail
   }
 
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, avx_> fnma_(EVE_SUPPORTS(avx2_),
-                                         wide<T, N, avx_> const &a,
-                                         wide<T, N, avx_> const &b,
-                                         wide<T, N, avx_> const &c) noexcept
+  EVE_FORCEINLINE wide<T, N, x86_256_> fnma_(EVE_SUPPORTS(avx2_),
+                                         wide<T, N, x86_256_> const &a,
+                                         wide<T, N, x86_256_> const &b,
+                                         wide<T, N, x86_256_> const &c) noexcept
   {
     if constexpr( std::is_floating_point_v<T> )
     {
@@ -68,11 +68,11 @@ namespace eve::detail
   /////////////////////////////////////////////////////////////////////////////////
   /// pedantic numeric
   template<decorator D, real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, sse_> fnma_(EVE_SUPPORTS(avx2_),
+  EVE_FORCEINLINE wide<T, N, x86_128_> fnma_(EVE_SUPPORTS(avx2_),
                                          D const &,
-                                         wide<T, N, sse_> const &a,
-                                         wide<T, N, sse_> const &b,
-                                         wide<T, N, sse_> const &c) noexcept
+                                         wide<T, N, x86_128_> const &a,
+                                         wide<T, N, x86_128_> const &b,
+                                         wide<T, N, x86_128_> const &c) noexcept
   {
     if constexpr( std::is_floating_point_v<T> )
     {
@@ -91,11 +91,11 @@ namespace eve::detail
   }
 
   template<decorator D, real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, avx_> fnma_(EVE_SUPPORTS(avx2_),
+  EVE_FORCEINLINE wide<T, N, x86_256_> fnma_(EVE_SUPPORTS(avx2_),
                                          D const &,
-                                         wide<T, N, avx_> const &a,
-                                         wide<T, N, avx_> const &b,
-                                         wide<T, N, avx_> const &c) noexcept
+                                         wide<T, N, x86_256_> const &a,
+                                         wide<T, N, x86_256_> const &b,
+                                         wide<T, N, x86_256_> const &c) noexcept
   {
     if constexpr( std::is_floating_point_v<T> )
     {

--- a/include/eve/module/core/function/simd/x86/fnms.hpp
+++ b/include/eve/module/core/function/simd/x86/fnms.hpp
@@ -22,10 +22,10 @@
 namespace eve::detail
 {
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, sse_> fnms_(EVE_SUPPORTS(avx2_),
-                                         wide<T, N, sse_> const &a,
-                                         wide<T, N, sse_> const &b,
-                                         wide<T, N, sse_> const &c) noexcept
+  EVE_FORCEINLINE wide<T, N, x86_128_> fnms_(EVE_SUPPORTS(avx2_),
+                                         wide<T, N, x86_128_> const &a,
+                                         wide<T, N, x86_128_> const &b,
+                                         wide<T, N, x86_128_> const &c) noexcept
   {
     if constexpr( std::is_floating_point_v<T> )
     {
@@ -56,10 +56,10 @@ namespace eve::detail
   }
 
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, avx_> fnms_(EVE_SUPPORTS(avx2_),
-                                         wide<T, N, avx_> const &a,
-                                         wide<T, N, avx_> const &b,
-                                         wide<T, N, avx_> const &c) noexcept
+  EVE_FORCEINLINE wide<T, N, x86_256_> fnms_(EVE_SUPPORTS(avx2_),
+                                         wide<T, N, x86_256_> const &a,
+                                         wide<T, N, x86_256_> const &b,
+                                         wide<T, N, x86_256_> const &c) noexcept
   {
     if constexpr( std::is_floating_point_v<T> )
     {
@@ -80,11 +80,11 @@ namespace eve::detail
   /////////////////////////////////////////////////////////////////////////////////
   /// pedantic numeric
   template<decorator D, real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, sse_> fnms_(EVE_SUPPORTS(avx2_),
+  EVE_FORCEINLINE wide<T, N, x86_128_> fnms_(EVE_SUPPORTS(avx2_),
                                          D const &,
-                                         wide<T, N, sse_> const &a,
-                                         wide<T, N, sse_> const &b,
-                                         wide<T, N, sse_> const &c) noexcept
+                                         wide<T, N, x86_128_> const &a,
+                                         wide<T, N, x86_128_> const &b,
+                                         wide<T, N, x86_128_> const &c) noexcept
   {
     if constexpr( std::is_floating_point_v<T> )
     {
@@ -115,11 +115,11 @@ namespace eve::detail
   }
 
   template<decorator D, real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, avx_> fnms_(EVE_SUPPORTS(avx2_),
+  EVE_FORCEINLINE wide<T, N, x86_256_> fnms_(EVE_SUPPORTS(avx2_),
                                          D const &,
-                                         wide<T, N, avx_> const &a,
-                                         wide<T, N, avx_> const &b,
-                                         wide<T, N, avx_> const &c) noexcept
+                                         wide<T, N, x86_256_> const &a,
+                                         wide<T, N, x86_256_> const &b,
+                                         wide<T, N, x86_256_> const &c) noexcept
   {
     if constexpr( std::is_floating_point_v<T> )
     {

--- a/include/eve/module/core/function/simd/x86/frac.hpp
+++ b/include/eve/module/core/function/simd/x86/frac.hpp
@@ -25,7 +25,7 @@ namespace eve::detail
   // 128 bits implementation for xop
   template<floating_real_scalar_value T, typename N>
   EVE_FORCEINLINE auto frac_(EVE_SUPPORTS(avx_),
-                             wide<T, N, sse_> const &a0) noexcept
+                             wide<T, N, x86_128_> const &a0) noexcept
   {
     if constexpr(supports_xop)
     {
@@ -39,7 +39,7 @@ namespace eve::detail
   // 256 bits implementation for xop
   template<floating_real_scalar_value T, typename N>
   EVE_FORCEINLINE auto frac_(EVE_SUPPORTS(avx_),
-                             wide<T, N, avx_> const &a0) noexcept
+                             wide<T, N, x86_256_> const &a0) noexcept
   {
     if constexpr(supports_xop)
     {

--- a/include/eve/module/core/function/simd/x86/if_else.hpp
+++ b/include/eve/module/core/function/simd/x86/if_else.hpp
@@ -23,10 +23,10 @@ namespace eve::detail
   //------------------------------------------------------------------------------------------------
   // 128 bits if_else
   template<real_scalar_value T, typename U, typename N>
-  EVE_FORCEINLINE wide<U, N, sse_> if_else_(EVE_SUPPORTS(sse4_1_),
-                                            logical<wide<T, N, sse_>> const &v0,
-                                            wide<U, N, sse_> const &v1,
-                                            wide<U, N, sse_> const &v2) noexcept
+  EVE_FORCEINLINE wide<U, N, x86_128_> if_else_(EVE_SUPPORTS(sse4_1_),
+                                            logical<wide<T, N, x86_128_>> const &v0,
+                                            wide<U, N, x86_128_> const &v1,
+                                            wide<U, N, x86_128_> const &v2) noexcept
   {
     if constexpr(std::is_same_v<U, float>)        return _mm_blendv_ps(v2, v1, bit_cast(bit_mask(v0),as(v2)));
     else if constexpr(std::is_same_v<U, double>)  return _mm_blendv_pd(v2, v1, bit_cast(bit_mask(v0),as(v2)));
@@ -34,28 +34,28 @@ namespace eve::detail
   }
 
   template<real_scalar_value T, typename U, typename N>
-  EVE_FORCEINLINE wide<U, N, sse_> if_else_(EVE_SUPPORTS(sse4_1_),
-                                            wide<T, N, sse_> const &v0,
-                                            wide<U, N, sse_> const &v1,
-                                            wide<U, N, sse_> const &v2) noexcept
+  EVE_FORCEINLINE wide<U, N, x86_128_> if_else_(EVE_SUPPORTS(sse4_1_),
+                                            wide<T, N, x86_128_> const &v0,
+                                            wide<U, N, x86_128_> const &v1,
+                                            wide<U, N, x86_128_> const &v2) noexcept
   {
     return if_else(is_nez(v0), v1, v2);
   }
 
   template<real_scalar_value T, typename U, typename N>
   EVE_FORCEINLINE auto if_else_(EVE_SUPPORTS(sse4_1_),
-                                logical<wide<T, N, sse_>> const &v0,
-                                logical<wide<U, N, sse_>> const &v1,
-                                logical<wide<U, N, sse_>> const &v2) noexcept
+                                logical<wide<T, N, x86_128_>> const &v0,
+                                logical<wide<U, N, x86_128_>> const &v1,
+                                logical<wide<U, N, x86_128_>> const &v2) noexcept
   {
     return bit_cast(if_else(v0, v1.mask(), v2.mask()), as(v2));
   }
 
   template<real_scalar_value T, typename U, typename N>
-  EVE_FORCEINLINE logical<wide<U, N, sse_>> if_else_(EVE_SUPPORTS(sse4_1_),
-                                            wide<T, N, sse_> const &v0,
-                                            logical<wide<U, N, sse_>> const &v1,
-                                            logical<wide<U, N, sse_>> const &v2) noexcept
+  EVE_FORCEINLINE logical<wide<U, N, x86_128_>> if_else_(EVE_SUPPORTS(sse4_1_),
+                                            wide<T, N, x86_128_> const &v0,
+                                            logical<wide<U, N, x86_128_>> const &v1,
+                                            logical<wide<U, N, x86_128_>> const &v2) noexcept
   {
     return if_else(is_nez(v0), v1, v2);
   }
@@ -63,10 +63,10 @@ namespace eve::detail
   //------------------------------------------------------------------------------------------------
   // 256 bits if_else
   template<real_scalar_value T, typename U, typename N>
-  EVE_FORCEINLINE wide<U, N, avx_> if_else_(EVE_SUPPORTS(avx_),
-                                            logical<wide<T, N, avx_>> const &v0,
-                                            wide<U, N, avx_> const &v1,
-                                            wide<U, N, avx_> const &v2) noexcept
+  EVE_FORCEINLINE wide<U, N, x86_256_> if_else_(EVE_SUPPORTS(avx_),
+                                            logical<wide<T, N, x86_256_>> const &v0,
+                                            wide<U, N, x86_256_> const &v1,
+                                            wide<U, N, x86_256_> const &v2) noexcept
   {
          if constexpr(std::is_same_v<U, float>)  return _mm256_blendv_ps(v2, v1,  bit_cast(v0.bits(),as(v2)));
     else if constexpr(std::is_same_v<U, double>) return _mm256_blendv_pd(v2, v1,  bit_cast(v0.bits(),as(v2)));
@@ -82,7 +82,7 @@ namespace eve::detail
         if constexpr(std::is_integral_v<U> && sizeof(U) <= 2)      return aggregate(if_else, v0, v1, v2);
         else if constexpr(std::is_integral_v<U> && sizeof(U) >= 4)
         {
-          using f_t = wide<as_floating_point_t<U>, N, avx_>;
+          using f_t = wide<as_floating_point_t<U>, N, x86_256_>;
           return bit_cast( if_else( v0, bit_cast(v1,as_<f_t>()), bit_cast(v2,as_<f_t>())), as(v2));
         }
       }
@@ -90,28 +90,28 @@ namespace eve::detail
   }
 
   template<real_scalar_value T, typename U, typename N>
-  EVE_FORCEINLINE wide<U, N, avx_> if_else_(EVE_SUPPORTS(avx_),
-                                            wide<T, N, avx_> const &v0,
-                                            wide<U, N, avx_> const &v1,
-                                            wide<U, N, avx_> const &v2) noexcept
+  EVE_FORCEINLINE wide<U, N, x86_256_> if_else_(EVE_SUPPORTS(avx_),
+                                            wide<T, N, x86_256_> const &v0,
+                                            wide<U, N, x86_256_> const &v1,
+                                            wide<U, N, x86_256_> const &v2) noexcept
   {
     return if_else(is_nez(v0), v1, v2);
   }
 
   template<real_scalar_value T, typename U, typename N>
   EVE_FORCEINLINE auto if_else_(EVE_SUPPORTS(avx_),
-                                            logical<wide<T, N, avx_>> const &v0,
-                                            logical<wide<U, N, avx_>> const &v1,
-                                            logical<wide<U, N, avx_>> const &v2) noexcept
+                                            logical<wide<T, N, x86_256_>> const &v0,
+                                            logical<wide<U, N, x86_256_>> const &v1,
+                                            logical<wide<U, N, x86_256_>> const &v2) noexcept
   {
     return bit_cast(if_else(v0, v1.mask(), v2.mask()), as(v2));
   }
 
   template<real_scalar_value T, typename U, typename N>
   EVE_FORCEINLINE auto if_else_(EVE_SUPPORTS(avx_),
-                                            wide<T, N, avx_> const &v0,
-                                            logical<wide<U, N, avx_>> const &v1,
-                                            logical<wide<U, N, avx_>> const &v2) noexcept
+                                            wide<T, N, x86_256_> const &v0,
+                                            logical<wide<U, N, x86_256_>> const &v1,
+                                            logical<wide<U, N, x86_256_>> const &v2) noexcept
   {
     return bit_cast(if_else(is_nez(v0), v1.mask(), v2.mask()), as(v2));
   }

--- a/include/eve/module/core/function/simd/x86/is_equal.hpp
+++ b/include/eve/module/core/function/simd/x86/is_equal.hpp
@@ -22,10 +22,10 @@ namespace eve::detail
   // 128 bits implementation
   template<real_scalar_value T, typename N>
   EVE_FORCEINLINE auto  is_equal_(EVE_SUPPORTS(sse2_)
-                                 , wide<T, N, sse_> const &v0
-                                 , wide<T, N, sse_> const &v1) noexcept
+                                 , wide<T, N, x86_128_> const &v0
+                                 , wide<T, N, x86_128_> const &v1) noexcept
   {
-    using t_t = wide<T, N, sse_>;
+    using t_t = wide<T, N, x86_128_>;
     using l_t = as_logical_t<t_t>;
     if constexpr(supports_xop)
     {
@@ -92,10 +92,10 @@ namespace eve::detail
   // 256 bits implementation
   template<typename T, typename N>
   EVE_FORCEINLINE auto is_equal_(EVE_SUPPORTS(avx_)
-                                , wide<T, N, avx_> const &v0
-                                , wide<T, N, avx_> const &v1) noexcept
+                                , wide<T, N, x86_256_> const &v0
+                                , wide<T, N, x86_256_> const &v1) noexcept
   {
-    using t_t = wide<T, N, avx_>;
+    using t_t = wide<T, N, x86_256_>;
     using l_t = as_logical_t<t_t>;
 
          if constexpr(std::is_same_v<T, float>)    return l_t(_mm256_cmp_ps(v0, v1, _CMP_EQ_OQ));

--- a/include/eve/module/core/function/simd/x86/is_greater.hpp
+++ b/include/eve/module/core/function/simd/x86/is_greater.hpp
@@ -23,10 +23,10 @@ namespace eve::detail
   // 128 bits implementation
   template<real_scalar_value T, typename N>
   EVE_FORCEINLINE auto is_greater_(EVE_SUPPORTS(sse2_)
-                                  , wide<T, N, sse_> const &v0
-                                  , wide<T, N, sse_> const &v1) noexcept
+                                  , wide<T, N, x86_128_> const &v0
+                                  , wide<T, N, x86_128_> const &v1) noexcept
   {
-    using t_t = wide<T, N, sse_>;
+    using t_t = wide<T, N, x86_128_>;
     using l_t = as_logical_t<t_t>;
 
          if constexpr(std::is_same_v<T, float>)  return l_t(_mm_cmpgt_ps(v0, v1));
@@ -46,7 +46,7 @@ namespace eve::detail
       }
       else if constexpr(std::is_unsigned_v<T>)
       {
-        using s_t    = eve::wide<eve::detail::as_integer_t<T, signed>, N, sse_>;
+        using s_t    = eve::wide<eve::detail::as_integer_t<T, signed>, N, x86_128_>;
         s_t const sm = signmask(eve::as<s_t>());
 
         return eve::bit_cast( eve::is_greater ( eve::bit_cast(v0,as(sm)) - sm,
@@ -60,10 +60,10 @@ namespace eve::detail
 
   template<real_scalar_value T, typename N>
   EVE_FORCEINLINE auto is_greater_(EVE_SUPPORTS(avx_),
-                                   wide<T, N, sse_> const &v0,
-                                   wide<T, N, sse_> const &v1) noexcept
+                                   wide<T, N, x86_128_> const &v0,
+                                   wide<T, N, x86_128_> const &v1) noexcept
   {
-    using t_t = wide<T, N, sse_>;
+    using t_t = wide<T, N, x86_128_>;
     using l_t = as_logical_t<t_t>;
 
     if constexpr(supports_xop)
@@ -115,10 +115,10 @@ namespace eve::detail
   // 256 bits implementation
   template<real_scalar_value T, typename N>
   EVE_FORCEINLINE auto is_greater_(EVE_SUPPORTS(avx_)
-                                  , wide<T, N, avx_> const &v0
-                                  , wide<T, N, avx_> const &v1) noexcept
+                                  , wide<T, N, x86_256_> const &v0
+                                  , wide<T, N, x86_256_> const &v1) noexcept
   {
-    using t_t = wide<T, N, avx_>;
+    using t_t = wide<T, N, x86_256_>;
     using l_t = as_logical_t<t_t>;
 
     if constexpr(std::is_same_v<T, float>)       return as_logical_t<t_t>(_mm256_cmp_ps(v0, v1, _CMP_GT_OQ));
@@ -136,7 +136,7 @@ namespace eve::detail
         }
         else
         {
-          using s_t    = eve::wide<eve::detail::as_integer_t<T, signed>, N, avx_>;
+          using s_t    = eve::wide<eve::detail::as_integer_t<T, signed>, N, x86_256_>;
           s_t const sm = signmask(eve::as<s_t>());
 
           return eve::bit_cast( eve::is_greater ( eve::bit_cast(v0,as(sm)) - sm,

--- a/include/eve/module/core/function/simd/x86/is_greater_equal.hpp
+++ b/include/eve/module/core/function/simd/x86/is_greater_equal.hpp
@@ -27,10 +27,10 @@ namespace eve::detail
   // 128 bits implementation
   template<real_scalar_value T, typename N>
   EVE_FORCEINLINE auto is_greater_equal_(EVE_SUPPORTS(sse2_),
-                                         wide<T, N, sse_> const &v0,
-                                         wide<T, N, sse_> const &v1) noexcept
+                                         wide<T, N, x86_128_> const &v0,
+                                         wide<T, N, x86_128_> const &v1) noexcept
   {
-    using t_t = wide<T, N, sse_>;
+    using t_t = wide<T, N, x86_128_>;
     using l_t = as_logical_t<t_t>;
 
          if constexpr(std::is_same_v<T, float>)  return l_t(_mm_cmpge_ps(v0, v1));
@@ -40,10 +40,10 @@ namespace eve::detail
 
   template<real_scalar_value T, typename N>
   EVE_FORCEINLINE auto is_greater_equal_(EVE_SUPPORTS(avx_),
-                                         wide<T, N, sse_> const &v0,
-                                         wide<T, N, sse_> const &v1) noexcept
+                                         wide<T, N, x86_128_> const &v0,
+                                         wide<T, N, x86_128_> const &v1) noexcept
   {
-    using t_t = wide<T, N, sse_>;
+    using t_t = wide<T, N, x86_128_>;
     using l_t = as_logical_t<t_t>;
 
     if constexpr(std::is_same_v<T, float>)       return l_t(_mm_cmp_ps(v0, v1, _CMP_GE_OQ));
@@ -100,10 +100,10 @@ namespace eve::detail
   // 256 bits implementation
   template<real_scalar_value T, typename N>
   EVE_FORCEINLINE auto is_greater_equal_(EVE_SUPPORTS(avx_),
-                                         wide<T, N, avx_> const &v0,
-                                         wide<T, N, avx_> const &v1) noexcept
+                                         wide<T, N, x86_256_> const &v0,
+                                         wide<T, N, x86_256_> const &v1) noexcept
   {
-    using t_t = wide<T, N, avx_>;
+    using t_t = wide<T, N, x86_256_>;
     using l_t = as_logical_t<t_t>;
 
     if constexpr(std::is_same_v<T, float>)       return l_t(_mm256_cmp_ps(v0, v1, _CMP_GE_OQ));

--- a/include/eve/module/core/function/simd/x86/is_less.hpp
+++ b/include/eve/module/core/function/simd/x86/is_less.hpp
@@ -28,10 +28,10 @@ namespace eve::detail
   // 128 bits implementation
   template<real_scalar_value T, typename N>
   EVE_FORCEINLINE auto is_less_(EVE_SUPPORTS(sse2_)
-                               , wide<T, N, sse_> const &v0
-                               , wide<T, N, sse_> const &v1) noexcept
+                               , wide<T, N, x86_128_> const &v0
+                               , wide<T, N, x86_128_> const &v1) noexcept
   {
-    using t_t = wide<T, N, sse_>;
+    using t_t = wide<T, N, x86_128_>;
     using l_t = as_logical_t<t_t>;
 
     if constexpr(std::is_same_v<T, float>)       return l_t(_mm_cmplt_ps(v0, v1));
@@ -55,10 +55,10 @@ namespace eve::detail
 
   template<real_scalar_value T, typename N>
   EVE_FORCEINLINE auto is_less_(EVE_SUPPORTS(avx_),
-                                   wide<T, N, sse_> const &v0,
-                                   wide<T, N, sse_> const &v1) noexcept
+                                   wide<T, N, x86_128_> const &v0,
+                                   wide<T, N, x86_128_> const &v1) noexcept
   {
-    using t_t = wide<T, N, sse_>;
+    using t_t = wide<T, N, x86_128_>;
     using l_t = as_logical_t<t_t>;
 
     if constexpr(supports_xop)
@@ -110,10 +110,10 @@ namespace eve::detail
   // 256 bits implementation
   template<real_scalar_value T, typename N>
   EVE_FORCEINLINE auto is_less_(EVE_SUPPORTS(avx_)
-                               , wide<T, N, avx_> const &v0
-                               , wide<T, N, avx_> const &v1) noexcept
+                               , wide<T, N, x86_256_> const &v0
+                               , wide<T, N, x86_256_> const &v1) noexcept
   {
-    using t_t = wide<T, N, avx_>;
+    using t_t = wide<T, N, x86_256_>;
     using l_t = as_logical_t<t_t>;
 
     if constexpr(std::is_same_v<T, float>)       return l_t(_mm256_cmp_ps(v0, v1, /*EVE_CMP_LT_OQ*/ 0x01));

--- a/include/eve/module/core/function/simd/x86/is_less_equal.hpp
+++ b/include/eve/module/core/function/simd/x86/is_less_equal.hpp
@@ -27,10 +27,10 @@ namespace eve::detail
   // 128 bits implementation
   template<real_scalar_value T, typename N>
   EVE_FORCEINLINE auto is_less_equal_(EVE_SUPPORTS(sse2_),
-                                      wide<T, N, sse_> const &v0,
-                                      wide<T, N, sse_> const &v1) noexcept
+                                      wide<T, N, x86_128_> const &v0,
+                                      wide<T, N, x86_128_> const &v1) noexcept
   {
-    using t_t = wide<T, N, sse_>;
+    using t_t = wide<T, N, x86_128_>;
     using l_t = as_logical_t<t_t>;
 
     if constexpr(std::is_same_v<T, float>)       return l_t(_mm_cmple_ps(v0, v1));
@@ -40,10 +40,10 @@ namespace eve::detail
 
   template<real_scalar_value T, typename N>
   EVE_FORCEINLINE auto is_less_equal_(EVE_SUPPORTS(avx_),
-                                      wide<T, N, sse_> const &v0,
-                                      wide<T, N, sse_> const &v1) noexcept
+                                      wide<T, N, x86_128_> const &v0,
+                                      wide<T, N, x86_128_> const &v1) noexcept
   {
-    using t_t = wide<T, N, sse_>;
+    using t_t = wide<T, N, x86_128_>;
     using l_t = as_logical_t<t_t>;
 
     if constexpr(std::is_same_v<T, float>)       return l_t(_mm_cmp_ps(v0, v1, _CMP_LE_OQ));
@@ -100,10 +100,10 @@ namespace eve::detail
   // 256 bits implementation
   template<real_scalar_value T, typename N>
   EVE_FORCEINLINE auto is_less_equal_(EVE_SUPPORTS(avx_),
-                                      wide<T, N, avx_> const &v0,
-                                      wide<T, N, avx_> const &v1) noexcept
+                                      wide<T, N, x86_256_> const &v0,
+                                      wide<T, N, x86_256_> const &v1) noexcept
   {
-    using t_t = wide<T, N, avx_>;
+    using t_t = wide<T, N, x86_256_>;
     using l_t = as_logical_t<t_t>;
 
     if constexpr(std::is_same_v<T, float>)       return l_t(_mm256_cmp_ps(v0, v1, _CMP_LE_OQ));

--- a/include/eve/module/core/function/simd/x86/is_lessgreater.hpp
+++ b/include/eve/module/core/function/simd/x86/is_lessgreater.hpp
@@ -21,10 +21,10 @@ namespace eve::detail
   // 256 bits implementation
   template<typename T, typename N>
   EVE_FORCEINLINE auto is_lessgreater_(EVE_SUPPORTS(avx_),
-                                       wide<T, N, avx_> const &v0,
-                                       wide<T, N, avx_> const &v1) noexcept
+                                       wide<T, N, x86_256_> const &v0,
+                                       wide<T, N, x86_256_> const &v1) noexcept
   {
-    using t_t = wide<T, N, avx_>;
+    using t_t = wide<T, N, x86_256_>;
     using l_t = as_logical_t<t_t>;
 
     if constexpr(std::is_same_v<T, float>)

--- a/include/eve/module/core/function/simd/x86/is_not_equal.hpp
+++ b/include/eve/module/core/function/simd/x86/is_not_equal.hpp
@@ -24,10 +24,10 @@ namespace eve::detail
   // 128 bits implementation
   template<real_value T, typename N>
   EVE_FORCEINLINE auto is_not_equal_(EVE_SUPPORTS(sse2_),
-                                     wide<T, N, sse_> const &v0,
-                                     wide<T, N, sse_> const &v1) noexcept
+                                     wide<T, N, x86_128_> const &v0,
+                                     wide<T, N, x86_128_> const &v1) noexcept
   {
-    using t_t = wide<T, N, sse_>;
+    using t_t = wide<T, N, x86_128_>;
     using l_t = as_logical_t<t_t>;
     if constexpr(supports_xop)
     {
@@ -78,15 +78,15 @@ namespace eve::detail
       else if constexpr(integral_value<T>)          return logical_not(is_equal(v0, v1));
     }
   }
-  
+
   // -----------------------------------------------------------------------------------------------
   // 256 bits implementation
   template<real_value T, typename N>
   EVE_FORCEINLINE auto is_not_equal_(EVE_SUPPORTS(avx_)
-                                    , wide<T, N, avx_> const &v0
-                                    , wide<T, N, avx_> const &v1) noexcept
+                                    , wide<T, N, x86_256_> const &v0
+                                    , wide<T, N, x86_256_> const &v1) noexcept
   {
-    using t_t = wide<T, N, avx_>;
+    using t_t = wide<T, N, x86_256_>;
     using l_t = as_logical_t<t_t>;
 
     if constexpr(std::is_same_v<T, float>)       return l_t(_mm256_cmp_ps(v0, v1, _CMP_NEQ_UQ));

--- a/include/eve/module/core/function/simd/x86/is_not_greater.hpp
+++ b/include/eve/module/core/function/simd/x86/is_not_greater.hpp
@@ -24,10 +24,10 @@ namespace eve::detail
   // 128 bits implementation
   template<floating_real_scalar_value T, typename N>
   EVE_FORCEINLINE auto is_not_greater_(EVE_SUPPORTS(sse2_),
-                                       wide<T, N, sse_> const &v0,
-                                       wide<T, N, sse_> const &v1) noexcept
+                                       wide<T, N, x86_128_> const &v0,
+                                       wide<T, N, x86_128_> const &v1) noexcept
   {
-    using t_t = wide<T, N, sse_>;
+    using t_t = wide<T, N, x86_128_>;
     using l_t = as_logical_t<t_t>;
 
     if constexpr(std::is_same_v<T, float>)  return l_t(_mm_cmpngt_ps(v0, v1));
@@ -38,10 +38,10 @@ namespace eve::detail
   // 256 bits implementation
   template<floating_real_scalar_value T, typename N>
   EVE_FORCEINLINE auto is_not_greater_(EVE_SUPPORTS(avx_),
-                                       wide<T, N, avx_> const &v0,
-                                       wide<T, N, avx_> const &v1) noexcept
+                                       wide<T, N, x86_256_> const &v0,
+                                       wide<T, N, x86_256_> const &v1) noexcept
   {
-    using t_t = wide<T, N, avx_>;
+    using t_t = wide<T, N, x86_256_>;
     using l_t = as_logical_t<t_t>;
 
     if constexpr(std::is_same_v<T, float>)  return l_t(_mm256_cmp_ps(v0, v1, _CMP_NGT_UQ));

--- a/include/eve/module/core/function/simd/x86/is_not_greater_equal.hpp
+++ b/include/eve/module/core/function/simd/x86/is_not_greater_equal.hpp
@@ -22,20 +22,20 @@ namespace eve::detail
 {
   template<floating_real_scalar_value T, typename N>
   EVE_FORCEINLINE auto is_not_greater_equal_(EVE_SUPPORTS(sse2_),
-                                             wide<T, N, sse_> const &v0,
-                                             wide<T, N, sse_> const &v1) noexcept
+                                             wide<T, N, x86_128_> const &v0,
+                                             wide<T, N, x86_128_> const &v1) noexcept
   {
-    using l_t = as_logical_t<wide<T, N, sse_>>;
+    using l_t = as_logical_t<wide<T, N, x86_128_>>;
          if constexpr(std::is_same_v<T, float>)  return l_t(_mm_cmpnge_ps(v0, v1));
     else if constexpr(std::is_same_v<T, double>) return l_t(_mm_cmpnge_pd(v0, v1));
   }
 
   template<floating_real_scalar_value T, typename N>
   EVE_FORCEINLINE auto is_not_greater_equal_(EVE_SUPPORTS(avx_),
-                                             wide<T, N, avx_> const &v0,
-                                             wide<T, N, avx_> const &v1) noexcept
+                                             wide<T, N, x86_256_> const &v0,
+                                             wide<T, N, x86_256_> const &v1) noexcept
   {
-    using l_t = as_logical_t<wide<T, N, avx_>>;
+    using l_t = as_logical_t<wide<T, N, x86_256_>>;
          if constexpr(std::is_same_v<T, float>)  return l_t(_mm256_cmp_ps(v0, v1, _CMP_NGE_UQ));
     else if constexpr(std::is_same_v<T, double>) return l_t(_mm256_cmp_pd(v0, v1, _CMP_NGE_UQ));
   }

--- a/include/eve/module/core/function/simd/x86/is_not_less.hpp
+++ b/include/eve/module/core/function/simd/x86/is_not_less.hpp
@@ -25,10 +25,10 @@ namespace eve::detail
   // 128 bits implementation
   template<floating_real_scalar_value T, typename N>
   EVE_FORCEINLINE auto is_not_less_(EVE_SUPPORTS(sse2_)
-                                   , wide<T, N, sse_> const &v0
-                                   , wide<T, N, sse_> const &v1) noexcept
+                                   , wide<T, N, x86_128_> const &v0
+                                   , wide<T, N, x86_128_> const &v1) noexcept
   {
-    using t_t = wide<T, N, sse_>;
+    using t_t = wide<T, N, x86_128_>;
     using l_t = as_logical_t<t_t>;
 
          if constexpr(std::is_same_v<T, float>)  return l_t(_mm_cmpnlt_ps(v0, v1));
@@ -39,10 +39,10 @@ namespace eve::detail
   // 256 bits implementation
   template<floating_real_scalar_value T, typename N>
   EVE_FORCEINLINE auto is_not_less_(EVE_SUPPORTS(avx_)
-                                   , wide<T, N, avx_> const &v0
-                                   , wide<T, N, avx_> const &v1) noexcept
+                                   , wide<T, N, x86_256_> const &v0
+                                   , wide<T, N, x86_256_> const &v1) noexcept
   {
-    using t_t = wide<T, N, avx_>;
+    using t_t = wide<T, N, x86_256_>;
     using l_t = as_logical_t<t_t>;
 
          if constexpr(std::is_same_v<T, float>)  return l_t(_mm256_cmp_ps(v0, v1, _CMP_NLT_UQ));

--- a/include/eve/module/core/function/simd/x86/is_not_less_equal.hpp
+++ b/include/eve/module/core/function/simd/x86/is_not_less_equal.hpp
@@ -20,10 +20,10 @@ namespace eve::detail
 {
   template<floating_real_scalar_value T, typename N>
   EVE_FORCEINLINE auto is_not_less_equal_(EVE_SUPPORTS(sse2_),
-                                          wide<T, N, sse_> const &v0,
-                                          wide<T, N, sse_> const &v1) noexcept
+                                          wide<T, N, x86_128_> const &v0,
+                                          wide<T, N, x86_128_> const &v1) noexcept
   {
-    using t_t = wide<T, N, sse_>;
+    using t_t = wide<T, N, x86_128_>;
     using l_t = as_logical_t<t_t>;
          if constexpr(std::is_same_v<T, float>)  return l_t(_mm_cmpnle_ps(v0, v1));
     else if constexpr(std::is_same_v<T, double>) return l_t(_mm_cmpnle_pd(v0, v1));
@@ -31,10 +31,10 @@ namespace eve::detail
 
   template<floating_real_scalar_value T, typename N>
   EVE_FORCEINLINE auto is_not_less_equal_(EVE_SUPPORTS(avx_),
-                                          wide<T, N, avx_> const &v0,
-                                          wide<T, N, avx_> const &v1) noexcept
+                                          wide<T, N, x86_256_> const &v0,
+                                          wide<T, N, x86_256_> const &v1) noexcept
   {
-    using l_t = as_logical_t<wide<T, N, avx_>>;
+    using l_t = as_logical_t<wide<T, N, x86_256_>>;
          if constexpr(std::is_same_v<T, float>)  return l_t(_mm256_cmp_ps(v0, v1, _CMP_NLE_UQ));
     else if constexpr(std::is_same_v<T, double>) return l_t(_mm256_cmp_pd(v0, v1, _CMP_NLE_UQ));
   }

--- a/include/eve/module/core/function/simd/x86/is_ordered.hpp
+++ b/include/eve/module/core/function/simd/x86/is_ordered.hpp
@@ -25,9 +25,9 @@ namespace eve::detail
   // 128 bits implementation
   template<typename T, typename N>
   EVE_FORCEINLINE auto
-  is_ordered_(EVE_SUPPORTS(sse2_), wide<T, N, sse_> const &v0, wide<T, N, sse_> const &v1) noexcept
+  is_ordered_(EVE_SUPPORTS(sse2_), wide<T, N, x86_128_> const &v0, wide<T, N, x86_128_> const &v1) noexcept
   {
-    using t_t = wide<T, N, sse_>;
+    using t_t = wide<T, N, x86_128_>;
     using l_t = as_logical_t<t_t>;
 
     if constexpr(std::is_same_v<T, float>) return l_t(_mm_cmpord_ps(v0, v1));
@@ -39,9 +39,9 @@ namespace eve::detail
   // 256 bits implementation
   template<typename T, typename N>
   EVE_FORCEINLINE auto
-  is_ordered_(EVE_SUPPORTS(avx_), wide<T, N, avx_> const &v0, wide<T, N, avx_> const &v1) noexcept
+  is_ordered_(EVE_SUPPORTS(avx_), wide<T, N, x86_256_> const &v0, wide<T, N, x86_256_> const &v1) noexcept
   {
-    using t_t = wide<T, N, avx_>;
+    using t_t = wide<T, N, x86_256_>;
     using l_t = as_logical_t<t_t>;
 
     if constexpr(std::is_same_v<T, float>) return l_t(_mm256_cmp_ps(v0, v1, _CMP_ORD_Q));

--- a/include/eve/module/core/function/simd/x86/is_unordered.hpp
+++ b/include/eve/module/core/function/simd/x86/is_unordered.hpp
@@ -25,10 +25,10 @@ namespace eve::detail
   // 128 bits implementation
   template<typename T, typename N>
   EVE_FORCEINLINE auto is_unordered_(EVE_SUPPORTS(sse2_),
-                                     wide<T, N, sse_> const &v0,
-                                     wide<T, N, sse_> const &v1) noexcept
+                                     wide<T, N, x86_128_> const &v0,
+                                     wide<T, N, x86_128_> const &v1) noexcept
   {
-    using t_t = wide<T, N, sse_>;
+    using t_t = wide<T, N, x86_128_>;
     using l_t = as_logical_t<t_t>;
 
     if constexpr(std::is_same_v<T, float>) return l_t(_mm_cmpunord_ps(v0, v1));
@@ -40,9 +40,9 @@ namespace eve::detail
   // 256 bits implementation
   template<typename T, typename N>
   EVE_FORCEINLINE auto
-  is_unordered_(EVE_SUPPORTS(avx_), wide<T, N, avx_> const &v0, wide<T, N, avx_> const &v1) noexcept
+  is_unordered_(EVE_SUPPORTS(avx_), wide<T, N, x86_256_> const &v0, wide<T, N, x86_256_> const &v1) noexcept
   {
-    using t_t = wide<T, N, avx_>;
+    using t_t = wide<T, N, x86_256_>;
     using l_t = as_logical_t<t_t>;
 
     if constexpr(std::is_same_v<T, float>) return l_t(_mm256_cmp_ps(v0, v1, _CMP_UNORD_Q));

--- a/include/eve/module/core/function/simd/x86/max.hpp
+++ b/include/eve/module/core/function/simd/x86/max.hpp
@@ -21,9 +21,9 @@ namespace eve::detail
   // -----------------------------------------------------------------------------------------------
   // 128 bits implementation
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, sse_> max_(EVE_SUPPORTS(sse2_)
-                                       , wide<T, N, sse_> const &v0
-                                       , wide<T, N, sse_> const &v1) noexcept
+  EVE_FORCEINLINE wide<T, N, x86_128_> max_(EVE_SUPPORTS(sse2_)
+                                       , wide<T, N, x86_128_> const &v0
+                                       , wide<T, N, x86_128_> const &v1) noexcept
   {
          if constexpr(std::is_same_v<T, double>)     return _mm_max_pd(v0, v1);
     else if constexpr(std::is_same_v<T, float>)      return _mm_max_ps(v0, v1);
@@ -52,9 +52,9 @@ namespace eve::detail
   // -----------------------------------------------------------------------------------------------
   // 256 bits implementation
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, avx_> max_(EVE_SUPPORTS(avx_)
-                                       , wide<T, N, avx_> const &v0
-                                       , wide<T, N, avx_> const &v1) noexcept
+  EVE_FORCEINLINE wide<T, N, x86_256_> max_(EVE_SUPPORTS(avx_)
+                                       , wide<T, N, x86_256_> const &v0
+                                       , wide<T, N, x86_256_> const &v1) noexcept
   {
          if constexpr(std::is_same_v<T, float>)        return _mm256_max_ps(v0, v1);
     else if constexpr(std::is_same_v<T, double>)       return _mm256_max_pd(v0, v1);

--- a/include/eve/module/core/function/simd/x86/min.hpp
+++ b/include/eve/module/core/function/simd/x86/min.hpp
@@ -21,9 +21,9 @@ namespace eve::detail
   // -----------------------------------------------------------------------------------------------
   // 128 bits implementation
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, sse_> min_(EVE_SUPPORTS(sse2_)
-                                       , wide<T, N, sse_> const &v0
-                                       , wide<T, N, sse_> const &v1) noexcept
+  EVE_FORCEINLINE wide<T, N, x86_128_> min_(EVE_SUPPORTS(sse2_)
+                                       , wide<T, N, x86_128_> const &v0
+                                       , wide<T, N, x86_128_> const &v1) noexcept
   {
          if constexpr(std::is_same_v<T, double>)   return _mm_min_pd(v0, v1);
     else if constexpr(std::is_same_v<T, float>)    return _mm_min_ps(v0, v1);
@@ -45,16 +45,16 @@ namespace eve::detail
           else if constexpr(sizeof(T) == 4)  return _mm_min_epu32(v0, v1);
         }
       }
-      else return map(min, v0, v1); 
+      else return map(min, v0, v1);
     }
   }
 
   // -----------------------------------------------------------------------------------------------
   // 256 bits implementation
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, avx_> min_(EVE_SUPPORTS(avx_)
-                                       , wide<T, N, avx_> const &v0
-                                       , wide<T, N, avx_> const &v1) noexcept
+  EVE_FORCEINLINE wide<T, N, x86_256_> min_(EVE_SUPPORTS(avx_)
+                                       , wide<T, N, x86_256_> const &v0
+                                       , wide<T, N, x86_256_> const &v1) noexcept
   {
          if constexpr(std::is_same_v<T, float>)  return _mm256_min_ps(v0, v1);
     else if constexpr(std::is_same_v<T, double>) return _mm256_min_pd(v0, v1);
@@ -75,7 +75,7 @@ namespace eve::detail
           else if constexpr(sizeof(T) == 4)  return _mm256_min_epu32(v0, v1);
         }
       }
-      else return aggregate(min, v0, v1); 
+      else return aggregate(min, v0, v1);
     }
   }
 }

--- a/include/eve/module/core/function/simd/x86/mul.hpp
+++ b/include/eve/module/core/function/simd/x86/mul.hpp
@@ -19,15 +19,15 @@ namespace eve::detail
   // -----------------------------------------------------------------------------------------------
   // 128 bits implementation
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, sse_>
-                  mul_(EVE_SUPPORTS(sse2_), wide<T, N, sse_> v0, wide<T, N, sse_> const &v1) noexcept
+  EVE_FORCEINLINE wide<T, N, x86_128_>
+                  mul_(EVE_SUPPORTS(sse2_), wide<T, N, x86_128_> v0, wide<T, N, x86_128_> const &v1) noexcept
   {
     return v0 *= v1;
   }
 
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, sse_>
-                  mul_(EVE_SUPPORTS(avx_), saturated_type const &, wide<T, N, sse_> v0, wide<T, N, sse_> const &v1) noexcept
+  EVE_FORCEINLINE wide<T, N, x86_128_>
+                  mul_(EVE_SUPPORTS(avx_), saturated_type const &, wide<T, N, x86_128_> v0, wide<T, N, x86_128_> const &v1) noexcept
   {
     if constexpr(supports_xop)
     {
@@ -41,8 +41,8 @@ namespace eve::detail
   // -----------------------------------------------------------------------------------------------
   // 256 bits implementation
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, avx_>
-                  mul_(EVE_SUPPORTS(avx_), wide<T, N, avx_> v0, wide<T, N, avx_> const &v1) noexcept
+  EVE_FORCEINLINE wide<T, N, x86_256_>
+                  mul_(EVE_SUPPORTS(avx_), wide<T, N, x86_256_> v0, wide<T, N, x86_256_> const &v1) noexcept
   {
     return v0 *= v1;
   }

--- a/include/eve/module/core/function/simd/x86/nearest.hpp
+++ b/include/eve/module/core/function/simd/x86/nearest.hpp
@@ -19,8 +19,8 @@ namespace eve::detail
   // -----------------------------------------------------------------------------------------------
   // 128 bits implementation
   template<floating_real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, sse_> nearest_(EVE_SUPPORTS(sse4_1_),
-                                            wide<T, N, sse_> const &a0) noexcept
+  EVE_FORCEINLINE wide<T, N, x86_128_> nearest_(EVE_SUPPORTS(sse4_1_),
+                                            wide<T, N, x86_128_> const &a0) noexcept
   {
     if constexpr(std::is_same_v<T, double>)
       return _mm_round_pd(a0, _MM_FROUND_TO_NEAREST_INT);
@@ -31,7 +31,7 @@ namespace eve::detail
   // -----------------------------------------------------------------------------------------------
   // 256 bits implementation
   template<floating_real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, avx_> nearest_(EVE_SUPPORTS(avx_), wide<T, N, avx_> const &a0) noexcept
+  EVE_FORCEINLINE wide<T, N, x86_256_> nearest_(EVE_SUPPORTS(avx_), wide<T, N, x86_256_> const &a0) noexcept
   {
     if constexpr(std::is_same_v<T, double>)
       return _mm256_round_pd(a0, _MM_FROUND_TO_NEAREST_INT);

--- a/include/eve/module/core/function/simd/x86/negate.hpp
+++ b/include/eve/module/core/function/simd/x86/negate.hpp
@@ -18,8 +18,8 @@ namespace eve::detail
   // -----------------------------------------------------------------------------------------------
   // 128 bits implementation
   template<signed_integral_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, sse_> negate_(EVE_SUPPORTS(ssse3_)
-                              , wide<T, N, sse_> const &a0, wide<T, N, sse_> const &a1) noexcept
+  EVE_FORCEINLINE wide<T, N, x86_128_> negate_(EVE_SUPPORTS(ssse3_)
+                              , wide<T, N, x86_128_> const &a0, wide<T, N, x86_128_> const &a1) noexcept
   {
     if (sizeof(T) == 8) return  map(negate, a0, a1);
     else if (sizeof(T) == 4) return  _mm_sign_epi32(a0, a1);
@@ -30,8 +30,8 @@ namespace eve::detail
    // -----------------------------------------------------------------------------------------------
   // 256 bits implementation
   template<signed_integral_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, avx_> negate_(EVE_SUPPORTS(avx2_)
-                              , wide<T, N, avx_> const &a0, wide<T, N, avx_> const &a1) noexcept
+  EVE_FORCEINLINE wide<T, N, x86_256_> negate_(EVE_SUPPORTS(avx2_)
+                              , wide<T, N, x86_256_> const &a0, wide<T, N, x86_256_> const &a1) noexcept
   {
     if (sizeof(T) == 8) return  negate_(EVE_RETARGET(sse2_), a0, a1);
     else if (sizeof(T) == 4) return  _mm256_sign_epi32(a0, a1);

--- a/include/eve/module/core/function/simd/x86/popcount.hpp
+++ b/include/eve/module/core/function/simd/x86/popcount.hpp
@@ -27,7 +27,7 @@ namespace eve::detail
 {
 
   template<integral_scalar_value T,  typename N>
-  EVE_FORCEINLINE auto popcount_(EVE_SUPPORTS(sse2_), wide<T, N, sse_>  x) noexcept
+  EVE_FORCEINLINE auto popcount_(EVE_SUPPORTS(sse2_), wide<T, N, x86_128_>  x) noexcept
   {
     auto putcounts = [](auto xx){
       using N8 = fixed<N::value*sizeof(T)>;
@@ -45,7 +45,7 @@ namespace eve::detail
     if constexpr(sizeof(T) == 8 || sizeof(T) == 1)
     {
       using N16 = fixed< (sizeof(T) < 8) ? 8u : sizeof(T)>;
-      using i16_t = wide < uint16_t, N16>; //typename wide<T,N,avx_>::template rebind<uint16_t,N16>;
+      using i16_t = wide < uint16_t, N16>;
       auto xx =  bit_cast(x, as<i16_t>());
       if constexpr(sizeof(T) == 8)
       {
@@ -76,7 +76,7 @@ namespace eve::detail
   /////////////////////////////////////////////////////////////////////////////
   // 256 bits
   template<integral_scalar_value T,  typename N>
-  EVE_FORCEINLINE auto popcount_(EVE_SUPPORTS(avx_), wide<T, N, avx_>  x) noexcept
+  EVE_FORCEINLINE auto popcount_(EVE_SUPPORTS(avx_), wide<T, N, x86_256_>  x) noexcept
   {
     using r_t = wide<as_integer_t<T, unsigned>, N>;
     if constexpr( current_api >=  avx2)

--- a/include/eve/module/core/function/simd/x86/rec.hpp
+++ b/include/eve/module/core/function/simd/x86/rec.hpp
@@ -20,8 +20,8 @@ namespace eve::detail
   // -----------------------------------------------------------------------------------------------
   // 128 bits implementation
   template<floating_real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, sse_>
-                  rec_(EVE_SUPPORTS(sse2_),  raw_type const &, wide<T, N, sse_> const &a0) noexcept
+  EVE_FORCEINLINE wide<T, N, x86_128_>
+                  rec_(EVE_SUPPORTS(sse2_),  raw_type const &, wide<T, N, x86_128_> const &a0) noexcept
   {
     if constexpr(std::is_same_v<T, double>)
     {
@@ -32,7 +32,7 @@ namespace eve::detail
   }
 
   template<floating_real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, sse_> rec_(EVE_SUPPORTS(sse2_), wide<T, N, sse_> const &a0) noexcept
+  EVE_FORCEINLINE wide<T, N, x86_128_> rec_(EVE_SUPPORTS(sse2_), wide<T, N, x86_128_> const &a0) noexcept
   {
     if constexpr(std::is_same_v<T, double>) { return _mm_div_pd(one(eve::as(a0)), a0); }
     else if constexpr(std::is_same_v<T, float>)
@@ -42,8 +42,8 @@ namespace eve::detail
   }
 
   template<floating_real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, sse_>
-                  rec_(EVE_SUPPORTS(sse2_), pedantic_type const &, wide<T, N, sse_> const &a0) noexcept
+  EVE_FORCEINLINE wide<T, N, x86_128_>
+                  rec_(EVE_SUPPORTS(sse2_), pedantic_type const &, wide<T, N, x86_128_> const &a0) noexcept
   {
     return  rec(a0);
   }
@@ -51,8 +51,8 @@ namespace eve::detail
   // -----------------------------------------------------------------------------------------------
   // 256 bits implementation
   template<floating_real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, avx_>
-                  rec_(EVE_SUPPORTS(avx_), raw_type const &, wide<T, N, avx_> const &a0) noexcept
+  EVE_FORCEINLINE wide<T, N, x86_256_>
+                  rec_(EVE_SUPPORTS(avx_), raw_type const &, wide<T, N, x86_256_> const &a0) noexcept
   {
     if constexpr(std::is_same_v<T, double>)
     {
@@ -63,7 +63,7 @@ namespace eve::detail
   }
 
   template<floating_real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, avx_> rec_(EVE_SUPPORTS(avx_), wide<T, N, avx_> const &a0) noexcept
+  EVE_FORCEINLINE wide<T, N, x86_256_> rec_(EVE_SUPPORTS(avx_), wide<T, N, x86_256_> const &a0) noexcept
   {
     if constexpr(std::is_same_v<T, double>) { return _mm256_div_pd(one(eve::as(a0)), a0); }
     else if constexpr(std::is_same_v<T, float>)
@@ -73,8 +73,8 @@ namespace eve::detail
   }
 
   template<floating_real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, avx_>
-                  rec_(EVE_SUPPORTS(avx_), pedantic_type const &, wide<T, N, avx_> const &a0) noexcept
+  EVE_FORCEINLINE wide<T, N, x86_256_>
+                  rec_(EVE_SUPPORTS(avx_), pedantic_type const &, wide<T, N, x86_256_> const &a0) noexcept
   {
     return rec(a0);
   }

--- a/include/eve/module/core/function/simd/x86/rotl.hpp
+++ b/include/eve/module/core/function/simd/x86/rotl.hpp
@@ -22,8 +22,8 @@ namespace eve::detail
   // -----------------------------------------------------------------------------------------------
   // 128 bits implementation
   template<integral_real_scalar_value T, integral_real_scalar_value I, typename N>
-  EVE_FORCEINLINE wide<T, N, sse_> rotl_(EVE_SUPPORTS(avx_),
-                                        wide<T, N, sse_> const &a0,
+  EVE_FORCEINLINE wide<T, N, x86_128_> rotl_(EVE_SUPPORTS(avx_),
+                                        wide<T, N, x86_128_> const &a0,
                                         I const &               a1) noexcept
   {
     if constexpr(supports_xop)

--- a/include/eve/module/core/function/simd/x86/rshl.hpp
+++ b/include/eve/module/core/function/simd/x86/rshl.hpp
@@ -18,8 +18,8 @@ namespace eve::detail
 {
   template<integral_real_scalar_value T, integral_real_scalar_value I, typename N>
   EVE_FORCEINLINE auto  rshl_(EVE_SUPPORTS(avx_),
-                              wide<T, N, sse_> const &a0,
-                              wide<I, N, sse_> const &a1)
+                              wide<T, N, x86_128_> const &a0,
+                              wide<I, N, x86_128_> const &a1)
   {
     if constexpr(supports_xop)
     {

--- a/include/eve/module/core/function/simd/x86/rshr.hpp
+++ b/include/eve/module/core/function/simd/x86/rshr.hpp
@@ -18,12 +18,12 @@ namespace eve::detail
 {
   template<integral_real_scalar_value T, integral_real_scalar_value I, typename N>
   EVE_FORCEINLINE auto rshr_(EVE_SUPPORTS(avx_),
-                             wide<T, N, sse_> const &a0,
-                             wide<I, N, sse_> const &a1) noexcept
+                             wide<T, N, x86_128_> const &a0,
+                             wide<I, N, x86_128_> const &a1) noexcept
   {
     if constexpr(supports_xop)
     {
-      using si_t = wide<as_integer_t<I, signed>, N, sse_>;
+      using si_t = wide<as_integer_t<I, signed>, N, x86_128_>;
       auto sa1   = -bit_cast(a1, as_<si_t>{});
       if(std::is_signed_v<I>)
       {

--- a/include/eve/module/core/function/simd/x86/rsqrt.hpp
+++ b/include/eve/module/core/function/simd/x86/rsqrt.hpp
@@ -86,7 +86,7 @@ namespace eve::detail
   //------------------------------------------------------------------------------------------------
   // Regular 128 bits rsqrt
   template<floating_real_scalar_value T, typename N>
-  EVE_FORCEINLINE auto rsqrt_(EVE_SUPPORTS(sse2_), wide<T, N, sse_> const &a0) noexcept
+  EVE_FORCEINLINE auto rsqrt_(EVE_SUPPORTS(sse2_), wide<T, N, x86_128_> const &a0) noexcept
   {
     if constexpr(std::is_same_v<T, double>) return rsqrt_x86_pedantic(a0);
     else return rsqrt_x86(a0);
@@ -97,7 +97,7 @@ namespace eve::detail
   template<floating_real_scalar_value T, typename N>
   EVE_FORCEINLINE auto rsqrt_(EVE_SUPPORTS(sse2_)
                              , pedantic_type const &
-                             , wide<T, N, sse_> const &a0) noexcept
+                             , wide<T, N, x86_128_> const &a0) noexcept
   {
      return rsqrt_x86_pedantic(a0);
   }
@@ -105,7 +105,7 @@ namespace eve::detail
   //------------------------------------------------------------------------------------------------
   // Regular 256 bits rsqrt
   template<floating_real_scalar_value T, typename N>
-  EVE_FORCEINLINE auto rsqrt_(EVE_SUPPORTS(avx_), wide<T, N, avx_> const &a0) noexcept
+  EVE_FORCEINLINE auto rsqrt_(EVE_SUPPORTS(avx_), wide<T, N, x86_256_> const &a0) noexcept
   {
     if constexpr(std::is_same_v<T, double>) return rsqrt_x86_pedantic(a0);
     else return rsqrt_x86(a0);
@@ -116,7 +116,7 @@ namespace eve::detail
   template<floating_real_scalar_value T, typename N>
   EVE_FORCEINLINE auto rsqrt_(EVE_SUPPORTS(avx_)
                              , pedantic_type const &
-                             , wide<T, N, avx_> const &a0) noexcept
+                             , wide<T, N, x86_256_> const &a0) noexcept
   {
     return rsqrt_x86_pedantic(a0);
   }
@@ -124,8 +124,8 @@ namespace eve::detail
 //------------------------------------------------------------------------------------------------
   // 128 bits raw rsqrt
   template<floating_real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, sse_>
-                  rsqrt_(EVE_SUPPORTS(sse2_), raw_type const &, wide<T, N, sse_> const &a0) noexcept
+  EVE_FORCEINLINE wide<T, N, x86_128_>
+                  rsqrt_(EVE_SUPPORTS(sse2_), raw_type const &, wide<T, N, x86_128_> const &a0) noexcept
   {
     if constexpr(std::is_same_v<T, double>)
     {
@@ -141,8 +141,8 @@ namespace eve::detail
   //------------------------------------------------------------------------------------------------
   // 256 bits raw rsqrt
   template<floating_real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, avx_>
-                  rsqrt_(EVE_SUPPORTS(avx_), raw_type const &, wide<T, N, avx_> const &a0) noexcept
+  EVE_FORCEINLINE wide<T, N, x86_256_>
+                  rsqrt_(EVE_SUPPORTS(avx_), raw_type const &, wide<T, N, x86_256_> const &a0) noexcept
   {
     if constexpr(std::is_same_v<T, double>)
     {

--- a/include/eve/module/core/function/simd/x86/shl.hpp
+++ b/include/eve/module/core/function/simd/x86/shl.hpp
@@ -22,14 +22,14 @@ namespace eve::detail
   // -----------------------------------------------------------------------------------------------
   // 128 bits implementation
   template<integral_real_scalar_value T, integral_real_scalar_value I, typename N>
-  EVE_FORCEINLINE wide<T, N, sse_> shl_(EVE_SUPPORTS(sse2_),
-                                        wide<T, N, sse_> const &a0,
+  EVE_FORCEINLINE wide<T, N, x86_128_> shl_(EVE_SUPPORTS(sse2_),
+                                        wide<T, N, x86_128_> const &a0,
                                         I const &               a1) noexcept
   {
 
     if constexpr(sizeof(T) == 1)
     {
-      using r_t = wide<T, N, sse_>;
+      using r_t = wide<T, N, x86_128_>;
       using N16 = fixed<N::value/2>;
       using i16_t = wide<std::uint16_t, N16>;
       const i16_t masklow(0xff);
@@ -54,10 +54,10 @@ namespace eve::detail
   }
 
   template<integral_real_scalar_value T, integral_real_scalar_value I, typename N>
-  EVE_FORCEINLINE wide<T, N, sse_>
+  EVE_FORCEINLINE wide<T, N, x86_128_>
   shl_(EVE_SUPPORTS(avx_),
-       wide<T, N, sse_> const &a0,
-       wide<I, N, sse_> const &a1) noexcept
+       wide<T, N, x86_128_> const &a0,
+       wide<I, N, x86_128_> const &a1) noexcept
   {
     if constexpr(supports_xop)
     {
@@ -77,15 +77,15 @@ namespace eve::detail
   // -----------------------------------------------------------------------------------------------
   // 256 bits implementation
   template<integral_real_scalar_value T, integral_real_scalar_value I, typename N>
-  EVE_FORCEINLINE wide<T, N, avx_>  shl_(EVE_SUPPORTS(avx_),
-                                         wide<T, N, avx_> const &a0,
+  EVE_FORCEINLINE wide<T, N, x86_256_>  shl_(EVE_SUPPORTS(avx_),
+                                         wide<T, N, x86_256_> const &a0,
                                          I const &               a1) noexcept
   {
     if constexpr(current_api >= avx2)
     {
       if constexpr(sizeof(T) == 1)
       {
-        using r_t = wide<T, N, avx_>;
+        using r_t = wide<T, N, x86_256_>;
         using N16 = fixed<N::value/2>;
         using i16_t = wide<std::uint16_t, N16>;
         const i16_t masklow(0xff);
@@ -107,10 +107,10 @@ namespace eve::detail
   }
 
   template<integral_real_scalar_value T, integral_real_scalar_value I, typename N>
-  EVE_FORCEINLINE wide<T, N, avx_>
+  EVE_FORCEINLINE wide<T, N, x86_256_>
   shl_(EVE_SUPPORTS(avx_),
-       wide<T, N, avx_> const &a0,
-       wide<I, N, avx_> const &a1) noexcept
+       wide<T, N, x86_256_> const &a0,
+       wide<I, N, x86_256_> const &a1) noexcept
   {
     [[ maybe_unused ]] auto ifxop_choice = [](const auto &a0, const auto &a1) {
       if constexpr(supports_xop)

--- a/include/eve/module/core/function/simd/x86/shr.hpp
+++ b/include/eve/module/core/function/simd/x86/shr.hpp
@@ -22,14 +22,14 @@ namespace eve::detail
   // -----------------------------------------------------------------------------------------------
   // 128 bits implementation
   template<integral_real_scalar_value T, integral_real_scalar_value I, typename N>
-  EVE_FORCEINLINE wide<T, N, sse_> shr_(EVE_SUPPORTS(sse2_)
-                                       , wide<T, N, sse_> const &a0, I const & a1) noexcept
+  EVE_FORCEINLINE wide<T, N, x86_128_> shr_(EVE_SUPPORTS(sse2_)
+                                       , wide<T, N, x86_128_> const &a0, I const & a1) noexcept
   {
     if constexpr(std::is_unsigned_v<T>)
     {
       if constexpr(sizeof(T) == 1)
       {
-        using t_t = wide<T, N, sse_>;
+        using t_t = wide<T, N, x86_128_>;
         using int_t     = std::uint16_t;
         using gen_t     = wide<int_t, fixed<N::value / 2>>;
         t_t const Mask1 = bit_cast(gen_t(0x00ff),as(a0));
@@ -58,13 +58,13 @@ namespace eve::detail
   }
 
   template<integral_real_scalar_value T,  integral_real_scalar_value I, typename N>
-  EVE_FORCEINLINE wide<T, N, sse_>  shr_(EVE_SUPPORTS(avx_),
-                                         wide<T, N, sse_> const &a0,
-                                         wide<I, N, sse_> const &a1) noexcept
+  EVE_FORCEINLINE wide<T, N, x86_128_>  shr_(EVE_SUPPORTS(avx_),
+                                         wide<T, N, x86_128_> const &a0,
+                                         wide<I, N, x86_128_> const &a1) noexcept
   {
     if constexpr(supports_xop)
     {
-      using si_t = wide<as_integer_t<I, signed>, N, sse_>;
+      using si_t = wide<as_integer_t<I, signed>, N, x86_128_>;
       auto sa1   = -bit_cast(a1, as_<si_t>{});
       if constexpr(std::is_unsigned_v<T>)
       {
@@ -103,7 +103,7 @@ namespace eve::detail
   // -----------------------------------------------------------------------------------------------
   // 256 bits implementation
   template<integral_real_scalar_value T, integral_real_scalar_value I, typename N>
-  EVE_FORCEINLINE wide<T, N, avx_> shr_(EVE_SUPPORTS(avx_), wide<T, N, avx_> const &a0,I const & a1) noexcept
+  EVE_FORCEINLINE wide<T, N, x86_256_> shr_(EVE_SUPPORTS(avx_), wide<T, N, x86_256_> const &a0,I const & a1) noexcept
   {
     if constexpr(current_api >= avx2)
     {
@@ -133,9 +133,9 @@ namespace eve::detail
   }
 
   template<integral_real_scalar_value T, integral_real_scalar_value I, typename N>
-  EVE_FORCEINLINE wide<T, N, avx_> shr_(EVE_SUPPORTS(avx_),
-       wide<T, N, avx_> const &a0,
-       wide<I, N, avx_> const &a1) noexcept
+  EVE_FORCEINLINE wide<T, N, x86_256_> shr_(EVE_SUPPORTS(avx_),
+       wide<T, N, x86_256_> const &a0,
+       wide<I, N, x86_256_> const &a1) noexcept
   {
     [[ maybe_unused ]] auto ifxop_choice = [](const auto &a0, const auto &a1) {
       if constexpr(supports_xop)

--- a/include/eve/module/core/function/simd/x86/sign.hpp
+++ b/include/eve/module/core/function/simd/x86/sign.hpp
@@ -18,12 +18,12 @@
 namespace eve::detail
 {
   template<integral_real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, sse_> sign_(EVE_SUPPORTS(ssse3_)
-                                        , wide<T, N, sse_> const &a) noexcept
+  EVE_FORCEINLINE wide<T, N, x86_128_> sign_(EVE_SUPPORTS(ssse3_)
+                                        , wide<T, N, x86_128_> const &a) noexcept
   {
     if constexpr(std::is_signed_v<T>)
     {
-      using t_t = wide<T, N, sse_>;
+      using t_t = wide<T, N, x86_128_>;
       if constexpr(sizeof(T) == 1)
         return t_t(_mm_sign_epi8(one(eve::as(a)), a));
       else if constexpr(sizeof(T) == 2)

--- a/include/eve/module/core/function/simd/x86/sqrt.hpp
+++ b/include/eve/module/core/function/simd/x86/sqrt.hpp
@@ -17,7 +17,7 @@
 namespace eve::detail
 {
   template<floating_real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, sse_> sqrt_(EVE_SUPPORTS(sse2_), wide<T, N, sse_> const &a0) noexcept
+  EVE_FORCEINLINE wide<T, N, x86_128_> sqrt_(EVE_SUPPORTS(sse2_), wide<T, N, x86_128_> const &a0) noexcept
   {
     if constexpr(std::is_same_v<T, float>)
       return _mm_sqrt_ps(a0);
@@ -26,7 +26,7 @@ namespace eve::detail
   }
 
   template<floating_real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, avx_> sqrt_(EVE_SUPPORTS(avx2_), wide<T, N, avx_> const &a0) noexcept
+  EVE_FORCEINLINE wide<T, N, x86_256_> sqrt_(EVE_SUPPORTS(avx2_), wide<T, N, x86_256_> const &a0) noexcept
   {
     if constexpr(std::is_same_v<T, float>)
       return _mm256_sqrt_ps(a0);

--- a/include/eve/module/core/function/simd/x86/store.hpp
+++ b/include/eve/module/core/function/simd/x86/store.hpp
@@ -21,9 +21,9 @@ namespace eve::detail
   // -----------------------------------------------------------------------------------------------
   // 128 bits implementation
   template<typename T, typename N>
-  EVE_FORCEINLINE auto store_(EVE_SUPPORTS(sse2_), wide<T, N, sse_> const &value, T *ptr) noexcept
+  EVE_FORCEINLINE auto store_(EVE_SUPPORTS(sse2_), wide<T, N, x86_128_> const &value, T *ptr) noexcept
   {
-    if constexpr(N::value * sizeof(T) == sse_::bytes)
+    if constexpr(N::value * sizeof(T) == x86_128_::bytes)
     {
       if constexpr(std::is_same_v<T, double>)
         _mm_storeu_pd(ptr, value);
@@ -40,11 +40,11 @@ namespace eve::detail
 
   template<typename T, typename N, std::size_t A>
   EVE_FORCEINLINE auto
-  store_(EVE_SUPPORTS(sse2_), wide<T, N, sse_> const &value, aligned_ptr<T, A> ptr) noexcept
+  store_(EVE_SUPPORTS(sse2_), wide<T, N, x86_128_> const &value, aligned_ptr<T, A> ptr) noexcept
   {
-    static constexpr auto alg = wide<T, N, sse_>::static_alignment;
+    static constexpr auto alg = wide<T, N, x86_128_>::static_alignment;
 
-    if constexpr(N::value * sizeof(T) == sse_::bytes && A >= alg)
+    if constexpr(N::value * sizeof(T) == x86_128_::bytes && A >= alg)
     {
       if constexpr(std::is_same_v<T, double>)
         _mm_store_pd(ptr.get(), value);
@@ -62,9 +62,9 @@ namespace eve::detail
   // -----------------------------------------------------------------------------------------------
   // 256 bits implementation
   template<typename T, typename N>
-  EVE_FORCEINLINE auto store_(EVE_SUPPORTS(avx_), wide<T, N, avx_> const &value, T *ptr) noexcept
+  EVE_FORCEINLINE auto store_(EVE_SUPPORTS(avx_), wide<T, N, x86_256_> const &value, T *ptr) noexcept
   {
-    if constexpr(N::value * sizeof(T) == avx_::bytes)
+    if constexpr(N::value * sizeof(T) == x86_128_::bytes)
     {
       if constexpr(std::is_same_v<T, double>)
         _mm256_storeu_pd(ptr, value);
@@ -81,11 +81,11 @@ namespace eve::detail
 
   template<typename T, typename N, std::size_t A>
   EVE_FORCEINLINE auto
-  store_(EVE_SUPPORTS(avx_), wide<T, N, avx_> const &value, aligned_ptr<T, A> ptr) noexcept
+  store_(EVE_SUPPORTS(avx_), wide<T, N, x86_256_> const &value, aligned_ptr<T, A> ptr) noexcept
   {
-    static constexpr auto alg = wide<T, N, avx_>::static_alignment;
+    static constexpr auto alg = wide<T, N, x86_256_>::static_alignment;
 
-    if constexpr(N::value * sizeof(T) == avx_::bytes && A >= alg)
+    if constexpr(N::value * sizeof(T) == x86_128_::bytes && A >= alg)
     {
       if constexpr(std::is_same_v<T, double>)
         _mm256_store_pd(ptr.get(), value);

--- a/include/eve/module/core/function/simd/x86/sub.hpp
+++ b/include/eve/module/core/function/simd/x86/sub.hpp
@@ -21,8 +21,8 @@ namespace eve::detail
   // -----------------------------------------------------------------------------------------------
   // 128 bits implementation
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, sse_>
-                  sub_(EVE_SUPPORTS(sse2_), wide<T, N, sse_> v0, wide<T, N, sse_> const &v1) noexcept
+  EVE_FORCEINLINE wide<T, N, x86_128_>
+                  sub_(EVE_SUPPORTS(sse2_), wide<T, N, x86_128_> v0, wide<T, N, x86_128_> const &v1) noexcept
   {
     return v0 -= v1;
   }
@@ -30,8 +30,8 @@ namespace eve::detail
   // -----------------------------------------------------------------------------------------------
   // 256 bits implementation
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, avx_>
-                  sub_(EVE_SUPPORTS(avx_), wide<T, N, avx_> v0, wide<T, N, avx_> const &v1) noexcept
+  EVE_FORCEINLINE wide<T, N, x86_256_>
+                  sub_(EVE_SUPPORTS(avx_), wide<T, N, x86_256_> v0, wide<T, N, x86_256_> const &v1) noexcept
   {
     return v0 -= v1;
   }
@@ -39,10 +39,10 @@ namespace eve::detail
   // -----------------------------------------------------------------------------------------------
   // 128 bits saturated implementation
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, sse_> sub_(EVE_SUPPORTS(sse2_),
+  EVE_FORCEINLINE wide<T, N, x86_128_> sub_(EVE_SUPPORTS(sse2_),
                                         saturated_type const &  st,
-                                        wide<T, N, sse_> const &v0,
-                                        wide<T, N, sse_> const &v1) noexcept
+                                        wide<T, N, x86_128_> const &v0,
+                                        wide<T, N, x86_128_> const &v1) noexcept
   {
     if constexpr( std::is_floating_point_v<T> )
       return sub(v0, v1);
@@ -72,10 +72,10 @@ namespace eve::detail
   // -----------------------------------------------------------------------------------------------
   // 256 bits saturated implementation
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, avx_> sub_(EVE_SUPPORTS(avx2_),
+  EVE_FORCEINLINE wide<T, N, x86_256_> sub_(EVE_SUPPORTS(avx2_),
                                         saturated_type const &  st,
-                                        wide<T, N, avx_> const &v0,
-                                        wide<T, N, avx_> const &v1) noexcept
+                                        wide<T, N, x86_256_> const &v0,
+                                        wide<T, N, x86_256_> const &v1) noexcept
   {
     if constexpr( std::is_floating_point_v<T> )
       return sub(v0, v1);

--- a/include/eve/module/core/function/simd/x86/trunc.hpp
+++ b/include/eve/module/core/function/simd/x86/trunc.hpp
@@ -23,8 +23,8 @@ namespace eve::detail
   // -----------------------------------------------------------------------------------------------
   // 128 bits implementation
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, sse_> trunc_(EVE_SUPPORTS(sse4_1_),
-                                          wide<T, N, sse_> const &a0) noexcept
+  EVE_FORCEINLINE wide<T, N, x86_128_> trunc_(EVE_SUPPORTS(sse4_1_),
+                                          wide<T, N, x86_128_> const &a0) noexcept
   {
     if constexpr(std::is_same_v<T, double>)     return _mm_round_pd(a0, _MM_FROUND_TO_ZERO);
     else if constexpr(std::is_same_v<T, float>) return _mm_round_ps(a0, _MM_FROUND_TO_ZERO);
@@ -32,17 +32,17 @@ namespace eve::detail
   }
 
  template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, sse_> trunc_(EVE_SUPPORTS(sse4_1_)
+  EVE_FORCEINLINE wide<T, N, x86_128_> trunc_(EVE_SUPPORTS(sse4_1_)
                                          , raw_type const &
-                                         , wide<T, N, sse_> const &a0) noexcept
+                                         , wide<T, N, x86_128_> const &a0) noexcept
   {
-    return trunc(a0); 
+    return trunc(a0);
   }
-  
+
   // -----------------------------------------------------------------------------------------------
   // 256 bits implementation
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, avx_> trunc_(EVE_SUPPORTS(avx_), wide<T, N, avx_> const &a0) noexcept
+  EVE_FORCEINLINE wide<T, N, x86_256_> trunc_(EVE_SUPPORTS(avx_), wide<T, N, x86_256_> const &a0) noexcept
   {
     if constexpr(std::is_same_v<T, double>)     return _mm256_round_pd(a0, _MM_FROUND_TO_ZERO);
     else if constexpr(std::is_same_v<T, float>) return _mm256_round_ps(a0, _MM_FROUND_TO_ZERO);
@@ -50,12 +50,12 @@ namespace eve::detail
   }
 
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, avx_> trunc_(EVE_SUPPORTS(avx_)
+  EVE_FORCEINLINE wide<T, N, x86_256_> trunc_(EVE_SUPPORTS(avx_)
                                          , raw_type const &
-                                         , wide<T, N, avx_> const &a0) noexcept
+                                         , wide<T, N, x86_256_> const &a0) noexcept
   {
-    return trunc(a0); 
+    return trunc(a0);
   }
-   
+
 }
 

--- a/include/eve/module/math/function/simd/x86/log.hpp
+++ b/include/eve/module/math/function/simd/x86/log.hpp
@@ -154,7 +154,7 @@ namespace eve::detail
   // -----------------------------------------------------------------------------------------------
   // 256 bits implementation for avx
   template<floating_real_scalar_value T, typename N>
-  EVE_FORCEINLINE auto log_(EVE_SUPPORTS(avx_), wide<T, N, avx_> const &v) noexcept
+  EVE_FORCEINLINE auto log_(EVE_SUPPORTS(avx_), wide<T, N, x86_256_> const &v) noexcept
   {
     if constexpr( current_api < avx2 )
       return plain(log)(v);

--- a/include/eve/module/math/function/simd/x86/log10.hpp
+++ b/include/eve/module/math/function/simd/x86/log10.hpp
@@ -189,7 +189,7 @@ namespace eve::detail
   // -----------------------------------------------------------------------------------------------
   // 256 bits implementation for avx
   template<floating_real_scalar_value T, typename N>
-  EVE_FORCEINLINE auto log10_(EVE_SUPPORTS(avx_), wide<T, N, avx_> const &v) noexcept
+  EVE_FORCEINLINE auto log10_(EVE_SUPPORTS(avx_), wide<T, N, x86_256_> const &v) noexcept
   {
     if constexpr( current_api < avx2 )
       return plain(log10)(v);

--- a/include/eve/module/math/function/simd/x86/log1p.hpp
+++ b/include/eve/module/math/function/simd/x86/log1p.hpp
@@ -110,7 +110,7 @@ namespace eve::detail
   // -----------------------------------------------------------------------------------------------
   // 256 bits implementation for avx
   template<floating_real_scalar_value T, typename N>
-  EVE_FORCEINLINE auto log1p_(EVE_SUPPORTS(avx_), wide<T, N, avx_> const &v) noexcept
+  EVE_FORCEINLINE auto log1p_(EVE_SUPPORTS(avx_), wide<T, N, x86_256_> const &v) noexcept
   {
     if constexpr( current_api < avx2 )
       return plain(log1p)(v);

--- a/include/eve/module/math/function/simd/x86/log2.hpp
+++ b/include/eve/module/math/function/simd/x86/log2.hpp
@@ -208,7 +208,7 @@ namespace eve::detail
   // -----------------------------------------------------------------------------------------------
   // 256 bits implementation for avx
   template<floating_real_scalar_value T, typename N>
-  EVE_FORCEINLINE auto log2_(EVE_SUPPORTS(avx_), wide<T, N, avx_> const &v) noexcept
+  EVE_FORCEINLINE auto log2_(EVE_SUPPORTS(avx_), wide<T, N, x86_256_> const &v) noexcept
   {
     if constexpr( current_api < avx2 )
       return plain(log2)(v);


### PR DESCRIPTION
sse_ and avx_ are now x86_128_ and x86_256_
neon64_ neon128_ become arm_64_ arm_128_