### PR TITLE
fix-455: -1 instruction for all > 4 bytes, ~ for < 4 bytes

### DIFF
--- a/include/eve/module/real/algorithm/function/regular/simd/arm/neon/all.hpp
+++ b/include/eve/module/real/algorithm/function/regular/simd/arm/neon/all.hpp
@@ -29,9 +29,22 @@ namespace eve::detail
       auto as_uint32 = eve::bit_cast(v0, eve::as_<eve::logical<wide_u32>>{});
 
       auto m = as_uint32.bits();
-      m = vand_u32(m, vrev64_u32(m));
-      if constexpr (sizeof(T) >= 4) return static_cast<bool>(m[0]);
-      else                          return m[0] == (std::uint32_t)(-1);
+
+      if constexpr ( sizeof( eve::element_type_t<T> ) >= 4 )
+      {
+        m = vreinterpret_u32_u64(vpaddl_u32(m));
+        uint32_t top = vget_lane_u32(m, 1);
+
+        return static_cast<bool>(top);
+      }
+      else
+      {
+        m = vmvn_u32(m);
+        m = vorr_u32(m, vrev64_u32(m));
+        uint32_t top = vget_lane_u32(m, 1);
+
+        return top == 0;
+      }
     }
   }
 


### PR DESCRIPTION
arm is tricky to disassemble, I'm not sure I can pull it off without having a complete implementation of all algorithm.
Nevertheless I think this trims of 1 instruction of > 4 bytes.

So should be 2 instructions > 4 bytes, 4 - < 4 bytes.
We had 3 but a constant, I'm not sure which is better.