### PR TITLE
Fix CI/Dockerhub interaction for post-november

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,17 +16,28 @@ docker_gcc: &docker_gcc
     - image: compilaction/gcc-dev:latest
       environment:
         COMPILER: g++
+      auth:
+        username: compilaction
+        password: $DOCKERHUB_PASSWORD
+
 docker_clang: &docker_clang
   docker:
     - image: compilaction/clang-dev:latest
       environment:
         COMPILER: clang++
+      auth:
+        username: compilaction
+        password: $DOCKERHUB_PASSWORD
+
 docker_aarch64: &docker_aarch64
   docker:
     - image: compilaction/gcc-dev:latest
       environment:
         RUN_COMMAND: qemu-aarch64
         COMPILER: aarch64-linux-gnu-g++
+      auth:
+        username: compilaction
+        password: $DOCKERHUB_PASSWORD
 
 ##==================================================================================================
 ## Build configurations
@@ -127,8 +138,10 @@ jobs:
 
 workflows:
   version: 2
-  build_and_test:
-    jobs:
+  jobs:
+    - build:
+        context:
+          - docker
       - x86_scalar
       - x86_sse2
       - x86_sse4


### PR DESCRIPTION
We now need authentification to Dockerhub