### PR TITLE
Fix #446: top bits avx512

### DIFF
--- a/include/eve/arch/x86/as_register.hpp
+++ b/include/eve/arch/x86/as_register.hpp
@@ -101,35 +101,34 @@ namespace eve
 
       // != and reverse are generated.
       // <=> didn't work for some reason for ==
-      friend bool operator==(mask_n, mask_n) = default;
-      friend bool operator==(mask_n m, type n) { return m == mask_n{n}; }
-      friend auto operator<=>(mask_n, mask_n) = default;
-
+      friend bool operator== (mask_n m, type n) { return m == mask_n{n}; }
+      friend bool operator== (mask_n  , mask_n) = default;
+      friend auto operator<=>(mask_n  , mask_n) = default;
 
       friend constexpr mask_n operator~(mask_n m) { return mask_n{type{~m.value}}; }
 
       friend constexpr mask_n& operator&=(mask_n& m, mask_n n) { m.value &= n.value; return m;     }
-      friend constexpr mask_n& operator&=(mask_n& m, type  n) { m.value &= n;       return m;     }
-      friend constexpr mask_n operator& (mask_n  m, mask_n n) { return mask_n{m.value & n.value};  }
-      friend constexpr mask_n operator& (mask_n  m, type  n) { return mask_n{m.value & n};        }
-      friend constexpr mask_n operator& (type   m, mask_n n) { return mask_n{n.value & n.value};  }
+      friend constexpr mask_n& operator&=(mask_n& m, type   n) { m.value &= n;       return m;     }
+      friend constexpr mask_n  operator& (mask_n  m, mask_n n) { mask_n t{m.value}; return t &= n; }
+      friend constexpr mask_n  operator& (mask_n  m, type   n) { mask_n t{n}; return t &= m;       }
+      friend constexpr mask_n  operator& (type    m, mask_n n) { mask_n t{m}; return t &= n;       }
 
       friend constexpr mask_n& operator|=(mask_n& m, mask_n n) { m.value |= n.value; return m;     }
-      friend constexpr mask_n& operator|=(mask_n& m, type  n) { m.value |= n;       return m;     }
-      friend constexpr mask_n operator| (mask_n  m, mask_n n) { return mask_n{m.value | n.value};  }
-      friend constexpr mask_n operator| (mask_n  m, type  n) { return mask_n{m.value | n};        }
-      friend constexpr mask_n operator| (type   m, mask_n n) { return mask_n{n.value | n.value};  }
+      friend constexpr mask_n& operator|=(mask_n& m, type   n) { m.value |= n;       return m;     }
+      friend constexpr mask_n  operator| (mask_n  m, mask_n n) { mask_n t{m.value}; return t |= n; }
+      friend constexpr mask_n  operator| (mask_n  m, type   n) { mask_n t{n}; return t |= m;       }
+      friend constexpr mask_n  operator| (type    m, mask_n n) { mask_n t{m}; return t |= n;       }
 
       friend constexpr mask_n& operator^=(mask_n& m, mask_n n) { m.value ^= n.value; return m;     }
-      friend constexpr mask_n& operator^=(mask_n& m, type  n) {  m.value ^= n;       return m;     }
-      friend constexpr mask_n operator^ (mask_n  m, mask_n n) { return mask_n{m.value ^ n.value};  }
-      friend constexpr mask_n operator^ (mask_n  m, type  n) { return mask_n{m.value ^ n};        }
-      friend constexpr mask_n operator^ (type   m, mask_n n) { return mask_n{n.value ^ n.value};  }
+      friend constexpr mask_n& operator^=(mask_n& m, type   n) { m.value ^= n;       return m;     }
+      friend constexpr mask_n  operator^ (mask_n  m, mask_n n) { mask_n t{m.value}; return t ^= n; }
+      friend constexpr mask_n  operator^ (mask_n  m, type   n) { mask_n t{n}; return t ^= m;       }
+      friend constexpr mask_n  operator^ (type    m, mask_n n) { mask_n t{m}; return t ^= n;       }
 
-      friend constexpr mask_n& operator<<=(mask_n& m, std::ptrdiff_t shift) { m.value <<= shift; return m; }
-      friend constexpr mask_n operator<<(mask_n m, std::ptrdiff_t shift) { return mask_n{m.value << shift}; }
-      friend constexpr mask_n& operator>>=(mask_n& m, std::ptrdiff_t shift) { m.value >>= shift; return m; }
-      friend constexpr mask_n operator>>(mask_n m, std::ptrdiff_t shift) { return mask_n{m.value >> shift}; }
+      friend constexpr mask_n&  operator<<=(mask_n& m, std::ptrdiff_t s) { m.value <<= s; return m; }
+      friend constexpr mask_n   operator<< (mask_n  m, std::ptrdiff_t s) { mask_n t{m.value}; return t <<= s; }
+      friend constexpr mask_n&  operator>>=(mask_n& m, std::ptrdiff_t s) { m.value >>= s; return m; }
+      friend constexpr mask_n   operator>> (mask_n  m, std::ptrdiff_t s) { mask_n t{m.value}; return t >>= s; }
 
       friend std::ostream& operator<<(std::ostream& out, const mask_n& m) { return out << m.value; }
 

--- a/include/eve/arch/x86/as_register.hpp
+++ b/include/eve/arch/x86/as_register.hpp
@@ -83,10 +83,52 @@ namespace eve
   {
     template<int N> struct as_mask;
 
-    struct mask8  { using type = __mmask8;  type value; };
-    struct mask16 { using type = __mmask16; type value; };
-    struct mask32 { using type = __mmask32; type value; };
-    struct mask64 { using type = __mmask64; type value; };
+    template<int N> struct inner_mask;
+
+    template<> struct inner_mask<8>   { using type = __mmask8;  };
+    template<> struct inner_mask<16>  { using type = __mmask16; };
+    template<> struct inner_mask<32>  { using type = __mmask32; };
+    template<> struct inner_mask<64>  { using type = __mmask64; };
+
+    template<int N> struct mmask
+    {
+      using type = typename inner_mask<N>::type;
+
+      constexpr mmask() {}
+      constexpr mmask(type v) : value(v) {}
+
+      constexpr mmask& operator=(type v ) { value = v; return *this; }
+      explicit constexpr operator type() const { return value; }
+
+      friend constexpr bool operator==(mmask m, mmask n)  { return m.value == n.value; }
+      friend constexpr bool operator==(mmask m, type  n)  { return m.value == n;       }
+      friend constexpr bool operator==(type  m, mmask n)  { return m       == n.value; }
+
+      friend constexpr bool operator!=(mmask m, mmask n)  { return m.value != n.value; }
+      friend constexpr bool operator!=(mmask m, type  n)  { return m.value != n;       }
+      friend constexpr bool operator!=(type  m, mmask n)  { return m       != n.value; }
+
+      friend constexpr mmask operator~(mmask m)  { return mmask{type{~m.value}}; }
+
+      friend constexpr mmask operator&=(mmask& m, mmask n)  { m.value &= n.value; return m;     }
+      friend constexpr mmask operator&=(mmask& m, type  n)  { m.value &= n;       return m;     }
+      friend constexpr mmask operator& (mmask  m, mmask n)  { return mmask{m.value & n.value};  }
+      friend constexpr mmask operator& (mmask  m, type  n)  { return mmask{m.value & n};        }
+      friend constexpr mmask operator& (type   m, mmask n)  { return mmask{n.value & n.value};  }
+
+      friend constexpr mmask operator|=(mmask& m, mmask n)  { m.value |= n.value; return m;     }
+      friend constexpr mmask operator|=(mmask& m, type  n)  { m.value |= n;       return m;     }
+      friend constexpr mmask operator| (mmask  m, mmask n)  { return mmask{m.value | n.value};  }
+      friend constexpr mmask operator| (mmask  m, type  n)  { return mmask{m.value | n};        }
+      friend constexpr mmask operator| (type   m, mmask n)  { return mmask{n.value | n.value};  }
+
+      type value;
+    };
+
+    using mask8  = mmask<8>;
+    using mask16 = mmask<16>;
+    using mask32 = mmask<32>;
+    using mask64 = mmask<64>;
 
     template<> struct as_mask<8>  { using type = mask8; };
     template<> struct as_mask<16> { using type = mask16; };

--- a/include/eve/arch/x86/as_register.hpp
+++ b/include/eve/arch/x86/as_register.hpp
@@ -11,7 +11,9 @@
 #pragma once
 
 #include <eve/arch/x86/predef.hpp>
+#include <compare>
 #include <type_traits>
+#include <ostream>
 
 namespace eve
 {
@@ -95,24 +97,41 @@ namespace eve
       using type = typename inner_mask<N>::type;
 
       explicit constexpr operator type() const { return value; }
+      explicit constexpr operator bool() const { return (bool)value; }
 
       // != and reverse are generated.
-      friend constexpr bool operator==(mask_n m, mask_n n)  { return m.value == n.value; }
-      friend constexpr bool operator==(mask_n m, type  n)  { return m.value == n;       }
+      // <=> didn't work for some reason for ==
+      friend bool operator==(mask_n, mask_n) = default;
+      friend bool operator==(mask_n m, type n) { return m == mask_n{n}; }
+      friend auto operator<=>(mask_n, mask_n) = default;
 
-      friend constexpr mask_n operator~(mask_n m)  { return mask_n{type{~m.value}}; }
 
-      friend constexpr mask_n& operator&=(mask_n& m, mask_n n)  { m.value &= n.value; return m;     }
-      friend constexpr mask_n& operator&=(mask_n& m, type  n)  { m.value &= n;       return m;     }
-      friend constexpr mask_n operator& (mask_n  m, mask_n n)  { return mask_n{m.value & n.value};  }
-      friend constexpr mask_n operator& (mask_n  m, type  n)  { return mask_n{m.value & n};        }
-      friend constexpr mask_n operator& (type   m, mask_n n)  { return mask_n{n.value & n.value};  }
+      friend constexpr mask_n operator~(mask_n m) { return mask_n{type{~m.value}}; }
 
-      friend constexpr mask_n& operator|=(mask_n& m, mask_n n)  { m.value |= n.value; return m;     }
-      friend constexpr mask_n& operator|=(mask_n& m, type  n)  { m.value |= n;       return m;     }
-      friend constexpr mask_n operator| (mask_n  m, mask_n n)  { return mask_n{m.value | n.value};  }
-      friend constexpr mask_n operator| (mask_n  m, type  n)  { return mask_n{m.value | n};        }
-      friend constexpr mask_n operator| (type   m, mask_n n)  { return mask_n{n.value | n.value};  }
+      friend constexpr mask_n& operator&=(mask_n& m, mask_n n) { m.value &= n.value; return m;     }
+      friend constexpr mask_n& operator&=(mask_n& m, type  n) { m.value &= n;       return m;     }
+      friend constexpr mask_n operator& (mask_n  m, mask_n n) { return mask_n{m.value & n.value};  }
+      friend constexpr mask_n operator& (mask_n  m, type  n) { return mask_n{m.value & n};        }
+      friend constexpr mask_n operator& (type   m, mask_n n) { return mask_n{n.value & n.value};  }
+
+      friend constexpr mask_n& operator|=(mask_n& m, mask_n n) { m.value |= n.value; return m;     }
+      friend constexpr mask_n& operator|=(mask_n& m, type  n) { m.value |= n;       return m;     }
+      friend constexpr mask_n operator| (mask_n  m, mask_n n) { return mask_n{m.value | n.value};  }
+      friend constexpr mask_n operator| (mask_n  m, type  n) { return mask_n{m.value | n};        }
+      friend constexpr mask_n operator| (type   m, mask_n n) { return mask_n{n.value | n.value};  }
+
+      friend constexpr mask_n& operator^=(mask_n& m, mask_n n) { m.value ^= n.value; return m;     }
+      friend constexpr mask_n& operator^=(mask_n& m, type  n) {  m.value ^= n;       return m;     }
+      friend constexpr mask_n operator^ (mask_n  m, mask_n n) { return mask_n{m.value ^ n.value};  }
+      friend constexpr mask_n operator^ (mask_n  m, type  n) { return mask_n{m.value ^ n};        }
+      friend constexpr mask_n operator^ (type   m, mask_n n) { return mask_n{n.value ^ n.value};  }
+
+      friend constexpr mask_n& operator<<=(mask_n& m, std::ptrdiff_t shift) { m.value <<= shift; return m; }
+      friend constexpr mask_n operator<<(mask_n m, std::ptrdiff_t shift) { return mask_n{m.value << shift}; }
+      friend constexpr mask_n& operator>>=(mask_n& m, std::ptrdiff_t shift) { m.value >>= shift; return m; }
+      friend constexpr mask_n operator>>(mask_n m, std::ptrdiff_t shift) { return mask_n{m.value >> shift}; }
+
+      friend std::ostream& operator<<(std::ostream& out, const mask_n& m) { return out << m.value; }
 
       type value;
     };

--- a/include/eve/arch/x86/as_register.hpp
+++ b/include/eve/arch/x86/as_register.hpp
@@ -90,45 +90,37 @@ namespace eve
     template<> struct inner_mask<32>  { using type = __mmask32; };
     template<> struct inner_mask<64>  { using type = __mmask64; };
 
-    template<int N> struct mmask
+    template<int N> struct mask_n
     {
       using type = typename inner_mask<N>::type;
 
-      constexpr mmask() {}
-      constexpr mmask(type v) : value(v) {}
-
-      constexpr mmask& operator=(type v ) { value = v; return *this; }
       explicit constexpr operator type() const { return value; }
 
-      friend constexpr bool operator==(mmask m, mmask n)  { return m.value == n.value; }
-      friend constexpr bool operator==(mmask m, type  n)  { return m.value == n;       }
-      friend constexpr bool operator==(type  m, mmask n)  { return m       == n.value; }
+      // != and reverse are generated.
+      friend constexpr bool operator==(mask_n m, mask_n n)  { return m.value == n.value; }
+      friend constexpr bool operator==(mask_n m, type  n)  { return m.value == n;       }
 
-      friend constexpr bool operator!=(mmask m, mmask n)  { return m.value != n.value; }
-      friend constexpr bool operator!=(mmask m, type  n)  { return m.value != n;       }
-      friend constexpr bool operator!=(type  m, mmask n)  { return m       != n.value; }
+      friend constexpr mask_n operator~(mask_n m)  { return mask_n{type{~m.value}}; }
 
-      friend constexpr mmask operator~(mmask m)  { return mmask{type{~m.value}}; }
+      friend constexpr mask_n& operator&=(mask_n& m, mask_n n)  { m.value &= n.value; return m;     }
+      friend constexpr mask_n& operator&=(mask_n& m, type  n)  { m.value &= n;       return m;     }
+      friend constexpr mask_n operator& (mask_n  m, mask_n n)  { return mask_n{m.value & n.value};  }
+      friend constexpr mask_n operator& (mask_n  m, type  n)  { return mask_n{m.value & n};        }
+      friend constexpr mask_n operator& (type   m, mask_n n)  { return mask_n{n.value & n.value};  }
 
-      friend constexpr mmask operator&=(mmask& m, mmask n)  { m.value &= n.value; return m;     }
-      friend constexpr mmask operator&=(mmask& m, type  n)  { m.value &= n;       return m;     }
-      friend constexpr mmask operator& (mmask  m, mmask n)  { return mmask{m.value & n.value};  }
-      friend constexpr mmask operator& (mmask  m, type  n)  { return mmask{m.value & n};        }
-      friend constexpr mmask operator& (type   m, mmask n)  { return mmask{n.value & n.value};  }
-
-      friend constexpr mmask operator|=(mmask& m, mmask n)  { m.value |= n.value; return m;     }
-      friend constexpr mmask operator|=(mmask& m, type  n)  { m.value |= n;       return m;     }
-      friend constexpr mmask operator| (mmask  m, mmask n)  { return mmask{m.value | n.value};  }
-      friend constexpr mmask operator| (mmask  m, type  n)  { return mmask{m.value | n};        }
-      friend constexpr mmask operator| (type   m, mmask n)  { return mmask{n.value | n.value};  }
+      friend constexpr mask_n& operator|=(mask_n& m, mask_n n)  { m.value |= n.value; return m;     }
+      friend constexpr mask_n& operator|=(mask_n& m, type  n)  { m.value |= n;       return m;     }
+      friend constexpr mask_n operator| (mask_n  m, mask_n n)  { return mask_n{m.value | n.value};  }
+      friend constexpr mask_n operator| (mask_n  m, type  n)  { return mask_n{m.value | n};        }
+      friend constexpr mask_n operator| (type   m, mask_n n)  { return mask_n{n.value | n.value};  }
 
       type value;
     };
 
-    using mask8  = mmask<8>;
-    using mask16 = mmask<16>;
-    using mask32 = mmask<32>;
-    using mask64 = mmask<64>;
+    using mask8  = mask_n<8>;
+    using mask16 = mask_n<16>;
+    using mask32 = mask_n<32>;
+    using mask64 = mask_n<64>;
 
     template<> struct as_mask<8>  { using type = mask8; };
     template<> struct as_mask<16> { using type = mask16; };

--- a/include/eve/detail/function/simd/x86/friends.hpp
+++ b/include/eve/detail/function/simd/x86/friends.hpp
@@ -25,8 +25,9 @@ namespace eve::detail
   {
     if constexpr( !ABI::is_wide_logical )
     {
-      using m_t = typename logical<wide<T, N, ABI>>::storage_type;
-      return m_t(~v.storage().value);
+      using l_t = logical<wide<T, N, ABI>>;
+      using m_t = typename l_t::storage_type;
+      return l_t{~v.storage()};
     }
     else
     {

--- a/include/eve/detail/top_bits.hpp
+++ b/include/eve/detail/top_bits.hpp
@@ -32,27 +32,9 @@ namespace eve::detail
 
 //================================================================================================
 
-// bit utilities ---------------------
-
-template <std::size_t N>
-auto uint_t_impl() {
-  if constexpr (N == 8) {
-    return std::uint8_t{};
-  } else if constexpr (N == 16) {
-    return std::uint16_t{};
-  } else if constexpr (N == 32) {
-    return std::uint32_t{};
-  } else if constexpr (N == 64) {
-    return std::uint64_t{};
-  }
-}
-
-template <std::size_t N>
-using uint_t = decltype(uint_t_impl<N>());
-
 template <typename N>
 EVE_FORCEINLINE constexpr N set_lower_n_bits(std::ptrdiff_t n) {
-  using uint_res = uint_t<sizeof(N) * 8>;
+  using uint_res = make_integer_t<sizeof(N), unsigned>;
 
   if constexpr (std::same_as<std::uint64_t, uint_res>) {
     if (n == 64) return { static_cast<std::uint64_t>(-1) };
@@ -72,7 +54,7 @@ EVE_FORCEINLINE auto movemask_raw(Logical p)
   using ABI = abi_type_t<Logical>;
   using e_t = element_type_t<Logical>;
 
-       if constexpr( eve::current_api == avx512 ) return p.storage();
+       if constexpr( !ABI::is_wide_logical ) return p.storage();
   else if constexpr( std::same_as<ABI, x86_128_> )
   {
          if constexpr( std::is_same_v<e_t, float > ) return (std::uint16_t)_mm_movemask_ps(p.storage());

--- a/include/eve/detail/top_bits.hpp
+++ b/include/eve/detail/top_bits.hpp
@@ -34,12 +34,34 @@ namespace eve::detail
 
 // bit utilities ---------------------
 
+template <std::size_t N>
+auto uint_t_impl() {
+  if constexpr (N == 8) {
+    return std::uint8_t{};
+  } else if constexpr (N == 16) {
+    return std::uint16_t{};
+  } else if constexpr (N == 32) {
+    return std::uint32_t{};
+  } else if constexpr (N == 64) {
+    return std::uint64_t{};
+  }
+}
+
+template <std::size_t N>
+using uint_t = decltype(uint_t_impl<N>());
+
 template <typename N>
 EVE_FORCEINLINE constexpr N set_lower_n_bits(std::ptrdiff_t n) {
+  using uint_res = uint_t<sizeof(N) * 8>;
+
+  if constexpr (std::same_as<std::uint64_t, uint_res>) {
+    if (n == 64) return { static_cast<std::uint64_t>(-1) };
+  }
+
   std::uint64_t res{1};
   res <<= n;
   res -= 1;
-  return static_cast<N>(res);
+  return { static_cast<uint_res>(res) };
 }
 
 // movemask_raw --------------------
@@ -50,7 +72,8 @@ EVE_FORCEINLINE auto movemask_raw(Logical p)
   using ABI = abi_type_t<Logical>;
   using e_t = element_type_t<Logical>;
 
-  if constexpr( std::same_as<ABI, x86_128_>)
+       if constexpr( eve::current_api == avx512 ) return p.storage();
+  else if constexpr( std::same_as<ABI, x86_128_> )
   {
          if constexpr( std::is_same_v<e_t, float > ) return (std::uint16_t)_mm_movemask_ps(p.storage());
     else if constexpr( std::is_same_v<e_t, double> ) return (std::uint16_t)_mm_movemask_pd(p.storage());
@@ -64,7 +87,7 @@ EVE_FORCEINLINE auto movemask_raw(Logical p)
     else if constexpr( std::is_same_v<e_t, double> ) return (std::uint32_t)_mm256_movemask_pd(p.storage());
     else if constexpr( sizeof(e_t) == 8 )            return (std::uint32_t)_mm256_movemask_pd((__m256d)p.storage());
     else if constexpr( sizeof(e_t) == 4 )            return (std::uint32_t)_mm256_movemask_ps((__m256)p.storage());
-    else if constexpr( current_api >= avx2 )         return (std::uint32_t)_mm256_movemask_epi8(p.storage());
+    else if constexpr( current_api == avx2 )         return (std::uint32_t)_mm256_movemask_epi8(p.storage());
     else if constexpr( current_api == avx )
     {
       auto [l, h] = p.slice();
@@ -77,10 +100,6 @@ EVE_FORCEINLINE auto movemask_raw(Logical p)
       return (top << s) | bottom;
     }
   }
-  else
-  {
-    return p.storage();
-  }
 }
 
 // top_bits ---------------------------------
@@ -92,7 +111,7 @@ struct top_bits
   static constexpr bool is_avx512_logical = !abi_type_t<Logical>::is_wide_logical;
   static constexpr std::ptrdiff_t static_size = Logical::static_size;
   static constexpr std::ptrdiff_t bits_per_element =
-    sizeof(element_type_t<Logical>) == 2 ? 2 : 1;
+    sizeof(element_type_t<Logical>) == 2 && !is_avx512_logical ? 2 : 1;
 
   private:
     EVE_FORCEINLINE static auto storage_type_impl()
@@ -229,7 +248,7 @@ struct top_bits
     {
       if constexpr ( !is_aggregated )
       {
-        storage_type bit_mask = set_lower_n_bits<int>(bits_per_element) << (i * bits_per_element);
+        storage_type bit_mask = set_lower_n_bits<storage_type>(bits_per_element) << (i * bits_per_element);
         if ( x ) storage |= bit_mask;
         else     storage &= ~bit_mask;
       }
@@ -242,7 +261,7 @@ struct top_bits
 
     EVE_FORCEINLINE constexpr bool get(std::ptrdiff_t i) const
     {
-      if constexpr ( !is_aggregated ) return (storage & (1 << (i * bits_per_element))) != 0;
+      if constexpr ( !is_aggregated ) return (storage & (storage_type{1} << (i * bits_per_element))) != 0;
       else
       {
         if ( i < static_size / 2 ) return storage[0].get(i);
@@ -254,7 +273,7 @@ struct top_bits
 
     EVE_FORCEINLINE constexpr explicit operator bool()
     {
-      if constexpr ( !is_aggregated ) return storage != storage_type(0);
+      if constexpr ( !is_aggregated ) return storage != storage_type{0};
       else
       {
         return (bool)storage[0] || (bool)storage[1];
@@ -355,7 +374,7 @@ EVE_FORCEINLINE Logical to_logical(top_bits<Logical> mmask)
     using bits_et   = element_type_t<bits_wide>;
 
     static constexpr auto bits_per_element = top_bits<Logical>::bits_per_element;
-    static constexpr int element_mask = set_lower_n_bits<int>(bits_per_element);
+    static constexpr auto element_mask = set_lower_n_bits<bits_et>(bits_per_element);
 
     bits_wide true_mmask([&](int i, int) {
       int shift = 0;

--- a/test/unit/internals/top_bits/top_bits/top_bits.hpp
+++ b/test/unit/internals/top_bits/top_bits/top_bits.hpp
@@ -11,7 +11,7 @@
 
 #include "test.hpp"
 
-#if defined(SPY_ARCH_IS_AMD64) && !defined(EVE_NO_SIMD) && !defined(SPY_SIMD_IS_X86_AVX512)
+#if defined(SPY_ARCH_IS_AMD64) && !defined(EVE_NO_SIMD)
 
 #include <eve/detail/top_bits.hpp>
 
@@ -80,7 +80,6 @@ TTS_CASE_TPL("top_bits, set", EVE_TYPE)
   }
 }
 
-
 TTS_CASE_TPL("Top bits are little endian", EVE_TYPE)
 {
   using logical = eve::logical<T>;
@@ -97,7 +96,6 @@ TTS_CASE_TPL("Top bits are little endian", EVE_TYPE)
   {
     TTS_PASS("no test for aggregated");
   }
-
 }
 
 TTS_CASE_TPL("bit operations", EVE_TYPE)


### PR DESCRIPTION
The `operator` looks a bit heavy.
Generally speaking - it's recommended that they all converge to the same one, but I copied what @jfalcou did. 
Up to you - I can rewrite in classic stl style.

Didn't find a `uint_t<N>` implementation, rolled my own. Do you maybe have one? 
I needed it because I need to figure out to what I should cast.

There is also a question if we maybe want to test `mask_n`