### PR TITLE
Issue #358: libcxx doesn't have cmath

### DIFF
--- a/test/unit/module/special/beta/regular/beta.hpp
+++ b/test/unit/module/special/beta/regular/beta.hpp
@@ -21,6 +21,7 @@
 #include <eve/constant/pi.hpp>
 #include <eve/platform.hpp>
 #include <cmath>
+#include <version>
 
 TTS_CASE_TPL("Check eve::beta return type", EVE_TYPE)
 {
@@ -46,11 +47,11 @@ TTS_CASE_TPL("Check eve::beta behavior", EVE_TYPE)
     TTS_ULP_EQUAL(eve__beta(T(1), eve::nan(eve::as<T>())), eve::nan(as<T>()), 0);
   }
 
-
+#if __cpp_lib_math_special_functions
   TTS_ULP_EQUAL(eve__beta(T(-0.0), T(-0.0)), T(std::beta(elt_t(-0.0), elt_t(-0.0))), 0);
   TTS_ULP_EQUAL(eve__beta(T( 0.0), T( 0.0)), T(std::beta(elt_t(0.0), elt_t(0.0))), 0);
   TTS_ULP_EQUAL(eve__beta(T( 1.0), T( 1.0)), T(std::beta(elt_t(1.0), elt_t(1.0))), 0);
   TTS_ULP_EQUAL(eve__beta(T( 2.0), T( 3.0)), T(std::beta(elt_t(2.0), elt_t(3.0))), 0);
   TTS_ULP_EQUAL(eve__beta(T( 2.5), T( 3.7)), T(std::beta(elt_t(2.5), elt_t(3.7))), 0);
-
+#endif  // __cpp_lib_math_special_functions
 }


### PR DESCRIPTION
`std::beta` is not supported by `libc++`

We can detect it using `version`.
Proof: https://godbolt.org/z/v8z9oG