### PR TITLE
Issue #362: min/max should use if/else for 64 bit ints

### DIFF
--- a/include/eve/module/core/function/simd/x86/max.hpp
+++ b/include/eve/module/core/function/simd/x86/max.hpp
@@ -10,14 +10,21 @@
 //==================================================================================================
 #pragma once
 
-#include <eve/detail/overload.hpp>
-#include <eve/detail/abi.hpp>
-#include <eve/forward.hpp>
-#include <type_traits>
 #include <eve/concept/value.hpp>
+#include <eve/detail/abi.hpp>
+#include <eve/detail/overload.hpp>
+#include <eve/forward.hpp>
+#include <eve/function/if_else.hpp>
+#include <type_traits>
 
 namespace eve::detail
 {
+   template <eve::simd_value Wide>
+   EVE_FORCEINLINE Wide if_else_max(Wide x, Wide y)
+   {
+     return eve::if_else(y > x, y, x);
+   }
+
   // -----------------------------------------------------------------------------------------------
   // 128 bits implementation
   template<real_scalar_value T, typename N>
@@ -25,27 +32,30 @@ namespace eve::detail
                                        , wide<T, N, x86_128_> const &v0
                                        , wide<T, N, x86_128_> const &v1) noexcept
   {
-         if constexpr(std::is_same_v<T, double>)     return _mm_max_pd(v0, v1);
-    else if constexpr(std::is_same_v<T, float>)      return _mm_max_ps(v0, v1);
-    else if constexpr( std::is_integral_v<T>)
+         if constexpr(std::is_same_v<T, double>) return _mm_max_pd(v0, v1);
+    else if constexpr(std::is_same_v<T, float>)  return _mm_max_ps(v0, v1);
+    else if constexpr(sizeof(T) == 1)
     {
-      constexpr bool issigned = std::is_signed_v<T>;
-      if constexpr(issigned && sizeof(T) == 2)       return _mm_max_epi16(v0, v1);
-      else if constexpr(!issigned && sizeof(T) == 1) return _mm_max_epu8(v0, v1);
-      else if constexpr(current_api >= sse4_1 && (sizeof(T) != 8))
-      {
-        if constexpr(issigned)
-        {
-          if constexpr(sizeof(T) == 1)               return _mm_max_epi8(v0, v1);
-          else if constexpr(sizeof(T) == 4)          return _mm_max_epi32(v0, v1);
-        }
-        else
-        {
-          if constexpr(sizeof(T) == 2)               return _mm_max_epu16(v0, v1);
-          else if constexpr(sizeof(T) == 4)          return _mm_max_epu32(v0, v1);
-        }
-      }
-      else                                           return map(max, v0, v1);
+           if constexpr(!std::is_signed_v<T>)    return _mm_max_epu8(v0, v1);
+      else if constexpr(current_api >= sse4_1)   return _mm_max_epi8(v0, v1);
+      else                                       return detail::if_else_max(v0, v1);
+    }
+    else if constexpr(sizeof(T) == 2)
+    {
+           if constexpr(std::is_signed_v<T>)     return _mm_max_epi16(v0, v1);
+      else if constexpr(current_api >= sse4_1)   return _mm_max_epu16(v0, v1);
+      else                                       return detail::if_else_max(v0, v1);
+    }
+    else if constexpr(sizeof(T) == 4)
+    {
+           if constexpr(current_api < sse4_1)    return detail::if_else_max(v0, v1);
+      else if constexpr(std::is_signed_v<T>)     return _mm_max_epi32(v0, v1);
+      else                                       return _mm_max_epu32(v0, v1);
+    }
+    else
+    {
+           if constexpr(current_api >= sse4_2)   return detail::if_else_max(v0, v1);
+      else                                       return map(max, v0, v1);
     }
   }
 
@@ -56,27 +66,21 @@ namespace eve::detail
                                        , wide<T, N, x86_256_> const &v0
                                        , wide<T, N, x86_256_> const &v1) noexcept
   {
-         if constexpr(std::is_same_v<T, float>)        return _mm256_max_ps(v0, v1);
-    else if constexpr(std::is_same_v<T, double>)       return _mm256_max_pd(v0, v1);
-    else // if constexpr(std::is_integral_v<T>)
-    {
-      if constexpr(current_api >= avx2 && sizeof(T) != 8)
+         if constexpr(std::is_same_v<T, float>)            return _mm256_max_ps(v0, v1);
+    else if constexpr(std::is_same_v<T, double>)           return _mm256_max_pd(v0, v1);
+    else if constexpr(current_api == avx && sizeof(T) < 8) return aggregate(max, v0, v1);
+    else if constexpr(sizeof(T) == 8)                      return detail::if_else_max(v0, v1);
+    else if constexpr(std::is_signed_v<T>)
       {
-        if constexpr(std::is_signed_v<T>)
-        {
-          if constexpr(sizeof(T) == 1)                 return _mm256_max_epi8(v0, v1);
-          else if constexpr(sizeof(T) == 2)            return _mm256_max_epi16(v0, v1);
-          else if constexpr(sizeof(T) == 4)            return _mm256_max_epi32(v0, v1);
-        }
-        else
-        {
-          if constexpr(sizeof(T) == 1)                 return _mm256_max_epu8(v0, v1);
-          else if constexpr(sizeof(T) == 2)            return _mm256_max_epu16(v0, v1);
-          else if constexpr(sizeof(T) == 4)            return _mm256_max_epu32(v0, v1);
-        }
+             if constexpr(sizeof(T) == 1)                  return _mm256_max_epi8(v0, v1);
+        else if constexpr(sizeof(T) == 2)                  return _mm256_max_epi16(v0, v1);
+        else if constexpr(sizeof(T) == 4)                  return _mm256_max_epi32(v0, v1);
       }
-      else                                             return aggregate(max, v0, v1);
-    }
+    else
+      {
+             if constexpr(sizeof(T) == 1)                  return _mm256_max_epu8(v0, v1);
+        else if constexpr(sizeof(T) == 2)                  return _mm256_max_epu16(v0, v1);
+        else if constexpr(sizeof(T) == 4)                  return _mm256_max_epu32(v0, v1);
+      }
   }
 }
-

--- a/test/unit/module/core/max/regular/max.hpp
+++ b/test/unit/module/core/max/regular/max.hpp
@@ -39,4 +39,13 @@ TTS_CASE_TPL("Check eve::max behavior", EVE_TYPE)
   TTS_EQUAL(eve::max(T(0), v_t(1)), T(1));
   TTS_EQUAL(eve::max(T(1), v_t(0)), T(1));
   TTS_EQUAL(eve::max(T(1), v_t(1)), T(1));
+
+  if constexpr (std::is_unsigned_v<v_t>)
+  {
+    TTS_EQUAL(eve::max(T(-1), v_t(1)), T(-1));
+  }
+  else
+  {
+    TTS_EQUAL(eve::max(T(-1), v_t(1)), T(1));
+  }
 }

--- a/test/unit/module/core/min/regular/min.hpp
+++ b/test/unit/module/core/min/regular/min.hpp
@@ -12,6 +12,7 @@
 #include <tts/tests/relation.hpp>
 #include <tts/tests/types.hpp>
 
+
 TTS_CASE_TPL("Check eve::min return type", EVE_TYPE)
 {
   using v_t = eve::element_type_t<T>;
@@ -37,4 +38,13 @@ TTS_CASE_TPL("Check eve::min behavior", EVE_TYPE)
   TTS_EQUAL(eve::min(T(0), v_t(1)), T(0));
   TTS_EQUAL(eve::min(T(1), v_t(0)), T(0));
   TTS_EQUAL(eve::min(T(1), v_t(1)), T(1));
+
+  if constexpr (std::is_unsigned_v<v_t>)
+  {
+    TTS_EQUAL(eve::min(T(-1), v_t(1)), T(1));
+  }
+  else
+  {
+    TTS_EQUAL(eve::min(T(-1), v_t(1)), T(-1));
+  }
 }


### PR DESCRIPTION
1) For `avx2` min/max can be done in 2 instructions for signed 4 for unsigned. (instead of splitting as now

(max is similar)

Signed

```
	vpcmpgtq	ymm2, ymm1, ymm0
	vblendvpd	ymm0, ymm1, ymm0, ymm2
```

Unsigned:

```
	vpbroadcastq	ymm2, qword ptr [rip + .LCPI0_0] # ymm2 = [9223372036854775808,...
	vpxor	ymm3, ymm0, ymm2
	vpxor	ymm2, ymm1, ymm2
	vpcmpgtq	ymm2, ymm2, ymm3
	vblendvpd	ymm0, ymm1, ymm0, ymm2
	ret
```

2) SSE 4.2 as well

Signed

```
	vpcmpgtq	xmm2, xmm1, xmm0
	vblendvpd	xmm0, xmm1, xmm0, xmm2
```

Unsigned

```
	vmovdqa	xmm2, xmmword ptr [rip + .LCPI0_0] # xmm2 = [9223372036854775808,9223372036854775808]
	vpxor	xmm3, xmm0, xmm2
	vpxor	xmm2, xmm1, xmm2
	vpcmpgtq	xmm2, xmm2, xmm3
	vblendvpd	xmm0, xmm1, xmm0, xmm2
```

(Though maybe it's questionable for unsigned).

3) For avx for 8 bytes I decided to do this as well instead of falling back completely on two `sse4.2` since there is at least a 256 blend.

```
	vpcmpgtq	xmm2, xmm0, xmm1
	vextractf128	xmm3, ymm0, 1
	vextractf128	xmm4, ymm1, 1
	vpcmpgtq	xmm3, xmm3, xmm4
	vinsertf128	ymm2, ymm2, xmm3, 1
	vblendvpd	ymm0, ymm0, ymm1, ymm2
```

As oppose to 

```
	vpcmpgtq	xmm2, xmm1, xmm0
	vblendvpd	xmm2, xmm1, xmm0, xmm2
	vextractf128	xmm0, ymm0, 1
	vextractf128	xmm1, ymm1, 1
	vpcmpgtq	xmm3, xmm1, xmm0
	vblendvpd	xmm0, xmm1, xmm0, xmm3
	vinsertf128	ymm0, ymm2, xmm0, 1
```