### PR TITLE
Fix #344: extending eve - first_true

### DIFF
--- a/docs/crumbs.html
+++ b/docs/crumbs.html
@@ -79,7 +79,7 @@
 <span class="dropdown">
   <span class="dropbtn">**Developer's Corner**</span>
   <span class="dropdown-content">
-    [**TODO**](developer/TODO.html)
+    [**Extending EVE (1) **](developer/extending_eve_basics.html)
   </span>
 </span>
 <hr>

--- a/docs/developer/extending_eve_basics.html
+++ b/docs/developer/extending_eve_basics.html
@@ -1,0 +1,172 @@
+<!--
+  EVE -  Expressive Vector Engine
+  Copyright 2020 Joel FALCOU
+  Copyright 2020 Jean-Thierry LAPRESTE
+  Copyright 2020 Denis YAROSHEVSKIY
+
+  Licensed under the MIT License <http://opensource.org/licenses/MIT>.
+  SPDX-License-Identifier: MIT
+ -->
+ <meta charset="utf-8" lang="en"><style class="fallback">body{visibility:hidden;}</style>
+ **Expressive Vector Engine**
+
+(insert ../crumbs.html here)
+
+# Extending EVE(1): adding a custom function implemented with intrinsics.
+
+*NOTE: this documentation was valid at [commit](https://github.com/jfalcou/eve/tree/64d40a4034e536cfa78eab916ceb7c4e68190709).
+The code samples are compiled but the text might get outdated.*<br/>
+*NOTE: In order to be extensible, EVE exposes a lot of it's internals. However they are subject
+to change even when the rest of the API is stable.*
+
+## Intoduction
+
+EVE like any other library of this nature is a collection of "tricks" implemented portably for different
+architectures. However, what if EVE doesn't provide what you need?<br/>
+
+1 - please create a feature request. <br/>
+2 - since you need a solution now in this tutorial we are going to look at how to write your own
+    functions that work with EVE.
+
+We are going to see:
+ * How to convert to register intrinsics and back.
+ * How to require certain architecture for your function.
+
+## Example problem
+
+We are going to pick `first_true` function as an example. Let's say that we need it to implement
+a variation on `std::find`. We are going to care about are all x86 from SSE2 to AVX2.
+
+In this tutorial we are only supporting the very basic functionality.
+
+## Starting simple
+
+In most cases you probably want to keep your solution as simple as possible.
+Let's say we just want EVE to generate certain intrinsics for 128 and 256 bit registers and that's it.
+
+*NOTE: the main idea for the solution is: get a bit mask using `movemask` instruction family and then count trailing
+bits to find the first one that's set.*<br/>
+*NOTE: `first_true` can be implemented slightly better for types that are at least 4 bytes but that's not the point of this tutorial.*
+
+Our first attempt could look something like
+
+<script type="preformatted">
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ c++
+#include <bit>
+#include <concepts>
+#include <cstdint>
+#include <optional>
+
+#include <eve/wide.hpp>
+
+template <eve::simd_value Wide>
+std::uint32_t movemask(const eve::logical<Wide>& test) {
+  using ABI = typename Wide::abi_type;
+
+  if constexpr (std::same_as<ABI, eve::x86_128_>) {
+    return _mm_movemask_epi8(test.storage());
+  } else if constexpr (std::same_as<ABI, eve::x86_256_>) {
+    if constexpr (eve::current_api == eve::avx) {
+      __m128i lo = _mm256_extractf128_si256(test.storage(), 0);
+      __m128i hi = _mm256_extractf128_si256(test.storage(), 1);
+      std::uint32_t mmask = _mm_movemask_epi8(hi);
+      mmask <<= 16;
+      mmask |= _mm_movemask_epi8(lo);
+      return mmask;
+    } else if constexpr (eve::current_api == eve::avx2) {
+      return _mm256_movemask_epi8(test.storage());
+   }
+  }
+}
+
+template <eve::simd_value Wide>
+std::optional<std::uint32_t> first_true(const eve::logical<Wide>& test) {
+  std::uint32_t mmask = movemask(test);
+
+  if (!mmask) return std::nullopt;
+  return std::countr_zero(mmask) / sizeof(eve::element_type_t<Wide>);
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</script>
+
+Let's break it down.
+
+First we see `eve::simd_value` concept. This allows for anything that looks like `eve::wide`.
+Alternatively we could've just used "`typename T, typename Size, typename ABI`".
+Both of these are not sufficiently restrictive - we will deal with that in a bit.
+
+`movemask` - is a function where we are actually going to do our intrinsics buisness.
+We want 3 implementations: for sse 2-4.2, for avx and for avx2.
+EVE provides two nobs to select which instruction set to use: ABI and API.
+ABI is an indication of are you dealing with `__m128(i)` or `__m256(i)`. You can access ABI from the `wide::abi_type`.
+Sometimes - it's enough - all instruction sets that support `128` bit registers support `_mm_movemask_epi8`.
+
+However for `avx` and `avx2` we want to do different things: on `avx2` we have `_mm256_movemask_epi8` that
+gives us what we want but on `avx` we have to split the register in 2. To understand which instruction set is
+currently avaliable, we use `eve::current_api` accessor. <br/>
+*NOTE: comparisons between apis are only defined within one architecture*.
+
+As for the rest of `movemask` function - `.storage()` accessor returns you an underlying representaion from both
+`eve::wide` and `eve::logical`. Both `eve::wide` and `eve::logical` are constructible from their underlying representation.
+In our case it is just `__m128i` and `__m256i` depending on the size.
+
+*NOTE: implicit conversions are also avaliable but I don't like them*.<br/>
+*TODO: link to complete description of all storages for all platforms*.
+
+## Being a better citizen
+
+As I mentioned, we are not very good with our restrictions. If we try to compile for ARM let's say
+or when AVX-512 support is in eve - we are likely to fail at the execution stage. We need better restrictions.
+
+One thing we could do would look something like this.
+
+<script type="preformatted">
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ c++
+#include <bit>
+#include <concepts>
+#include <cstdint>
+#include <optional>
+
+#include <eve/wide.hpp>
+
+template <typename Wide, typename ABI>
+  concept expected_wide_for_abi = std::same_as<
+      Wide,
+      eve::wide<eve::element_type_t<Wide>,
+                eve::expected_cardinal_t<eve::element_type_t<Wide>, ABI>, ABI>>;
+
+  template <typename Wide>
+  concept supported_wide = expected_wide_for_abi<Wide, eve::x86_128_> ||
+                           expected_wide_for_abi<Wide, eve::x86_256_>;
+
+  template <supported_wide Wide>
+  std::uint32_t movemask(const eve::logical<Wide>& test) requires(
+      eve::current_api <= eve::avx2) {
+...
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</script>
+
+The interesting part here is `eve::expected_cardinal_t` - this is a helper that tells you the default number of elements
+in `eve::wide` for a given `ABI`. Example would be 8 `short` for `x86_128_` and 16 `short` for `x86_256_`.
+
+With this I'd say we are done with the basic functionality.
+You can support more things but I'd say they are in "implement when you actually need it" camp.
+
+## Conclusion
+
+Extensibility is absolutely a feature of eve. In other tutorials we'll have a look at how to support non-native
+register sizes, conditionals and modifiers from EVE expressions language and how to generate function objects similar
+to EVE's ones.
+
+----------------------------------------------------------------------------------------------------
+<!-- Shortcuts -->
+
+<!-- Footnotes -->
+
+<!-- End of Document -->
+<style class="fallback">body{visibility:hidden}</style><script>markdeepOptions={tocStyle:'none'};</script>
+<link rel="stylesheet" href="../eve.css">
+<!-- Markdeep: -->
+<script src="../markdeep.min.js"></script>
+<script src="https://casual-effects.com/markdeep/latest/markdeep.min.js?" charset="utf-8"></script>


### PR DESCRIPTION
Fix for https://github.com/jfalcou/eve/issues/344
Example on how one can write custom functions for EVE: in this case first true.

Here is my gist with code:
https://gist.github.com/DenisYaroshevskiy/9b2254ebbdb850bda0f8508ea25fa290

The testing is bad but the functionality mostly copy-pasted from my normal implementation.
I don't know your testing framework unfortunately and I can't build your tests, I would prefer if somebody cleaned that up after me if possible. Or let me know what you need.
