### PR TITLE
Provide an extension system to decorators

### DIFF
--- a/include/eve/detail/meta.hpp
+++ b/include/eve/detail/meta.hpp
@@ -157,13 +157,13 @@ namespace eve::detail
   // Upgrade a type (u)int(xx) -> (u)int(min(2xx, 64)
   //                float -> double,  double -> double
   template < typename T, bool is = std::is_integral_v<T>>
-  struct upgrade
+  struct upgrader
   {
     using type = T;
   };
 
   template < typename T>
-  struct upgrade < T, true>
+  struct upgrader < T, true>
   {
     template<std::size_t Size, bool Sign, typename Dummy = void>
     struct fetch;
@@ -216,9 +216,14 @@ namespace eve::detail
   };
 
   template < typename T>
-  struct upgrade < T, false>
+  struct upgrader< T, false>
   {
     using type = double;
+  };
+
+  template<typename T>
+  struct upgrade : upgrader<T>
+  {
   };
 
   template<typename T>
@@ -240,8 +245,15 @@ namespace eve::detail
     using type = make_integer_t<sizeof(T), Sign>;
   };
 
+  template<typename T>
+  struct as_uinteger : as_integer<T,unsigned>
+  {};
+
   template<typename T, typename Sign = sign_of_t<T>>
   using as_integer_t = typename as_integer<T, Sign>::type;
+
+  template<typename T>
+  using as_uinteger_t = typename as_uinteger<T>::type;
 
   // Generate integral types from sign + size
   template<std::size_t Size>

--- a/include/eve/forward.hpp
+++ b/include/eve/forward.hpp
@@ -23,7 +23,4 @@ namespace eve
            typename Size = expected_cardinal_t<Type>,
            typename ABI  = expected_abi_t<Type, Size>>
   struct wide;
-
-  template <typename T> struct converter_type;
 }
-

--- a/include/eve/function/derivative.hpp
+++ b/include/eve/function/derivative.hpp
@@ -11,28 +11,26 @@
 #pragma once
 
 #include <eve/detail/overload.hpp>
-#include <eve/detail/abi.hpp>
 
 namespace eve
 {
-  //================================================================================================
-  // Function decorators mark-up used in function overloads
-  template <auto PARAM>
-  struct derivative_type : decorator_
-  {
-    template<typename Function>
-    constexpr EVE_FORCEINLINE auto operator()(Function f) const noexcept
-    {
-      return  [f](auto&&... args)
-              {
-                return f(derivative_type<PARAM>{}, std::forward<decltype(args)>(args)...);
-              };
-    }
-  };
+  struct pedantic_;
 
   //================================================================================================
   // Function decorator - derivative mode
-  inline constexpr derivative_type<1>  const derivative = {};
+  template<auto Param> struct derivative_
+  {
+    template<typename D> static constexpr auto combine( D const& ) noexcept =delete;
+
+    template<auto N> static constexpr auto combine( decorated<pedantic_> const& ) noexcept
+    {
+      return decorated<derivative_(pedantic_)>{};
+    }
+  };
+
+  template<auto Param> using derivative_type = decorated<derivative_<Param>()>;
+
+  inline constexpr derivative_type<1> const derivative = {};
   inline constexpr derivative_type<1> const derivative_1st = {};
   inline constexpr derivative_type<2> const derivative_2nd = {};
   inline constexpr derivative_type<3> const derivative_3rd = {};

--- a/include/eve/function/numeric.hpp
+++ b/include/eve/function/numeric.hpp
@@ -11,26 +11,16 @@
 #pragma once
 
 #include <eve/detail/overload.hpp>
-#include <eve/detail/abi.hpp>
 
 namespace eve
 {
   //================================================================================================
-  // Function decorators mark-up used in function overloads
-  struct numeric_type : decorator_
+  // Function decorator - numeric mode
+  struct numeric_
   {
-    template<typename Function>
-    constexpr EVE_FORCEINLINE auto operator()(Function f) const noexcept
-    {
-      return  [f](auto&&... args)
-              {
-                return f(numeric_type{}, std::forward<decltype(args)>(args)...);
-              };
-    }
+    template<typename D> static constexpr auto combine( D const& ) noexcept =delete;
   };
 
-  //================================================================================================
-  // Function decorator - numeric mode
+  using numeric_type = decorated<numeric_()>;
   inline constexpr numeric_type const numeric = {};
 }
-

--- a/include/eve/function/pedantic.hpp
+++ b/include/eve/function/pedantic.hpp
@@ -11,26 +11,16 @@
 #pragma once
 
 #include <eve/detail/overload.hpp>
-#include <eve/detail/abi.hpp>
 
 namespace eve
 {
   //================================================================================================
-  // Function decorators mark-up used in function overloads
-  struct pedantic_type : decorator_
+  // Function decorator - pedantic mode
+  struct pedantic_
   {
-    template<typename Function>
-    constexpr EVE_FORCEINLINE auto operator()(Function f) const noexcept
-    {
-      return  [f](auto&&... args)
-              {
-                return f(pedantic_type{}, std::forward<decltype(args)>(args)...);
-              };
-    }
+    template<typename D> static constexpr auto combine( D const& ) noexcept =delete;
   };
 
-  //================================================================================================
-  // Function decorator - pedantic mode
+  using pedantic_type = decorated<pedantic_()>;
   inline constexpr pedantic_type const pedantic = {};
 }
-

--- a/include/eve/function/raw.hpp
+++ b/include/eve/function/raw.hpp
@@ -11,26 +11,16 @@
 #pragma once
 
 #include <eve/detail/overload.hpp>
-#include <eve/detail/abi.hpp>
 
 namespace eve
 {
   //================================================================================================
-  // Function decorators mark-up used in function overloads
-  struct raw_type : decorator_
+  // Function decorator - raw mode
+  struct raw_
   {
-    template<typename Function>
-    constexpr EVE_FORCEINLINE auto operator()(Function f) const noexcept
-    {
-      return  [f](auto&&... args)
-              {
-                return f(raw_type{}, std::forward<decltype(args)>(args)...);
-              };
-    }
+    template<typename D> static constexpr auto combine( D const& ) noexcept =delete;
   };
 
-  //================================================================================================
-  // Function decorator - raw mode
+  using raw_type = decorated<raw_()>;
   inline constexpr raw_type const raw = {};
 }
-

--- a/include/eve/function/roundings.hpp
+++ b/include/eve/function/roundings.hpp
@@ -10,65 +10,39 @@
 //==================================================================================================
 #pragma once
 
-#include <eve/detail/abi.hpp>
+#include <eve/detail/overload.hpp>
 
 namespace eve
 {
   //================================================================================================
-  // Rounding decorator types
-  struct upward_type : decorator_
-  {
-    template<typename Function>
-    constexpr EVE_FORCEINLINE auto operator()(Function f) const noexcept
-    {
-      return  [f](auto const&... args)
-              {
-                return f(upward_type{}, args...);
-              };
-    }
-  };
-
-  struct downward_type : decorator_
-  {
-    template<typename Function>
-    constexpr EVE_FORCEINLINE auto operator()(Function f) const noexcept
-    {
-      return  [f](auto const&... args)
-              {
-                return f(downward_type{}, args...);
-              };
-    }
-  };
-
-  struct to_nearest_type : decorator_
-  {
-    template<typename Function>
-    constexpr EVE_FORCEINLINE auto operator()(Function f) const noexcept
-    {
-      return  [f](auto const&... args)
-              {
-                return f(to_nearest_type{}, args...);
-              };
-    }
-  };
-
-  struct toward_zero_type : decorator_
-  {
-    template<typename Function>
-    constexpr EVE_FORCEINLINE auto operator()(Function f) const noexcept
-    {
-      return  [f](auto const&... args)
-              {
-                return f(toward_zero_type{}, args...);
-              };
-    }
-  };
-
-  //================================================================================================
   // Rounding decorator objects
+  struct upward_
+  {
+    template<typename D> static constexpr auto combine( D const& ) noexcept =delete;
+  };
+
+  struct downward_
+  {
+    template<typename D> static constexpr auto combine( D const& ) noexcept =delete;
+  };
+
+  struct to_nearest_
+  {
+    template<typename D> static constexpr auto combine( D const& ) noexcept =delete;
+  };
+
+  struct toward_zero_
+  {
+    template<typename D> static constexpr auto combine( D const& ) noexcept =delete;
+  };
+
+  using upward_type      = decorated<upward_()>;
+  using downward_type    = decorated<downward_()>;
+  using to_nearest_type  = decorated<to_nearest_()>;
+  using toward_zero_type = decorated<toward_zero_()>;
+
   inline constexpr upward_type      const upward       = {};
   inline constexpr downward_type    const downward     = {};
   inline constexpr to_nearest_type  const to_nearest   = {};
   inline constexpr toward_zero_type const toward_zero  = {};
 }
-

--- a/include/eve/function/saturated.hpp
+++ b/include/eve/function/saturated.hpp
@@ -11,26 +11,19 @@
 #pragma once
 
 #include <eve/detail/overload.hpp>
-#include <eve/detail/abi.hpp>
 
 namespace eve
 {
   //================================================================================================
   // Function decorators mark-up used in function overloads
-  struct saturated_type : decorator_
+  struct saturated_
   {
-    template<typename Function>
-    constexpr EVE_FORCEINLINE auto operator()(Function f) const noexcept
-    {
-      return  [f](auto&&... args)
-              {
-                return f(saturated_type{}, std::forward<decltype(args)>(args)...);
-              };
-    }
+    template<typename D> static constexpr auto combine( D const& ) noexcept =delete;
   };
+
+  using saturated_type = decorated<saturated_()>;
 
   //================================================================================================
   // Function decorator - saturated mode
   inline constexpr saturated_type const saturated = {};
 }
-

--- a/include/eve/function/trigo_tags.hpp
+++ b/include/eve/function/trigo_tags.hpp
@@ -10,48 +10,39 @@
 //==================================================================================================
 #pragma once
 
-#include <eve/detail/abi.hpp>
+#include <eve/detail/overload.hpp>
 
 namespace eve
 {
   //================================================================================================
-  // Trigonometric decorators
-  struct restricted_type : decorator_
+  // Rounding decorator objects
+  struct restricted_
   {
-    template<typename Function> constexpr EVE_FORCEINLINE auto operator()(Function f) const noexcept
-    {
-      return [f](auto const &... args) { return f(restricted_type {}, args...); };
-    }
+    template<typename D> static constexpr auto combine( D const& ) noexcept =delete;
   };
 
-  struct small_type : decorator_
+  struct small_
   {
-    template<typename Function> constexpr EVE_FORCEINLINE auto operator()(Function f) const noexcept
-    {
-      return [f](auto const &... args) { return f(small_type {}, args...); };
-    }
+    template<typename D> static constexpr auto combine( D const& ) noexcept =delete;
   };
 
-  struct medium_type : decorator_
+  struct medium_
   {
-    template<typename Function> constexpr EVE_FORCEINLINE auto operator()(Function f) const noexcept
-    {
-      return [f](auto const &... args) { return f(medium_type {}, args...); };
-    }
+    template<typename D> static constexpr auto combine( D const& ) noexcept =delete;
   };
 
-  struct big_type : decorator_
+  struct big_
   {
-    template<typename Function> constexpr EVE_FORCEINLINE auto operator()(Function f) const noexcept
-    {
-      return [f](auto const &... args) { return f(big_type {}, args...); };
-    }
+    template<typename D> static constexpr auto combine( D const& ) noexcept =delete;
   };
 
-  //================================================================================================
-  // Trigonometric decorator objects
-  inline constexpr restricted_type  const restricted = {};
-  inline constexpr small_type       const small      = {};
-  inline constexpr medium_type      const medium     = {};
-  inline constexpr big_type         const big        = {};
+  using restricted_type = decorated<restricted_()>;
+  using small_type      = decorated<small_()>;
+  using medium_type     = decorated<medium_()>;
+  using big_type        = decorated<big_()>;
+
+  inline constexpr restricted_type  const restricted  = {};
+  inline constexpr small_type       const small       = {};
+  inline constexpr medium_type      const medium      = {};
+  inline constexpr big_type         const big         = {};
 }

--- a/include/eve/module/real/combinatorial/function/regular/generic/prime_ceil.hpp
+++ b/include/eve/module/real/combinatorial/function/regular/generic/prime_ceil.hpp
@@ -11,6 +11,7 @@
 #pragma once
 
 #include <eve/concept/value.hpp>
+#include <eve/detail/apply_over.hpp>
 #include <eve/detail/implementation.hpp>
 #include <eve/detail/skeleton_calls.hpp>
 #include <eve/function/any.hpp>
@@ -21,11 +22,9 @@
 #include <eve/function/if_else.hpp>
 #include <eve/function/inc.hpp>
 #include <type_traits>
-#include <eve/detail/apply_over.hpp>
 
 namespace eve::detail
 {
-
   template<unsigned_value T>
   EVE_FORCEINLINE auto prime_ceil_(EVE_SUPPORTS(cpu_), T n) noexcept
   {
@@ -51,26 +50,16 @@ namespace eve::detail
       return apply_over(prime_ceil, n);
   }
 
-  template<unsigned_value T, typename D>
-  EVE_FORCEINLINE constexpr auto prime_ceil_(EVE_SUPPORTS(cpu_), D const &, T n) noexcept
-  requires(is_one_of<D>(types<
-                        converter_type<std::uint8_t>
-                       , converter_type<std::uint16_t>
-                       , converter_type<std::uint32_t>
-                       , converter_type<std::uint64_t>
-                       , converter_type<float>
-                       , converter_type<double>>{}))
+  template<unsigned_value T, unsigned_scalar_value D>
+  EVE_FORCEINLINE constexpr auto prime_ceil_(EVE_SUPPORTS(cpu_), converter_type<D> d, T n) noexcept
   {
-    if constexpr(is_one_of<D>(types<converter_type<float>, converter_type<double>>{}))
-    {
-      auto r =  D()(prime_ceil(n));
-      return if_else(is_eqz(r), allbits, r);
-    }
-    else
-    {
-      return prime_ceil(D()(n));
-    }
+    return prime_ceil(d(n));
   }
 
-
+  template<unsigned_value T, floating_scalar_value D>
+  EVE_FORCEINLINE constexpr auto prime_ceil_(EVE_SUPPORTS(cpu_), converter_type<D> d, T n) noexcept
+  {
+    auto r = d(prime_ceil(n));
+    return if_else(is_eqz(r), allbits, r);
+  }
 }

--- a/include/eve/module/real/combinatorial/function/regular/generic/prime_floor.hpp
+++ b/include/eve/module/real/combinatorial/function/regular/generic/prime_floor.hpp
@@ -13,6 +13,7 @@
 #include <eve/concept/value.hpp>
 #include <eve/detail/implementation.hpp>
 #include <eve/detail/skeleton_calls.hpp>
+#include <eve/detail/apply_over.hpp>
 #include <eve/function/any.hpp>
 #include <eve/function/average.hpp>
 #include <eve/function/convert.hpp>
@@ -21,12 +22,9 @@
 #include <eve/function/nth_prime.hpp>
 #include <eve/function/if_else.hpp>
 #include <type_traits>
-#include <typeinfo>
-#include <eve/detail/apply_over.hpp>
 
 namespace eve::detail
 {
-
   template<unsigned_value T>
   EVE_FORCEINLINE auto prime_floor_(EVE_SUPPORTS(cpu_), T n) noexcept
   {
@@ -50,26 +48,16 @@ namespace eve::detail
       return apply_over(prime_floor, n);
   }
 
-  template<unsigned_value T, typename D>
-  EVE_FORCEINLINE constexpr auto prime_floor_(EVE_SUPPORTS(cpu_), D const &, T n) noexcept
-  requires(is_one_of<D>(types<
-                        converter_type<std::uint8_t>
-                       , converter_type<std::uint16_t>
-                       , converter_type<std::uint32_t>
-                       , converter_type<std::uint64_t>
-                       , converter_type<float>
-                       , converter_type<double>>{}))
+  template<unsigned_value T, unsigned_scalar_value D>
+  EVE_FORCEINLINE constexpr auto prime_floor_(EVE_SUPPORTS(cpu_), converter_type<D> d, T n) noexcept
   {
-    if constexpr(is_one_of<D>(types<converter_type<float>, converter_type<double>>{}))
-    {
-      auto r =  D()(prime_floor(n));
-      return if_else(is_eqz(r), allbits, r);
-    }
-    else
-    {
-      return prime_floor(D()(n));
-    }
+    return prime_floor(d(n));
   }
 
-
+  template<unsigned_value T, floating_scalar_value D>
+  EVE_FORCEINLINE constexpr auto prime_floor_(EVE_SUPPORTS(cpu_), converter_type<D> d, T n) noexcept
+  {
+    auto r = d(prime_floor(n));
+    return if_else(is_eqz(r), allbits, r);
+  }
 }

--- a/include/eve/module/real/core/function/regular/generic/load.hpp
+++ b/include/eve/module/real/core/function/regular/generic/load.hpp
@@ -19,6 +19,10 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #endif
+namespace eve
+{
+  template<scalar_value T> struct convert_to_;
+}
 
 namespace eve::detail
 {
@@ -111,7 +115,7 @@ namespace eve::detail
 
   template<typename Ptr, scalar_value T>
   EVE_FORCEINLINE auto load_( EVE_SUPPORTS(cpu_)
-                            , converter_type<T> const&, Ptr p, scalar_cardinal const&
+                            , decorated<convert_to_<T>()> const&, Ptr p, scalar_cardinal const&
                             ) noexcept
   {
     return static_cast<T>(*p);

--- a/include/eve/module/real/math/function/regular/generic/exp2.hpp
+++ b/include/eve/module/real/math/function/regular/generic/exp2.hpp
@@ -122,7 +122,7 @@ namespace eve::detail
     {
       if constexpr(is_one_of<D>(types<converter_type<float>, converter_type<double>>{}))
       {
-        using vd_t = value_type_t<D>;
+        using vd_t = value_type_t<typename D::base_type>;
         using i_t  = as_integer_t<vd_t>;
         auto x = to_<i_t>(xx);
         auto z = is_nez(x);


### PR DESCRIPTION
Decorators may need to be combined so we needed a way to
make decorator type open-ended and easily specified.

This is done by having all decorator be an instance of a template
type decorated<T(A...)> that allow for decorators to aggregate info
when combined so that function specializations can inspect those
combos and act upon them.

Cleanup and small scale adaptations of existing code has been performed.