### PR TITLE
FIX-#459: memcpy warning on arm gcc

### DIFF
--- a/include/eve/module/complex/function/core/regular/generic/load.hpp
+++ b/include/eve/module/complex/function/core/regular/generic/load.hpp
@@ -69,14 +69,14 @@ namespace eve::detail
         {
           r_t that(cond.alternative);
           auto* dst   = (e_t*)(&that.storage());
-          std::memcpy( dst + offset, ptr + offset, cond.count( as_<r_t>{} ) );
+          std::memcpy( (void*)(dst + offset), ptr + offset, cond.count( as_<r_t>{} ) );
           return that;
         }
         else
         {
           [[maybe_unused]] r_t that;
           auto* dst   = (e_t*)(&that.storage());
-          std::memcpy( dst + offset, ptr + offset, cond.count( as_<r_t>{} ) );
+          std::memcpy( (void*)(dst + offset), ptr + offset, cond.count( as_<r_t>{} ) );
           return that;
         }
       }
@@ -117,14 +117,14 @@ namespace eve::detail
         {
           [[maybe_unused]] r_t that(cond.alternative);
           auto* dst   = (e_t*)(&that.storage());
-          std::memcpy( dst + offset, ptr + offset, cond.count( as_<r_t>{} ) );
+          std::memcpy((void*)(dst + offset), ptr + offset, cond.count( as_<r_t>{} ) );
           return that;
         }
         else
         {
           [[maybe_unused]] r_t that;
           auto* dst   = (e_t*)(&that.storage());
-          std::memcpy( dst + offset, ptr + offset, cond.count( as_<r_t>{} ) );
+          std::memcpy((void*)(dst + offset), ptr + offset, cond.count( as_<r_t>{} ) );
           return that;
         }
       }

--- a/include/eve/module/real/core/function/regular/generic/load.hpp
+++ b/include/eve/module/real/core/function/regular/generic/load.hpp
@@ -90,14 +90,14 @@ namespace eve::detail
         {
           [[maybe_unused]] r_t that(cond.alternative);
           auto* dst   = (e_t*)(&that.storage());
-          std::memcpy( dst + offset, ptr + offset, sizeof(e_t) * cond.count( as_<r_t>{} ) );
+          std::memcpy( (void*)(dst + offset), ptr + offset, sizeof(e_t) * cond.count( as_<r_t>{} ) );
           return that;
         }
         else
         {
           [[maybe_unused]] r_t that;
           auto* dst   = (e_t*)(&that.storage());
-          std::memcpy( dst + offset, ptr + offset, sizeof(e_t) * cond.count( as_<r_t>{} ) );
+          std::memcpy( (void*)(dst + offset), ptr + offset, sizeof(e_t) * cond.count( as_<r_t>{} ) );
           return that;
         }
       }


### PR DESCRIPTION
You can't memcpy to a non-trivial types according to gcc.
But we can cast to void*