### PR TITLE
Issue #356: reverse example: writing a test

### DIFF
--- a/test/doc/CMakeLists.txt
+++ b/test/doc/CMakeLists.txt
@@ -10,3 +10,4 @@
 
 add_subdirectory(constant)
 add_subdirectory(core)
+add_subdirectory(developer)

--- a/test/doc/developer/CMakeLists.txt
+++ b/test/doc/developer/CMakeLists.txt
@@ -1,0 +1,1 @@
+make_unit( "doc.developer" reverse.cpp  )

--- a/test/doc/developer/CMakeLists.txt
+++ b/test/doc/developer/CMakeLists.txt
@@ -1,1 +1,12 @@
+##==================================================================================================
+##  EVE - Expressive Vector Engine
+##
+##  Copyright 2020 Joel FALCOU
+##  Copyright 2020 Jean-Thierry LAPRESTE
+##  Copyright 2020 Denis YAROSHEVSKIY
+##
+##  Licensed under the MIT License <http://opensource.org/licenses/MIT>.
+##  SPDX-License-Identifier: MIT
+##==================================================================================================
+
 make_unit( "doc.developer" reverse.cpp  )

--- a/test/doc/developer/reverse.cpp
+++ b/test/doc/developer/reverse.cpp
@@ -1,233 +1,56 @@
+#include "test.hpp"
+#include "reverse.hpp"
 
-#include <eve/wide.hpp>
-#include <eve/function/bit_cast.hpp>
-#include <eve/function/store.hpp>
-
-#include <algorithm>
-#include <bit>
-#include <concepts>
-#include <cstdint>
-
-#include <type_traits>
-
-#if defined(EVE_HW_X86) && !defined(SPY_SIMD_IS_X86_AVX512)
-
-namespace eve_extra {
-namespace _reverse {
-
-template <typename T, typename N, eve::x86_abi ABI>
-eve::wide<T, N, ABI> actual_reverse(eve::wide<T, N, ABI> x) requires(sizeof(T) == 8)
+TTS_CASE("Check for reverse behavior")
 {
-       if constexpr(std::same_as<ABI, eve::x86_128_>) return {_mm_shuffle_epi32(x.storage(), _MM_SHUFFLE(1, 0, 3, 2))};
-  else if constexpr(std::same_as<ABI, eve::x86_256_>) return {_mm256_permutevar8x32_epi32(x.storage(), _MM_SHUFFLE(3, 2, 1, 0))};
+  #if defined(EVE_HW_X86) && !defined(SPY_SIMD_IS_X86_AVX512)
+
+  #endif
 }
 
-template <typename N>
-constexpr std::uint32_t mm_shuffle() {
-  if constexpr(N() == 4) return _MM_SHUFFLE(0, 1, 2, 3);
-  if constexpr(N() == 2) return _MM_SHUFFLE(3, 2, 0, 1);
-}
+// template<typename T, typename Test>
+// void for_all_test_pack_sizes(Test test)
+// {
+//   constexpr int number_of_packs = std::countr_zero(256u >> sizeof(T)) + 2;
 
-template <typename T, typename N, eve::x86_abi ABI>
-eve::wide<T, N, ABI> actual_reverse(eve::wide<T, N, ABI> x) requires(sizeof(T) == 4)
-{
-  auto raw = x.storage();
+//   [&]<int... idx>(std::integer_sequence<int, idx...>)
+//   {
+//     (test(eve::wide<T, eve::fixed<static_cast<size_t>(1 << idx)>> {}), ...);
+//   } (std::make_integer_sequence<int, number_of_packs>());
+// }
 
-       if constexpr(std::same_as<ABI, eve::x86_128_>) return {_mm_shuffle_epi32(raw, mm_shuffle<N>())};
-  else if constexpr(std::same_as<ABI, eve::x86_256_>)
-  {
-    using mask_type = eve::wide<int, eve::fixed<8>>;
-    auto mask = mask_type([](int i, int) { return 7 - i; }).storage();
+// template <typename Test>
+// void for_all_test_packs(Test test)
+// {
+//   [&]<typename...T>(T...) { (for_all_test_pack_sizes<T>(test), ...); }
+//   (std::int8_t{},  std::uint8_t{},
+//    std::int16_t{}, std::uint16_t{},
+//    std::int32_t{}, std::uint32_t{},
+//    std::int64_t{}, std::uint64_t{},
+//    float{},        double{});
+// }
 
-    return {_mm256_permutevar8x32_epi32(raw, mask)};
-  }
-}
+// int main()
+// {
+//   auto test = []<typename wide>(wide) {
+//     wide input([](int i, int) { return i ; });
+//     input.set(0, std::numeric_limits<typename wide::value_type>::min());
+//     input.set(wide::static_size - 1, std::numeric_limits<typename wide::value_type>::max());
 
-inline __m256i reverse_256_using_128_mask(__m256i x, __m128i mask_128)
-{
-  __m256i mask_256 = _mm256_set_m128i(mask_128, mask_128);
-  __m256i each_half = _mm256_shuffle_epi8(x, mask_256);
+//     wide expected([](int i, int size) { return size - 1 - i; });
+//     expected.set(wide::static_size - 1, std::numeric_limits<typename wide::value_type>::min());
+//     expected.set(0, std::numeric_limits<typename wide::value_type>::max());
 
-  return {_mm256_permute4x64_epi64(each_half, _MM_SHUFFLE(1, 0, 3, 2))};
-}
+//     wide actual = eve_extra::reverse(input);
 
-template <typename N>
-inline __m128i reverse_8_shorts_mask() {
-  return eve::wide<short, eve::fixed<8>>([](int i, int) {
-    auto as_chars_idx = [](int i) { return (i * 2 + 1) << 8 | (i * 2); };
-    return as_chars_idx(i >= N() ? i : (N() - i - 1));
-  }).storage();
-}
+//     if (eve::all(expected == actual)) return;
 
-template <typename T, typename N, eve::x86_abi ABI>
-eve::wide<T, N, ABI> actual_reverse(eve::wide<T, N, ABI> x) requires(sizeof(T) == 2)
-{
-  auto raw = x.storage();
+//     std::cerr << "wide: element_size: " << sizeof(eve::element_type_t<wide>) << " N: " << wide::static_size << std::endl;
+//     std::cerr << "expected != actual \n  expected: " << expected << "\n  actual:   " << actual << std::endl;
+//     std::terminate();
+//   };
 
-       if constexpr(N() < 8) return {_mm_shufflelo_epi16(raw, mm_shuffle<N>())};
-  else if constexpr(eve::current_api <= eve::sse3)  // N == 8
-  {
-     raw = _mm_shufflehi_epi16(raw, _MM_SHUFFLE(0, 1, 2, 3));
-     raw = _mm_shufflelo_epi16(raw, _MM_SHUFFLE(0, 1, 2, 3));
-     raw = _mm_shuffle_epi32(raw, _MM_SHUFFLE(1, 0, 3, 2));
-
-     return {raw};
-  }
-  else if constexpr(std::same_as<ABI, eve::x86_128_>) return {_mm_shuffle_epi8(raw, reverse_8_shorts_mask<N>())};
-  else if constexpr(std::same_as<ABI, eve::x86_256_>) return {reverse_256_using_128_mask(raw, reverse_8_shorts_mask<N>())};
-}
-
-template <typename N>
-__m128i reverse_16_chars_mask()
-{
-  return eve::wide<char, eve::fixed<16>>(
-    [](int i, int) { return i >= N() ? i : N() - 1 - i; }
-  ).storage();
-}
-
-template <typename T, typename N, eve::x86_abi ABI>
-eve::wide<T, N, ABI> actual_reverse(eve::wide<T, N, ABI> x)
-  requires(sizeof(T) == 1 && eve::current_api > eve::sse3)
-{
-  auto raw = x.storage();
-
-       if constexpr(std::same_as<ABI, eve::x86_128_>) return {_mm_shuffle_epi8(raw, reverse_16_chars_mask<N>())};
-  else if constexpr(std::same_as<ABI, eve::x86_256_>) return {reverse_256_using_128_mask(raw, reverse_16_chars_mask<N>())};
-}
-
-template <eve::simd_value Wide>
-constexpr bool treat_like_aggregated()
-{
-  using ABI = typename Wide::abi_type;
-
-       if constexpr(eve::has_aggregated_abi_v<Wide>)        return true;
-  else if constexpr(eve::current_api == eve::avx &&
-                    std::same_as<ABI, eve::x86_256_> &&
-                    sizeof(eve::element_type_t<Wide>) <= 4) return true;
-  else                                                      return false;
-}
-
-template <typename N>
-auto convert_epu8_epu16(eve::wide<std::uint8_t, N> x)
-{
-  __m128i zeroes = _mm_setzero_si128();
-
-  if constexpr (N() <= 8)
-  {
-    return eve::wide<std::uint16_t, N>{_mm_unpacklo_epi8(x.storage(), zeroes)};
-  }
-  else
-  {
-    using wide_8_epu8 = eve::wide<std::uint16_t, eve::fixed<8>>;
-    wide_8_epu8 hi {_mm_unpackhi_epi8(x.storage(), zeroes)};
-    wide_8_epu8 lo {_mm_unpacklo_epi8(x.storage(), zeroes)};
-    return eve::wide<std::uint16_t, N>{lo, hi};
-  }
-}
-
-template <typename N>
-inline auto convert_epu16_epu8(eve::wide<std::uint16_t, N> x)
-{
-  if constexpr (N() <= 8)
-  {
-    __m128i zeroes = _mm_setzero_si128();
-    __m128i packed = _mm_packus_epi16(x.storage(), zeroes);
-    return eve::wide<std::uint8_t, N>(packed);
-  }
-  else
-  {
-    auto [l, h] = x.slice();
-    __m128i packed = _mm_packus_epi16(l.storage(), h.storage());
-    return eve::wide<std::uint8_t, N>{packed};
-  }
-}
-
-}  // namespace _reverse
-
-template <typename T, typename N, typename ABI>
-eve::wide<T, N, ABI> reverse(eve::wide<T, N, ABI> x) {
-  using Wide = eve::wide<T, N, ABI>;
-
-       if constexpr(Wide::static_size == 1) return x;
-  else if constexpr(_reverse::treat_like_aggregated<Wide>())
-  {
-    auto [l, h] = x.slice();
-    l = eve_extra::reverse(l);
-    h = eve_extra::reverse(h);
-    return Wide(h, l);
-  }
-  else if constexpr(std::same_as<T, float>)
-  {
-    auto as_ints = eve::bit_cast(x, eve::as_<eve::wide<std::int32_t, N>>{});
-    as_ints = eve_extra::reverse(as_ints);
-    return eve::bit_cast(as_ints, eve::as_<Wide>{});
-  }
-  else if constexpr(std::same_as<T, double>)
-  {
-    auto as_ints = eve::bit_cast(x, eve::as_<eve::wide<std::int64_t, N>>{});
-    as_ints = eve_extra::reverse(as_ints);
-    return eve::bit_cast(as_ints, eve::as_<Wide>{});
-  }
-  else if constexpr(sizeof(T) == 1 && eve::current_api <= eve::sse3)
-  {
-    auto as_epu8 = eve::bit_cast(x, eve::as_<eve::wide<std::uint8_t, N>>{});
-    auto as_epu16 = _reverse::convert_epu8_epu16(as_epu8);
-    as_epu16 = eve_extra::reverse(as_epu16);
-    as_epu8 =_reverse::convert_epu16_epu8(as_epu16);
-    return eve::bit_cast(as_epu8, eve::as_<Wide>{});
-  }
-  else return _reverse::actual_reverse(x);
-}
-
-}  // namespace eve_extra
-
-
-template<typename T, typename Test>
-void for_all_test_pack_sizes(Test test)
-{
-  constexpr int number_of_packs = std::countr_zero(256u >> sizeof(T)) + 2;
-
-  [&]<int... idx>(std::integer_sequence<int, idx...>)
-  {
-    (test(eve::wide<T, eve::fixed<static_cast<size_t>(1 << idx)>> {}), ...);
-  } (std::make_integer_sequence<int, number_of_packs>());
-}
-
-template <typename Test>
-void for_all_test_packs(Test test)
-{
-  [&]<typename...T>(T...) { (for_all_test_pack_sizes<T>(test), ...); }
-  (std::int8_t{},  std::uint8_t{},
-   std::int16_t{}, std::uint16_t{},
-   std::int32_t{}, std::uint32_t{},
-   std::int64_t{}, std::uint64_t{},
-   float{},        double{});
-}
-
-int main()
-{
-  auto test = []<typename wide>(wide) {
-    wide input([](int i, int) { return i ; });
-    input.set(0, std::numeric_limits<typename wide::value_type>::min());
-    input.set(wide::static_size - 1, std::numeric_limits<typename wide::value_type>::max());
-
-    wide expected([](int i, int size) { return size - 1 - i; });
-    expected.set(wide::static_size - 1, std::numeric_limits<typename wide::value_type>::min());
-    expected.set(0, std::numeric_limits<typename wide::value_type>::max());
-
-    wide actual = eve_extra::reverse(input);
-
-    if (eve::all(expected == actual)) return;
-
-    std::cerr << "wide: element_size: " << sizeof(eve::element_type_t<wide>) << " N: " << wide::static_size << std::endl;
-    std::cerr << "expected != actual \n  expected: " << expected << "\n  actual:   " << actual << std::endl;
-    std::terminate();
-  };
-
-  for_all_test_packs(test);
-}
-#else
-
-int main() {}
+//   for_all_test_packs(test);
+// }
 
 #endif  // (EVE_HW_X86) && !defined(SPY_SIMD_IS_X86_AVX512)

--- a/test/doc/developer/reverse.cpp
+++ b/test/doc/developer/reverse.cpp
@@ -1,0 +1,233 @@
+
+#include <eve/wide.hpp>
+#include <eve/function/bit_cast.hpp>
+#include <eve/function/store.hpp>
+
+#include <algorithm>
+#include <bit>
+#include <concepts>
+#include <cstdint>
+
+#include <type_traits>
+
+#if defined(EVE_HW_X86) && !defined(SPY_SIMD_IS_X86_AVX512)
+
+namespace eve_extra {
+namespace _reverse {
+
+template <typename T, typename N, eve::x86_abi ABI>
+eve::wide<T, N, ABI> actual_reverse(eve::wide<T, N, ABI> x) requires(sizeof(T) == 8)
+{
+       if constexpr(std::same_as<ABI, eve::x86_128_>) return {_mm_shuffle_epi32(x.storage(), _MM_SHUFFLE(1, 0, 3, 2))};
+  else if constexpr(std::same_as<ABI, eve::x86_256_>) return {_mm256_permutevar8x32_epi32(x.storage(), _MM_SHUFFLE(3, 2, 1, 0))};
+}
+
+template <typename N>
+constexpr std::uint32_t mm_shuffle() {
+  if constexpr(N() == 4) return _MM_SHUFFLE(0, 1, 2, 3);
+  if constexpr(N() == 2) return _MM_SHUFFLE(3, 2, 0, 1);
+}
+
+template <typename T, typename N, eve::x86_abi ABI>
+eve::wide<T, N, ABI> actual_reverse(eve::wide<T, N, ABI> x) requires(sizeof(T) == 4)
+{
+  auto raw = x.storage();
+
+       if constexpr(std::same_as<ABI, eve::x86_128_>) return {_mm_shuffle_epi32(raw, mm_shuffle<N>())};
+  else if constexpr(std::same_as<ABI, eve::x86_256_>)
+  {
+    using mask_type = eve::wide<int, eve::fixed<8>>;
+    auto mask = mask_type([](int i, int) { return 7 - i; }).storage();
+
+    return {_mm256_permutevar8x32_epi32(raw, mask)};
+  }
+}
+
+inline __m256i reverse_256_using_128_mask(__m256i x, __m128i mask_128)
+{
+  __m256i mask_256 = _mm256_set_m128i(mask_128, mask_128);
+  __m256i each_half = _mm256_shuffle_epi8(x, mask_256);
+
+  return {_mm256_permute4x64_epi64(each_half, _MM_SHUFFLE(1, 0, 3, 2))};
+}
+
+template <typename N>
+inline __m128i reverse_8_shorts_mask() {
+  return eve::wide<short, eve::fixed<8>>([](int i, int) {
+    auto as_chars_idx = [](int i) { return (i * 2 + 1) << 8 | (i * 2); };
+    return as_chars_idx(i >= N() ? i : (N() - i - 1));
+  }).storage();
+}
+
+template <typename T, typename N, eve::x86_abi ABI>
+eve::wide<T, N, ABI> actual_reverse(eve::wide<T, N, ABI> x) requires(sizeof(T) == 2)
+{
+  auto raw = x.storage();
+
+       if constexpr(N() < 8) return {_mm_shufflelo_epi16(raw, mm_shuffle<N>())};
+  else if constexpr(eve::current_api <= eve::sse3)  // N == 8
+  {
+     raw = _mm_shufflehi_epi16(raw, _MM_SHUFFLE(0, 1, 2, 3));
+     raw = _mm_shufflelo_epi16(raw, _MM_SHUFFLE(0, 1, 2, 3));
+     raw = _mm_shuffle_epi32(raw, _MM_SHUFFLE(1, 0, 3, 2));
+
+     return {raw};
+  }
+  else if constexpr(std::same_as<ABI, eve::x86_128_>) return {_mm_shuffle_epi8(raw, reverse_8_shorts_mask<N>())};
+  else if constexpr(std::same_as<ABI, eve::x86_256_>) return {reverse_256_using_128_mask(raw, reverse_8_shorts_mask<N>())};
+}
+
+template <typename N>
+__m128i reverse_16_chars_mask()
+{
+  return eve::wide<char, eve::fixed<16>>(
+    [](int i, int) { return i >= N() ? i : N() - 1 - i; }
+  ).storage();
+}
+
+template <typename T, typename N, eve::x86_abi ABI>
+eve::wide<T, N, ABI> actual_reverse(eve::wide<T, N, ABI> x)
+  requires(sizeof(T) == 1 && eve::current_api > eve::sse3)
+{
+  auto raw = x.storage();
+
+       if constexpr(std::same_as<ABI, eve::x86_128_>) return {_mm_shuffle_epi8(raw, reverse_16_chars_mask<N>())};
+  else if constexpr(std::same_as<ABI, eve::x86_256_>) return {reverse_256_using_128_mask(raw, reverse_16_chars_mask<N>())};
+}
+
+template <eve::simd_value Wide>
+constexpr bool treat_like_aggregated()
+{
+  using ABI = typename Wide::abi_type;
+
+       if constexpr(eve::has_aggregated_abi_v<Wide>)        return true;
+  else if constexpr(eve::current_api == eve::avx &&
+                    std::same_as<ABI, eve::x86_256_> &&
+                    sizeof(eve::element_type_t<Wide>) <= 4) return true;
+  else                                                      return false;
+}
+
+template <typename N>
+auto convert_epu8_epu16(eve::wide<std::uint8_t, N> x)
+{
+  __m128i zeroes = _mm_setzero_si128();
+
+  if constexpr (N() <= 8)
+  {
+    return eve::wide<std::uint16_t, N>{_mm_unpacklo_epi8(x.storage(), zeroes)};
+  }
+  else
+  {
+    using wide_8_epu8 = eve::wide<std::uint16_t, eve::fixed<8>>;
+    wide_8_epu8 hi {_mm_unpackhi_epi8(x.storage(), zeroes)};
+    wide_8_epu8 lo {_mm_unpacklo_epi8(x.storage(), zeroes)};
+    return eve::wide<std::uint16_t, N>{lo, hi};
+  }
+}
+
+template <typename N>
+inline auto convert_epu16_epu8(eve::wide<std::uint16_t, N> x)
+{
+  if constexpr (N() <= 8)
+  {
+    __m128i zeroes = _mm_setzero_si128();
+    __m128i packed = _mm_packus_epi16(x.storage(), zeroes);
+    return eve::wide<std::uint8_t, N>(packed);
+  }
+  else
+  {
+    auto [l, h] = x.slice();
+    __m128i packed = _mm_packus_epi16(l.storage(), h.storage());
+    return eve::wide<std::uint8_t, N>{packed};
+  }
+}
+
+}  // namespace _reverse
+
+template <typename T, typename N, typename ABI>
+eve::wide<T, N, ABI> reverse(eve::wide<T, N, ABI> x) {
+  using Wide = eve::wide<T, N, ABI>;
+
+       if constexpr(Wide::static_size == 1) return x;
+  else if constexpr(_reverse::treat_like_aggregated<Wide>())
+  {
+    auto [l, h] = x.slice();
+    l = eve_extra::reverse(l);
+    h = eve_extra::reverse(h);
+    return Wide(h, l);
+  }
+  else if constexpr(std::same_as<T, float>)
+  {
+    auto as_ints = eve::bit_cast(x, eve::as_<eve::wide<std::int32_t, N>>{});
+    as_ints = eve_extra::reverse(as_ints);
+    return eve::bit_cast(as_ints, eve::as_<Wide>{});
+  }
+  else if constexpr(std::same_as<T, double>)
+  {
+    auto as_ints = eve::bit_cast(x, eve::as_<eve::wide<std::int64_t, N>>{});
+    as_ints = eve_extra::reverse(as_ints);
+    return eve::bit_cast(as_ints, eve::as_<Wide>{});
+  }
+  else if constexpr(sizeof(T) == 1 && eve::current_api <= eve::sse3)
+  {
+    auto as_epu8 = eve::bit_cast(x, eve::as_<eve::wide<std::uint8_t, N>>{});
+    auto as_epu16 = _reverse::convert_epu8_epu16(as_epu8);
+    as_epu16 = eve_extra::reverse(as_epu16);
+    as_epu8 =_reverse::convert_epu16_epu8(as_epu16);
+    return eve::bit_cast(as_epu8, eve::as_<Wide>{});
+  }
+  else return _reverse::actual_reverse(x);
+}
+
+}  // namespace eve_extra
+
+
+template<typename T, typename Test>
+void for_all_test_pack_sizes(Test test)
+{
+  constexpr int number_of_packs = std::countr_zero(256u >> sizeof(T)) + 2;
+
+  [&]<int... idx>(std::integer_sequence<int, idx...>)
+  {
+    (test(eve::wide<T, eve::fixed<static_cast<size_t>(1 << idx)>> {}), ...);
+  } (std::make_integer_sequence<int, number_of_packs>());
+}
+
+template <typename Test>
+void for_all_test_packs(Test test)
+{
+  [&]<typename...T>(T...) { (for_all_test_pack_sizes<T>(test), ...); }
+  (std::int8_t{},  std::uint8_t{},
+   std::int16_t{}, std::uint16_t{},
+   std::int32_t{}, std::uint32_t{},
+   std::int64_t{}, std::uint64_t{},
+   float{},        double{});
+}
+
+int main()
+{
+  auto test = []<typename wide>(wide) {
+    wide input([](int i, int) { return i ; });
+    input.set(0, std::numeric_limits<typename wide::value_type>::min());
+    input.set(wide::static_size - 1, std::numeric_limits<typename wide::value_type>::max());
+
+    wide expected([](int i, int size) { return size - 1 - i; });
+    expected.set(wide::static_size - 1, std::numeric_limits<typename wide::value_type>::min());
+    expected.set(0, std::numeric_limits<typename wide::value_type>::max());
+
+    wide actual = eve_extra::reverse(input);
+
+    if (eve::all(expected == actual)) return;
+
+    std::cerr << "wide: element_size: " << sizeof(eve::element_type_t<wide>) << " N: " << wide::static_size << std::endl;
+    std::cerr << "expected != actual \n  expected: " << expected << "\n  actual:   " << actual << std::endl;
+    std::terminate();
+  };
+
+  for_all_test_packs(test);
+}
+#else
+
+int main() {}
+
+#endif  // (EVE_HW_X86) && !defined(SPY_SIMD_IS_X86_AVX512)

--- a/test/doc/developer/reverse.cpp
+++ b/test/doc/developer/reverse.cpp
@@ -16,7 +16,7 @@
 template<typename T, typename Test>
 void check_all_sizes(Test test)
 {
-  constexpr int number_of_packs = std::countr_zero(256u >> sizeof(T)) + 2;
+  constexpr int number_of_packs = std::countr_zero(256u / sizeof(T));
   [&]<int... idx>(std::integer_sequence<int, idx...>)
   {
     (test(eve::wide<T, eve::fixed<static_cast<size_t>(1 << idx)>> {}), ...);

--- a/test/doc/developer/reverse.cpp
+++ b/test/doc/developer/reverse.cpp
@@ -1,56 +1,39 @@
+//==================================================================================================
+/**
+  EVE - Expressive Vector Engine
+  Copyright 2020 Denis YAROSHEVSKIY
+  Copyright 2020 Joel FALCOU
+
+  Licensed under the MIT License <http://opensource.org/licenses/MIT>.
+  SPDX-License-Identifier: MIT
+**/
+//==================================================================================================
 #include "test.hpp"
+
+#if defined(EVE_HW_X86) && !defined(SPY_SIMD_IS_X86_AVX512)
 #include "reverse.hpp"
 
-TTS_CASE("Check for reverse behavior")
+TTS_CASE_TPL( "Check for reverse behavior", float,double )
 {
-  #if defined(EVE_HW_X86) && !defined(SPY_SIMD_IS_X86_AVX512)
+  using type = eve::wide<T>;
 
-  #endif
+  type input( [](auto i, auto size)
+              {
+                if(i == 0     ) return std::numeric_limits<T>::min();
+                if(i == size-1) return std::numeric_limits<T>::max();
+                return static_cast<T>(i);
+              }
+            );
+
+  type expected( [](auto i, auto size)
+              {
+                if(i == 0     ) return std::numeric_limits<T>::max();
+                if(i == size-1) return std::numeric_limits<T>::min();
+                return static_cast<T>(size - 1 - i);
+              }
+            );
+
+  TTS_EQUAL(eve_extra::reverse(input), expected);
 }
 
-// template<typename T, typename Test>
-// void for_all_test_pack_sizes(Test test)
-// {
-//   constexpr int number_of_packs = std::countr_zero(256u >> sizeof(T)) + 2;
-
-//   [&]<int... idx>(std::integer_sequence<int, idx...>)
-//   {
-//     (test(eve::wide<T, eve::fixed<static_cast<size_t>(1 << idx)>> {}), ...);
-//   } (std::make_integer_sequence<int, number_of_packs>());
-// }
-
-// template <typename Test>
-// void for_all_test_packs(Test test)
-// {
-//   [&]<typename...T>(T...) { (for_all_test_pack_sizes<T>(test), ...); }
-//   (std::int8_t{},  std::uint8_t{},
-//    std::int16_t{}, std::uint16_t{},
-//    std::int32_t{}, std::uint32_t{},
-//    std::int64_t{}, std::uint64_t{},
-//    float{},        double{});
-// }
-
-// int main()
-// {
-//   auto test = []<typename wide>(wide) {
-//     wide input([](int i, int) { return i ; });
-//     input.set(0, std::numeric_limits<typename wide::value_type>::min());
-//     input.set(wide::static_size - 1, std::numeric_limits<typename wide::value_type>::max());
-
-//     wide expected([](int i, int size) { return size - 1 - i; });
-//     expected.set(wide::static_size - 1, std::numeric_limits<typename wide::value_type>::min());
-//     expected.set(0, std::numeric_limits<typename wide::value_type>::max());
-
-//     wide actual = eve_extra::reverse(input);
-
-//     if (eve::all(expected == actual)) return;
-
-//     std::cerr << "wide: element_size: " << sizeof(eve::element_type_t<wide>) << " N: " << wide::static_size << std::endl;
-//     std::cerr << "expected != actual \n  expected: " << expected << "\n  actual:   " << actual << std::endl;
-//     std::terminate();
-//   };
-
-//   for_all_test_packs(test);
-// }
-
-#endif  // (EVE_HW_X86) && !defined(SPY_SIMD_IS_X86_AVX512)
+#endif

--- a/test/doc/developer/reverse.hpp
+++ b/test/doc/developer/reverse.hpp
@@ -1,3 +1,13 @@
+//==================================================================================================
+/**
+  EVE - Expressive Vector Engine
+  Copyright 2020 Denis YAROSHEVSKIY
+  Copyright 2020 Joel FALCOU
+
+  Licensed under the MIT License <http://opensource.org/licenses/MIT>.
+  SPDX-License-Identifier: MIT
+**/
+//==================================================================================================
 #pragma once
 
 #if defined(EVE_HW_X86) && !defined(SPY_SIMD_IS_X86_AVX512)
@@ -24,7 +34,8 @@ eve::wide<T, N, ABI> actual_reverse(eve::wide<T, N, ABI> x) requires(sizeof(T) =
 }
 
 template <typename N>
-constexpr std::uint32_t mm_shuffle() {
+constexpr std::uint32_t mm_shuffle()
+{
   if constexpr(N() == 4) return _MM_SHUFFLE(0, 1, 2, 3);
   if constexpr(N() == 2) return _MM_SHUFFLE(3, 2, 0, 1);
 }
@@ -33,8 +44,8 @@ template <typename T, typename N, eve::x86_abi ABI>
 eve::wide<T, N, ABI> actual_reverse(eve::wide<T, N, ABI> x) requires(sizeof(T) == 4)
 {
   auto raw = x.storage();
-
-       if constexpr(std::same_as<ABI, eve::x86_128_>) return {_mm_shuffle_epi32(raw, mm_shuffle<N>())};
+  constexpr auto mask = mm_shuffle<N>();
+       if constexpr(std::same_as<ABI, eve::x86_128_>) return {_mm_shuffle_epi32(raw, mask)};
   else if constexpr(std::same_as<ABI, eve::x86_256_>)
   {
     using mask_type = eve::wide<int, eve::fixed<8>>;
@@ -49,7 +60,7 @@ inline __m256i reverse_256_using_128_mask(__m256i x, __m128i mask_128)
   __m256i mask_256 = _mm256_set_m128i(mask_128, mask_128);
   __m256i each_half = _mm256_shuffle_epi8(x, mask_256);
 
-  return {_mm256_permute4x64_epi64(each_half, _MM_SHUFFLE(1, 0, 3, 2))};
+  return _mm256_permute4x64_epi64(each_half, _MM_SHUFFLE(1, 0, 3, 2));
 }
 
 template <typename N>

--- a/test/doc/developer/reverse.hpp
+++ b/test/doc/developer/reverse.hpp
@@ -1,0 +1,185 @@
+#pragma once
+
+#if defined(EVE_HW_X86) && !defined(SPY_SIMD_IS_X86_AVX512)
+
+#include <eve/wide.hpp>
+#include <eve/function/bit_cast.hpp>
+#include <eve/function/store.hpp>
+
+#include <algorithm>
+#include <bit>
+#include <concepts>
+#include <cstdint>
+
+#include <type_traits>
+
+namespace eve_extra {
+namespace _reverse {
+
+template <typename T, typename N, eve::x86_abi ABI>
+eve::wide<T, N, ABI> actual_reverse(eve::wide<T, N, ABI> x) requires(sizeof(T) == 8)
+{
+       if constexpr(std::same_as<ABI, eve::x86_128_>) return {_mm_shuffle_epi32(x.storage(), _MM_SHUFFLE(1, 0, 3, 2))};
+  else if constexpr(std::same_as<ABI, eve::x86_256_>) return {_mm256_permutevar8x32_epi32(x.storage(), _MM_SHUFFLE(3, 2, 1, 0))};
+}
+
+template <typename N>
+constexpr std::uint32_t mm_shuffle() {
+  if constexpr(N() == 4) return _MM_SHUFFLE(0, 1, 2, 3);
+  if constexpr(N() == 2) return _MM_SHUFFLE(3, 2, 0, 1);
+}
+
+template <typename T, typename N, eve::x86_abi ABI>
+eve::wide<T, N, ABI> actual_reverse(eve::wide<T, N, ABI> x) requires(sizeof(T) == 4)
+{
+  auto raw = x.storage();
+
+       if constexpr(std::same_as<ABI, eve::x86_128_>) return {_mm_shuffle_epi32(raw, mm_shuffle<N>())};
+  else if constexpr(std::same_as<ABI, eve::x86_256_>)
+  {
+    using mask_type = eve::wide<int, eve::fixed<8>>;
+    auto mask = mask_type([](int i, int) { return 7 - i; }).storage();
+
+    return {_mm256_permutevar8x32_epi32(raw, mask)};
+  }
+}
+
+inline __m256i reverse_256_using_128_mask(__m256i x, __m128i mask_128)
+{
+  __m256i mask_256 = _mm256_set_m128i(mask_128, mask_128);
+  __m256i each_half = _mm256_shuffle_epi8(x, mask_256);
+
+  return {_mm256_permute4x64_epi64(each_half, _MM_SHUFFLE(1, 0, 3, 2))};
+}
+
+template <typename N>
+inline __m128i reverse_8_shorts_mask() {
+  return eve::wide<short, eve::fixed<8>>([](int i, int) {
+    auto as_chars_idx = [](int i) { return (i * 2 + 1) << 8 | (i * 2); };
+    return as_chars_idx(i >= N() ? i : (N() - i - 1));
+  }).storage();
+}
+
+template <typename T, typename N, eve::x86_abi ABI>
+eve::wide<T, N, ABI> actual_reverse(eve::wide<T, N, ABI> x) requires(sizeof(T) == 2)
+{
+  auto raw = x.storage();
+
+       if constexpr(N() < 8) return {_mm_shufflelo_epi16(raw, mm_shuffle<N>())};
+  else if constexpr(eve::current_api <= eve::sse3)  // N == 8
+  {
+     raw = _mm_shufflehi_epi16(raw, _MM_SHUFFLE(0, 1, 2, 3));
+     raw = _mm_shufflelo_epi16(raw, _MM_SHUFFLE(0, 1, 2, 3));
+     raw = _mm_shuffle_epi32(raw, _MM_SHUFFLE(1, 0, 3, 2));
+
+     return {raw};
+  }
+  else if constexpr(std::same_as<ABI, eve::x86_128_>) return {_mm_shuffle_epi8(raw, reverse_8_shorts_mask<N>())};
+  else if constexpr(std::same_as<ABI, eve::x86_256_>) return {reverse_256_using_128_mask(raw, reverse_8_shorts_mask<N>())};
+}
+
+template <typename N>
+__m128i reverse_16_chars_mask()
+{
+  return eve::wide<char, eve::fixed<16>>(
+    [](int i, int) { return i >= N() ? i : N() - 1 - i; }
+  ).storage();
+}
+
+template <typename T, typename N, eve::x86_abi ABI>
+eve::wide<T, N, ABI> actual_reverse(eve::wide<T, N, ABI> x)
+  requires(sizeof(T) == 1 && eve::current_api > eve::sse3)
+{
+  auto raw = x.storage();
+
+       if constexpr(std::same_as<ABI, eve::x86_128_>) return {_mm_shuffle_epi8(raw, reverse_16_chars_mask<N>())};
+  else if constexpr(std::same_as<ABI, eve::x86_256_>) return {reverse_256_using_128_mask(raw, reverse_16_chars_mask<N>())};
+}
+
+template <eve::simd_value Wide>
+constexpr bool treat_like_aggregated()
+{
+  using ABI = typename Wide::abi_type;
+
+       if constexpr(eve::has_aggregated_abi_v<Wide>)        return true;
+  else if constexpr(eve::current_api == eve::avx &&
+                    std::same_as<ABI, eve::x86_256_> &&
+                    sizeof(eve::element_type_t<Wide>) <= 4) return true;
+  else                                                      return false;
+}
+
+template <typename N>
+auto convert_epu8_epu16(eve::wide<std::uint8_t, N> x)
+{
+  __m128i zeroes = _mm_setzero_si128();
+
+  if constexpr (N() <= 8)
+  {
+    return eve::wide<std::uint16_t, N>{_mm_unpacklo_epi8(x.storage(), zeroes)};
+  }
+  else
+  {
+    using wide_8_epu8 = eve::wide<std::uint16_t, eve::fixed<8>>;
+    wide_8_epu8 hi {_mm_unpackhi_epi8(x.storage(), zeroes)};
+    wide_8_epu8 lo {_mm_unpacklo_epi8(x.storage(), zeroes)};
+    return eve::wide<std::uint16_t, N>{lo, hi};
+  }
+}
+
+template <typename N>
+inline auto convert_epu16_epu8(eve::wide<std::uint16_t, N> x)
+{
+  if constexpr (N() <= 8)
+  {
+    __m128i zeroes = _mm_setzero_si128();
+    __m128i packed = _mm_packus_epi16(x.storage(), zeroes);
+    return eve::wide<std::uint8_t, N>(packed);
+  }
+  else
+  {
+    auto [l, h] = x.slice();
+    __m128i packed = _mm_packus_epi16(l.storage(), h.storage());
+    return eve::wide<std::uint8_t, N>{packed};
+  }
+}
+
+}  // namespace _reverse
+
+template <typename T, typename N, typename ABI>
+eve::wide<T, N, ABI> reverse(eve::wide<T, N, ABI> x) {
+  using Wide = eve::wide<T, N, ABI>;
+
+       if constexpr(Wide::static_size == 1) return x;
+  else if constexpr(_reverse::treat_like_aggregated<Wide>())
+  {
+    auto [l, h] = x.slice();
+    l = eve_extra::reverse(l);
+    h = eve_extra::reverse(h);
+    return Wide(h, l);
+  }
+  else if constexpr(std::same_as<T, float>)
+  {
+    auto as_ints = eve::bit_cast(x, eve::as_<eve::wide<std::int32_t, N>>{});
+    as_ints = eve_extra::reverse(as_ints);
+    return eve::bit_cast(as_ints, eve::as_<Wide>{});
+  }
+  else if constexpr(std::same_as<T, double>)
+  {
+    auto as_ints = eve::bit_cast(x, eve::as_<eve::wide<std::int64_t, N>>{});
+    as_ints = eve_extra::reverse(as_ints);
+    return eve::bit_cast(as_ints, eve::as_<Wide>{});
+  }
+  else if constexpr(sizeof(T) == 1 && eve::current_api <= eve::sse3)
+  {
+    auto as_epu8 = eve::bit_cast(x, eve::as_<eve::wide<std::uint8_t, N>>{});
+    auto as_epu16 = _reverse::convert_epu8_epu16(as_epu8);
+    as_epu16 = eve_extra::reverse(as_epu16);
+    as_epu8 =_reverse::convert_epu16_epu8(as_epu16);
+    return eve::bit_cast(as_epu8, eve::as_<Wide>{});
+  }
+  else return _reverse::actual_reverse(x);
+}
+
+}  // namespace eve_extra
+
+#endif


### PR DESCRIPTION
OK - so this is a test for reverse example - which is suppose to illustrate how to work with non-native ABI sizes.

The test successfully reverses everything on x86 from sse2 to AVX2.

Please have a look - see how much does it look like example you are looking for

I have questions:
1) I don't believe I can compile with `EVE_NO_SIMD` in a meaningful way since `current_api` is still going to be SSE2, correct?
https://github.com/jfalcou/eve/blob/e749a9ce6f029d362825ff16961e7dc59ff190cf/include/eve/arch/spec.hpp#L27

2) I don't know how to correctly disable this test for anything but the ones I want. Like - avx512 is still going to try to compile my test with current macro?

3) How do I include parts of the test in the doc and not the entire code? There is a bit of boiler plate that is probably not necessary in the doc.