### PR TITLE
Fix #380 - Remove static_alignment from the API

### DIFF
--- a/benchmarks/experiment.hpp
+++ b/benchmarks/experiment.hpp
@@ -153,7 +153,8 @@ namespace eve::bench
 
       auto loader = []<typename Tgt>(auto* ptr, as_<Tgt> const& )
       {
-        if constexpr( simd_value<Tgt> ) return Tgt( eve::as_aligned<alignof(Tgt)>(ptr) );
+        constexpr auto algt = eve::alignment_v<Tgt>;
+        if constexpr( simd_value<Tgt> ) return Tgt( eve::as_aligned<algt>(ptr) );
         else                            return *ptr;
       };
 

--- a/benchmarks/module/core/gather/aligned/gather.hpp
+++ b/benchmarks/module/core/gather/aligned/gather.hpp
@@ -13,7 +13,7 @@
 
 int main()
 {
-  constexpr auto alg = alignof(EVE_TYPE);
+  constexpr auto alg = eve::alignment_v<EVE_TYPE>;
   using EVE_VALUE = eve::detail::value_type_t<EVE_TYPE>;
   using I_VALUE =  eve::detail::as_integer_t<EVE_VALUE>;
   using I_TYPE =  eve::detail::as_integer_t<EVE_TYPE>;

--- a/benchmarks/module/core/gather/aligned/gather.hpp
+++ b/benchmarks/module/core/gather/aligned/gather.hpp
@@ -13,7 +13,7 @@
 
 int main()
 {
-  constexpr auto alg = EVE_TYPE::static_alignment;
+  constexpr auto alg = alignof(EVE_TYPE);
   using EVE_VALUE = eve::detail::value_type_t<EVE_TYPE>;
   using I_VALUE =  eve::detail::as_integer_t<EVE_VALUE>;
   using I_TYPE =  eve::detail::as_integer_t<EVE_TYPE>;

--- a/docs/reference/types/traits.html
+++ b/docs/reference/types/traits.html
@@ -8,18 +8,26 @@
  -->
 <meta charset="utf-8" lang="en"><style class="fallback">body{visibility:hidden;}</style>
                       **Expressive Vector Engine**
-                        Type traits
-<br>
-Using **EVE** types and functions may requires informations about some properties of the processed
-types that are accessible through the following traits.
-
-The header `eve/traits.hpp` allows the inclusion of all **EVE** specific traits.
 
   (insert ../../crumbs.html here)
 
-  (insert traits/cardinal.html        here)
-  (insert traits/element_type.html    here)
-  (insert traits/as_wide.html         here)
+# Type Traits
+
+Using **EVE** types and functions may requires informations about some properties of the processed
+types that are accessible through the following traits.
+
+## Types and Helpers
+
+**Convenience header:** <script type="preformatted">`#include <eve/traits.hpp>`</script>
+
+[`eve::alignment`<br>`eve::alignment_v` ](traits/alignment.html)
+:   computes the proper alignment of a given type
+[`eve::cardinal`<br>`eve::cardinal_t`<br>`eve::cardinal-v`](traits/cardinal.html)
+:   computes the cardinal of a given type
+[`eve::element_type`<br>`eve::element_type_t`](traits/element_type.html)
+:   retrieves the most fundamental type of a given type
+[`eve::as_wide`<br>`eve::as_wide_t`](traits/as_wide.html)
+:   converts a type into the proper SIMD type
 
 <!-- End of Document -->
 <style class="fallback">body{visibility:hidden}</style><script>markdeepOptions={tocStyle:'none'};</script>

--- a/docs/reference/types/traits/alignment.html
+++ b/docs/reference/types/traits/alignment.html
@@ -1,0 +1,110 @@
+<!--
+  EVE -  Expressive Vector Engine
+  Copyright 2020 Joel FALCOU
+  Copyright 2020 Jean-Thierry LAPRESTE
+
+  Licensed under the MIT License <http://opensource.org/licenses/MIT>.
+  SPDX-License-Identifier: MIT
+ -->
+ <meta charset="utf-8" lang="en"><style class="fallback">body{visibility:hidden;}</style>
+                              **Expressive Vector Engine**
+                                  `eve::alignment`
+<br>
+
+ (insert ../../../crumbs.html here)
+
+ Synopsis
+ ====================================================================================================
+
+ **Required header:**
+
+ <script type="preformatted">
+ `#include <eve/traits/alignment.hpp>`
+ </script>
+
+ <script type="preformatted">
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ c++
+ namespace eve
+ {
+   template<typename T> struct alignment;
+ }
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ </script>
+
+ Determines the alignment of `T`. This is to be used instead of `alignof` as the implementation
+ of some `wide` types may have alignment constraints less than their physical storage.
+
+ **Member Constants:**
+
+ `value`
+ :
+    The numerical value of the [alignment](../../../glossary.html#alignment) of `T`
+
+ **Member Types:**
+
+ `type`
+ :
+    The [alignment](../../../glossary.html#alignment) type of `T`. This type is an implementation-defined
+    type that behaves as an [Integral Constant](https://en.cppreference.com/w/cpp/types/integral_constant).
+
+ **Helper Variable Template:**
+ <script type="preformatted">
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ c++
+ namespace eve
+ {
+   template<typename T>
+   inline constexpr bool alignment_v = alignment<T>::value;
+ }
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ </script>
+
+ **Helper Types:**
+ <script type="preformatted">
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ c++
+ namespace eve
+ {
+   template<typename T>
+   using alignment_t = typename alignment<T>::type;
+ }
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ </script>
+
+ **Example:**
+
+ <script type="preformatted">
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ c++
+ #include <eve/traits/alignment.hpp>
+ #include <eve/wide.hpp>
+ #include <iostream>
+
+ int main()
+ {
+  // Retrieve the alignment value
+  std::cout << eve::alignment_v<float>                            << "\n";
+  std::cout << eve::alignment_v<eve::wide<char>>                  << "\n";
+  std::cout << eve::alignment_v<eve::wide<double, eve::fixed<1>>> << "\n";
+}
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ </script>
+
+ **Possible Output:**
+
+ <script type="preformatted">
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ bash
+ 1
+ 16
+ 8
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ </script>
+
+ ----------------------------------------------------------------------------------------------------
+ <!-- Shortcuts -->
+
+ <!-- Footnotes -->
+
+ <!-- End of Document -->
+ <style class="fallback">body{visibility:hidden}</style><script>markdeepOptions={tocStyle:'none'};</script>
+ <link rel="stylesheet" href="../../../eve.css">
+ <!-- Markdeep: -->
+ <script src="../../../markdeep.min.js"></script>
+ <script src="https://casual-effects.com/markdeep/latest/markdeep.min.js?" charset="utf-8"></script>

--- a/docs/reference/types/traits/as_arithmetic.html
+++ b/docs/reference/types/traits/as_arithmetic.html
@@ -7,6 +7,9 @@
   SPDX-License-Identifier: MIT
  -->
 <meta charset="utf-8" lang="en"><style class="fallback">body{visibility:hidden;}</style>
+                                **Expressive Vector Engine**
+
+(insert ../../../crumbs.html here)
 
 eve::as_arithmetic
 ====================================================================================================

--- a/docs/reference/types/traits/as_wide.html
+++ b/docs/reference/types/traits/as_wide.html
@@ -7,8 +7,13 @@
   SPDX-License-Identifier: MIT
  -->
 <meta charset="utf-8" lang="en"><style class="fallback">body{visibility:hidden;}</style>
+                            **Expressive Vector Engine**
+                              `eve::as_wide`
+<br>
 
-eve::as_wide
+(insert ../../../crumbs.html here)
+
+Synopsis
 ====================================================================================================
 
 **Required header:**
@@ -37,10 +42,13 @@ Build a [SIMD type](../../../concept.html#simd_value) from a given [element type
    evaluates to `wide&lt;eve::element_t&lt;Type>,Cardinal>`, i.e it overwrites the initial type's cardinal.
 
  - If `Type` is a template type satisfies Rebindable, `eve::as_wide&lt;Type,Cardinal>::type`
-   evaluates to `std::tuple&lt;eve::as_wide_t&lt;Ts>...>`.
+   evaluates to `std::tuple&lt;eve::as_wide_t&lt;Ts,Cardinal>...>`.
 
- - If `Type` is an instance of `std::pair` or `std::array`, evaluates and instance of the
-   same type but with its parameters replaced by the proper evaluation of `eve::as_wide_t`.
+ - If `Type` is an instance of `std::pair&lt;T,U>`, evaluates `std::pair&lt;eve::as_wide_t&lt;T>,eve::as_wide_t&lt;U>>`.
+
+ - If `Type` is an instance of `std::array&lt;T,N>`, evaluates `std::array&lt;eve::as_wide_t&lt;T>,N>`.
+
+
 
 **Member types:**
 
@@ -118,7 +126,7 @@ true
 
 <!-- End of Document -->
 <style class="fallback">body{visibility:hidden}</style><script>markdeepOptions={tocStyle:'none'};</script>
-<link rel="stylesheet" href="../../eve.css">
+<link rel="stylesheet" href="../../../eve.css">
 <!-- Markdeep: -->
-<script src="../../markdeep.min.js"></script>
+<script src="../../../markdeep.min.js"></script>
 <script src="https://casual-effects.com/markdeep/latest/markdeep.min.js?" charset="utf-8"></script>

--- a/docs/reference/types/traits/cardinal.html
+++ b/docs/reference/types/traits/cardinal.html
@@ -7,8 +7,13 @@
   SPDX-License-Identifier: MIT
  -->
 <meta charset="utf-8" lang="en"><style class="fallback">body{visibility:hidden;}</style>
+                              **Expressive Vector Engine**
+                                  `eve::cardinal`
+<br>
 
-eve::cardinal
+(insert ../../../crumbs.html here)
+
+Synopsis
 ====================================================================================================
 
 **Required header:**
@@ -104,7 +109,7 @@ int main()
 
 <!-- End of Document -->
 <style class="fallback">body{visibility:hidden}</style><script>markdeepOptions={tocStyle:'none'};</script>
-<link rel="stylesheet" href="../../eve.css">
+<link rel="stylesheet" href="../../../eve.css">
 <!-- Markdeep: -->
-<script src="../../markdeep.min.js"></script>
+<script src="../../../markdeep.min.js"></script>
 <script src="https://casual-effects.com/markdeep/latest/markdeep.min.js?" charset="utf-8"></script>

--- a/docs/reference/types/traits/element_type.html
+++ b/docs/reference/types/traits/element_type.html
@@ -7,8 +7,13 @@
   SPDX-License-Identifier: MIT
  -->
 <meta charset="utf-8" lang="en"><style class="fallback">body{visibility:hidden;}</style>
+                            **Expressive Vector Engine**
+                              `eve::element_type`
+<br>
 
-eve::element_type
+  (insert ../../../crumbs.html here)
+
+Synopsis
 ====================================================================================================
 
 **Required header:**
@@ -84,7 +89,7 @@ true
 
 <!-- End of Document -->
 <style class="fallback">body{visibility:hidden}</style><script>markdeepOptions={tocStyle:'none'};</script>
-<link rel="stylesheet" href="../../eve.css">
+<link rel="stylesheet" href="../../../eve.css">
 <!-- Markdeep: -->
-<script src="../../markdeep.min.js"></script>
+<script src="../../../markdeep.min.js"></script>
 <script src="https://casual-effects.com/markdeep/latest/markdeep.min.js?" charset="utf-8"></script>

--- a/include/eve/arch/cpu/logical_wide.hpp
+++ b/include/eve/arch/cpu/logical_wide.hpp
@@ -39,7 +39,6 @@ namespace eve
     using target_type            = typename parent::target_type;
 
     static constexpr size_type   static_size      = parent::static_size;
-    static constexpr std::size_t static_alignment = parent::static_alignment;
 
     template<typename T, typename C = expected_cardinal_t<T>>
     using rebind = logical<wide<T,C>>;
@@ -109,14 +108,12 @@ namespace eve
 
     template<std::size_t Alignment>
     EVE_FORCEINLINE explicit logical(aligned_ptr<logical<Type>, Alignment> ptr) noexcept
-                    requires(Alignment >= static_alignment)
                   : data_(detail::load(eve::as_<logical>{}, abi_type{}, ptr))
     {
     }
 
     template<std::size_t Alignment>
     EVE_FORCEINLINE explicit logical(aligned_ptr<logical<Type> const, Alignment> ptr) noexcept
-                    requires(Alignment >= static_alignment)
                   : data_(detail::load(eve::as_<logical>{}, abi_type{}, ptr))
     {
     }
@@ -206,7 +203,6 @@ namespace eve
     //==============================================================================================
     // alignment interface
     //==============================================================================================
-    static EVE_FORCEINLINE constexpr size_type alignment() noexcept { return static_alignment; }
 
     //==============================================================================================
     // array-like interface

--- a/include/eve/arch/cpu/logical_wide.hpp
+++ b/include/eve/arch/cpu/logical_wide.hpp
@@ -38,7 +38,8 @@ namespace eve
     using size_type              = typename parent::size_type;
     using target_type            = typename parent::target_type;
 
-    static constexpr size_type   static_size      = parent::static_size;
+    static constexpr size_type  static_size       = parent::static_size;
+    static constexpr size_type  static_alignment  = parent::static_alignment;
 
     template<typename T, typename C = expected_cardinal_t<T>>
     using rebind = logical<wide<T,C>>;
@@ -200,9 +201,14 @@ namespace eve
     EVE_FORCEINLINE operator storage_type&       () &        noexcept { return data_; }
     EVE_FORCEINLINE operator storage_type        () &&       noexcept { return data_; }
 
+
     //==============================================================================================
     // alignment interface
     //==============================================================================================
+    static EVE_FORCEINLINE constexpr size_type alignment() noexcept
+    {
+      return static_alignment;
+    }
 
     //==============================================================================================
     // array-like interface

--- a/include/eve/arch/cpu/wide.hpp
+++ b/include/eve/arch/cpu/wide.hpp
@@ -56,19 +56,6 @@ namespace eve
     using rebind = wide<T,N>;
 
     static constexpr size_type    static_size = Size::value;
-    static constexpr std::size_t  static_alignment = []()
-    {
-      if constexpr( std::is_same_v<aggregated_,ABI> )
-      {
-        return storage_type::value_type::static_alignment;
-      }
-      else
-      {
-        std::size_t native = alignof(storage_type);
-        std::size_t limit  = Size::value * sizeof(Type);
-        return std::min(limit, native);
-      }
-    }();
 
     //==============================================================================================
     // Default constructor
@@ -111,14 +98,14 @@ namespace eve
 
     template<std::size_t Alignment>
     EVE_FORCEINLINE explicit wide(aligned_ptr<Type const, Alignment> ptr) noexcept
-                    requires(Alignment >= static_alignment)
+                    requires(Alignment >= alignof(storage_type))
                   : data_(detail::load(eve::as_<wide>{}, abi_type{}, ptr))
     {
     }
 
     template<std::size_t Alignment>
     EVE_FORCEINLINE explicit wide(aligned_ptr<Type, Alignment> ptr) noexcept
-                    requires(Alignment >= static_alignment)
+                    requires(Alignment >= alignof(storage_type))
                   : data_(detail::load(eve::as_<wide>{}, abi_type{}, ptr))
     {
     }
@@ -203,7 +190,7 @@ namespace eve
     //==============================================================================================
     // alignment interface
     //==============================================================================================
-    static EVE_FORCEINLINE constexpr size_type alignment() noexcept { return static_alignment; }
+    static EVE_FORCEINLINE constexpr size_type alignment() noexcept { return alignof(storage_type); }
 
     //==============================================================================================
     // array-like interface

--- a/include/eve/arch/cpu/wide.hpp
+++ b/include/eve/arch/cpu/wide.hpp
@@ -55,7 +55,10 @@ namespace eve
     template<typename T, typename N = expected_cardinal_t<T>>
     using rebind = wide<T,N>;
 
-    static constexpr size_type    static_size = Size::value;
+    static constexpr size_type  static_size       = Size::value;
+    static constexpr size_type  static_alignment  = std::min( sizeof(Type)*Size::value
+                                                            , alignof(storage_type)
+                                                            );
 
     //==============================================================================================
     // Default constructor
@@ -67,9 +70,9 @@ namespace eve
     //==============================================================================================
     EVE_FORCEINLINE wide(storage_type const &r) noexcept : data_(r) {}
 
-    //==============================================================================================
+    //====================================================²==========================================
     // Constructs a wide from a Range
-    //==============================================================================================
+    //====================================================²==========================================
     template<std::input_iterator Iterator>
     EVE_FORCEINLINE explicit wide(Iterator b, Iterator e) noexcept
                   : data_(detail::load(eve::as_<wide>{}, abi_type{}, b, e))
@@ -98,14 +101,14 @@ namespace eve
 
     template<std::size_t Alignment>
     EVE_FORCEINLINE explicit wide(aligned_ptr<Type const, Alignment> ptr) noexcept
-                    requires(Alignment >= alignof(storage_type))
+                    requires(Alignment >= static_alignment)
                   : data_(detail::load(eve::as_<wide>{}, abi_type{}, ptr))
     {
     }
 
     template<std::size_t Alignment>
     EVE_FORCEINLINE explicit wide(aligned_ptr<Type, Alignment> ptr) noexcept
-                    requires(Alignment >= alignof(storage_type))
+                    requires(Alignment >= static_alignment)
                   : data_(detail::load(eve::as_<wide>{}, abi_type{}, ptr))
     {
     }
@@ -186,6 +189,14 @@ namespace eve
 
     EVE_FORCEINLINE auto  end()        noexcept { return begin() + static_size; }
     EVE_FORCEINLINE auto  end() const  noexcept { return begin() + static_size; }
+
+    //==============================================================================================
+    // alignment interface
+    //==============================================================================================
+    static EVE_FORCEINLINE constexpr size_type alignment() noexcept
+    {
+      return static_alignment;
+    }
 
     //==============================================================================================
     // array-like interface

--- a/include/eve/arch/cpu/wide.hpp
+++ b/include/eve/arch/cpu/wide.hpp
@@ -188,11 +188,6 @@ namespace eve
     EVE_FORCEINLINE auto  end() const  noexcept { return begin() + static_size; }
 
     //==============================================================================================
-    // alignment interface
-    //==============================================================================================
-    static EVE_FORCEINLINE constexpr size_type alignment() noexcept { return alignof(storage_type); }
-
-    //==============================================================================================
     // array-like interface
     //==============================================================================================
     static EVE_FORCEINLINE constexpr size_type size()     noexcept { return static_size; }

--- a/include/eve/function/load.hpp
+++ b/include/eve/function/load.hpp
@@ -13,6 +13,7 @@
 #include <eve/memory/aligned_ptr.hpp>
 #include <eve/detail/overload.hpp>
 #include <eve/detail/abi.hpp>
+#include <eve/traits/alignment.hpp>
 #include <eve/forward.hpp>
 #include <eve/as.hpp>
 
@@ -45,7 +46,9 @@ namespace eve
     return *ptr;
   }
 
-  template<typename T, std::size_t Align, typename = std::enable_if_t<(Align >= alignof(T))>>
+  template< typename T, std::size_t Align
+          , typename = std::enable_if_t<(Align >= alignment_v<T>)>
+          >
   EVE_FORCEINLINE auto load(aligned_ptr<T const, Align> ptr, as_<T> const &) noexcept
   {
     return *ptr;
@@ -53,7 +56,7 @@ namespace eve
 
   template<typename T, std::size_t Align>
   EVE_FORCEINLINE auto load(aligned_ptr<T, Align> ptr, as_<T> const &) noexcept
-  requires(Align >= alignof(T))
+  requires(Align >= alignment_v<T>)
   {
     return *ptr;
   }
@@ -88,14 +91,14 @@ namespace eve
 
   template<typename Size,typename ABI,typename T,std::size_t Align>
   EVE_FORCEINLINE auto load(aligned_ptr<T const, Align> ptr, as_<wide<T, Size, ABI>> const &) noexcept
-  requires(Align >= alignof(wide<T, Size>))
+  requires(Align >= wide<T, Size>::static_alignment)
   {
     return wide<T, Size>(ptr);
   }
 
   template<typename Size,typename ABI,typename T,std::size_t Align>
   EVE_FORCEINLINE auto load(aligned_ptr<T, Align> ptr, as_<wide<T, Size, ABI>> const &) noexcept
-  requires(Align >= alignof(wide<T, Size>))
+  requires(Align >= wide<T, Size>::static_alignment)
   {
     return wide<T, Size>(ptr);
   }
@@ -111,7 +114,7 @@ namespace eve
   template<typename Size,typename ABI,typename T,std::size_t Align>
   EVE_FORCEINLINE auto load ( aligned_ptr<logical<T> const, Align> ptr,
                               as_<logical<wide<T, Size, ABI>>> const&
-                            ) noexcept requires(Align >= alignof(wide<T, Size>))
+                            ) noexcept requires(Align >= wide<T, Size>::static_alignment)
   {
     return logical<wide<T, Size, ABI>>(ptr);
   }
@@ -119,7 +122,7 @@ namespace eve
   template<typename Size,typename ABI,typename T,std::size_t Align>
   EVE_FORCEINLINE auto load ( aligned_ptr<logical<T>, Align> ptr,
                               as_<logical<wide<T, Size, ABI>>> const&
-                            ) noexcept requires(Align >= alignof(wide<T, Size>))
+                            ) noexcept requires(Align >= wide<T, Size>::static_alignment)
   {
     return logical<wide<T, Size, ABI>>(ptr);
   }

--- a/include/eve/function/load.hpp
+++ b/include/eve/function/load.hpp
@@ -88,14 +88,14 @@ namespace eve
 
   template<typename Size,typename ABI,typename T,std::size_t Align>
   EVE_FORCEINLINE auto load(aligned_ptr<T const, Align> ptr, as_<wide<T, Size, ABI>> const &) noexcept
-  requires(Align >= wide<T, Size>::static_alignment)
+  requires(Align >= alignof(wide<T, Size>))
   {
     return wide<T, Size>(ptr);
   }
 
   template<typename Size,typename ABI,typename T,std::size_t Align>
   EVE_FORCEINLINE auto load(aligned_ptr<T, Align> ptr, as_<wide<T, Size, ABI>> const &) noexcept
-  requires(Align >= wide<T, Size>::static_alignment)
+  requires(Align >= alignof(wide<T, Size>))
   {
     return wide<T, Size>(ptr);
   }
@@ -111,7 +111,7 @@ namespace eve
   template<typename Size,typename ABI,typename T,std::size_t Align>
   EVE_FORCEINLINE auto load ( aligned_ptr<logical<T> const, Align> ptr,
                               as_<logical<wide<T, Size, ABI>>> const&
-                            ) noexcept requires(Align >= wide<T, Size>::static_alignment)
+                            ) noexcept requires(Align >= alignof(wide<T, Size>))
   {
     return logical<wide<T, Size, ABI>>(ptr);
   }
@@ -119,7 +119,7 @@ namespace eve
   template<typename Size,typename ABI,typename T,std::size_t Align>
   EVE_FORCEINLINE auto load ( aligned_ptr<logical<T>, Align> ptr,
                               as_<logical<wide<T, Size, ABI>>> const&
-                            ) noexcept requires(Align >= wide<T, Size>::static_alignment)
+                            ) noexcept requires(Align >= alignof(wide<T, Size>))
   {
     return logical<wide<T, Size, ABI>>(ptr);
   }

--- a/include/eve/memory/aligned_ptr.hpp
+++ b/include/eve/memory/aligned_ptr.hpp
@@ -10,14 +10,18 @@
 //==================================================================================================
 #pragma once
 
-#include <eve/memory/is_aligned.hpp>
 #include <eve/detail/concepts.hpp>
+#include <eve/memory/is_aligned.hpp>
+#include <eve/traits/alignment.hpp>
 #include <eve/assert.hpp>
 #include <compare>
 
 namespace eve
 {
-  template<typename Type, std::size_t Alignment = alignof(Type)> requires(is_power_of_2(Alignment))
+  template< typename Type
+          , std::size_t Alignment = alignment_v<Type>
+          >
+  requires(is_power_of_2(Alignment))
   struct aligned_ptr
   {
     using pointer = std::add_pointer_t<Type>;
@@ -51,7 +55,6 @@ namespace eve
       pointer_ = static_cast<pointer>(p.get());
       return *this;
     }
-
 
     template<std::size_t A>
     aligned_ptr &operator=(aligned_ptr<void, A> p) noexcept  requires(A >= Alignment)

--- a/include/eve/memory/aligned_ptr.hpp
+++ b/include/eve/memory/aligned_ptr.hpp
@@ -19,7 +19,7 @@
 namespace eve
 {
   template< typename Type
-          , std::size_t Alignment = alignment_v<Type>
+          , std::size_t Alignment = sizeof(Type) * expected_cardinal_v<Type>
           >
   requires(is_power_of_2(Alignment))
   struct aligned_ptr
@@ -74,8 +74,9 @@ namespace eve
 
     aligned_ptr &operator-=(std::ptrdiff_t o) noexcept
     {
-      EVE_ASSERT(is_aligned<Alignment>(pointer_ - o),
-                 (void *)(pointer_) << " - " << o << " is not aligned on " << Alignment << ".");
+      EVE_ASSERT( is_aligned<Alignment>(pointer_ - o)
+                , (void *)(pointer_) << " - " << o << " is not aligned on " << Alignment << "."
+                );
 
       pointer_ -= o;
       return *this;

--- a/include/eve/module/core/function/generic/store.hpp
+++ b/include/eve/module/core/function/generic/store.hpp
@@ -68,7 +68,7 @@ namespace eve::detail
   template<real_scalar_value T, typename S, std::size_t N>
   EVE_FORCEINLINE void
   store_(EVE_SUPPORTS(cpu_), wide<T, S, emulated_> const &value, aligned_ptr<T, N> ptr) noexcept
-      requires(wide<T, S, emulated_>::static_alignment <= N)
+      requires(alignof(wide<T, S, emulated_>) <= N)
   {
     store(value, ptr.get());
   }
@@ -76,7 +76,7 @@ namespace eve::detail
   template<real_scalar_value T, typename S, std::size_t N>
   EVE_FORCEINLINE void
   store_(EVE_SUPPORTS(cpu_), wide<T, S, aggregated_> const &value, aligned_ptr<T, N> ptr) noexcept
-      requires(wide<T, S, aggregated_>::static_alignment <= N)
+      requires(alignof(wide<T, S, aggregated_>) <= N)
   {
     value.storage().apply
     ( [&]<typename... Sub>(Sub&... v)
@@ -91,7 +91,7 @@ namespace eve::detail
   EVE_FORCEINLINE void store_(EVE_SUPPORTS(cpu_),
                               logical<wide<T, S, ABI>> const &value,
                               aligned_ptr<logical<T>, N>      ptr) noexcept
-      requires(logical<wide<T, S, ABI>>::static_alignment <= N)
+      requires(alignof(logical<wide<T, S, ABI>>) <= N)
   {
     auto rawdata = bit_cast(value, as_<wide<T, S, ABI>> {});
     store(rawdata, (T *)(ptr.get()));

--- a/include/eve/module/core/function/generic/store.hpp
+++ b/include/eve/module/core/function/generic/store.hpp
@@ -68,7 +68,7 @@ namespace eve::detail
   template<real_scalar_value T, typename S, std::size_t N>
   EVE_FORCEINLINE void
   store_(EVE_SUPPORTS(cpu_), wide<T, S, emulated_> const &value, aligned_ptr<T, N> ptr) noexcept
-      requires(alignof(wide<T, S, emulated_>) <= N)
+      requires(wide<T, S, emulated_>::static_alignment <= N)
   {
     store(value, ptr.get());
   }
@@ -76,7 +76,7 @@ namespace eve::detail
   template<real_scalar_value T, typename S, std::size_t N>
   EVE_FORCEINLINE void
   store_(EVE_SUPPORTS(cpu_), wide<T, S, aggregated_> const &value, aligned_ptr<T, N> ptr) noexcept
-      requires(alignof(wide<T, S, aggregated_>) <= N)
+      requires(wide<T, S, aggregated_>::static_alignment <= N)
   {
     value.storage().apply
     ( [&]<typename... Sub>(Sub&... v)
@@ -91,7 +91,7 @@ namespace eve::detail
   EVE_FORCEINLINE void store_(EVE_SUPPORTS(cpu_),
                               logical<wide<T, S, ABI>> const &value,
                               aligned_ptr<logical<T>, N>      ptr) noexcept
-      requires(alignof(logical<wide<T, S, ABI>>) <= N)
+      requires(logical<wide<T, S, ABI>>::static_alignment <= N)
   {
     auto rawdata = bit_cast(value, as_<wide<T, S, ABI>> {});
     store(rawdata, (T *)(ptr.get()));

--- a/include/eve/module/core/function/simd/common/load.hpp
+++ b/include/eve/module/core/function/simd/common/load.hpp
@@ -28,7 +28,7 @@ namespace eve
 
   template<typename Size,typename ABI,typename T,std::size_t Align>
   EVE_FORCEINLINE auto load(aligned_ptr<T, Align> ptr, as_<wide<T, Size, ABI>> const &) noexcept
-  requires(Align >= wide<T, Size>::static_alignment)
+  requires(Align >= alignof(wide<T, Size>))
   {
     return wide<T, Size>(ptr);
   }
@@ -44,7 +44,7 @@ namespace eve
   template<typename Size,typename ABI,typename T,std::size_t Align>
   EVE_FORCEINLINE auto load(aligned_ptr<logical<T>, Align> ptr,
                             as_<logical<wide<T, Size, ABI>>> const &) noexcept
-  requires(Align >= wide<T, Size>::static_alignment)
+  requires(Align >= alignof(wide<T, Size>))
   {
     return logical<wide<T, Size, ABI>>(ptr);
   }

--- a/include/eve/module/core/function/simd/common/load.hpp
+++ b/include/eve/module/core/function/simd/common/load.hpp
@@ -28,7 +28,7 @@ namespace eve
 
   template<typename Size,typename ABI,typename T,std::size_t Align>
   EVE_FORCEINLINE auto load(aligned_ptr<T, Align> ptr, as_<wide<T, Size, ABI>> const &) noexcept
-  requires(Align >= alignof(wide<T, Size>))
+  requires(Align >= wide<T, Size>::static_alignment)
   {
     return wide<T, Size>(ptr);
   }
@@ -44,7 +44,7 @@ namespace eve
   template<typename Size,typename ABI,typename T,std::size_t Align>
   EVE_FORCEINLINE auto load(aligned_ptr<logical<T>, Align> ptr,
                             as_<logical<wide<T, Size, ABI>>> const &) noexcept
-  requires(Align >= alignof(wide<T, Size>))
+  requires(Align >= wide<T, Size>::static_alignment)
   {
     return logical<wide<T, Size, ABI>>(ptr);
   }

--- a/include/eve/module/core/function/simd/x86/store.hpp
+++ b/include/eve/module/core/function/simd/x86/store.hpp
@@ -42,7 +42,7 @@ namespace eve::detail
   EVE_FORCEINLINE auto
   store_(EVE_SUPPORTS(sse2_), wide<T, N, x86_128_> const &value, aligned_ptr<T, A> ptr) noexcept
   {
-    if constexpr(N::value * sizeof(T) == x86_128_::bytes && A >= alignof(wide<T, N, x86_128_>))
+    if constexpr(N::value * sizeof(T) == x86_128_::bytes && A >= wide<T, N, x86_128_>::static_alignment)
     {
       if constexpr(std::is_same_v<T, double>)
         _mm_store_pd(ptr.get(), value);
@@ -81,7 +81,7 @@ namespace eve::detail
   EVE_FORCEINLINE auto
   store_(EVE_SUPPORTS(avx_), wide<T, N, x86_256_> const &value, aligned_ptr<T, A> ptr) noexcept
   {
-    if constexpr(N::value * sizeof(T) == x86_256_::bytes && A >= alignof(wide<T, N, x86_256_>))
+    if constexpr(N::value * sizeof(T) == x86_256_::bytes && A >= wide<T, N, x86_256_>::static_alignment)
     {
       if constexpr(std::is_same_v<T, double>)
         _mm256_store_pd(ptr.get(), value);

--- a/include/eve/module/core/function/simd/x86/store.hpp
+++ b/include/eve/module/core/function/simd/x86/store.hpp
@@ -42,9 +42,7 @@ namespace eve::detail
   EVE_FORCEINLINE auto
   store_(EVE_SUPPORTS(sse2_), wide<T, N, x86_128_> const &value, aligned_ptr<T, A> ptr) noexcept
   {
-    static constexpr auto alg = wide<T, N, x86_128_>::static_alignment;
-
-    if constexpr(N::value * sizeof(T) == x86_128_::bytes && A >= alg)
+    if constexpr(N::value * sizeof(T) == x86_128_::bytes && A >= alignof(wide<T, N, x86_128_>))
     {
       if constexpr(std::is_same_v<T, double>)
         _mm_store_pd(ptr.get(), value);
@@ -83,9 +81,7 @@ namespace eve::detail
   EVE_FORCEINLINE auto
   store_(EVE_SUPPORTS(avx_), wide<T, N, x86_256_> const &value, aligned_ptr<T, A> ptr) noexcept
   {
-    static constexpr auto alg = wide<T, N, x86_256_>::static_alignment;
-
-    if constexpr(N::value * sizeof(T) == x86_256_::bytes && A >= alg)
+    if constexpr(N::value * sizeof(T) == x86_256_::bytes && A >= alignof(wide<T, N, x86_256_>))
     {
       if constexpr(std::is_same_v<T, double>)
         _mm256_store_pd(ptr.get(), value);

--- a/include/eve/module/math/detail/generic/rempio2_kernel.hpp
+++ b/include/eve/module/math/detail/generic/rempio2_kernel.hpp
@@ -41,6 +41,7 @@
 #include <eve/function/shr.hpp>
 #include <eve/module/math/detail/constant/rempio2_limits.hpp>
 #include <eve/module/math/detail/generic/workaround.hpp>
+#include <eve/traits/alignment.hpp>
 #include <bit>
 #include <tuple>
 #include <type_traits>
@@ -154,8 +155,8 @@ namespace eve::detail
       using i32_tv  = as_wide_t<int32_t, fixed<2 * cardinal_v<T>>>;
       using i32_t =  std::conditional_t<scalar_value<T>, i32_ts, i32_tv>;
       using ui64_t=  std::conditional_t<scalar_value<T>, ui64_ts, ui64_tv>;
-      
-      constexpr auto alg = alignof(T);
+
+      constexpr auto alg = alignment_v<T>;
       alignas(alg) constexpr double toverp[75] = {
           /*  2/ PI base 24*/
           10680707.0, 7228996.0,  1387004.0,  2578385.0,  16069853.0, 12639074.0, 9804092.0,
@@ -282,7 +283,7 @@ namespace eve::detail
       using ui_t          = std::conditional_t<scalar_value<T>, ui_ts, ui_tv>;
       using wui_t         = std::conditional_t<scalar_value<T>, wui_ts, wui_tv>;
 
-      constexpr auto alg = alignof(ui_t);
+      constexpr auto alg = alignment_v<ui_t>;
       // Table with 4/PI to 192 bit precision.  To avoid unaligned accesses
       //   only 8 new bits are added per entry, making the table 4 times larger.
       alignas(alg) constexpr const uint32_t __inv_pio4[24] = {

--- a/include/eve/module/math/function/generic/rem_pio2.hpp
+++ b/include/eve/module/math/function/generic/rem_pio2.hpp
@@ -18,7 +18,7 @@
 #include <eve/detail/implementation.hpp>
 #include <eve/function/load.hpp>
 #include <eve/function/abs.hpp>
-#include <eve/traits/alignemnt.hpp>
+#include <eve/traits/alignment.hpp>
 #include <eve/module/math/detail/scalar/ieee_754_rem_pio2.hpp>
 
 #include <tuple>

--- a/include/eve/module/math/function/generic/rem_pio2.hpp
+++ b/include/eve/module/math/function/generic/rem_pio2.hpp
@@ -34,14 +34,14 @@ namespace eve::detail
     using elt_t = element_type_t<T>;
 
     static constexpr uint32_t                            size = cardinal_v<T>;
-    alignas(T::static_alignment) std::array<elt_t, size> tmp;
-    alignas(T::static_alignment) std::array<elt_t, size> txr;
-    alignas(T::static_alignment) std::array<elt_t, size> tyr;
+    alignas(T) std::array<elt_t, size> tmp;
+    alignas(T) std::array<elt_t, size> txr;
+    alignas(T) std::array<elt_t, size> tyr;
     for( uint32_t i = 0; i != size; ++i )
     { std::tie(tmp[i], txr[i], tyr[i]) = eve::rem_pio2(a0[i]); }
-    return std::make_tuple(eve::load(eve::as_aligned<T::static_alignment>(&tmp[0]), eve::as_<T>()),
-                           eve::load(eve::as_aligned<T::static_alignment>(&txr[0]), eve::as_<T>()),
-                           eve::load(eve::as_aligned<T::static_alignment>(&tyr[0]), eve::as_<T>()));
+    return std::make_tuple(eve::load(eve::as_aligned<alignof(T)>(&tmp[0]), eve::as_<T>()),
+                           eve::load(eve::as_aligned<alignof(T)>(&txr[0]), eve::as_<T>()),
+                           eve::load(eve::as_aligned<alignof(T)>(&tyr[0]), eve::as_<T>()));
   }
 
   EVE_FORCEINLINE auto rem_pio2_(EVE_SUPPORTS(cpu_), double const &a0) noexcept

--- a/include/eve/module/math/function/generic/rem_pio2.hpp
+++ b/include/eve/module/math/function/generic/rem_pio2.hpp
@@ -18,6 +18,7 @@
 #include <eve/detail/implementation.hpp>
 #include <eve/function/load.hpp>
 #include <eve/function/abs.hpp>
+#include <eve/traits/alignemnt.hpp>
 #include <eve/module/math/detail/scalar/ieee_754_rem_pio2.hpp>
 
 #include <tuple>
@@ -39,9 +40,9 @@ namespace eve::detail
     alignas(T) std::array<elt_t, size> tyr;
     for( uint32_t i = 0; i != size; ++i )
     { std::tie(tmp[i], txr[i], tyr[i]) = eve::rem_pio2(a0[i]); }
-    return std::make_tuple(eve::load(eve::as_aligned<alignof(T)>(&tmp[0]), eve::as_<T>()),
-                           eve::load(eve::as_aligned<alignof(T)>(&txr[0]), eve::as_<T>()),
-                           eve::load(eve::as_aligned<alignof(T)>(&tyr[0]), eve::as_<T>()));
+    return std::make_tuple(eve::load(eve::as_aligned<alignment_v<T>>(&tmp[0]), eve::as_<T>()),
+                           eve::load(eve::as_aligned<alignment_v<T>>(&txr[0]), eve::as_<T>()),
+                           eve::load(eve::as_aligned<alignment_v<T>>(&tyr[0]), eve::as_<T>()));
   }
 
   EVE_FORCEINLINE auto rem_pio2_(EVE_SUPPORTS(cpu_), double const &a0) noexcept

--- a/include/eve/traits.hpp
+++ b/include/eve/traits.hpp
@@ -10,6 +10,7 @@
 //==================================================================================================
 #pragma once
 
+#include <eve/traits/alignment.hpp>
 #include <eve/traits/as_arithmetic.hpp>
 #include <eve/traits/as_logical.hpp>
 #include <eve/traits/as_wide.hpp>

--- a/include/eve/traits/alignment.hpp
+++ b/include/eve/traits/alignment.hpp
@@ -1,0 +1,37 @@
+//==================================================================================================
+/**
+  EVE - Expressive Vector Engine
+  Copyright 2020 Joel FALCOU
+  Copyright 2020 Jean-Thierry LAPRESTE
+
+  Licensed under the MIT License <http://opensource.org/licenses/MIT>.
+  SPDX-License-Identifier: MIT
+**/
+//==================================================================================================
+#pragma once
+
+#include <eve/forward.hpp>
+#include <cstddef>
+
+namespace eve
+{
+  template<typename Type>
+  struct alignment : std::integral_constant<std::size_t,alignof(Type)>
+  {};
+
+  template<typename Type, typename Size, typename ABI>
+  struct  alignment<wide<Type, Size, ABI>>
+        : std::integral_constant<std::size_t,wide<Type, Size, ABI>::static_alignment>
+  {};
+
+  template<typename Type>
+  struct alignment<logical<Type>> : alignment<Type>
+  {
+  };
+
+  template<typename Type>
+  using alignment_t = typename alignment<Type>::type;
+
+  template<typename Type>
+  inline constexpr auto alignment_v = alignment<Type>::value;
+}

--- a/test/producers.hpp
+++ b/test/producers.hpp
@@ -63,7 +63,6 @@ namespace tts
     static auto retrieve(T const* src) noexcept
     {
       // realign on SIMD boundaries
-//      auto p = eve::align(src, eve::under{type::static_alignment});
       return type(src);
     }
 
@@ -93,7 +92,6 @@ namespace tts
     static auto retrieve(eve::logical<T> const* src) noexcept
     {
       // realign on SIMD boundaries
-//      auto p = eve::align(src, eve::under{type::static_alignment});
       return type(src);
     }
 

--- a/test/unit/api/memory/aligned_ptr.cpp
+++ b/test/unit/api/memory/aligned_ptr.cpp
@@ -85,7 +85,7 @@ TTS_CASE("aligned_ptr provides pointer-like interface")
 
     TTS_AND_THEN("we check the proper default alignment")
     {
-      TTS_EQUAL(ptr.alignment(), alignof(type));
+      TTS_EQUAL(ptr.alignment(), eve::alignment_v<type>);
     }
 
     TTS_AND_THEN("we check access to its pointee members")

--- a/test/unit/api/memory/aligned_ptr.cpp
+++ b/test/unit/api/memory/aligned_ptr.cpp
@@ -21,15 +21,19 @@ TTS_CASE("aligned_ptr constructor from nullptr")
   TTS_EQUAL(nullptr_constructed_ptr       , nullptr);
 }
 
-TTS_CASE("aligned_ptr factory functions")
+TTS_CASE("aligned_ptr factory functions - Default SIMD alignment")
 {
-  alignas(8) std::array<char, 10> values;
+  alignas(32) std::array<char, 64> values;
   TTS_EQUAL(eve::as_aligned(&values[ 0 ]).get()   , &values[ 0 ]);
   TTS_EQUAL(eve::as_aligned(&values[ 0 ])         , &values[ 0 ]);
   TTS_EQUAL(eve::as_aligned(&values[ 0 ])         , eve::as_aligned(&values[ 0 ]));
   TTS_NOT_EQUAL(eve::as_aligned(&values[ 0 ])     , &values[ 3 ]);
-  TTS_NOT_EQUAL(eve::as_aligned(&values[ 0 ])     , eve::as_aligned(&values[ 3 ]));
+  TTS_NOT_EQUAL(eve::as_aligned(&values[ 0 ])     , eve::as_aligned(&values[ 32 ]));
+}
 
+TTS_CASE("aligned_ptr factory functions - Specific alignment")
+{
+  alignas(8) std::array<char, 64> values;
   TTS_EQUAL(eve::as_aligned<8>(&values[ 0 ]).get(), &values[ 0 ]);
   TTS_EQUAL(eve::as_aligned<8>(&values[ 0 ])      , &values[ 0 ]);
   TTS_EQUAL(eve::as_aligned<8>(&values[ 0 ])      , eve::as_aligned<8>(&values[ 0 ]));
@@ -42,13 +46,15 @@ TTS_CASE("aligned_ptr ordering")
   char                      values[ 2 ];
   eve::aligned_ptr<char, 1> ptr = &values[ 0 ];
   eve::aligned_ptr<char, 1> ptr1= ptr;
+
   ptr1++;
   TTS_EXPECT(ptr < ptr1);
+
   ptr1--;
   TTS_EXPECT(ptr ==  ptr1);
+
   ptr1--;
   TTS_EXPECT(ptr >  ptr1);
-
 }
 
 TTS_CASE("aligned_ptr pre/post increment & decrement")
@@ -58,10 +64,13 @@ TTS_CASE("aligned_ptr pre/post increment & decrement")
 
   ptr++;
   TTS_EQUAL(ptr.get(), &values[ 1 ]);
+
   ptr--;
   TTS_EQUAL(ptr.get(), &values[ 0 ]);
+
   ++ptr;
   TTS_EQUAL(ptr.get(), &values[ 1 ]);
+
   --ptr;
   TTS_EQUAL(ptr.get(), &values[ 0 ]);
 }
@@ -79,8 +88,8 @@ TTS_CASE("aligned_ptr provides pointer-like interface")
     type values[2] = {{42},{17}};
     alignas(8) type extra_aligned_value{87};
 
-    eve::aligned_ptr<type>    ptr           = &values[0];
-    eve::aligned_ptr<type>    other_ptr     = &values[1];
+    eve::aligned_ptr<type, 1> ptr           = &values[0];
+    eve::aligned_ptr<type, 1> other_ptr     = &values[1];
     eve::aligned_ptr<type, 8> realigned_ptr = &extra_aligned_value;
 
     TTS_AND_THEN("we check the proper default alignment")

--- a/test/unit/api/wide/load/arithmetic/load.hpp
+++ b/test/unit/api/wide/load/arithmetic/load.hpp
@@ -19,7 +19,7 @@
 template<typename T, typename N>
 auto data_block()
 {
-  using alloc_t = eve::aligned_allocator<T, eve::wide<T, N>::static_alignment>;
+  using alloc_t = eve::aligned_allocator<T, alignof(eve::wide<T, N>)>;
 
   auto nb_elem  = 4096/sizeof(T);
   auto start    = nb_elem - N::value;
@@ -67,7 +67,7 @@ TTS_CASE_TPL("Check ctor from const unaligned pointer for wide", EVE_TYPE )
 
 TTS_CASE_TPL("Check ctor from aligned pointer for wide", EVE_TYPE )
 {
-  auto constexpr algt = T::static_alignment;
+  auto constexpr algt = alignof(T);
   auto [data,idx]     = data_block<EVE_VALUE, eve::fixed<EVE_CARDINAL>>();
   auto* ref_ptr       = &data[idx];
 
@@ -85,7 +85,7 @@ TTS_CASE_TPL("Check ctor from aligned pointer for wide", EVE_TYPE )
 
 TTS_CASE_TPL("Check ctor from const aligned pointer for wide", EVE_TYPE )
 {
-  auto constexpr algt = T::static_alignment;
+  auto constexpr algt = alignof(T);
   auto [data,idx]     = data_block<EVE_VALUE, eve::fixed<EVE_CARDINAL>>();
   auto const* ref_ptr = &data[idx];
 

--- a/test/unit/api/wide/load/arithmetic/load.hpp
+++ b/test/unit/api/wide/load/arithmetic/load.hpp
@@ -19,7 +19,7 @@
 template<typename T, typename N>
 auto data_block()
 {
-  constexpr std::ptrdiff_t algt = alignof(eve::wide<T, N>);
+  constexpr std::ptrdiff_t algt = eve::alignment_v<eve::wide<T, N>>;
   using alloc_t = eve::aligned_allocator<T, algt>;
 
   auto nb_elem  = 4096/sizeof(T);
@@ -68,7 +68,7 @@ TTS_CASE_TPL("Check ctor from const unaligned pointer for wide", EVE_TYPE )
 
 TTS_CASE_TPL("Check ctor from aligned pointer for wide", EVE_TYPE )
 {
-  auto constexpr algt = alignof(T);
+  auto constexpr algt = eve::alignment_v<T>;
   auto [data,idx]     = data_block<EVE_VALUE, eve::fixed<EVE_CARDINAL>>();
   auto* ref_ptr       = &data[idx];
 
@@ -86,7 +86,7 @@ TTS_CASE_TPL("Check ctor from aligned pointer for wide", EVE_TYPE )
 
 TTS_CASE_TPL("Check ctor from const aligned pointer for wide", EVE_TYPE )
 {
-  auto constexpr algt = alignof(T);
+  auto constexpr algt = eve::alignment_v<T>;
   auto [data,idx]     = data_block<EVE_VALUE, eve::fixed<EVE_CARDINAL>>();
   auto const* ref_ptr = &data[idx];
 

--- a/test/unit/api/wide/load/arithmetic/load.hpp
+++ b/test/unit/api/wide/load/arithmetic/load.hpp
@@ -19,10 +19,11 @@
 template<typename T, typename N>
 auto data_block()
 {
-  using alloc_t = eve::aligned_allocator<T, alignof(eve::wide<T, N>)>;
+  constexpr std::ptrdiff_t algt = alignof(eve::wide<T, N>);
+  using alloc_t = eve::aligned_allocator<T, algt>;
 
   auto nb_elem  = 4096/sizeof(T);
-  auto start    = nb_elem - N::value;
+  auto start    = nb_elem - std::max(algt,N::value);
   std::vector<T, alloc_t> ref(nb_elem);
 
   T k = {};

--- a/test/unit/api/wide/load/logical/load.hpp
+++ b/test/unit/api/wide/load/logical/load.hpp
@@ -24,8 +24,8 @@ using eve::fixed;
 template<typename T, typename N>
 auto data_block()
 {
-  constexpr std::ptrdiff_t algt = alignof(eve::wide<T, N>);
-  using alloc_t = eve::aligned_allocator<T, algt>;
+  constexpr std::ptrdiff_t algt = alignof(eve::logical<eve::wide<T, N>>);
+  using alloc_t = eve::aligned_allocator<eve::logical<T>, algt>;
 
   auto nb_elem  = 4096/sizeof(T);
   auto start    = nb_elem - std::max(algt,N::value);

--- a/test/unit/api/wide/load/logical/load.hpp
+++ b/test/unit/api/wide/load/logical/load.hpp
@@ -24,10 +24,11 @@ using eve::fixed;
 template<typename T, typename N>
 auto data_block()
 {
-  using alloc_t = eve::aligned_allocator<logical<T>, alignof(logical<eve::wide<T, N>>)>;
+  constexpr std::ptrdiff_t algt = alignof(eve::wide<T, N>);
+  using alloc_t = eve::aligned_allocator<T, algt>;
 
   auto nb_elem  = 4096/sizeof(T);
-  auto start    = nb_elem - N::value;
+  auto start    = nb_elem - std::max(algt,N::value);
   std::vector<logical<T>, alloc_t> ref(nb_elem);
 
   bool k = true;

--- a/test/unit/api/wide/load/logical/load.hpp
+++ b/test/unit/api/wide/load/logical/load.hpp
@@ -24,7 +24,7 @@ using eve::fixed;
 template<typename T, typename N>
 auto data_block()
 {
-  using alloc_t = eve::aligned_allocator<logical<T>, logical<eve::wide<T, N>>::static_alignment>;
+  using alloc_t = eve::aligned_allocator<logical<T>, alignof(logical<eve::wide<T, N>>)>;
 
   auto nb_elem  = 4096/sizeof(T);
   auto start    = nb_elem - N::value;
@@ -70,7 +70,7 @@ TTS_CASE_TPL( "Check ctor from const unaligned pointer for wide", EVE_TYPE )
 
 TTS_CASE_TPL( "Check ctor from aligned pointer for wide", EVE_TYPE )
 {
-  auto constexpr  algt        = logical<T>::static_alignment;
+  auto constexpr  algt        = alignof(logical<T>);
   auto            [data,idx]  = data_block<EVE_VALUE, eve::fixed<EVE_CARDINAL>>();
   auto*           ref_ptr     = &data[idx];
 
@@ -88,7 +88,7 @@ TTS_CASE_TPL( "Check ctor from aligned pointer for wide", EVE_TYPE )
 
 TTS_CASE_TPL("Check ctor from const aligned pointer for wide", EVE_TYPE)
 {
-  auto constexpr  algt        = logical<T>::static_alignment;
+  auto constexpr  algt        = alignof(logical<T>);
   auto            [data,idx]  = data_block<EVE_VALUE, eve::fixed<EVE_CARDINAL>>();
   auto const*     ref_ptr     = &data[idx];
 

--- a/test/unit/api/wide/load/logical/load.hpp
+++ b/test/unit/api/wide/load/logical/load.hpp
@@ -24,7 +24,7 @@ using eve::fixed;
 template<typename T, typename N>
 auto data_block()
 {
-  constexpr std::ptrdiff_t algt = alignof(eve::logical<eve::wide<T, N>>);
+  constexpr std::ptrdiff_t algt = eve::logical<eve::wide<T, N>>::alignment();
   using alloc_t = eve::aligned_allocator<eve::logical<T>, algt>;
 
   auto nb_elem  = 4096/sizeof(T);
@@ -71,7 +71,7 @@ TTS_CASE_TPL( "Check ctor from const unaligned pointer for wide", EVE_TYPE )
 
 TTS_CASE_TPL( "Check ctor from aligned pointer for wide", EVE_TYPE )
 {
-  auto constexpr  algt        = alignof(logical<T>);
+  auto constexpr  algt        = eve::alignment_v<eve::logical<T>>;
   auto            [data,idx]  = data_block<EVE_VALUE, eve::fixed<EVE_CARDINAL>>();
   auto*           ref_ptr     = &data[idx];
 
@@ -89,7 +89,7 @@ TTS_CASE_TPL( "Check ctor from aligned pointer for wide", EVE_TYPE )
 
 TTS_CASE_TPL("Check ctor from const aligned pointer for wide", EVE_TYPE)
 {
-  auto constexpr  algt        = alignof(logical<T>);
+  auto constexpr  algt        = eve::alignment_v<eve::logical<T>>;
   auto            [data,idx]  = data_block<EVE_VALUE, eve::fixed<EVE_CARDINAL>>();
   auto const*     ref_ptr     = &data[idx];
 

--- a/test/unit/api/wide/store/arithmetic/store.hpp
+++ b/test/unit/api/wide/store/arithmetic/store.hpp
@@ -36,7 +36,7 @@ TTS_CASE_TPL("Check store behavior to unaligned arithmetic pointer", EVE_TYPE)
 
 TTS_CASE_TPL("Check store behavior to aligned arithmetic pointer", EVE_TYPE)
 {
-  constexpr auto algt = alignof(T);
+  constexpr auto algt = eve::alignment_v<T>;
 
   std::array<EVE_VALUE, 3 * EVE_CARDINAL> ref;
   T value([](auto i, auto) { return 1 + i * 3; });
@@ -48,7 +48,7 @@ TTS_CASE_TPL("Check store behavior to aligned arithmetic pointer", EVE_TYPE)
     ref[ i + 2*EVE_CARDINAL ] =  1 + i * 3;
   }
 
-  alignas(T) std::array<EVE_VALUE, 3 * EVE_CARDINAL> target;
+  alignas(algt) std::array<EVE_VALUE, 3 * EVE_CARDINAL> target;
 
   eve::store(value, eve::as_aligned<algt>(&target[ 0                ]) );
   eve::store(value, eve::as_aligned<algt>(&target[ EVE_CARDINAL     ]) );

--- a/test/unit/api/wide/store/arithmetic/store.hpp
+++ b/test/unit/api/wide/store/arithmetic/store.hpp
@@ -36,7 +36,8 @@ TTS_CASE_TPL("Check store behavior to unaligned arithmetic pointer", EVE_TYPE)
 
 TTS_CASE_TPL("Check store behavior to aligned arithmetic pointer", EVE_TYPE)
 {
-  constexpr auto algt = T::alignment();
+  constexpr auto algt = alignof(T);
+
   std::array<EVE_VALUE, 3 * EVE_CARDINAL> ref;
   T value([](auto i, auto) { return 1 + i * 3; });
 
@@ -47,7 +48,7 @@ TTS_CASE_TPL("Check store behavior to aligned arithmetic pointer", EVE_TYPE)
     ref[ i + 2*EVE_CARDINAL ] =  1 + i * 3;
   }
 
-  alignas(T::alignment()) std::array<EVE_VALUE, 3 * EVE_CARDINAL> target;
+  alignas(T) std::array<EVE_VALUE, 3 * EVE_CARDINAL> target;
 
   eve::store(value, eve::as_aligned<algt>(&target[ 0                ]) );
   eve::store(value, eve::as_aligned<algt>(&target[ EVE_CARDINAL     ]) );

--- a/test/unit/api/wide/store/logical/store.hpp
+++ b/test/unit/api/wide/store/logical/store.hpp
@@ -37,7 +37,7 @@ TTS_CASE_TPL("Check store behavior to unaligned logical pointer",EVE_TYPE)
 
 TTS_CASE_TPL("Check store behavior to aligned logical pointer",EVE_TYPE)
 {
-  constexpr auto algt = alignof(T);
+  constexpr auto algt = eve::alignment_v<T>;
   std::array<eve::logical<EVE_VALUE>, 3 * EVE_CARDINAL> ref;
   eve::logical<T> value([](auto i, auto) { return i % 3 == 0; });
 
@@ -48,7 +48,7 @@ TTS_CASE_TPL("Check store behavior to aligned logical pointer",EVE_TYPE)
     ref[ i + 2*EVE_CARDINAL ] = (i % 3 == 0);
   }
 
-  alignas(T) std::array<eve::logical<EVE_VALUE>, 3 * EVE_CARDINAL> target;
+  alignas(algt) std::array<eve::logical<EVE_VALUE>, 3 * EVE_CARDINAL> target;
 
   eve::store(value, eve::as_aligned<algt>(&target[ 0                ]) );
   eve::store(value, eve::as_aligned<algt>(&target[ EVE_CARDINAL     ]) );

--- a/test/unit/api/wide/store/logical/store.hpp
+++ b/test/unit/api/wide/store/logical/store.hpp
@@ -37,7 +37,7 @@ TTS_CASE_TPL("Check store behavior to unaligned logical pointer",EVE_TYPE)
 
 TTS_CASE_TPL("Check store behavior to aligned logical pointer",EVE_TYPE)
 {
-  constexpr auto algt = T::alignment();
+  constexpr auto algt = alignof(T);
   std::array<eve::logical<EVE_VALUE>, 3 * EVE_CARDINAL> ref;
   eve::logical<T> value([](auto i, auto) { return i % 3 == 0; });
 
@@ -48,7 +48,7 @@ TTS_CASE_TPL("Check store behavior to aligned logical pointer",EVE_TYPE)
     ref[ i + 2*EVE_CARDINAL ] = (i % 3 == 0);
   }
 
-  alignas(T::alignment()) std::array<eve::logical<EVE_VALUE>, 3 * EVE_CARDINAL> target;
+  alignas(T) std::array<eve::logical<EVE_VALUE>, 3 * EVE_CARDINAL> target;
 
   eve::store(value, eve::as_aligned<algt>(&target[ 0                ]) );
   eve::store(value, eve::as_aligned<algt>(&target[ EVE_CARDINAL     ]) );

--- a/test/unit/module/core/gather/aligned/gather.hpp
+++ b/test/unit/module/core/gather/aligned/gather.hpp
@@ -16,7 +16,7 @@ TTS_CASE_TPL("Check eve::gather behavior with 32 bits indexes", EVE_TYPE)
 {
   using v_t = eve::element_type_t<T>;
 
-  constexpr auto alg = alignof(eve::logical<T>);
+  constexpr auto alg = eve::alignment_v<eve::logical<T>>;
   alignas(alg) v_t data[EVE_CARDINAL];
 
   for(std::size_t i = 0;i<EVE_CARDINAL;++i) data[i] = v_t(1) + i;
@@ -33,7 +33,7 @@ TTS_CASE_TPL("Check eve::gather behavior with 64 bits indexes", EVE_TYPE)
 {
   using v_t = eve::element_type_t<T>;
 
-  constexpr auto alg = alignof(eve::logical<T>);
+  constexpr auto alg = eve::alignment_v<eve::logical<T>>;
   alignas(alg) v_t data[EVE_CARDINAL];
 
   for(std::size_t i = 0;i<EVE_CARDINAL;++i) data[i] = v_t(1) + i;

--- a/test/unit/module/core/gather/aligned/gather.hpp
+++ b/test/unit/module/core/gather/aligned/gather.hpp
@@ -16,7 +16,7 @@ TTS_CASE_TPL("Check eve::gather behavior with 32 bits indexes", EVE_TYPE)
 {
   using v_t = eve::element_type_t<T>;
 
-  constexpr auto alg = T::static_alignment;
+  constexpr auto alg = alignof(logical<T>);
   alignas(alg) v_t data[EVE_CARDINAL];
 
   for(std::size_t i = 0;i<EVE_CARDINAL;++i) data[i] = v_t(1) + i;
@@ -33,7 +33,7 @@ TTS_CASE_TPL("Check eve::gather behavior with 64 bits indexes", EVE_TYPE)
 {
   using v_t = eve::element_type_t<T>;
 
-  constexpr auto alg = T::static_alignment;
+  constexpr auto alg = alignof(logical<T>);
   alignas(alg) v_t data[EVE_CARDINAL];
 
   for(std::size_t i = 0;i<EVE_CARDINAL;++i) data[i] = v_t(1) + i;

--- a/test/unit/module/core/gather/aligned/gather.hpp
+++ b/test/unit/module/core/gather/aligned/gather.hpp
@@ -16,7 +16,7 @@ TTS_CASE_TPL("Check eve::gather behavior with 32 bits indexes", EVE_TYPE)
 {
   using v_t = eve::element_type_t<T>;
 
-  constexpr auto alg = alignof(logical<T>);
+  constexpr auto alg = alignof(eve::logical<T>);
   alignas(alg) v_t data[EVE_CARDINAL];
 
   for(std::size_t i = 0;i<EVE_CARDINAL;++i) data[i] = v_t(1) + i;
@@ -33,7 +33,7 @@ TTS_CASE_TPL("Check eve::gather behavior with 64 bits indexes", EVE_TYPE)
 {
   using v_t = eve::element_type_t<T>;
 
-  constexpr auto alg = alignof(logical<T>);
+  constexpr auto alg = alignof(eve::logical<T>);
   alignas(alg) v_t data[EVE_CARDINAL];
 
   for(std::size_t i = 0;i<EVE_CARDINAL;++i) data[i] = v_t(1) + i;


### PR DESCRIPTION
Make all wide like type use proper natural alignment so alignof(T) always works.