### PR TITLE
Fix #443 - No [] for logical. Nope.

### DIFF
--- a/include/eve/arch/cpu/base.hpp
+++ b/include/eve/arch/cpu/base.hpp
@@ -75,7 +75,7 @@ namespace eve::detail
     }
 
     template<typename Index>
-    EVE_FORCEINLINE auto operator[](wide<Index,cardinal_t<Derived>> const& idx) noexcept
+    EVE_FORCEINLINE auto operator[](wide<Index,cardinal_t<Derived>> const& idx) const noexcept
     {
       return lookup(self(),idx);
     }

--- a/include/eve/arch/cpu/logical.hpp
+++ b/include/eve/arch/cpu/logical.hpp
@@ -44,7 +44,13 @@ namespace eve
     //==============================================================================================
     // Assignment
     //==============================================================================================
-    EVE_FORCEINLINE constexpr logical &operator=(bool v) noexcept
+    EVE_FORCEINLINE constexpr logical &operator=(logical v) & noexcept
+    {
+      value_ = v.value_;
+      return *this;
+    }
+
+    EVE_FORCEINLINE constexpr logical &operator=(bool v) & noexcept
     {
       value_ = v ? true_mask : false_mask;
       return *this;


### PR DESCRIPTION
```
logical<wide<int>> l;
l[i] = true;
```

now properly fails at compile-time instead of being a silent noop.

Implementation is based on :
https://lesleylai.info/en/type-of-assignment-operators/
http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2009/n2819.html