### PR TITLE
Fix #472: all (scalar and x86)

### DIFF
--- a/include/eve/detail/hz_device.hpp
+++ b/include/eve/detail/hz_device.hpp
@@ -38,7 +38,7 @@ namespace eve
     }
     else
     {
-      if(any(todo))
+      if(eve::any(todo))
       {
         r = if_else(todo, f(ts...), r);
         return logical_notand(todo, notdone);
@@ -57,7 +57,7 @@ namespace eve
     }
     else
     {
-      if(any(todo))  r = if_else(todo, f(ts...), r);
+      if(eve::any(todo))  r = if_else(todo, f(ts...), r);
       return eve::false_(as(r));
     }
   }

--- a/include/eve/detail/unordered_hz_device.hpp
+++ b/include/eve/detail/unordered_hz_device.hpp
@@ -35,7 +35,7 @@ namespace eve
     }
     else
     {
-      if(any(todo)) {r = if_else(todo, f(ts...), r); return !todo &&  notdone; };
+      if(eve::any(todo)) {r = if_else(todo, f(ts...), r); return !todo &&  notdone; };
     }
     return notdone;
   }
@@ -50,7 +50,7 @@ namespace eve
     }
     else
     {
-      if(any(todo)){  r = if_else(todo, f(ts...), r); return !todo && notdone; };
+      if(eve::any(todo)){  r = if_else(todo, f(ts...), r); return !todo && notdone; };
     }
     return notdone;
   }
@@ -65,7 +65,7 @@ namespace eve
     }
     else
     {
-      if(any(todo))  r = if_else(todo, f(ts...), r);
+      if(eve::any(todo))  r = if_else(todo, f(ts...), r);
       return eve::false_(as(r));
     }
   }

--- a/include/eve/function/exp10.hpp
+++ b/include/eve/function/exp10.hpp
@@ -29,10 +29,10 @@ namespace eve
       using vt_t = value_type_t<T>;
       if constexpr(std::is_integral_v<vt_t>)
       {
-        EVE_ASSERT( all(is_gez(s)),
+        EVE_ASSERT( eve::all(is_gez(s)),
                     "[eve::exp10] - with integral entries the parameter element(s) must be greater then 0"
                   );
-        EVE_ASSERT( all(is_less(s, maxlog10(eve::as<T>()))),
+        EVE_ASSERT( eve::all(is_less(s, maxlog10(eve::as<T>()))),
                     "[eve::exp10]  - overflow caused by too large integral entry"
                   );
       }

--- a/include/eve/function/exp2.hpp
+++ b/include/eve/function/exp2.hpp
@@ -32,10 +32,10 @@ namespace eve
       using vt_t = value_type_t<T>;
       if constexpr(std::is_integral_v<vt_t>)
       {
-        EVE_ASSERT( all(is_gez(s)),
+        EVE_ASSERT( eve::all(is_gez(s)),
                     "[eve::exp2] - with integral entries the parameter element(s) must be greater than 0"
                   );
-        EVE_ASSERT( all(is_less(s, sizeof(vt_t)*8-std::is_signed_v<vt_t>)),
+        EVE_ASSERT( eve::all(is_less(s, sizeof(vt_t)*8-std::is_signed_v<vt_t>)),
                     "[eve::exp2]  - overflow caused by too large integral entry"
                   );
       }

--- a/include/eve/function/ldexp.hpp
+++ b/include/eve/function/ldexp.hpp
@@ -24,7 +24,7 @@ namespace eve
     EVE_FORCEINLINE void check(EVE_SUPPORTS(eve::tag::ldexp_), T const&, [[maybe_unused]]  U const& b)
     {
       if constexpr(std::is_floating_point_v<value_type_t<U>>)
-        EVE_ASSERT(all(is_flint(b)), "[eve::ldexp] argument 2 is floating but not a flint");
+        EVE_ASSERT(eve::all(is_flint(b)), "[eve::ldexp] argument 2 is floating but not a flint");
     }
   }
 

--- a/include/eve/function/next.hpp
+++ b/include/eve/function/next.hpp
@@ -27,13 +27,13 @@ namespace eve
     template<real_value T, integral_real_value U>
     EVE_FORCEINLINE void check(EVE_MATCH_CALL(eve::tag::next_), T const&, [[ maybe_unused ]] U const & n)
     {
-      EVE_ASSERT(all(is_gez(n)), "[eve::next] : second parameter must be positive");
+      EVE_ASSERT(eve::all(is_gez(n)), "[eve::next] : second parameter must be positive");
     }
 
     template<real_value T, integral_real_value U>
     EVE_FORCEINLINE void check(EVE_MATCH_CALL(saturated_type, eve::tag::next_), T const&,[[ maybe_unused ]]  U const & n)
     {
-      EVE_ASSERT(all(is_gez(n)), "[eve::saturated(eve::next)] : second parameter must be positive");
+      EVE_ASSERT(eve::all(is_gez(n)), "[eve::saturated(eve::next)] : second parameter must be positive");
     }
   }
 

--- a/include/eve/function/pedantic/ldexp.hpp
+++ b/include/eve/function/pedantic/ldexp.hpp
@@ -21,7 +21,7 @@ namespace eve
     EVE_FORCEINLINE void check(EVE_SUPPORTS(eve::tag::ldexp_), pedantic_type const&, T const&,  [[maybe_unused]] U const& b)
     {
       if constexpr(std::is_floating_point_v<value_type_t<U>>)
-        EVE_ASSERT(all(is_flint(b)), "ldexp argument 2 is floating but not a flint");
+        EVE_ASSERT(eve::all(is_flint(b)), "ldexp argument 2 is floating but not a flint");
     }
   }
 }

--- a/include/eve/function/prev.hpp
+++ b/include/eve/function/prev.hpp
@@ -27,13 +27,13 @@ namespace eve
     template<typename T, typename U>
     EVE_FORCEINLINE void check(EVE_MATCH_CALL(eve::tag::prev_), T const&, [[ maybe_unused ]] U const & n)
     {
-      EVE_ASSERT(all(is_gez(n)), "[eve::prev] : second parameter must be positive");
+      EVE_ASSERT(eve::all(is_gez(n)), "[eve::prev] : second parameter must be positive");
     }
 
     template<typename T, typename U>
     EVE_FORCEINLINE void check(EVE_MATCH_CALL(saturated_type, eve::tag::prev_), T const&,[[ maybe_unused ]]  U const & n)
     {
-      EVE_ASSERT(all(is_gez(n)), "[[eve::saturated([eve::prev)] : second parameter must be positive");
+      EVE_ASSERT(eve::all(is_gez(n)), "[[eve::saturated([eve::prev)] : second parameter must be positive");
     }
   }
 

--- a/include/eve/function/rempio2.hpp
+++ b/include/eve/function/rempio2.hpp
@@ -25,7 +25,7 @@ namespace eve
     template<typename T, typename U>
     EVE_FORCEINLINE void check(EVE_MATCH_CALL(eve::tag::rempio2_), [[maybe_unused]]  T const& x)
     {
-      EVE_ASSERT(all(is_nltz(x)), "[eve::rempio2] :  parameter must be positive or nan, found:" << x);
+      EVE_ASSERT(eve::all(is_nltz(x)), "[eve::rempio2] :  parameter must be positive or nan, found:" << x);
     }
  }
 

--- a/include/eve/module/real/algorithm/function/regular/generic/all.hpp
+++ b/include/eve/module/real/algorithm/function/regular/generic/all.hpp
@@ -1,4 +1,4 @@
-//==================================================================================================
+  //==================================================================================================
 /**
   EVE - Expressive Vector Engine
   Copyright 2020 Joel FALCOU
@@ -29,7 +29,8 @@ namespace eve::detail
       {
         if constexpr( has_aggregated_abi_v<T> )
         {
-          return v.storage().apply( [](auto const &... e) { return eve::all((e && ...)); } );
+          auto [l, h] = v.slice();
+          return eve::all(l && h);
         }
         else
         {
@@ -51,11 +52,11 @@ namespace eve::detail
   template<simd_value T, relative_conditional_expr C>
   EVE_FORCEINLINE bool all_(EVE_SUPPORTS(cpu_), C const &cond, T const &v) noexcept
   {
-         if constexpr (! is_logical_v<T>) return all[cond](to_logical(v));
-    else if constexpr (C::is_complete)
+         if constexpr ( !is_logical_v<T> ) return all[cond](to_logical(v));
+    else if constexpr ( C::is_complete )
     {
-      if constexpr (!C::is_inverted) return false;
-      else                           return all(v);
+      if constexpr ( !C::is_inverted ) return true;
+      else                             return all(v);
     }
     else
     {

--- a/include/eve/module/real/algorithm/function/regular/generic/all.hpp
+++ b/include/eve/module/real/algorithm/function/regular/generic/all.hpp
@@ -47,4 +47,25 @@ namespace eve::detail
       }
     }
   }
+
+  template<simd_value T, relative_conditional_expr C>
+  EVE_FORCEINLINE bool all_(EVE_SUPPORTS(cpu_), C const &cond, T const &v) noexcept
+  {
+         if constexpr (! is_logical_v<T>) return all[cond](to_logical(v));
+    else if constexpr (C::is_complete)
+    {
+      if constexpr (!C::is_inverted) return false;
+      else                           return all(v);
+    }
+    else
+    {
+      bool res = true;
+
+      std::ptrdiff_t first = cond.offset(eve::as_<T>{});
+      std::ptrdiff_t last = first + cond.count(eve::as_<T>{});
+      while (first != last) res = res && v[first++];
+
+      return res;
+    }
+  }
 }

--- a/include/eve/module/real/algorithm/function/regular/generic/any.hpp
+++ b/include/eve/module/real/algorithm/function/regular/generic/any.hpp
@@ -44,7 +44,7 @@ namespace eve::detail
       }
       else
       {
-        return any(to_logical(v));
+        return eve::any(to_logical(v));
       }
     }
   }

--- a/include/eve/module/real/algorithm/function/regular/generic/none.hpp
+++ b/include/eve/module/real/algorithm/function/regular/generic/none.hpp
@@ -26,8 +26,7 @@ namespace eve::detail
     }
     else if constexpr(simd_value<T>)
     {
-      return !any(v);
+      return !eve::any(v);
     }
   }
 }
-

--- a/include/eve/module/real/algorithm/function/regular/simd/x86/all.hpp
+++ b/include/eve/module/real/algorithm/function/regular/simd/x86/all.hpp
@@ -12,8 +12,8 @@
 
 #include <eve/concept/value.hpp>
 #include <eve/detail/concepts.hpp>
-#include <eve/detail/implementation.hpp>
-#include <eve/function/bit_cast.hpp>
+#include <eve/detail/top_bits.hpp>
+
 
 namespace eve::detail
 {
@@ -23,20 +23,19 @@ namespace eve::detail
   template<real_scalar_value T, typename N, x86_abi ABI>
   EVE_FORCEINLINE bool all_(EVE_SUPPORTS(sse2_), logical<wide<T, N, ABI>> const &v) noexcept
   {
-    if constexpr( N::value == 1)
-    {
-      return v[0];
-    }
-    else if constexpr(sizeof(T) == 2)
-    {
-      using tgt = typename logical<wide<T, N, ABI>>::template rebind< std::uint8_t
-                                                                    , typename N::combined_type
-                                                                    >;
-      return bit_cast(v, as_<tgt>()).bitmap().all();
-    }
-    else
-    {
-      return v.bitmap().all();
-    }
+    if constexpr( N::value == 1) return v[0];
+    else                         return eve::detail::all(eve::detail::top_bits{v});
+  }
+
+  template<logical_simd_value T, relative_conditional_expr C>
+    requires (!eve::has_emulated_abi_v<T>)
+  EVE_FORCEINLINE bool all_(EVE_SUPPORTS(sse2_), C const &cond, T const &v) noexcept
+  {
+    eve::detail::top_bits mmask{v};
+    eve::detail::top_bits<T> ignore_mmask{cond};
+
+    mmask |= ~ignore_mmask; // we need 1 in ignored elements;
+
+    return eve::detail::all(mmask);
   }
 }

--- a/include/eve/module/real/algorithm/function/regular/simd/x86/all.hpp
+++ b/include/eve/module/real/algorithm/function/regular/simd/x86/all.hpp
@@ -28,8 +28,7 @@ namespace eve::detail
   }
 
   template<logical_simd_value T, relative_conditional_expr C>
-    requires (!eve::has_emulated_abi_v<T>)
-  EVE_FORCEINLINE bool all_(EVE_SUPPORTS(sse2_), C const &cond, T const &v) noexcept
+  EVE_FORCEINLINE bool all_ignore_impl(C const& cond, T const &v) noexcept
   {
     eve::detail::top_bits mmask{v};
     eve::detail::top_bits<T> ignore_mmask{cond};
@@ -37,5 +36,19 @@ namespace eve::detail
     mmask |= ~ignore_mmask; // we need 1 in ignored elements;
 
     return eve::detail::all(mmask);
+  }
+
+  template<real_scalar_value T, typename N, x86_abi ABI, relative_conditional_expr C>
+  EVE_FORCEINLINE bool all_(EVE_SUPPORTS(sse2_), C const &cond,
+                            logical<wide<T, N, ABI>> const &v) noexcept
+  {
+    return all_ignore_impl(cond, v);
+  }
+
+  template<real_scalar_value T, typename N, relative_conditional_expr C>
+  EVE_FORCEINLINE bool all_(EVE_SUPPORTS(sse2_), C const &cond,
+                            logical<wide<T, N, aggregated_>> const &v) noexcept
+  {
+    return all_ignore_impl(cond, v);
   }
 }

--- a/include/eve/module/real/combinatorial/function/regular/generic/double_factorial.hpp
+++ b/include/eve/module/real/combinatorial/function/regular/generic/double_factorial.hpp
@@ -47,7 +47,7 @@ namespace eve::detail
           auto n = i >> 1;
           auto r =  (factorial(i) / ldexp(factorial(n), n));
           auto test =  i <= 171;
-          if (all(test)) return r;
+          if (eve::all(test)) return r;
           else
           {
             constexpr double invsqrtpi = 0.564189583547756286948079451560772585844050629329;
@@ -65,7 +65,7 @@ namespace eve::detail
       auto r = inf(as<decltype(factorial(i))>()); //perhaps 0 should be fine
       auto notdone =  i <= 300;
       notdone = next_interval(odd, notdone, is_odd(i), r, i);
-      if(any(notdone))
+      if(eve::any(notdone))
       {
         last_interval(even, notdone, r, i);
       }

--- a/include/eve/module/real/combinatorial/function/regular/generic/gcd.hpp
+++ b/include/eve/module/real/combinatorial/function/regular/generic/gcd.hpp
@@ -61,7 +61,7 @@ namespace eve::detail
       {
         auto test = is_nez(b);
         T r(0);
-        while (any(test))
+        while (eve::any(test))
         {
           b = if_else(test, b, allbits);
           r = a % b;
@@ -131,7 +131,7 @@ namespace eve::detail
         b = if_else(valid, b, zero);
         auto test = is_nez(b);
         T r(0);
-        while (any(test))
+        while (eve::any(test))
         {
           r = rem(a, b);
           a = if_else(test, b, a);
@@ -167,7 +167,7 @@ namespace eve::detail
       {
         auto test = is_nez(b);
         T r(0);
-        while (any(test))
+        while (eve::any(test))
         {
           r = rem(a, b);
           a = if_else(test, b, a);

--- a/include/eve/module/real/combinatorial/function/regular/generic/prime_ceil.hpp
+++ b/include/eve/module/real/combinatorial/function/regular/generic/prime_ceil.hpp
@@ -36,7 +36,7 @@ namespace eve::detail
       auto first = T(0);
       auto last = sizeof(elt_t) == 1 ? T(53u) : T(10000);
       n =  if_else(n > max_n, zero, n);
-      while (any(inc(first) < last))
+      while (eve::any(inc(first) < last))
       {
         auto mid = average(first, last);
         auto pmid = nth_prime(mid);

--- a/include/eve/module/real/combinatorial/function/regular/generic/prime_floor.hpp
+++ b/include/eve/module/real/combinatorial/function/regular/generic/prime_floor.hpp
@@ -33,7 +33,7 @@ namespace eve::detail
     {
       auto first = T(0);
       auto last = sizeof(elt_t) == 1 ? T(53u) : T(10000);
-      while (any(inc(first) < last))
+      while (eve::any(inc(first) < last))
       {
          auto mid = average(first, last);
          auto pmid = convert(nth_prime(mid), as<elt_t>());

--- a/include/eve/module/real/core/function/regular/simd/x86/rsqrt.hpp
+++ b/include/eve/module/real/core/function/regular/simd/x86/rsqrt.hpp
@@ -70,7 +70,7 @@ namespace eve::detail
   EVE_FORCEINLINE Pack rsqrt_x86_pedantic(Pack const &x) noexcept
   {
     using v_t =  typename Pack::value_type;
-    if(any(is_denormal(x)) || (std::is_same_v<v_t, double> && any(eve::abs(x) < smallestposval(eve::as<float>()) || eve::abs(x) > valmax(eve::as<float>()))))
+    if(eve::any(is_denormal(x)) || (std::is_same_v<v_t, double> && eve::any(eve::abs(x) < smallestposval(eve::as<float>()) || eve::abs(x) > valmax(eve::as<float>()))))
       // this is necessary because of the poor initialisation by float intrinsic
     {
       auto [a00, nn] =  pedantic(ifrexp)(x);

--- a/include/eve/module/real/elliptic/function/regular/generic/am.hpp
+++ b/include/eve/module/real/elliptic/function/regular/generic/am.hpp
@@ -112,8 +112,8 @@ namespace eve::detail
         int n = 0;
         for (; n < N; n++)
         {
-          if (all(is_not_greater_equal(abs(c[n]), tol))) break;
-//          if (all(is_not_greater_equal(eve::abs(a[n] - g[n]),tol*a[n]))) break;
+          if (eve::all(is_not_greater_equal(abs(c[n]), tol))) break;
+//          if (eve::all(is_not_greater_equal(eve::abs(a[n] - g[n]),tol*a[n]))) break;
           two_n += two_n;
           a[n+1] = average(a[n], g[n]);
           g[n+1] = sqrt(a[n] * g[n]);
@@ -129,8 +129,8 @@ namespace eve::detail
         return phi;
       };
       T r;
-      if (any(xxisone)) r = fms(T(2), atan(exp(u)), pio_2(as(xx)));
-      if (all(xxisone)) return r;
+      if (eve::any(xxisone)) r = fms(T(2), atan(exp(u)), pio_2(as(xx)));
+      if (eve::all(xxisone)) return r;
       return if_else(xxisone, r, am_kernel());
     }
     else

--- a/include/eve/module/real/elliptic/function/regular/generic/ellint_1.hpp
+++ b/include/eve/module/real/elliptic/function/regular/generic/ellint_1.hpp
@@ -49,7 +49,7 @@ namespace eve::detail
       auto a = one(as(x));
       auto b = sqrt(oneminus(sqr(xx)));
       auto c = xx;
-      while (any((eve::abs(c) > eps(as(x)))))
+      while (eve::any((eve::abs(c) > eps(as(x)))))
       {
         auto an=average(a, b);
         auto bn=sqrt(a*b);
@@ -97,14 +97,14 @@ namespace eve::detail
       auto c = if_else(notdone, rec(sinp), allbits);
       auto r = s*ellint_rf(cosp*c, c-sqr(x), c);
       auto xis1 = x == one(as(x));
-      if (any(xis1))
+      if (eve::any(xis1))
       {
         r = if_else(xis1, if_else(phi == pio_2(as(x)), inf(as(x)), asinh(tan(phi0))), r);
       }
       r = if_else(rphi < smallestposval(as(x)), s*rphi, r);
       auto mgt0 =  is_nez(m) && notdone;
       auto greatphi = eps(as(phi))*phi > one(as(phi))&&notdone;
-      if (any((mgt0||greatphi)&&notdone))
+      if (eve::any((mgt0||greatphi)&&notdone))
       {
         auto z = ellint_1(x);
         r += m*z;

--- a/include/eve/module/real/elliptic/function/regular/generic/ellint_2.hpp
+++ b/include/eve/module/real/elliptic/function/regular/generic/ellint_2.hpp
@@ -99,7 +99,7 @@ namespace eve::detail
       r = if_else(testz, phi, r);
       r = if_else(test1, sinp, r);
       auto mgt0 =  is_nez(m) && notdone;
-      if (any(mgt0))
+      if (eve::any(mgt0))
       {
         m =  if_else(test1 || testz, zero, m);
         r += m*ellint_2(x);

--- a/include/eve/module/real/elliptic/function/regular/generic/ellint_3.hpp
+++ b/include/eve/module/real/elliptic/function/regular/generic/ellint_3.hpp
@@ -79,7 +79,7 @@ namespace eve::detail
       auto sphi2= sqr(sphi);
       auto notdone  = (k2*sphi2 < one(as(phi))) && (v*sphi2 <   one(as(phi)));
       auto r = nan(as(v));
-      if (any(notdone))
+      if (eve::any(notdone))
       {
         auto br_v0 =  [](auto phi, auto k) //v == 0
           {
@@ -87,7 +87,7 @@ namespace eve::detail
             return if_else(is_eqz(k), phi, ellint_1(phi, k));
           };
         notdone = next_interval(br_v0, notdone, is_eqz(v), r, phi, k);
-        if (any(notdone))
+        if (eve::any(notdone))
         {
           auto vis1 = v == one(as(v));
           auto tanphi = tan(phi);
@@ -96,7 +96,7 @@ namespace eve::detail
               return tanphi;
             };
           notdone = next_interval(br_v1k0, notdone, vis1 && is_eqz(k), r);
-          if (any(notdone))
+          if (eve::any(notdone))
           {
             auto br_v1 =  [sphi2, k2, tanphi](auto phi, auto k) //p < 0
               {
@@ -105,14 +105,14 @@ namespace eve::detail
                 return result + ellint_1(phi, k);
               };
             notdone = next_interval(br_v1, notdone, vis1, r, phi, k);
-            if (any(notdone))
+            if (eve::any(notdone))
             {
               auto br_philarge =  [aphi, vc](auto v,  auto phi,  auto k) //aphi*eps(as(aphi)) > one(as(aphi))
                 {
                   return copysign(aphi*ellint_3(v, k, vc)/pio_2(as(phi)), phi);
                 };
               notdone = next_interval(br_philarge, notdone, aphi*eps(as(aphi)) > one(as(aphi)), r, v, phi, k);
-              if (any(notdone))
+              if (eve::any(notdone))
               {
                  auto br_phigepio2 =  [aphi, vc](auto v,  auto phi,  auto k) //phi >= pi/2 || phi < 0
                 {
@@ -129,7 +129,7 @@ namespace eve::detail
                   return copysign(result, phi);
                 };
                  notdone = next_interval(br_phigepio2, notdone, (phi >= pio_2(as(phi))) || (phi < 0) , r, v, phi, k);
-                 if (any(notdone))
+                 if (eve::any(notdone))
                  {
                    auto br_k0 =  [tanphi](auto vc) ///k == 0
                      {
@@ -139,7 +139,7 @@ namespace eve::detail
                        return if_else(test, atan(arg), average(log1p(arg), -log1p(-arg)))/vcr;
                      };
                    notdone = next_interval(br_k0, notdone, k == 0, r, vc);
-                   if (any(notdone))
+                   if (eve::any(notdone))
                    {
                      auto br_vlt0k2le1 =  [k2, sphi2](auto phi, auto k, auto v, auto vc) /// (v < 0) && (k2 <= 1)
                        {
@@ -158,7 +158,7 @@ namespace eve::detail
                          return result;
                        };
                      notdone = next_interval(br_vlt0k2le1, notdone, k == 0, r, phi, k, v, vc);
-                     if (any(notdone))
+                     if (eve::any(notdone))
                      {
                        auto br_k1 =  [tanphi](auto phi, auto v, auto vc) /// (v >=  0) && (k == 1)
                          {
@@ -170,7 +170,7 @@ namespace eve::detail
                            return result;
                          };
                        notdone = next_interval(br_k1, notdone, k == 1, r, phi, v, vc); // v is already >= 0 here
-                       if (any(notdone))
+                       if (eve::any(notdone))
                        {
                          auto br_last =  [k2, sphi2, sphi](auto phi, auto v, auto vc) /// (v >=  0) && (k == 1)
                            {
@@ -222,7 +222,7 @@ namespace eve::detail
       auto k2 = sqr(k);
       auto notdone  = (k2 < one(as(k))) && (v < one(as(k)));
       auto r = nan(as(k));
-      if (any(notdone))
+      if (eve::any(notdone))
       {
         auto br_v0 =  [](auto k) //v == 0
           {
@@ -230,7 +230,7 @@ namespace eve::detail
             return if_else(is_eqz(k), pio_2(as(k)), ellint_1(k));
           };
         notdone = next_interval(br_v0, notdone, is_eqz(v), r, k);
-        if (any(notdone))
+        if (eve::any(notdone))
         {
           auto br_vlt0 =  [k2](auto k, auto v) //v <  0
             {
@@ -246,7 +246,7 @@ namespace eve::detail
               return result;
             };
           notdone = next_interval(br_vlt0, notdone, is_ltz(v), r, k, v);
-          if (any(notdone))
+          if (eve::any(notdone))
           {
             auto br_last =  [k2](auto v)
               {

--- a/include/eve/module/real/elliptic/function/regular/generic/ellint_d.hpp
+++ b/include/eve/module/real/elliptic/function/regular/generic/ellint_d.hpp
@@ -77,14 +77,14 @@ namespace eve::detail
       auto r = nan(as(aphi));
       auto notdone  = is_finite(aphi); //&& test;
       r = if_else(notdone, r, inf(as(phi0)));
-      if (any(notdone))
+      if (eve::any(notdone))
       {
         auto br_philarge =  [aphi](auto k) //aphi*eps(as(aphi)) > one(as(aphi))
         {
           return  aphi * ellint_d(k) / pio_2(as(aphi));
         };
         notdone = next_interval(br_philarge, notdone, aphi*eps(as(aphi)) > one(as(aphi)), r, k);
-        if (any(notdone))
+        if (eve::any(notdone))
         {
           auto rphi = rem(aphi, pio_2(as(aphi)));
           auto m = nearest((aphi - rphi) /pio_2(as(aphi)));
@@ -100,7 +100,7 @@ namespace eve::detail
             {
               auto z = if_else(is_finite(c), s * ellint_rd(cm1, c - k2, c) / 3, zero);
               auto test =  is_nez(m);
-              if(any(test)){
+              if(eve::any(test)){
                 return z+m*ellint_d(k);
               }
               else return z;

--- a/include/eve/module/real/elliptic/function/regular/generic/ellint_rc.hpp
+++ b/include/eve/module/real/elliptic/function/regular/generic/ellint_rc.hpp
@@ -53,7 +53,7 @@ namespace eve::detail
     {
       auto ylt0 = is_ltz(y);
       auto prefix = one(as(x));
-      if (any(ylt0)) //provisions for y < 0
+      if (eve::any(ylt0)) //provisions for y < 0
       {
         prefix = if_else(ylt0, sqrt(x / (x - y)), one);
         x =  sub[ ylt0](x, y);
@@ -62,7 +62,7 @@ namespace eve::detail
       // now all y are >= 0
       auto r =  nan(as(x));
       auto notdone = is_nltz(x) && is_nez(y);
-      if (any(notdone))
+      if (eve::any(notdone))
       {
         auto tmp0 = rsqrt(y);
         auto br_0 =  [tmp0](auto x,  auto y) // x == y || x == 0
@@ -71,7 +71,7 @@ namespace eve::detail
             return z;  //if_else(x == y, tmp0, tmp0*pio_2(as(y)));
           };
         notdone = next_interval(br_0, notdone, (x == y) || is_eqz(x), r, x, y);
-        if  (any(notdone))
+        if  (eve::any(notdone))
         {
           auto tmp1 = sqrt(eve::abs(x - y));
           auto tmp2 = rsqrt(x);
@@ -81,14 +81,14 @@ namespace eve::detail
               return atan(tmp3)/tmp1;
             };
           notdone = next_interval(br_1, notdone, y > x, r);
-          if  (any(notdone))
+          if  (eve::any(notdone))
           {
             auto br_2 =  [tmp1, tmp3]() // y > 0.5*x
               {
                 return atanh(tmp3)/tmp1;
               };
             notdone = next_interval(br_2, notdone, y > T(0.5)*x , r);
-            if(any(notdone))
+            if(eve::any(notdone))
             {
               auto br_3 = [tmp0, tmp1](auto x)
                 {

--- a/include/eve/module/real/elliptic/function/regular/generic/ellint_rj.hpp
+++ b/include/eve/module/real/elliptic/function/regular/generic/ellint_rj.hpp
@@ -71,7 +71,7 @@ namespace eve::detail
     {
       auto r =  nan(as(x));
       auto notdone = is_nltz(x) &&  is_nltz(y) && is_nltz(z) && is_nez(p) && is_nez(x+y) && is_nez(z+y) && is_nez(x+z);
-      if (any(notdone))
+      if (eve::any(notdone))
       {
         auto br_pneg =  [](auto x,  auto y, auto z, auto p) //p < 0
           {
@@ -96,7 +96,7 @@ namespace eve::detail
             return v;
           };
         notdone = next_interval(br_pneg, notdone, is_ltz(p), r, x, y, z, p);
-        if  (any(notdone))
+        if  (eve::any(notdone))
         {
           auto br_eqxy =  [](auto x,  auto p) // (x == y) && (x == z)
             {
@@ -104,14 +104,14 @@ namespace eve::detail
               return if_else(x == p, rsqtx/x, 3*ellint_rc(x, p) - rsqtx/(x - p));
             };
           notdone = next_interval(br_eqxy, notdone, (x == y) && (x == z), r, x, p);
-          if  (any(notdone))
+          if  (eve::any(notdone))
           {
             auto br_eqzp =  [](auto x,  auto y, auto z) //  (p == z)
               {
                 return ellint_rd(x, y, z);
               };
             notdone = next_interval(br_eqzp, notdone, (z == p), r, x, y, z);
-           if  (any(notdone))
+           if  (eve::any(notdone))
             {
               x = if_else(notdone, x, one);
               y = if_else(notdone, y, one);
@@ -168,15 +168,15 @@ namespace eve::detail
           {
             auto r =  zero(as(y));
             auto notdone = true_(as(y)); //!= mone(as(y));
-            if(any(notdone))
+            if(eve::any(notdone))
             {
               auto br_yltm1 =  [](auto my){ return rsqrt(my)*ellint_rc(my, dec(my)); };
               notdone = next_interval(br_yltm1, notdone, y < mone(as(y)), r, -y);
-              if(any(notdone))
+              if(eve::any(notdone))
               {
                 auto br_ygt0 =  [](auto y){ return  atan(sqrt(y))*rsqrt(y);; };
                 notdone = next_interval(br_ygt0, notdone, is_gtz(y), r, y);
-                if(any(notdone))
+                if(eve::any(notdone))
                 {
                   auto arg = sqrt(-y);
                   auto log1parg = log1p(arg);
@@ -185,7 +185,7 @@ namespace eve::detail
                       return  if_else(is_eqz(arg), T(1), (log1parg-log1p(-arg))/(2*arg));
                     };
                   notdone = next_interval(br_ygtmhf, notdone, y > T(-0.5), r);
-                  if(any(notdone))
+                  if(eve::any(notdone))
                   {
                    auto br_last =  [arg, log1parg](auto y)
                       {
@@ -199,7 +199,7 @@ namespace eve::detail
             return r;
           };
 
-        if(any(test))
+        if(eve::any(test))
         {
           //
           // occationally en ~ -1, we then have no means of calculating
@@ -231,7 +231,7 @@ namespace eve::detail
         an = (an + lambda)*T(0.25); // / 4;
         fmn /= 4;
 
-        if(all(fmn * q < an)) break;
+        if(eve::all(fmn * q < an)) break;
 
         xn = (xn + lambda)*T(0.25); // / 4;
         yn = (yn + lambda)*T(0.25); // / 4;

--- a/include/eve/module/real/elliptic/function/regular/generic/heuman_lambda.hpp
+++ b/include/eve/module/real/elliptic/function/regular/generic/heuman_lambda.hpp
@@ -48,7 +48,7 @@ namespace eve::detail
       auto k2 = sqr(k);
       auto kp = oneminus(k2);
       T r1(zero(as(k))), r2(zero(as(k)));
-      if (any(test))
+      if (eve::any(test))
       {
         auto [sinp, cosp] = sincos(phi);
         auto s2 = sqr(sinp);
@@ -59,7 +59,7 @@ namespace eve::detail
         auto z2 =  ellint_rj(zero(as(k)), kp, one(as(k)), oneminus(k2*invsqrdelta))*invsqrdelta/3;
         r1 *= fma(k2, z2, z1);
       }
-      if (any(!test))
+      if (eve::any(!test))
       {
         auto rkp = sqrt(kp);
         auto  ratio = ellint_1(phi, rkp) / ellint_1(rkp);

--- a/include/eve/module/real/math/detail/generic/rempio2_kernel.hpp
+++ b/include/eve/module/real/math/detail/generic/rempio2_kernel.hpp
@@ -117,7 +117,7 @@ namespace eve::detail
       da       = (t - a) + da;
       auto fa  = float32(a);
       auto dfa = float32((a - float64(fa)) + da);
-      if( any(fa >= pio_4(eve::as<float>()) || fa < -pio_4(eve::as<float>())) )
+      if( eve::any(fa >= pio_4(eve::as<float>()) || fa < -pio_4(eve::as<float>())) )
       {
         T n1;
         std::tie(n1, fa, dfa) = rempio2_small(fa);
@@ -132,16 +132,16 @@ namespace eve::detail
   template<floating_real_value T> EVE_FORCEINLINE auto rempio2_big(T const &xx) noexcept
   {
     using elt_t             = element_type_t<T>;
-    if (all(xx < Rempio2_limit(restricted_type(), as(xx))))
+    if ( eve::all(xx < Rempio2_limit(restricted_type(), as(xx))) )
     {
       return std::make_tuple(T(0), xx, T(0));
     }
     auto xlerfl = (xx <= Rempio2_limit(small_type(), as<elt_t>()));
-    if( all(xlerfl) )
+    if( eve::all(xlerfl) )
     {
       return rempio2_small(xx);
     }
-    if (all(xx < Rempio2_limit(medium_type(), as(xx))))
+    if ( eve::all(xx < Rempio2_limit(medium_type(), as(xx))) )
     {
       return rempio2_medium(xx);
     }

--- a/include/eve/module/real/math/function/pedantic/generic/log.hpp
+++ b/include/eve/module/real/math/function/pedantic/generic/log.hpp
@@ -67,7 +67,7 @@ namespace eve::detail
         if constexpr( eve::platform::supports_denormals )
         {
           test = is_less(a0, smallestposval(eve::as<T>())) && isnez;
-          if( any(test) )
+          if( eve::any(test) )
           {
             k = sub[test](k, iT(23));
             x = if_else(test, x * T(8388608ul), x);
@@ -121,7 +121,7 @@ namespace eve::detail
         if constexpr( eve::platform::supports_denormals )
         {
           test = is_less(a0, smallestposval(eve::as<T>())) && isnez;
-          if( any(test) )
+          if( eve::any(test) )
           {
             k = sub[test](k, iT(54));
             x = if_else(test, x * T(18014398509481984ull), x);

--- a/include/eve/module/real/math/function/pedantic/generic/log10.hpp
+++ b/include/eve/module/real/math/function/pedantic/generic/log10.hpp
@@ -69,7 +69,7 @@ namespace eve::detail
         if constexpr( eve::platform::supports_denormals )
         {
           test = is_less(a0, smallestposval(eve::as<T>())) && isnez;
-          if( any(test) )
+          if( eve::any(test) )
           {
             k = sub[test](k, iT(25));
             x = if_else(test, x * T(33554432ul), x);
@@ -131,7 +131,7 @@ namespace eve::detail
         if constexpr( eve::platform::supports_denormals )
         {
           test = is_less(a0, smallestposval(eve::as<T>())) && isnez;
-          if( any(test) )
+          if( eve::any(test) )
           {
             k = sub[test](k, iT(54));
             x = if_else(test, x * T(18014398509481984ull), x);

--- a/include/eve/module/real/math/function/pedantic/generic/lpnorm.hpp
+++ b/include/eve/module/real/math/function/pedantic/generic/lpnorm.hpp
@@ -45,9 +45,9 @@ namespace eve::detail
 
       if constexpr(has_native_abi_v<r_t>)
       {
-        if (all(p == P(2))) return pedantic(hypot)(r_t(a0), r_t(a1), r_t(args)...);
-        else if (all(p == P(1))) return pedantic(manhattan)(r_t(a0), r_t(a1), r_t(args)...);
-        else if (all(p == eve::inf(as(p)))) return numeric(max)(abs(r_t(a0)), r_t(a1), abs(r_t(args))...);
+        if (eve::all(p == P(2))) return pedantic(hypot)(r_t(a0), r_t(a1), r_t(args)...);
+        else if (eve::all(p == P(1))) return pedantic(manhattan)(r_t(a0), r_t(a1), r_t(args)...);
+        else if (eve::all(p == eve::inf(as(p)))) return numeric(max)(abs(r_t(a0)), r_t(a1), abs(r_t(args))...);
         else
         {
           auto rp =  r_t(p);
@@ -62,10 +62,10 @@ namespace eve::detail
           };
           that = addppow(that,r_t(a1));
           auto isinfp = is_infinite(rp);
-          if (any(isinfp))
+          if (eve::any(isinfp))
           {
             auto r = numeric(max)(abs(r_t(a0)), abs(r_t(a1)), abs(r_t(args))...);
-            if (all(isinfp)) return r;
+            if (eve::all(isinfp)) return r;
             ((that = addppow(that,r_t(args))),...);
             return if_else(isinfp, r,  if_else(inf_found, inf(as<r_t>()),
                                                pedantic(ldexp)(pow_abs(that, rec(rp)), -e)));

--- a/include/eve/module/real/math/function/regular/generic/cos.hpp
+++ b/include/eve/module/real/math/function/regular/generic/cos.hpp
@@ -126,11 +126,11 @@ namespace eve::detail
     if constexpr( has_native_abi_v<T> )
     {
       auto x = abs(a0);
-      if( all(x <= pio_4(eve::as(x))) )
+      if( eve::all(x <= pio_4(eve::as(x))) )
         return restricted(cos)(a0);
-      else if( all(x <= pio_2(eve::as(x))) )
+      else if( eve::all(x <= pio_2(eve::as(x))) )
         return small(cos)(a0);
-      else if( all(x <= Rempio2_limit(medium_type(), as(a0))) )
+      else if( eve::all(x <= Rempio2_limit(medium_type(), as(a0))) )
         return medium(cos)(a0);
       else
         return big(cos)(a0);

--- a/include/eve/module/real/math/function/regular/generic/cospi.hpp
+++ b/include/eve/module/real/math/function/regular/generic/cospi.hpp
@@ -83,7 +83,7 @@ namespace eve::detail
     if constexpr( has_native_abi_v<T> )
     {
       auto x = abs(a0);
-      if( all(eve::abs(x) <= T(0.25)) )
+      if( eve::all(eve::abs(x) <= T(0.25)) )
         return restricted(cospi)(x);
       else
         return big(cospi)(x);
@@ -101,4 +101,3 @@ namespace eve::detail
       return apply_over(cospi, a0);
   }
 }
-

--- a/include/eve/module/real/math/function/regular/generic/cot.hpp
+++ b/include/eve/module/real/math/function/regular/generic/cot.hpp
@@ -134,11 +134,11 @@ namespace eve::detail
     if constexpr( has_native_abi_v<T> )
     {
       auto x = eve::abs(a0);
-      if( all(x <= pio_4(eve::as(x))) )
+      if( eve::all(x <= pio_4(eve::as(x))) )
         return restricted(cot)(a0);
-      else if( all(x <= pio_2(eve::as(x))) )
+      else if( eve::all(x <= pio_2(eve::as(x))) )
         return small(cot)(a0);
-      else if( all(x <= Rempio2_limit(eve::medium_type(), as(a0))) )
+      else if( eve::all(x <= Rempio2_limit(eve::medium_type(), as(a0))) )
         return medium(cot)(a0);
       else
         return big(cot)(a0);

--- a/include/eve/module/real/math/function/regular/generic/cotpi.hpp
+++ b/include/eve/module/real/math/function/regular/generic/cotpi.hpp
@@ -91,7 +91,7 @@ namespace eve::detail
     if constexpr( has_native_abi_v<T> )
     {
       auto x = abs(a0);
-      if( all(eve::abs(x) <= T(0.25)) )
+      if( eve::all(eve::abs(x) <= T(0.25)) )
         return restricted(cotpi)(a0);
       else
         return big(cotpi)(a0);
@@ -100,4 +100,3 @@ namespace eve::detail
       return apply_over(cotpi, a0);
   }
 }
-

--- a/include/eve/module/real/math/function/regular/generic/cscpi.hpp
+++ b/include/eve/module/real/math/function/regular/generic/cscpi.hpp
@@ -73,7 +73,7 @@ namespace eve::detail
   {
     if constexpr( has_native_abi_v<T> )
     {
-      if( all(eve::abs(a0) <= T(0.25)) )
+      if( eve::all(eve::abs(a0) <= T(0.25)) )
         return restricted(cscpi)(a0);
       else
         return big(cscpi)(a0);
@@ -82,4 +82,3 @@ namespace eve::detail
       return apply_over(cscpi, a0);
   }
 }
-

--- a/include/eve/module/real/math/function/regular/generic/log.hpp
+++ b/include/eve/module/real/math/function/regular/generic/log.hpp
@@ -71,7 +71,7 @@ namespace eve::detail
         if constexpr( eve::platform::supports_denormals )
         {
           test = is_less(a0, smallestposval(eve::as<T>())) && isnez;
-          if( any(test) )
+          if( eve::any(test) )
           {
             k = sub[test](k, iT(23));
             x = if_else(test, x * T(8388608ul), x);
@@ -125,7 +125,7 @@ namespace eve::detail
         if constexpr( eve::platform::supports_denormals )
         {
           test = is_less(a0, smallestposval(eve::as<T>())) && isnez;
-          if( any(test) )
+          if( eve::any(test) )
           {
             k = sub[test](k, iT(54));
             x = if_else(test, x * T(18014398509481984ull), x);

--- a/include/eve/module/real/math/function/regular/generic/log10.hpp
+++ b/include/eve/module/real/math/function/regular/generic/log10.hpp
@@ -72,7 +72,7 @@ namespace eve::detail
         if constexpr( eve::platform::supports_denormals )
         {
           test = is_less(a0, smallestposval(eve::as<T>())) && isnez;
-          if( any(test) )
+          if( eve::any(test) )
           {
             k = sub[test](k, iT(25));
             x = if_else(test, x * T(33554432ul), x);
@@ -134,7 +134,7 @@ namespace eve::detail
         if constexpr( eve::platform::supports_denormals )
         {
           test = is_less(a0, smallestposval(eve::as<T>())) && isnez;
-          if( any(test) )
+          if( eve::any(test) )
           {
             k = sub[test](k, iT(54));
             x = if_else(test, x * T(18014398509481984ull), x);

--- a/include/eve/module/real/math/function/regular/generic/log2.hpp
+++ b/include/eve/module/real/math/function/regular/generic/log2.hpp
@@ -72,7 +72,7 @@ namespace eve::detail
         if constexpr( eve::platform::supports_denormals )
         {
           test = is_less(a0, smallestposval(eve::as<T>())) && isnez;
-          if( any(test) )
+          if( eve::any(test) )
           {
             k = sub[test](k, iT(25));
             x = if_else(test, x * T(33554432ul), x);
@@ -136,7 +136,7 @@ namespace eve::detail
         if constexpr( eve::platform::supports_denormals )
         {
           test = is_less(a0, smallestposval(eve::as<T>())) && isnez;
-          if( any(test) )
+          if( eve::any(test) )
           {
             k = sub[test](k, iT(54));
             x = if_else(test, x * T(18014398509481984ull), x);

--- a/include/eve/module/real/math/function/regular/generic/logspace_sub.hpp
+++ b/include/eve/module/real/math/function/regular/generic/logspace_sub.hpp
@@ -46,8 +46,8 @@ namespace eve::detail
     {
       auto x = if_else(a == b, zero, b-a);
       auto test = x > -log_2(as(x));
-      if (all(test)) return  a+eve::log(-expm1(x));
-      else if (any(test)) return a+if_else(test, log(-expm1(x)), log1p(-exp(x)));
+      if (eve::all(test)) return  a+eve::log(-expm1(x));
+      else if (eve::any(test)) return a+if_else(test, log(-expm1(x)), log1p(-exp(x)));
       else return a + log1p(-exp(x));
     }
     else

--- a/include/eve/module/real/math/function/regular/generic/lpnorm.hpp
+++ b/include/eve/module/real/math/function/regular/generic/lpnorm.hpp
@@ -44,9 +44,9 @@ namespace eve::detail
       using r_t = common_compatible_t<T0,T1,Ts...>;
       if constexpr(has_native_abi_v<r_t>)
       {
-        if (all(p == P(2))) return hypot(r_t(a0), r_t(a1), r_t(args)...);
-        else if (all(p == P(1))) return manhattan(r_t(a0), r_t(a1), r_t(args)...);
-        else if (all(p == eve::inf(as(p)))) return eve::max(eve::abs(r_t(a0)), eve::abs(r_t(a1)), eve::abs(r_t(args))...);
+        if (eve::all(p == P(2))) return hypot(r_t(a0), r_t(a1), r_t(args)...);
+        else if (eve::all(p == P(1))) return manhattan(r_t(a0), r_t(a1), r_t(args)...);
+        else if (eve::all(p == eve::inf(as(p)))) return eve::max(eve::abs(r_t(a0)), eve::abs(r_t(a1)), eve::abs(r_t(args))...);
         else
         {
           auto rp =  r_t(p);
@@ -58,10 +58,10 @@ namespace eve::detail
           that = addppow(that,  r_t(a1));
           ((that = addppow(that,args)),...);
           auto isinfp = is_infinite(rp);
-          if (any(isinfp))
+          if (eve::any(isinfp))
           {
             auto r = eve::max(eve::abs(r_t(a0)), eve::abs(r_t(a1)), eve::abs(r_t(args))...);
-            if (all(isinfp)) return r;
+            if (eve::all(isinfp)) return r;
             return if_else(isinfp, r, pow_abs(that, rec(rp)));
           }
           return pow_abs(that, rec(rp));

--- a/include/eve/module/real/math/function/regular/generic/pow.hpp
+++ b/include/eve/module/real/math/function/regular/generic/pow.hpp
@@ -124,7 +124,7 @@ namespace eve::detail
       U expo = a1;
 
       T result(1);
-      while( any(expo) )
+      while( eve::any(expo) )
       {
         result *= if_else(is_odd(expo), base, T(1));
         expo = shr(expo, 1);

--- a/include/eve/module/real/math/function/regular/generic/pow_abs.hpp
+++ b/include/eve/module/real/math/function/regular/generic/pow_abs.hpp
@@ -109,7 +109,7 @@ namespace eve::detail
 
     auto russian = [](T base, i_t expo){
       T result(1);
-      while( any(expo) )
+      while( eve::any(expo) )
       {
         result *= if_else(is_odd(expo), base, T(1));
         expo = shr(expo, 1);

--- a/include/eve/module/real/math/function/regular/generic/powm1.hpp
+++ b/include/eve/module/real/math/function/regular/generic/powm1.hpp
@@ -41,7 +41,7 @@ namespace eve::detail
     {
       T r = dec(pow(x, y));
       auto test = (abs(y * dec(x)) < T(0.5) || (abs(y) < T(0.2)));
-      if (any(test))
+      if ( eve::any(test) )
       {
         // We don't have any good/quick approximation for log(x) * y
         // so just try it and see:

--- a/include/eve/module/real/math/function/regular/generic/rempio2.hpp
+++ b/include/eve/module/real/math/function/regular/generic/rempio2.hpp
@@ -57,11 +57,11 @@ namespace eve::detail
   {
     if constexpr( has_native_abi_v<T> )
     {
-      if( all(x <= Rempio2_limit(restricted_type(), as(x))) )
+      if( eve::all(x <= Rempio2_limit(restricted_type(), as(x))) )
         return std::make_tuple(T(0), x, T(0));
-      else if( all(x <= Rempio2_limit(small_type(), as(x))) )
+      else if( eve::all(x <= Rempio2_limit(small_type(), as(x))) )
         return small(rempio2)(x);
-      else if( all(x <= Rempio2_limit(medium_type(), as(x))) )
+      else if( eve::all(x <= Rempio2_limit(medium_type(), as(x))) )
         return medium(rempio2)(x);
       else
         return big(rempio2)(x);

--- a/include/eve/module/real/math/function/regular/generic/sin.hpp
+++ b/include/eve/module/real/math/function/regular/generic/sin.hpp
@@ -128,11 +128,11 @@ namespace eve::detail
     if constexpr( has_native_abi_v<T> )
     {
       auto x = abs(a0);
-      if( all(x <= pio_4(eve::as(x))) )
+      if( eve::all(x <= pio_4(eve::as(x))) )
         return restricted(sin)(a0);
-      else if( all(x <= pio_2(eve::as(x))) )
+      else if( eve::all(x <= pio_2(eve::as(x))) )
         return small(sin)(a0);
-      else if( all(x <= Rempio2_limit(medium_type(), as(a0))) )
+      else if( eve::all(x <= Rempio2_limit(medium_type(), as(a0))) )
         return medium(sin)(a0);
       else
         return big(sin)(a0);

--- a/include/eve/module/real/math/function/regular/generic/sincos.hpp
+++ b/include/eve/module/real/math/function/regular/generic/sincos.hpp
@@ -144,11 +144,11 @@ namespace eve::detail
     if constexpr( has_native_abi_v<T> )
     {
       auto x = abs(a0);
-      if( all(x <= pio_4(eve::as(x))) )
+      if( eve::all(x <= pio_4(eve::as(x))) )
         return restricted(sincos)(a0);
-      else if( all(x <= pio_2(eve::as(x))) )
+      else if( eve::all(x <= pio_2(eve::as(x))) )
         return small(sincos)(a0);
-      else if( all(x <= Rempio2_limit(medium_type(), as(a0))) )
+      else if( eve::all(x <= Rempio2_limit(medium_type(), as(a0))) )
         return medium(sincos)(a0);
       else
         return big(sincos)(a0);

--- a/include/eve/module/real/math/function/regular/generic/sinpi.hpp
+++ b/include/eve/module/real/math/function/regular/generic/sinpi.hpp
@@ -74,7 +74,7 @@ namespace eve::detail
     if constexpr( has_native_abi_v<T> )
     {
       auto x = abs(a0);
-      if( all(eve::abs(x) <= T(0.25)) )
+      if( eve::all(eve::abs(x) <= T(0.25)) )
         return restricted(sinpi)(a0);
       else
         return big(sinpi)(a0);
@@ -84,4 +84,3 @@ namespace eve::detail
   }
 
 }
-

--- a/include/eve/module/real/math/function/regular/generic/sinpicospi.hpp
+++ b/include/eve/module/real/math/function/regular/generic/sinpicospi.hpp
@@ -79,7 +79,7 @@ namespace eve::detail
     if constexpr( has_native_abi_v<T> )
     {
       auto x = abs(a0);
-      if( all(x <= T(0.25)) )
+      if( eve::all(x <= T(0.25)) )
         return restricted(sinpicospi)(a0);
       else
         return big(sinpicospi)(a0);
@@ -88,4 +88,3 @@ namespace eve::detail
       return apply_over2(sinpicospi, a0);
   }
 }
-

--- a/include/eve/module/real/math/function/regular/generic/tan.hpp
+++ b/include/eve/module/real/math/function/regular/generic/tan.hpp
@@ -131,11 +131,11 @@ namespace eve::detail
     if constexpr( has_native_abi_v<T> )
     {
       auto x = abs(a0);
-      if( all(x <= pio_4(eve::as(x))) )
+      if( eve::all(x <= pio_4(eve::as(x))) )
         return restricted(tan)(a0);
-      else if( all(x <= pio_2(eve::as(x))) )
+      else if( eve::all(x <= pio_2(eve::as(x))) )
         return small(tan)(a0);
-      else if( all(x <= Rempio2_limit(medium_type(), as(a0))) )
+      else if( eve::all(x <= Rempio2_limit(medium_type(), as(a0))) )
         return medium(tan)(a0);
       else
         return big(tan)(a0);
@@ -145,4 +145,3 @@ namespace eve::detail
   }
 
 }
-

--- a/include/eve/module/real/math/function/regular/generic/tanpi.hpp
+++ b/include/eve/module/real/math/function/regular/generic/tanpi.hpp
@@ -76,7 +76,7 @@ namespace eve::detail
     if constexpr( has_native_abi_v<T> )
     {
       auto x = abs(a0);
-      if( all(eve::abs(x) <= T(0.25)) )
+      if( eve::all(eve::abs(x) <= T(0.25)) )
         return restricted(tanpi)(a0);
       else
         return big(tanpi)(a0);
@@ -86,4 +86,3 @@ namespace eve::detail
   }
 
 }
-

--- a/include/eve/module/real/math/function/regular/simd/x86/log.hpp
+++ b/include/eve/module/real/math/function/regular/simd/x86/log.hpp
@@ -59,7 +59,7 @@ namespace eve::detail
         if constexpr( eve::platform::supports_denormals )
         {
           auto test = is_less(a0, smallestposval(eve::as<T>())) && isnez;
-          if( any(test) )
+          if( eve::any(test) )
           {
             dk = sub[test](dk, T(23));
             xx = if_else(test, xx * T(8388608ul), xx);
@@ -111,7 +111,7 @@ namespace eve::detail
         logical<T> test = is_less(a0, smallestposval(eve::as<T>())) && isnez;
         if constexpr( eve::platform::supports_denormals )
         {
-          if( any(test) )
+          if( eve::any(test) )
           {
             dk = sub[test](dk, T(54));
             xx = if_else(test, xx * T(18014398509481984ull), xx);

--- a/include/eve/module/real/math/function/regular/simd/x86/log10.hpp
+++ b/include/eve/module/real/math/function/regular/simd/x86/log10.hpp
@@ -71,7 +71,7 @@ namespace eve::detail
         if constexpr( eve::platform::supports_denormals )
         {
           auto test = is_less(a0, smallestposval(eve::as<T>())) && isnez;
-          if( any(test) )
+          if( eve::any(test) )
           {
             dk = sub[test](dk, T(25));
             xx = if_else(test, xx * T(33554432ul), xx);
@@ -129,7 +129,7 @@ namespace eve::detail
         logical<T> test = is_less(a0, smallestposval(eve::as<T>())) && isnez;
         if constexpr( eve::platform::supports_denormals )
         {
-          if( any(test) )
+          if( eve::any(test) )
           {
             dk = sub[test](dk, T(54));
             xx = if_else(test, xx * T(18014398509481984ull), xx);

--- a/include/eve/module/real/math/function/regular/simd/x86/log2.hpp
+++ b/include/eve/module/real/math/function/regular/simd/x86/log2.hpp
@@ -55,7 +55,7 @@ namespace eve::detail
         if constexpr( eve::platform::supports_denormals )
         {
           auto test = is_less(a0, smallestposval(eve::as<T>())) && isnez;
-          if( any(test) )
+          if( eve::any(test) )
           {
             dk = sub[test](dk, T(25));
             xx = if_else(test, xx * T(33554432ul), xx);
@@ -118,7 +118,7 @@ namespace eve::detail
         logical<T> test = is_less(a0, smallestposval(eve::as<T>())) && isnez;
         if constexpr( eve::platform::supports_denormals )
         {
-          if( any(test) )
+          if( eve::any(test) )
           {
             dk = sub[test](dk, T(54));
             xx = if_else(test, xx * T(18014398509481984ull), xx);

--- a/include/eve/module/real/special/function/regular/generic/betainc.hpp
+++ b/include/eve/module/real/special/function/regular/generic/betainc.hpp
@@ -71,7 +71,7 @@ namespace eve::detail
         c = maxmag(fma(aa, rec(c), o), fpmin);
         auto del=d*c;
         h *= del;
-        if (all(eve::abs(oneminus(del)) < epsi)) return h; //Are we done?
+        if (eve::all(eve::abs(oneminus(del)) < epsi)) return h; //Are we done?
       }
       return h;
     };

--- a/include/eve/module/real/special/function/regular/generic/betainc_inv.hpp
+++ b/include/eve/module/real/special/function/regular/generic/betainc_inv.hpp
@@ -89,7 +89,7 @@ namespace eve::detail
     auto x = nan(as(p));
     auto notdone =  is_not_nan(p);
     notdone = next_interval(large, notdone, test, x, p, a, b);
-    if(any(notdone))
+    if(eve::any(notdone))
     {
       last_interval(small, notdone, x, p, a, b);
     }
@@ -103,7 +103,7 @@ namespace eve::detail
       x -= u/inc( -0.5*m);
       auto tt = inc[x >= o](t);
       x = if_else(is_lez(x) && (x >= o), average(x, tt), x);
-      if (all(eve::abs(t) <= epsi*x) && j) break;
+      if (eve::all(eve::abs(t) <= epsi*x) && j) break;
     }
     return if_else(is_lez(p),  zero, if_else(p >= o, one, x));
   }

--- a/include/eve/module/real/special/function/regular/generic/cyl_bessel_j.hpp
+++ b/include/eve/module/real/special/function/regular/generic/cyl_bessel_j.hpp
@@ -79,24 +79,24 @@ namespace eve::detail
       auto isneza1 =  is_nez(a1);
       auto notdone = (!is_odd(a0) || is_nltz(a1)) && is_flint(a0) && isneza1;
       T r = if_else(isneza1, nan(as(a1)), zero);
-      if (any(notdone))
+      if (eve::any(notdone))
       {
         auto j0 = cyl_bessel_j0(a1);
         auto br_0 =  [](auto j0) { return j0;};
         notdone = next_interval(br_0, notdone, is_eqz(a0), r, j0);
-        if (any(notdone))
+        if (eve::any(notdone))
         {
           auto j1 = cyl_bessel_j1(a1);
           auto br_1 =  [](auto j1) { return j1;};
           notdone = next_interval(br_1, notdone, a0 == 1, r, j1);
-          if (any(notdone))
+          if (eve::any(notdone))
           {
             auto br_2 =  [](auto a1, auto j0,  auto j1)
               {
                 return fms(T(2)*j1, rec(a1), j0);
               };
             notdone = next_interval(br_2, notdone, a0 == 2, r, a1, j0, j1);
-            if (any(notdone))
+            if (eve::any(notdone))
             {
               auto br_last = [](auto a0,  auto a1,  auto j0, auto j1)
                 {
@@ -125,7 +125,7 @@ namespace eve::detail
                     r = r-T(2);
                     k = dec(k);
                   }
-                  while( any(is_gtz(k)) );
+                  while( eve::any(is_gtz(k)) );
                   return if_else(abs(pk) > pkm1, j1/pk, j0/pkm1);
                 };
               last_interval(br_last, notdone, r, a0, a1, j0, j1);

--- a/include/eve/module/real/special/function/regular/generic/cyl_bessel_j0.hpp
+++ b/include/eve/module/real/special/function/regular/generic/cyl_bessel_j0.hpp
@@ -84,7 +84,7 @@ namespace eve::detail
         };
 
         auto xlt2 = x < T(2);
-        if (all(xlt2))        return branch1(x);
+        if (eve::all(xlt2))        return branch1(x);
         else if (none(xlt2))  return branch2(x);
         else                  return if_else(xlt2, branch1(x), branch2(x));
       }
@@ -173,7 +173,7 @@ namespace eve::detail
         };
 
         auto xlt5 = x < T(5);
-        if (all(xlt5))        return branch1(x);
+        if (eve::all(xlt5))        return branch1(x);
         else if (none(xlt5))  return branch2(x);
         else                  return if_else(xlt5, branch1(x), branch2(x));
       }

--- a/include/eve/module/real/special/function/regular/generic/cyl_bessel_j1.hpp
+++ b/include/eve/module/real/special/function/regular/generic/cyl_bessel_j1.hpp
@@ -85,7 +85,7 @@ namespace eve::detail
         };
 
         auto xlt2 = x < T(2);
-        if (all(xlt2))        return branch1(x);
+        if (eve::all(xlt2))        return branch1(x);
         else if (none(xlt2))  return branch2(x);
         else                  return if_else(xlt2, branch1(x), branch2(x));
       }
@@ -170,7 +170,7 @@ namespace eve::detail
         };
 
         auto xlt5 = x < T(5);
-        if (all(xlt5))        return branch1(x);
+        if (eve::all(xlt5))        return branch1(x);
         else if (none(xlt5))  return branch2(x);
         else                  return if_else(xlt5, branch1(x), branch2(x));
       }

--- a/include/eve/module/real/special/function/regular/generic/cyl_bessel_y.hpp
+++ b/include/eve/module/real/special/function/regular/generic/cyl_bessel_y.hpp
@@ -78,17 +78,17 @@ namespace eve::detail
       auto isneza1 =  is_nez(a1);
       auto notdone = is_nlez(a1) && is_flint(a0);
       T r = if_else(isneza1, allbits, minf(as(a1)));
-      if (any(notdone))
+      if (eve::any(notdone))
       {
         auto y0 = cyl_bessel_y0(a1);
         auto br_0 =  [](auto y0) { return y0;};
         notdone = next_interval(br_0, notdone, is_eqz(a0), r, y0);
-        if (any(notdone))
+        if (eve::any(notdone))
         {
           auto y1 = cyl_bessel_y1(a1);
           auto br_1 =  [](auto y1) { return y1;};
           notdone = next_interval(br_1, notdone, a0 == 1, r, y1);
-          if (any(notdone))
+          if (eve::any(notdone))
           {
             auto br_last = [](auto n1,  auto x,  auto y0, auto y1)
               {
@@ -106,7 +106,7 @@ namespace eve::detail
                   r += T(2);
                   test = (r < n1);
                 }
-                while(any(test) );
+                while(eve::any(test) );
                 return an;
               };
             last_interval(br_last, notdone, r, 2*abs(a0), a1, y0, y1);

--- a/include/eve/module/real/special/function/regular/generic/cyl_bessel_y0.hpp
+++ b/include/eve/module/real/special/function/regular/generic/cyl_bessel_y0.hpp
@@ -98,10 +98,10 @@ namespace eve::detail
 
         auto r = nan(as<T>()); //nan case treated here
         auto notdone =  is_nltz(a0);
-        if(any(notdone))
+        if(eve::any(notdone))
         {
           notdone = next_interval(branch1, notdone, a0 < T(2), r, a0);
-          if (any(notdone))
+          if (eve::any(notdone))
           {
             last_interval(branch2, notdone, r, a0);
           }
@@ -187,10 +187,10 @@ namespace eve::detail
 
         auto r = nan(as<T>()); //nan case treated here
         auto notdone =  is_nltz(a0);
-        if(any(notdone))
+        if(eve::any(notdone))
         {
           notdone = next_interval(branch1, notdone, a0 < T(5), r, a0);
-          if (any(notdone))
+          if (eve::any(notdone))
           {
             last_interval(branch2, notdone, r, a0);
           }

--- a/include/eve/module/real/special/function/regular/generic/cyl_bessel_y1.hpp
+++ b/include/eve/module/real/special/function/regular/generic/cyl_bessel_y1.hpp
@@ -95,10 +95,10 @@ namespace eve::detail
 
         auto r = nan(as<T>()); //nan case treated here
         auto notdone =  is_nltz(a0);
-        if(any(notdone))
+        if(eve::any(notdone))
         {
           notdone = next_interval(branch1, notdone, a0 < T(2), r, a0);
-          if (any(notdone))
+          if (eve::any(notdone))
           {
             last_interval(branch2, notdone, r, a0);
           }
@@ -185,10 +185,10 @@ namespace eve::detail
 
         auto r = nan(as<T>()); //nan case treated here
         auto notdone =  is_nltz(a0);
-        if(any(notdone))
+        if(eve::any(notdone))
         {
           notdone = next_interval(branch1, notdone, a0 < T(5), r, a0);
-          if (any(notdone))
+          if (eve::any(notdone))
           {
             last_interval(branch2, notdone, r, a0);
           }

--- a/include/eve/module/real/special/function/regular/generic/dawson.hpp
+++ b/include/eve/module/real/special/function/regular/generic/dawson.hpp
@@ -205,13 +205,13 @@ namespace eve::detail
       auto notdone =  is_not_nan(x);
       notdone = next_interval(dawson1, notdone, x < elt_t(3.25), r, xx, x);
       rx = rec(x); xx = sqr(rx);
-      if(any(notdone))
+      if(eve::any(notdone))
       {
         notdone = next_interval(dawson2,  notdone, x < elt_t(6.25), r, xx, rx, x);
-        if(any(notdone))
+        if(eve::any(notdone))
         {
           notdone = next_interval(dawson3,  notdone, x < elt_t(1.0e9), r, xx, rx, x);
-          if(any(notdone))
+          if(eve::any(notdone))
           {
             last_interval(dawson4, x >= elt_t(1.0e9), r, rx);
           }

--- a/include/eve/module/real/special/function/regular/generic/digamma.hpp
+++ b/include/eve/module/real/special/function/regular/generic/digamma.hpp
@@ -168,7 +168,7 @@ namespace eve::detail
         auto notdone = is_not_nan(x);
         auto result = zero(as(x));
         auto test = is_lez(x);
-        if(any(test))
+        if( eve::any(test) )
         {
           auto a = x;
           x = oneminus[test](x);
@@ -180,22 +180,22 @@ namespace eve::detail
           result = if_else(test, result, zero);
         }
         auto r = nan(as<T>()); //nan case treated here
-        if(any(notdone))
+        if( eve::any(notdone) )
         {
           notdone = next_interval(br_large,  notdone, x > dlarge, r, x, result);
-          if(any(notdone))
+          if( eve::any(notdone) )
           {
             // If x > 2 reduce to the interval [1,2]:
             x = if_else(x > dlarge, one, x);
             auto cond = x > 2;
-            while(any(cond))
+            while( eve::any(cond) )
             {
               x =  dec[cond](x);
               result = add[cond](result,rec(x));
               cond = x > 2;
             }
             cond = x < 1;
-            if(any(cond)) // back one step
+            if( eve::any(cond) ) // back one step
             {
               result = add[cond](-rec(x), result);
               x =  inc[cond](x);

--- a/include/eve/module/real/special/function/regular/generic/erf_inv.hpp
+++ b/include/eve/module/real/special/function/regular/generic/erf_inv.hpp
@@ -52,7 +52,7 @@ namespace eve::detail
           > (w);
         };
         notdone = next_interval(br_wlt5, notdone, test, r, w);
-        if (any(notdone))
+        if (eve::any(notdone))
         {
           auto br_wge5 = [](auto w)
             {
@@ -110,7 +110,7 @@ namespace eve::detail
           > (w);
         };
         notdone = next_interval(br_wlt6_25, notdone, wlt6_25, r, w);
-        if (any(notdone))
+        if (eve::any(notdone))
         {
           auto br_wlt16 = [](auto w)
             {
@@ -137,7 +137,7 @@ namespace eve::detail
               > (w);
             };
           notdone = next_interval(br_wlt16, notdone, wlt16, r, w);
-          if (any(notdone))
+          if (eve::any(notdone))
           {
             auto br_wge16 = [](auto w)
               {

--- a/include/eve/module/real/special/function/regular/generic/erfc_inv.hpp
+++ b/include/eve/module/real/special/function/regular/generic/erfc_inv.hpp
@@ -52,7 +52,7 @@ namespace eve::detail
           > (w);
         };
         notdone = next_interval(br_wlt5, notdone, test, r, w);
-        if (any(notdone))
+        if (eve::any(notdone))
         {
           auto br_wge5 = [a00](auto w)
             {
@@ -111,7 +111,7 @@ namespace eve::detail
           > (w);
         };
         notdone = next_interval(br_wlt6_25, notdone, wlt6_25, r, w);
-        if (any(notdone))
+        if (eve::any(notdone))
         {
           auto br_wlt16 = [](auto w)
             {
@@ -138,7 +138,7 @@ namespace eve::detail
               > (w);
             };
           notdone = next_interval(br_wlt16, notdone, wlt16, r, w);
-          if (any(notdone))
+          if (eve::any(notdone))
           {
             auto br_wge16 = [](auto w)
               {

--- a/include/eve/module/real/special/function/regular/generic/erfcx.hpp
+++ b/include/eve/module/real/special/function/regular/generic/erfcx.hpp
@@ -125,7 +125,7 @@ namespace eve::detail
     r = fma (e, r, q);
     if (eve::any(a > ll)) r =  if_else(a > ll, invsqrtpi*rec(a), r);
     auto xpos = (x >= 0);
-    if (all(xpos)) return r;
+    if (eve::all(xpos)) return r;
     /* Handle negative arguments: erfcx(x) = 2*exp(x*x) - erfcx(|x|) */
     auto r1 = fms(T(2), expx2(x), r);
     r1 =  if_else(is_nan(r1), inf(as<T>()), r1);

--- a/include/eve/module/real/special/function/regular/generic/exp_int.hpp
+++ b/include/eve/module/real/special/function/regular/generic/exp_int.hpp
@@ -95,7 +95,7 @@ namespace eve::detail
        return exp(-x)/x;
      };
      notdone = next_interval(br_zeron, notdone, is_eqz(n), r, x); // n == 0
-     if (any(notdone))
+     if (eve::any(notdone))
      {
        auto br_largen = [](auto n,  auto x){ //n >  5000
          auto xk = x + n;
@@ -107,7 +107,7 @@ namespace eve::detail
          return inc(ans)*exp(-x)/xk;
        };
        notdone = next_interval(br_largen, notdone, n > 5000, r, n, x); // n >  5000
-       if (any(notdone))
+       if (eve::any(notdone))
        {
          auto br_xlt1 = [](auto n,  auto x){ // here x is always le 1
            auto eqzx = is_eqz(x);
@@ -131,14 +131,14 @@ namespace eve::detail
              ans = add[is_nez(pk)](ans, yk/pk);
              t = if_else(is_nez(ans), abs(yk/ans), one);
            }
-           while( any(t > halfeps(as(x))));
+           while( eve::any(t > halfeps(as(x))));
            auto in = int_(n);
            return add[eqzx]((eve::pow(z, dec(in)) * psi / tgamma(n)) - ans, inf(as(x)));
          };
          auto xlt1 = x < 1;
          T xx = if_else(xlt1, x, one);
          notdone = next_interval(br_xlt1, notdone, xlt1, r, n, xx); // x <  1
-         if(any(notdone))
+         if(eve::any(notdone))
          {
            auto br_xge1 = [](auto n,  auto x){ // here x is always gt 1
              auto exp_intbig = (sizeof(elt_t) == 8) ? T(1ull << 57) : T(1ull << 24);
@@ -173,7 +173,7 @@ namespace eve::detail
                qkm2 *= fac;
                qkm1 *= fac;
              }
-             while(any(t > eps(as(x))));
+             while(eve::any(t > eps(as(x))));
              return  add[x < maxlog(as(x))](zero(as(x)), ans*exp(-x));
 
            };

--- a/include/eve/module/real/special/function/regular/generic/gamma_p.hpp
+++ b/include/eve/module/real/special/function/regular/generic/gamma_p.hpp
@@ -52,7 +52,7 @@ namespace eve::detail
     auto notdone =  is_not_nan(x);
     const auto amax = T(1048576);
     auto test = (a > amax);
-    if (any(test))
+    if (eve::any(test))
     {
       auto z = eve::fma( 1024*rsqrt(a), x-(a-third), amax-third);
       x =  eve::max(z, zero(as(x)));
@@ -68,7 +68,7 @@ namespace eve::detail
       auto del = one(as(ap));
       auto sum = del;
 
-      while ( any(abs(del) >=  T(100)*epsilon(maximum(abs(sum)))))
+      while ( eve::any(abs(del) >=  T(100)*epsilon(maximum(abs(sum)))))
       {
         ap  += one(as(ap));
         del  = x*del/ap;
@@ -114,7 +114,7 @@ namespace eve::detail
 
     test = x < inc(a);
     notdone = next_interval(lginc, notdone, test, res, x, a, test);
-    if (any(notdone)) last_interval(uginc, notdone, res, x, a, !test);
+    if (eve::any(notdone)) last_interval(uginc, notdone, res, x, a, !test);
     return res;
   }
 }

--- a/include/eve/module/real/special/function/regular/generic/lgamma.hpp
+++ b/include/eve/module/real/special/function/regular/generic/lgamma.hpp
@@ -244,7 +244,7 @@ namespace eve::detail
               auto    txgt250 = is_greater(tx, _250);
 
               // x >= 1.5
-              while( any(logical_and(xge150, txgt250)) )
+              while( eve::any(logical_and(xge150, txgt250)) )
               {
                 nx      = dec[txgt250](nx);
                 tx      = if_else(txgt250, x + nx, tx);
@@ -258,7 +258,7 @@ namespace eve::detail
               // x >= 1.25 && x < 1.5
               auto xge125  = is_greater_equal(x, _125);
               auto xge125t = logical_andnot(xge125, xge150);
-              if( any(xge125) )
+              if( eve::any(xge125) )
               {
                 r0x = if_else(xge125t, dec(x), r0x);
                 r0z = if_else(xge125t, z * x, r0z);
@@ -267,7 +267,7 @@ namespace eve::detail
               // x >= 0.75&& x < 1.5
               auto xge075  = is_greater_equal(x, _075);
               auto xge075t = logical_andnot(xge075, xge125);
-              if( any(xge075t) )
+              if( eve::any(xge075t) )
               {
                 kernelC = xge075t;
                 r0x     = if_else(xge075t, dec(x), r0x);
@@ -277,10 +277,10 @@ namespace eve::detail
               }
               // tx < 1.5 && x < 0.75
               auto txlt150 = logical_andnot(is_less(tx, _150), xge075);
-              if( any(txlt150) )
+              if( eve::any(txlt150) )
               {
                 auto orig = txlt150;
-                while( any(txlt150) )
+                while( eve::any(txlt150) )
                 {
                   z       = if_else(txlt150, z * tx, z);
                   nx      = inc[txlt150](nx);
@@ -409,7 +409,7 @@ namespace eve::detail
               T    p     = zero(as<T>());
               T    u     = if_else(test, x, eve::zero);
               auto test1 = is_greater_equal(u, T(3));
-              while( any(test1) )
+              while( eve::any(test1) )
               {
                 p     = dec[test1](p);
                 u     = if_else(test1, x + p, u);
@@ -419,7 +419,7 @@ namespace eve::detail
               // all u are less than 3
               auto test2 = is_less(u, T(2));
 
-              while( any(test2) )
+              while( eve::any(test2) )
               {
                 z     = if_else(test2, z / u, z);
                 p     = inc[test2](p);

--- a/include/eve/module/real/special/function/regular/generic/tgamma.hpp
+++ b/include/eve/module/real/special/function/regular/generic/tgamma.hpp
@@ -170,7 +170,7 @@ namespace eve::detail
           }
           auto z     = one(eve::as<T>());
           auto test1 = is_greater_equal(x, T(3));
-          while( any(test1) )
+          while( eve::any(test1) )
           {
             x     = dec[test1](x);
             z     = if_else(test1, z * x, z);
@@ -178,7 +178,7 @@ namespace eve::detail
           }
           // all x are less than 3
           test1 = is_ltz(x);
-          while( any(test1) )
+          while( eve::any(test1) )
           {
             z     = if_else(test1, z / x, z);
             x     = inc[test1](x);
@@ -186,7 +186,7 @@ namespace eve::detail
           }
           // all x are greater than 0 and less than 3
           auto test2 = is_less(x, T(2));
-          while( any(test2) )
+          while( eve::any(test2) )
           {
             z     = if_else(test2, z / x, z);
             x     = inc[test2](x);
@@ -232,4 +232,3 @@ namespace eve::detail
     return tgamma(regular_type(), x);
   }
 }
-

--- a/include/eve/module/real/special/function/regular/generic/zeta.hpp
+++ b/include/eve/module/real/special/function/regular/generic/zeta.hpp
@@ -87,10 +87,10 @@ namespace eve::detail
         };
       auto r = nan(as(x));
       auto notdone = x != one(as(x)) || is_not_nan(x);
-      if (any(notdone))
+      if ( eve::any(notdone) )
       {
         notdone =  next_interval(zetp, notdone, is_gez(x), r, x);
-        if  (any(notdone))
+        if  ( eve::any(notdone) )
         {
           auto reflec = [zetp](auto x)
             {

--- a/test/unit/module/real/algorithm/all/regular/all.hpp
+++ b/test/unit/module/real/algorithm/all/regular/all.hpp
@@ -9,12 +9,14 @@
 **/
 //==================================================================================================
 #include <eve/function/all.hpp>
+
+#include <eve/conditional.hpp>
+#include <eve/constant/false.hpp>
 #include <eve/constant/mzero.hpp>
 #include <eve/constant/nan.hpp>
 #include <eve/constant/true.hpp>
-#include <eve/constant/false.hpp>
-#include <eve/platform.hpp>
 #include <eve/logical.hpp>
+#include <eve/platform.hpp>
 #include <type_traits>
 
 TTS_CASE_TPL("Check eve::all return type", EVE_TYPE)
@@ -66,3 +68,81 @@ TTS_CASE_TPL("Check eve::all behavior on logical", EVE_TYPE)
   TTS_EXPECT    (eve::all(eve::true_(eve::as<T>())));
   TTS_EXPECT_NOT(eve::all(eve::false_(eve::as<T>())));
 }
+
+#if defined(EVE_SIMD_TESTS)
+
+TTS_CASE_TPL("Check eve::all[ignore]", EVE_TYPE)
+{
+  // complete
+  {
+    eve::logical<T> mask(true);
+
+    TTS_EXPECT(eve::all[eve::ignore_none](mask));
+    TTS_EXPECT_NOT(eve::all[eve::ignore_all](mask));
+  }
+
+  // some special cases
+  {
+    eve::logical<T> mask(true);
+
+    TTS_EXPECT(eve::all[eve::ignore_first(1)](mask));
+    TTS_EXPECT(eve::all[eve::ignore_last(1)](mask));
+
+    mask.set(0, false);
+    TTS_EXPECT(eve::all[eve::ignore_first(1)](mask));
+    TTS_EXPECT(eve::all[eve::ignore_last(T::static_size)](mask));
+    TTS_EXPECT_NOT(eve::all[eve::ignore_last(T::static_size - 1)](mask));
+  }
+
+  // ignore_first
+  {
+    eve::logical<T> mask(true);
+
+    for(int i = 0; i != T::static_size; ++i )
+    {
+      TTS_EXPECT(eve::all[eve::ignore_first(i)](mask));
+      mask.set(i, false);
+      TTS_EXPECT_NOT(eve::all[eve::ignore_first(i)](mask));
+      TTS_EXPECT(eve::all[eve::ignore_first(i + 1)](mask));
+    }
+  }
+
+  // ignore_last
+  {
+    eve::logical<T> mask(true);
+
+    for(int i = 0; i != T::static_size; ++i )
+    {
+      TTS_EXPECT(eve::all[eve::ignore_last(i)](mask));
+      mask.set(T::static_size - i - 1, false);
+      TTS_EXPECT_NOT(eve::all[eve::ignore_last(i)](mask));
+      TTS_EXPECT(eve::all[eve::ignore_last(i + 1)](mask));
+    }
+  }
+
+  // ignore_extrema_
+  {
+    for (int i = 0; i < T::static_size + 1; ++i)
+    {
+      for (int j = T::static_size - i; j ; --j)
+      {
+        eve::logical<T> mask([&](int k, int) { return (k >= i) && (T::static_size - k) > j; });
+        TTS_EXPECT(eve::all[eve::ignore_extrema_(i, j)](mask));
+
+        if (i + j == T::static_size) continue;
+
+        mask.set(i, false);
+
+        TTS_EXPECT_NOT(eve::all[eve::ignore_extrema_(i, j)](mask));
+        TTS_EXPECT(eve::all[eve::ignore_extrema_(i + 1, j)](mask));
+        mask.set(i, true);
+
+        mask.set(T::static_size - j - 1, false);
+        TTS_EXPECT_NOT(eve::all[eve::ignore_extrema_(i, j)](mask));
+        TTS_EXPECT(eve::all[eve::ignore_extrema_(i, j + 1)](mask));
+      }
+    }
+  }
+}
+
+#endif

--- a/test/unit/module/real/algorithm/all/regular/all.hpp
+++ b/test/unit/module/real/algorithm/all/regular/all.hpp
@@ -78,7 +78,9 @@ TTS_CASE_TPL("Check eve::all[ignore]", EVE_TYPE)
     eve::logical<T> mask(true);
 
     TTS_EXPECT(eve::all[eve::ignore_none](mask));
-    TTS_EXPECT_NOT(eve::all[eve::ignore_all](mask));
+
+    mask = eve::logical<T>{false};
+    TTS_EXPECT(eve::all[eve::ignore_all](mask));
   }
 
   // some special cases

--- a/test/unit/module/real/core/bitofsign/regular/bitofsign.hpp
+++ b/test/unit/module/real/core/bitofsign/regular/bitofsign.hpp
@@ -38,20 +38,20 @@ TTS_CASE_TPL("Check eve::bitofsign behavior", EVE_TYPE)
     {
       TTS_EQUAL( bitofsign(eve::inf(eve::as<T>()) ), T(0)           );
       TTS_EQUAL( bitofsign(eve::minf(eve::as<T>())), T(-0.));
-      TTS_EXPECT( all(is_positive(bitofsign( eve::inf(eve::as<T>())))) );
-      TTS_EXPECT( all(is_negative(bitofsign(eve::minf(eve::as<T>())))) );
+      TTS_EXPECT( eve::all(is_positive(bitofsign( eve::inf(eve::as<T>())))) );
+      TTS_EXPECT( eve::all(is_negative(bitofsign(eve::minf(eve::as<T>())))) );
     }
 
     TTS_EQUAL (bitofsign(T(0))  , T(0));
     TTS_EQUAL (bitofsign(T(-0.)), T(-0.));
-    TTS_EXPECT( all(is_positive(bitofsign(T(0)))) );
-    TTS_EXPECT( all(is_negative(bitofsign(T(-0.)))) );
+    TTS_EXPECT( eve::all(is_positive(bitofsign(T(0)))) );
+    TTS_EXPECT( eve::all(is_negative(bitofsign(T(-0.)))) );
 
     TTS_EQUAL (bitofsign(T(1)), T(0));
-    TTS_EXPECT( all(is_positive(bitofsign(T(1)))) );
+    TTS_EXPECT( eve::all(is_positive(bitofsign(T(1)))) );
 
     TTS_EQUAL (bitofsign(T(-1)), T(-0.));
-    TTS_EXPECT( all(is_negative(bitofsign(T(-1)))) );
+    TTS_EXPECT( eve::all(is_negative(bitofsign(T(-1)))) );
   }
   else if constexpr( eve::unsigned_value<T> )
   {

--- a/test/unit/module/real/core/cbrt/regular/cbrt.hpp
+++ b/test/unit/module/real/core/cbrt/regular/cbrt.hpp
@@ -43,6 +43,6 @@ TTS_CASE_TPL("Check eve::eve::cbrt behavior", EVE_TYPE)
   TTS_ULP_EQUAL(eve::cbrt(T(0))   , T( 0), 0  );
   TTS_ULP_EQUAL(eve::cbrt(T(-0.)) , T( 0), 0.5);
 
-  TTS_EXPECT( all(is_negative(eve::cbrt(T(-0.)))) );
-  TTS_EXPECT( all(is_positive(eve::cbrt(T(0)))  ) );
+  TTS_EXPECT( eve::all(is_negative(eve::cbrt(T(-0.)))) );
+  TTS_EXPECT( eve::all(is_positive(eve::cbrt(T(0)))  ) );
 }

--- a/test/unit/module/real/math/acos/raw/acos.hpp
+++ b/test/unit/module/real/math/acos/raw/acos.hpp
@@ -44,7 +44,7 @@ TTS_CASE_TPL("Check raw(eve::acos) behavior", EVE_TYPE)
   TTS_ULP_EQUAL(raw(eve::acos)(T( 1. )) , T(0)             , 0   );
   TTS_ULP_EQUAL(raw(eve::acos)(T( 0. )) , eve::pio_2(eve::as<T>())  , 0   );
 
-  TTS_EXPECT( all(eve::is_positive(eve::acos(T(1)))) );
+  TTS_EXPECT( eve::all(eve::is_positive(eve::acos(T(1)))) );
 
   TTS_ULP_EQUAL(raw(eve::acos)(T(8.414715528e-01)), T(std::acos(v_t(8.414715528e-01))), 1.5 );
   TTS_ULP_EQUAL(raw(eve::acos)(T(9.689134359e-01)), T(std::acos(v_t(9.689134359e-01))), 4.0 );

--- a/test/unit/module/real/math/acos/regular/acos.hpp
+++ b/test/unit/module/real/math/acos/regular/acos.hpp
@@ -40,7 +40,7 @@ TTS_CASE_TPL("Check eve::acos behavior", EVE_TYPE)
   TTS_ULP_EQUAL(eve::acos(T( 1. )) , T(0)             , 0   );
   TTS_ULP_EQUAL(eve::acos(T( 0. )) , eve::pio_2(eve::as<T>())  , 0   );
 
-  TTS_EXPECT( all(eve::is_positive(eve::acos(T(1)))) );
+  TTS_EXPECT( eve::all(eve::is_positive(eve::acos(T(1)))) );
 
   TTS_ULP_EQUAL(eve::acos(T(8.414715528e-01)), T(std::acos(v_t(8.414715528e-01))), 1);
   TTS_ULP_EQUAL(eve::acos(T(9.689134359e-01)), T(std::acos(v_t(9.689134359e-01))), 1);

--- a/test/unit/module/real/math/acosd/raw/acosd.hpp
+++ b/test/unit/module/real/math/acosd/raw/acosd.hpp
@@ -39,7 +39,7 @@ TTS_CASE_TPL("Check eve::raw(eve::acosd) behavior", EVE_TYPE)
   TTS_ULP_EQUAL(eve::raw(eve::acosd)(T( 1. )), T(0)   , 0  );
   TTS_ULP_EQUAL(eve::raw(eve::acosd)(T( 0. )), T(90)  , 0.5);
 
-  TTS_EXPECT( all(eve::is_positive(eve::raw(eve::acosd)(T(1.)))) );
+  TTS_EXPECT( eve::all(eve::is_positive(eve::raw(eve::acosd)(T(1.)))) );
 
   TTS_ULP_EQUAL(eve::raw(eve::acosd)(T(8.414715528e-01)), T(radindeg(std::acos(v_t(8.414715528e-01)))), 1.5 );
   TTS_ULP_EQUAL(eve::raw(eve::acosd)(T(9.689134359e-01)), T(radindeg(std::acos(v_t(9.689134359e-01)))), 4.0 );

--- a/test/unit/module/real/math/acosd/regular/acosd.hpp
+++ b/test/unit/module/real/math/acosd/regular/acosd.hpp
@@ -39,7 +39,7 @@ TTS_CASE_TPL("Check eve::acosd behavior", EVE_TYPE)
   TTS_ULP_EQUAL(eve::acosd(T( 1. )), T(0)   , 0  );
   TTS_ULP_EQUAL(eve::acosd(T( 0. )), T(90)  , 0.5);
 
-  TTS_EXPECT( all(eve::is_positive(eve::acosd(T(1.)))) );
+  TTS_EXPECT( eve::all(eve::is_positive(eve::acosd(T(1.)))) );
 
   TTS_ULP_EQUAL(eve::acosd(T(8.414715528e-01)), T(radindeg(std::acos(v_t(8.414715528e-01)))), 1.5 );
   TTS_ULP_EQUAL(eve::acosd(T(9.689134359e-01)), T(radindeg(std::acos(v_t(9.689134359e-01)))), 4.0 );

--- a/test/unit/module/real/math/acospi/pedantic/acospi.hpp
+++ b/test/unit/module/real/math/acospi/pedantic/acospi.hpp
@@ -41,7 +41,7 @@ TTS_CASE_TPL("Check eve::raw(eve::acospi) behavior", EVE_TYPE)
   TTS_ULP_EQUAL(eve::raw(eve::acospi)(T( 1. )), T(0)    , 0  );
   TTS_ULP_EQUAL(eve::raw(eve::acospi)(T( 0. )), T(0.5)  , 0.5);
 
-  TTS_EXPECT( all(eve::is_positive(eve::raw(eve::acospi)(T(1.)))) );
+  TTS_EXPECT( eve::all(eve::is_positive(eve::raw(eve::acospi)(T(1.)))) );
 
   TTS_ULP_EQUAL(eve::raw(eve::acospi)(T(8.414715528e-01)), T(radinpi(std::acos(v_t(8.414715528e-01)))), 2.0 );
   TTS_ULP_EQUAL(eve::raw(eve::acospi)(T(9.689134359e-01)), T(radinpi(std::acos(v_t(9.689134359e-01)))), 4.0 );

--- a/test/unit/module/real/math/acospi/regular/acospi.hpp
+++ b/test/unit/module/real/math/acospi/regular/acospi.hpp
@@ -40,7 +40,7 @@ TTS_CASE_TPL("Check eve::acospi behavior", EVE_TYPE)
   TTS_ULP_EQUAL(eve::acospi(T( 1. )), T(0)    , 0  );
   TTS_ULP_EQUAL(eve::acospi(T( 0. )), T(0.5)  , 0.5);
 
-  TTS_EXPECT( all(eve::is_positive(eve::acospi(T(1.)))) );
+  TTS_EXPECT( eve::all(eve::is_positive(eve::acospi(T(1.)))) );
 
   TTS_ULP_EQUAL(eve::acospi(T(8.414715528e-01)), T(radinpi(std::acos(v_t(8.414715528e-01)))), 1);
   TTS_ULP_EQUAL(eve::acospi(T(9.689134359e-01)), T(radinpi(std::acos(v_t(9.689134359e-01)))), 1);

--- a/test/unit/module/real/math/asin/regular/asin.hpp
+++ b/test/unit/module/real/math/asin/regular/asin.hpp
@@ -43,6 +43,6 @@ TTS_CASE_TPL("Check eve::eve::asin behavior", EVE_TYPE)
 
   TTS_ULP_EQUAL(eve::asin(T(-0.)), T(0), 0.5);
 
-  TTS_EXPECT( all(is_negative(eve::asin(T(-0.)))) );
-  TTS_EXPECT( all(is_positive(eve::asin(T(0))))   );
+  TTS_EXPECT( eve::all(is_negative(eve::asin(T(-0.)))) );
+  TTS_EXPECT( eve::all(is_positive(eve::asin(T(0))))   );
 }

--- a/test/unit/module/real/math/asind/regular/asind.hpp
+++ b/test/unit/module/real/math/asind/regular/asind.hpp
@@ -41,6 +41,6 @@ TTS_CASE_TPL("Check eve::eve::asind behavior", EVE_TYPE)
 
   TTS_ULP_EQUAL(eve::asind(T(-0.)), T(0), 0.5);
 
-  TTS_EXPECT( all(is_negative(eve::asind(T(-0.)))) );
-  TTS_EXPECT( all(is_positive(eve::asind(T(0))))   );
+  TTS_EXPECT( eve::all(is_negative(eve::asind(T(-0.)))) );
+  TTS_EXPECT( eve::all(is_positive(eve::asind(T(0))))   );
 }

--- a/test/unit/module/real/math/asinpi/regular/asinpi.hpp
+++ b/test/unit/module/real/math/asinpi/regular/asinpi.hpp
@@ -41,6 +41,6 @@ TTS_CASE_TPL("Check eve::eve::asinpi behavior", EVE_TYPE)
 
   TTS_ULP_EQUAL(eve::asinpi(T(-0.)), T(0), 0.5);
 
-  TTS_EXPECT( all(is_negative(eve::asinpi(T(-0.)))) );
-  TTS_EXPECT( all(is_positive(eve::asinpi(T(0))))   );
+  TTS_EXPECT( eve::all(is_negative(eve::asinpi(T(-0.)))) );
+  TTS_EXPECT( eve::all(is_positive(eve::asinpi(T(0))))   );
 }

--- a/test/unit/module/real/math/atan/regular/atan.hpp
+++ b/test/unit/module/real/math/atan/regular/atan.hpp
@@ -45,6 +45,6 @@ TTS_CASE_TPL("Check eve::eve::atan behavior", EVE_TYPE)
   TTS_ULP_EQUAL(eve::atan(T(1.))   ,  eve::pio_4(eve::as<T>())         , 0.5);
   TTS_ULP_EQUAL(eve::atan(T(0.))   , T(0)                     , 0.5);
 
-  TTS_EXPECT(all(eve::is_positive(eve::atan((T(0))))) );
-  TTS_EXPECT(all(eve::is_negative(eve::atan(T(-0.)))) );
+  TTS_EXPECT(eve::all(eve::is_positive(eve::atan((T(0))))) );
+  TTS_EXPECT(eve::all(eve::is_negative(eve::atan(T(-0.)))) );
 }

--- a/test/unit/module/real/math/atan2/pedantic/atan2.hpp
+++ b/test/unit/module/real/math/atan2/pedantic/atan2.hpp
@@ -46,8 +46,8 @@ TTS_CASE_TPL("Check pedantic(eve::atan2) behavior", EVE_TYPE)
     TTS_ULP_EQUAL(pedantic(eve::atan2)((T( 1.)) , eve::inf(eve::as<T>())        ), T(0.)         , 0.5);
     TTS_ULP_EQUAL(pedantic(eve::atan2)((T(-1.)) , eve::inf(eve::as<T>())        ), T(-0.)          , 0.5);
 
-    TTS_EXPECT( all(is_negative(pedantic(eve::atan2)((T(-1.)), eve::inf(eve::as<T>())))) );
-    TTS_EXPECT( all(is_positive(pedantic(eve::atan2)((T(1.)) , eve::inf(eve::as<T>())))) );
+    TTS_EXPECT( eve::all(is_negative(pedantic(eve::atan2)((T(-1.)), eve::inf(eve::as<T>())))) );
+    TTS_EXPECT( eve::all(is_positive(pedantic(eve::atan2)((T(1.)) , eve::inf(eve::as<T>())))) );
 
     TTS_ULP_EQUAL(pedantic(eve::atan2)(eve::minf(eve::as<T>()), eve::minf(eve::as<T>())), -3*eve::pio_4(eve::as<T>()), 0.5);
     TTS_ULP_EQUAL(pedantic(eve::atan2)(eve::inf(eve::as<T>()) , eve::minf(eve::as<T>())),  3*eve::pio_4(eve::as<T>()), 0.5);

--- a/test/unit/module/real/math/atan2/regular/atan2.hpp
+++ b/test/unit/module/real/math/atan2/regular/atan2.hpp
@@ -49,8 +49,8 @@ TTS_CASE_TPL("Check eve::atan2 behavior", EVE_TYPE)
     TTS_ULP_EQUAL(eve::atan2((T( 1.)) , inf         ), (T(0.))         , 0.5);
     TTS_ULP_EQUAL(eve::atan2((T(-1.)) , inf         ), mzero              , 0.5);
 
-    TTS_EXPECT( all(is_negative(eve::atan2((T(-1.)), inf))) );
-    TTS_EXPECT( all(is_positive(eve::atan2((T(1.)) , inf))) );
+    TTS_EXPECT( eve::all(is_negative(eve::atan2((T(-1.)), inf))) );
+    TTS_EXPECT( eve::all(is_positive(eve::atan2((T(1.)) , inf))) );
 
     TTS_ULP_EQUAL(eve::atan2(minf, minf      ),  eve::nan(eve::as<T>())   , 0.5);
     TTS_ULP_EQUAL(eve::atan2(inf , minf      ),  eve::nan(eve::as<T>())   , 0.5);

--- a/test/unit/module/real/math/atan2d/pedantic/atan2d.hpp
+++ b/test/unit/module/real/math/atan2d/pedantic/atan2d.hpp
@@ -48,8 +48,8 @@ TTS_CASE_TPL("Check pedantic(eve::atan2d)  behavior", EVE_TYPE)
     TTS_ULP_EQUAL(pedantic(eve::atan2d)((T( 1.)) , inf         ), (T(0.))  , 0.5);
     TTS_ULP_EQUAL(pedantic(eve::atan2d)((T(-1.)) , inf         ), mzero       , 0.5);
 
-    TTS_EXPECT( all(is_negative(pedantic(eve::atan2d)((T(-1.)), inf))) );
-    TTS_EXPECT( all(is_positive(pedantic(eve::atan2d)((T(1.)) , inf))) );
+    TTS_EXPECT( eve::all(is_negative(pedantic(eve::atan2d)((T(-1.)), inf))) );
+    TTS_EXPECT( eve::all(is_positive(pedantic(eve::atan2d)((T(1.)) , inf))) );
 
     TTS_ULP_EQUAL(pedantic(eve::atan2d)(minf, minf      ), -3*(T(45)), 0.5);
     TTS_ULP_EQUAL(pedantic(eve::atan2d)(inf , minf      ),  3*(T(45)), 0.5);

--- a/test/unit/module/real/math/atan2d/regular/atan2d.hpp
+++ b/test/unit/module/real/math/atan2d/regular/atan2d.hpp
@@ -45,8 +45,8 @@ TTS_CASE_TPL("Check eve::atan2d behavior", EVE_TYPE)
     TTS_ULP_EQUAL(eve::atan2d((T( 1.)) , inf         ), (T(0.))  , 0.5);
     TTS_ULP_EQUAL(eve::atan2d((T(-1.)) , inf         ), mzero       , 0.5);
 
-    TTS_EXPECT( all(is_negative(eve::atan2d((T(-1.)), inf))) );
-    TTS_EXPECT( all(is_positive(eve::atan2d((T(1.)) , inf))) );
+    TTS_EXPECT( eve::all(is_negative(eve::atan2d((T(-1.)), inf))) );
+    TTS_EXPECT( eve::all(is_positive(eve::atan2d((T(1.)) , inf))) );
 
     TTS_ULP_EQUAL(eve::atan2d(minf, minf      ), eve::nan(eve::as<T>()) , 0.5);
     TTS_ULP_EQUAL(eve::atan2d(inf , minf      ), eve::nan(eve::as<T>()) , 0.5);

--- a/test/unit/module/real/math/atan2pi/pedantic/atan2pi.hpp
+++ b/test/unit/module/real/math/atan2pi/pedantic/atan2pi.hpp
@@ -52,8 +52,8 @@ TTS_CASE_TPL("Check pedantic(eve::atan2pi) behavior", EVE_TYPE)
     TTS_ULP_EQUAL(pedantic(eve::atan2pi)((T( 1.)) , inf         ), (T(0.))   , 0.5);
     TTS_ULP_EQUAL(pedantic(eve::atan2pi)((T(-1.)) , inf         ), mzero        , 0.5);
 
-    TTS_EXPECT( all(is_negative(pedantic(eve::atan2pi)((T(-1.)), inf))) );
-    TTS_EXPECT( all(is_positive(pedantic(eve::atan2pi)((T(1.)) , inf))) );
+    TTS_EXPECT( eve::all(is_negative(pedantic(eve::atan2pi)((T(-1.)), inf))) );
+    TTS_EXPECT( eve::all(is_positive(pedantic(eve::atan2pi)((T(1.)) , inf))) );
 
     TTS_ULP_EQUAL(pedantic(eve::atan2pi)(minf, minf      ), (T(-0.75)), 0.5);
     TTS_ULP_EQUAL(pedantic(eve::atan2pi)(inf , minf      ), (T(0.75)) , 0.5);

--- a/test/unit/module/real/math/atan2pi/regular/atan2pi.hpp
+++ b/test/unit/module/real/math/atan2pi/regular/atan2pi.hpp
@@ -49,8 +49,8 @@ TTS_CASE_TPL("Check eve::atan2pi behavior", EVE_TYPE)
     TTS_ULP_EQUAL(eve::atan2pi((T( 1.)) , inf         ), (T(0.))  , 0.5);
     TTS_ULP_EQUAL(eve::atan2pi((T(-1.)) , inf         ), mzero       , 0.5);
 
-    TTS_EXPECT( all(is_negative(eve::atan2pi((T(-1.)), inf))) );
-    TTS_EXPECT( all(is_positive(eve::atan2pi((T(1.)) , inf))) );
+    TTS_EXPECT( eve::all(is_negative(eve::atan2pi((T(-1.)), inf))) );
+    TTS_EXPECT( eve::all(is_positive(eve::atan2pi((T(1.)) , inf))) );
 
     TTS_ULP_EQUAL(eve::atan2pi(minf, minf      ),  eve::nan(eve::as<T>()) , 0.5);
     TTS_ULP_EQUAL(eve::atan2pi(inf , minf      ),  eve::nan(eve::as<T>()) , 0.5);

--- a/test/unit/module/real/math/atand/regular/atand.hpp
+++ b/test/unit/module/real/math/atand/regular/atand.hpp
@@ -47,6 +47,6 @@ TTS_CASE_TPL("Check eve::eve::atand behavior", EVE_TYPE)
   TTS_ULP_EQUAL(eve::atand(T(1.))   , (T(45))                                 , 0.5);
   TTS_ULP_EQUAL(eve::atand(T(0.))   , (T(0))                                  , 0.5);
 
-  TTS_EXPECT(all(eve::is_positive(eve::atand((T(0)))))          );
-  TTS_EXPECT(all(eve::is_negative(eve::atand(T(-0.)))) );
+  TTS_EXPECT(eve::all(eve::is_positive(eve::atand((T(0)))))          );
+  TTS_EXPECT(eve::all(eve::is_negative(eve::atand(T(-0.)))) );
 }

--- a/test/unit/module/real/math/atanpi/regular/atanpi.hpp
+++ b/test/unit/module/real/math/atanpi/regular/atanpi.hpp
@@ -44,6 +44,6 @@ TTS_CASE_TPL("Check eve::eve::atanpi behavior", EVE_TYPE)
   TTS_ULP_EQUAL(eve::atanpi(T(1.))   ,  T(0.25)                                 , 0.5);
   TTS_ULP_EQUAL(eve::atanpi(T(0.))   ,  T(0)                                    , 0.5);
 
-  TTS_EXPECT(all(eve::is_positive(eve::atanpi((T(0)))))  );
-  TTS_EXPECT(all(eve::is_negative(eve::atanpi(T(-0.)))) );
+  TTS_EXPECT(eve::all(eve::is_positive(eve::atanpi((T(0)))))  );
+  TTS_EXPECT(eve::all(eve::is_negative(eve::atanpi(T(-0.)))) );
 }


### PR DESCRIPTION
(I was a bit optimistic when I was naming the branch).

For ignore any - just do the top bits. Well. except we need to invert the ignore.
Maybe we could do smth clever with aggregated case and ignore but I didn't figure it out.

Because the logic is quite different I left both ignore and non ignore overloads.

ARM and any/none will do separately at some point.