### PR TITLE
FIX-495: fix load/store over-aligned

### DIFF
--- a/include/eve/detail/function/simd/common/load.hpp
+++ b/include/eve/detail/function/simd/common/load.hpp
@@ -53,12 +53,19 @@ namespace eve::detail
   {
     wide<T,N,aggregated_> that;
 
+    auto cast = []<typename Ptr, typename Sub>(Ptr ptr, as_<Sub>)
+    {
+      using a_p = eve::aligned_ptr<const T, Sub::static_alignment>;
+      if constexpr (std::is_pointer_v<Ptr>) return ptr;
+      else                                  return a_p{ptr.get()};
+    };
+
     that.storage().apply
     (
       [&]<typename... Sub>(Sub&... v)
       {
         int offset = 0;
-        (((v = Sub(ptr + offset), offset += Sub::static_size), ...));
+        (((v = Sub(cast(ptr, as_<Sub>{}) + offset), offset += Sub::static_size), ...));
       }
     );
 

--- a/include/eve/module/real/core/function/regular/simd/x86/store.hpp
+++ b/include/eve/module/real/core/function/regular/simd/x86/store.hpp
@@ -72,30 +72,4 @@ namespace eve::detail
       memcpy(ptr, (T const*)(&value), N::value * sizeof(T));
     }
   }
-
-  template< scalar_value T, typename N, x86_abi ABI
-          , simd_compatible_ptr<logical<wide<T, N, ABI>>> Ptr
-          >
-  EVE_FORCEINLINE void store_(EVE_SUPPORTS(sse2_), logical<wide<T,N,ABI>> const &value, Ptr ptr) noexcept
-  {
-    if constexpr( !ABI::is_wide_logical )
-    {
-      auto[l,h] = value.mask().slice();
-
-      if constexpr( !std::is_pointer_v<Ptr> )
-      {
-        store(l, aligned_ptr<T,Ptr::alignment()/2>((T*)ptr.get())             );
-        store(h, aligned_ptr<T,Ptr::alignment()/2>((T*)(ptr.get()+N::value/2)));
-      }
-      else
-      {
-        store(l, (T*)ptr);
-        store(h, (T*)(ptr+N::value/2));
-      }
-    }
-    else
-    {
-      store_(EVE_RETARGET(cpu_), value, ptr) ;
-    }
-  }
 }

--- a/test/unit/api/wide/load/arithmetic/load.hpp
+++ b/test/unit/api/wide/load/arithmetic/load.hpp
@@ -13,6 +13,9 @@
 #include <eve/memory/aligned_ptr.hpp>
 #include <eve/function/load.hpp>
 #include <eve/wide.hpp>
+
+#include <array>
+#include <numeric>
 #include <vector>
 #include <list>
 
@@ -292,4 +295,36 @@ TTS_CASE_TPL("Check load from range for wide", EVE_TYPE )
 
   T from_begin_end(ref_ptr.begin(), ref_ptr.end());
   TTS_EQUAL(from_begin_end, ref);
+}
+
+TTS_CASE_TPL("load for different alignment", EVE_TYPE )
+{
+  using e_t = EVE_VALUE;
+  std::array<e_t, 256> data;
+
+  std::iota(data.begin(), data.end(), 0);
+
+  for (const e_t* f =  data.begin();
+                  f != data.end() - EVE_CARDINAL + 1;
+                  ++f)
+  {
+    T expected(f);
+
+    auto test = [&]<std::ptrdiff_t A>(eve::fixed<A>) {
+      if (!eve::is_aligned<A>(f)) return;
+      if constexpr (A >= T::static_alignment)
+      {
+        eve::aligned_ptr<const e_t, static_cast<std::size_t>(A)> ptr{f};
+        T actual{ptr};
+        TTS_EQUAL(actual, expected);
+      }
+    };
+
+    test(eve::lane<128>);
+    test(eve::lane<64>);
+    test(eve::lane<32>);
+    test(eve::lane<16>);
+    test(eve::lane<8>);
+    test(eve::lane<4>);
+  }
 }

--- a/test/unit/api/wide/store/arithmetic/store.hpp
+++ b/test/unit/api/wide/store/arithmetic/store.hpp
@@ -13,6 +13,9 @@
 #include <eve/function/store.hpp>
 #include <eve/wide.hpp>
 
+#include <array>
+#include <numeric>
+
 TTS_CASE_TPL("Check store behavior to unaligned arithmetic pointer", EVE_TYPE)
 {
   std::array<EVE_VALUE, 3 * EVE_CARDINAL> ref;
@@ -55,4 +58,34 @@ TTS_CASE_TPL("Check store behavior to aligned arithmetic pointer", EVE_TYPE)
   eve::store(value, eve::as_aligned<algt>(&target[ 2 * EVE_CARDINAL ]) );
 
   TTS_ALL_EQUAL(target, ref);
+}
+
+TTS_CASE_TPL("store for different alignment", EVE_TYPE )
+{
+  using e_t = EVE_VALUE;
+  std::array<e_t, 256> data;
+
+  const T what{[](int i, int) { return i; }};
+
+  for (e_t* f =  data.begin();
+            f != data.end() - EVE_CARDINAL + 1;
+          ++f)
+  {
+    auto test = [&]<std::ptrdiff_t A>(eve::fixed<A>) {
+      if (!eve::is_aligned<A>(f)) return;
+      if constexpr (A >= T::static_alignment)
+      {
+        eve::aligned_ptr<e_t, static_cast<std::size_t>(A)> ptr{f};
+        eve::store(what, ptr);
+        TTS_EQUAL(T{f}, what);
+      }
+    };
+
+    test(eve::lane<128>);
+    test(eve::lane<64>);
+    test(eve::lane<32>);
+    test(eve::lane<16>);
+    test(eve::lane<8>);
+    test(eve::lane<4>);
+  }
 }

--- a/test/unit/api/wide/store/logical/store.hpp
+++ b/test/unit/api/wide/store/logical/store.hpp
@@ -56,3 +56,33 @@ TTS_CASE_TPL("Check store behavior to aligned logical pointer",EVE_TYPE)
 
   TTS_ALL_EQUAL(target, ref);
 }
+
+TTS_CASE_TPL("store for different alignment", EVE_TYPE )
+{
+  using e_t = eve::logical<EVE_VALUE>;
+  std::array<e_t, 256> data;
+
+  const eve::logical<T> what{[](int i, int) { return i % 2 == 0; }};
+
+  for (e_t* f =  data.begin();
+            f != data.end() - EVE_CARDINAL + 1;
+          ++f)
+  {
+    auto test = [&]<std::ptrdiff_t A>(eve::fixed<A>) {
+      if (!eve::is_aligned<A>(f)) return;
+      if constexpr (A >= T::static_alignment)
+      {
+        eve::aligned_ptr<e_t, static_cast<std::size_t>(A)> ptr{f};
+        eve::store(what, ptr);
+        TTS_EQUAL(eve::logical<T>{f}, what);
+      }
+    };
+
+    test(eve::lane<128>);
+    test(eve::lane<64>);
+    test(eve::lane<32>);
+    test(eve::lane<16>);
+    test(eve::lane<8>);
+    test(eve::lane<4>);
+  }
+}


### PR DESCRIPTION
I dunno if there is something similar I should do for load/store of logical. Or does it always forward to the wide?

Also not too sure about tests.