### PR TITLE
FIX #456: clang warnings

### DIFF
--- a/cmake/test.cmake
+++ b/cmake/test.cmake
@@ -15,7 +15,7 @@ set(_TestCurrentDir "${CMAKE_CURRENT_LIST_DIR}")
 set(_TestSrcDir     "${PROJECT_BINARY_DIR}/tmp-src")
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-  set( _TestOptions -std=c++20 -Wall -Werror=unused-parameter)
+  set( _TestOptions -std=c++20 -Werror -Wall -Wpedantic -Wextra -Wno-gnu-zero-variadic-macro-arguments)
 elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   set( _TestOptions -std=c++20 -Wall -Werror=unused-parameter)
 elseif (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")

--- a/include/eve/arch/cpu/logical.hpp
+++ b/include/eve/arch/cpu/logical.hpp
@@ -41,6 +41,9 @@ namespace eve
                   : value_((v != 0) ? true_mask : false_mask)
     {}
 
+    EVE_FORCEINLINE constexpr logical(const logical&) = default;
+    EVE_FORCEINLINE constexpr logical(logical&&) noexcept = default;
+
     //==============================================================================================
     // Assignment
     //==============================================================================================

--- a/test/unit/api/logical/regular/logical.hpp
+++ b/test/unit/api/logical/regular/logical.hpp
@@ -97,3 +97,19 @@ TTS_CASE_TPL("logical bits conversion", EVE_TYPE)
   TTS_EQUAL(bool_f.bits(), bits_t(0));
   TTS_IEEE_EQUAL(bool_t.bits(), eve::allbits(eve::as<bits_t>()));
 }
+
+
+#if defined(EVE_SIMD_TESTS)
+TTS_CASE_TPL("logical getters and setters", EVE_TYPE)
+{
+  eve::logical<T> x{false};
+
+  for (int i = 0; i != T::static_size; ++i) {
+    TTS_EXPECT_NOT(x[i]);
+    x.set(i, true);
+    TTS_EXPECT(x[i]);
+    x.set(i, false);
+    TTS_EXPECT_NOT(x[i]);
+  }
+}
+#endif  // defined(EVE_SIMD_TESTS)


### PR DESCRIPTION
Enabling clang warnings on CI.

I couldn't reproduce the warning I had those with eve tests. But I fixed it anyways.

Added a test for logical set/operator[] - let me if we actually had one and I missed it.