### PR TITLE
Use (current_api >= avx512) instead of confusing wide_logical

### DIFF
--- a/include/eve/detail/function/simd/x86/bitmask.hpp
+++ b/include/eve/detail/function/simd/x86/bitmask.hpp
@@ -31,7 +31,7 @@ namespace eve::detail
   template<typename T, typename N, x86_abi ABI>
   EVE_FORCEINLINE wide<T, N, ABI> to_mask(sse2_ const&, logical<wide<T, N, ABI>> const& p ) noexcept
   {
-    if constexpr( !ABI::is_wide_logical )
+    if constexpr( current_api >= avx512 )
     {
       auto z = wide<T, N, ABI>(0);
       auto a = allbits(as_<wide<T, N, ABI>>());

--- a/include/eve/detail/function/simd/x86/friends.hpp
+++ b/include/eve/detail/function/simd/x86/friends.hpp
@@ -61,7 +61,7 @@ namespace eve::detail
     constexpr auto c = categorize<wide<T, N, ABI>>();
     constexpr auto f = to_integer(cmp_flt::eq_oq);
 
-    if constexpr( !ABI::is_wide_logical )
+    if constexpr( current_api >= avx512 )
     {
             if constexpr( c == category::float32x16 ) return mask16{_mm512_cmp_ps_mask(v, w, f )};
       else  if constexpr( c == category::float32x8  ) return mask8 {_mm256_cmp_ps_mask(v, w, f )};
@@ -160,7 +160,7 @@ namespace eve::detail
     constexpr auto c = categorize<wide<T, N, ABI>>();
     constexpr auto f = to_integer(cmp_flt::neq_uq);
 
-    if constexpr( !ABI::is_wide_logical )
+    if constexpr( current_api >= avx512 )
     {
             if constexpr( c == category::float32x16 ) return mask16{_mm512_cmp_ps_mask   (v,w,f)};
       else  if constexpr( c == category::float32x8  ) return mask8 {_mm256_cmp_ps_mask   (v,w,f)};
@@ -220,7 +220,7 @@ namespace eve::detail
     if constexpr( !ABI::is_wide_logical )
     {
       using s_t = typename logical<wide<T,N,ABI>>::storage_type;
-      return logical<wide<T,N,ABI>>{ s_t(v.storage().value ^ w.storage().value) };
+      return logical<wide<T,N,ABI>>{ s_t({v.storage().value ^ w.storage().value}) };
     }
     else
     {
@@ -235,7 +235,7 @@ namespace eve::detail
     constexpr auto c = categorize<wide<T, N, ABI>>();
     constexpr auto f = to_integer(cmp_flt::lt_oq);
 
-    if constexpr( !ABI::is_wide_logical )
+    if constexpr( current_api >= avx512 )
     {
             if constexpr( c == category::float32x16 ) return mask16{_mm512_cmp_ps_mask(v, w, f) };
       else  if constexpr( c == category::float32x8  ) return mask8 {_mm256_cmp_ps_mask(v, w, f) };
@@ -325,7 +325,7 @@ namespace eve::detail
     constexpr auto c = categorize<wide<T, N, ABI>>();
     constexpr auto f = to_integer(cmp_flt::gt_oq);
 
-    if constexpr( !ABI::is_wide_logical )
+    if constexpr( current_api >= avx512 )
     {
             if constexpr( c == category::float32x16 ) return mask16{_mm512_cmp_ps_mask(v, w, f) };
       else  if constexpr( c == category::float32x8  ) return mask8 {_mm256_cmp_ps_mask(v, w, f) };
@@ -418,7 +418,7 @@ namespace eve::detail
     constexpr auto c = categorize<wide<T, N, ABI>>();
     constexpr auto f = to_integer(cmp_flt::ge_oq);
 
-    if constexpr( !ABI::is_wide_logical )
+    if constexpr( current_api >= avx512 )
     {
             if constexpr( c == category::float32x16 ) return mask16{_mm512_cmp_ps_mask(v, w, f) };
       else  if constexpr( c == category::float32x8  ) return mask8 {_mm256_cmp_ps_mask(v, w, f) };
@@ -479,7 +479,7 @@ namespace eve::detail
     constexpr auto c = categorize<wide<T, N, ABI>>();
     constexpr auto f = to_integer(cmp_flt::le_oq);
 
-    if constexpr( !ABI::is_wide_logical )
+    if constexpr( current_api >= avx512 )
     {
             if constexpr( c == category::float32x16 ) return mask16{_mm512_cmp_ps_mask(v, w, f) };
       else  if constexpr( c == category::float32x8  ) return mask8 {_mm256_cmp_ps_mask(v, w, f) };

--- a/include/eve/detail/function/simd/x86/to_logical.hpp
+++ b/include/eve/detail/function/simd/x86/to_logical.hpp
@@ -28,7 +28,7 @@ namespace eve::detail
     constexpr auto c = categorize<wide<T, N, ABI>>();
     [[maybe_unused]] wide<T,N,ABI> const z{0};
 
-    if constexpr( !ABI::is_wide_logical )
+    if constexpr( current_api >= avx512 )
     {
       constexpr auto m = fpclass::poszero | fpclass::negzero;
 

--- a/include/eve/module/real/core/function/regular/simd/x86/load.hpp
+++ b/include/eve/module/real/core/function/regular/simd/x86/load.hpp
@@ -33,7 +33,6 @@ namespace eve::detail
   {
     using b_t   = std::remove_cvref_t<decltype(*p)>;
     using r_t   = as_wide_t<b_t, typename Cardinal::type>;
-    using abi_t = typename r_t::abi_type;
 
     if constexpr( is_logical_v<b_t> )
     {
@@ -54,7 +53,7 @@ namespace eve::detail
       if constexpr( current_api >= avx512 ) return to_logical(block).storage();
       else                                  return bit_cast(block, as_<r_t>{});
     }
-    else if constexpr( !abi_t::is_wide_logical )
+    else if constexpr( current_api >= avx512 )
     {
       if constexpr( C::is_complete )
       {


### PR DESCRIPTION
Testing for AVX512 code path use current_api instead of relying on the related but orthogonal check on logical storage.