### PR TITLE
Fix #501: Top bits everywhere: tests + emulated and arm-v7 implementations

### DIFF
--- a/include/eve/detail/function/movemask.hpp
+++ b/include/eve/detail/function/movemask.hpp
@@ -1,0 +1,18 @@
+//==================================================================================================
+/**
+  EVE - Expressive Vector Engine
+  Copyright 2021 Joel FALCOU
+  Copyright 2021 Jean-Thierry LAPRESTE
+  Copyright 2021 Dens YAROSHEVKIY
+
+  Licensed under the MIT License <http://opensource.org/licenses/MIT>.
+  SPDX-License-Identifier: MIT
+**/
+//==================================================================================================
+#pragma once
+
+#include <eve/arch.hpp>
+
+#if defined(EVE_HW_X86)
+#  include <eve/detail/function/simd/x86/movemask.hpp>
+#endif

--- a/include/eve/detail/function/movemask.hpp
+++ b/include/eve/detail/function/movemask.hpp
@@ -18,3 +18,7 @@
 #if defined(EVE_HW_X86)
 #  include <eve/detail/function/simd/x86/movemask.hpp>
 #endif
+
+#if defined(EVE_HW_ARM)
+#  include <eve/detail/function/simd/arm/neon/movemask.hpp>
+#endif

--- a/include/eve/detail/function/movemask.hpp
+++ b/include/eve/detail/function/movemask.hpp
@@ -13,6 +13,8 @@
 
 #include <eve/arch.hpp>
 
+#include <eve/detail/function/simd/common/movemask.hpp>
+
 #if defined(EVE_HW_X86)
 #  include <eve/detail/function/simd/x86/movemask.hpp>
 #endif

--- a/include/eve/detail/function/simd/arm/neon/movemask.hpp
+++ b/include/eve/detail/function/simd/arm/neon/movemask.hpp
@@ -1,0 +1,116 @@
+//==================================================================================================
+/**
+  EVE - Expressive Vector Engine
+  Copyright 2021 Joel FALCOU
+  Copyright 2021 Jean-Thierry LAPRESTE
+  Copyright 2021 Dens YAROSHEVKIY
+
+  Licensed under the MIT License <http://opensource.org/licenses/MIT>.
+  SPDX-License-Identifier: MIT
+**/
+//==================================================================================================
+#pragma once
+
+#include <eve/arch/logical.hpp>
+#include <eve/detail/meta.hpp>
+#include <eve/function/convert.hpp>
+
+#include <bit>
+
+namespace eve::detail
+{
+  template<typename T>
+  EVE_FORCEINLINE std::uint32_t every_2nd_byte_arm64(T const& v) noexcept
+  {
+    using u8_8  = wide<std::uint8_t,  eve::fixed<8>, arm_64_>;
+    using u32_2 = wide<std::uint32_t, eve::fixed<2>, arm_64_>;
+
+    auto bytes    = eve::bit_cast(v, eve::as_<u8_8>{});
+    auto selected = vtbl1_u8(bytes, u8_8(0, 2, 4, 6, 0, 0, 0, 0));
+    auto dwords   = eve::bit_cast(selected, eve::as_<u32_2>{});
+
+    return vget_lane_u32(dwords, 0);
+  }
+
+  template<typename T>
+  EVE_FORCEINLINE std::uint32_t every_4th_byte_arm128(T const& v) noexcept
+  {
+    using u8_8  = wide<std::uint8_t,  eve::fixed<8>, arm_64_>;
+    using u8_16 = wide<std::uint8_t,  eve::fixed<16>, arm_128_>;
+    using u32_2 = wide<std::uint32_t, eve::fixed<2>, arm_64_>;
+
+    auto bytes = eve::bit_cast(v, eve::as_<u8_16>{});
+
+    uint8x8x2_t table = {{ vget_low_u8(bytes), vget_high_u8(bytes) }};
+    u8_8     selected = vtbl2_u8(table, u8_8(0, 4, 8, 12, 0, 0, 0, 0));
+    auto     dwords   = eve::bit_cast(selected, eve::as_<u32_2>{});
+
+    return vget_lane_u32(dwords, 0);
+  }
+
+  template<real_scalar_value T, typename N>
+  EVE_FORCEINLINE auto movemask (logical<wide<T, N, arm_64_>> const &v) noexcept
+  {
+    using u16_4 = wide<std::uint16_t, eve::fixed<2>, arm_64_>;
+    using u32_2 = wide<std::uint32_t, eve::fixed<2>, arm_64_>;
+
+         if constexpr ( N() == 1 ) return std::pair{ (std::uint8_t) v.bits().get(0), eve::lane<8> };
+    else if constexpr ( sizeof(T) == 1 && N() == 2 )
+    {
+      auto words = eve::bit_cast(v, eve::as_<u16_4>{});
+      return std::pair{ vget_lane_u16(words, 0), eve::lane<8> };
+    }
+    else if constexpr ( sizeof(T) * N() == 4)
+    {
+      auto dwords = eve::bit_cast(v, eve::as_<u32_2>{});
+      return std::pair{ vget_lane_u32(dwords, 0), eve::lane<sizeof(T) * 8> };
+    }
+    else if constexpr ( sizeof(T) >= 2 )
+    {
+      return std::pair{ every_2nd_byte_arm64(v), eve::lane<sizeof(T) * 4> };
+    }
+    else   // chars
+    {
+      auto words = eve::bit_cast(v, eve::as_<u16_4>{});
+      words = vshr_n_u16(words, 4);
+
+      return std::pair{ every_2nd_byte_arm64(words), eve::lane<sizeof(T) * 4> };
+    }
+  }
+
+  template<real_scalar_value T, typename N>
+  EVE_FORCEINLINE auto movemask (logical<wide<T, N, arm_128_>> const &v) noexcept
+  {
+    using u8_8  = wide<std::uint8_t,  eve::fixed<8>,  arm_64_>;
+    using u16_8 = wide<std::uint16_t, eve::fixed<8>,  arm_128_>;
+    using u32_4 = wide<std::uint32_t, eve::fixed<4>,  arm_128_>;
+    using u64_1 = wide<std::uint64_t, eve::fixed<1>,  arm_64_>;
+
+    if constexpr ( sizeof(T) >= 4 )
+    {
+      return std::pair{ every_4th_byte_arm128(v), eve::lane<sizeof(T) * 2> };
+    }
+    else if constexpr ( sizeof(T) == 2 )
+    {
+      // pack 2 shorts into byte
+      auto dwords = eve::bit_cast(v, eve::as_<u32_4>{});
+      dwords = vshrq_n_u32(dwords, 12);
+
+      return std::pair{ every_4th_byte_arm128(dwords), eve::lane<sizeof(T) * 2> };
+    }
+    else  // bytes
+    {
+      // Couldn't figure out anything nice.
+      // We will have to suck up the 64 bit emulation on arm-v7, which is not ideal.
+
+      auto words_16 = eve::bit_cast(v, eve::as_<u16_8>{});
+      words_16 = vshrq_n_u16(words_16, 4);
+
+      // drop top byte
+      u8_8  bytes_8  = vmovn_u16(words_16);
+      u64_1 as_u64_1 = eve::bit_cast(bytes_8, eve::as_<u64_1>{});
+
+      return std::pair{ vget_lane_u64(as_u64_1, 0), eve::lane<4> };
+    }
+  }
+}

--- a/include/eve/detail/function/simd/arm/neon/movemask.hpp
+++ b/include/eve/detail/function/simd/arm/neon/movemask.hpp
@@ -19,11 +19,11 @@
 
 namespace eve::detail
 {
-  template<typename T>
+  template <typename T>
   EVE_FORCEINLINE std::uint32_t every_2nd_byte_arm64(T const& v) noexcept
   {
-    using u8_8  = wide<std::uint8_t,  eve::fixed<8>, arm_64_>;
-    using u32_2 = wide<std::uint32_t, eve::fixed<2>, arm_64_>;
+    using u8_8  = typename T::template rebind<std::uint8_t,  eve::fixed<8>>;
+    using u32_2 = typename T::template rebind<std::uint32_t, eve::fixed<2>>;
 
     auto bytes    = eve::bit_cast(v, eve::as_<u8_8>{});
     auto selected = vtbl1_u8(bytes, u8_8(0, 2, 4, 6, 0, 0, 0, 0));
@@ -35,9 +35,9 @@ namespace eve::detail
   template<typename T>
   EVE_FORCEINLINE std::uint32_t every_4th_byte_arm128(T const& v) noexcept
   {
-    using u8_8  = wide<std::uint8_t,  eve::fixed<8>, arm_64_>;
-    using u8_16 = wide<std::uint8_t,  eve::fixed<16>, arm_128_>;
-    using u32_2 = wide<std::uint32_t, eve::fixed<2>, arm_64_>;
+    using u8_8  = typename T::template rebind<std::uint8_t,  eve::fixed<8>>;
+    using u8_16 = typename T::template rebind<std::uint8_t,  eve::fixed<16>>;
+    using u32_2 = typename T::template rebind<std::uint32_t, eve::fixed<2>>;
 
     auto bytes = eve::bit_cast(v, eve::as_<u8_16>{});
 
@@ -51,8 +51,9 @@ namespace eve::detail
   template<real_scalar_value T, typename N>
   EVE_FORCEINLINE auto movemask (logical<wide<T, N, arm_64_>> const &v) noexcept
   {
-    using u16_4 = wide<std::uint16_t, eve::fixed<2>, arm_64_>;
-    using u32_2 = wide<std::uint32_t, eve::fixed<2>, arm_64_>;
+    using w_t = wide<T, N, arm_64_>;
+    using u16_4 = typename w_t::template rebind<std::uint16_t, eve::fixed<4>>;
+    using u32_2 = typename w_t::template rebind<std::uint32_t, eve::fixed<2>>;
 
          if constexpr ( N() == 1 ) return std::pair{ (std::uint8_t) v.bits().get(0), eve::lane<8> };
     else if constexpr ( sizeof(T) == 1 && N() == 2 )
@@ -67,7 +68,7 @@ namespace eve::detail
     }
     else if constexpr ( sizeof(T) >= 2 )
     {
-      return std::pair{ every_2nd_byte_arm64(v), eve::lane<sizeof(T) * 4> };
+      return std::pair{ every_2nd_byte_arm64(v.bits()), eve::lane<sizeof(T) * 4> };
     }
     else   // chars
     {
@@ -81,14 +82,15 @@ namespace eve::detail
   template<real_scalar_value T, typename N>
   EVE_FORCEINLINE auto movemask (logical<wide<T, N, arm_128_>> const &v) noexcept
   {
-    using u8_8  = wide<std::uint8_t,  eve::fixed<8>,  arm_64_>;
-    using u16_8 = wide<std::uint16_t, eve::fixed<8>,  arm_128_>;
-    using u32_4 = wide<std::uint32_t, eve::fixed<4>,  arm_128_>;
-    using u64_1 = wide<std::uint64_t, eve::fixed<1>,  arm_64_>;
+    using w_t = wide<T, N, arm_128_>;
+    using u8_8  = typename w_t::template rebind <std::uint8_t,  eve::fixed<8>>;
+    using u16_8 = typename w_t::template rebind <std::uint16_t, eve::fixed<8>>;
+    using u32_4 = typename w_t::template rebind <std::uint32_t, eve::fixed<4>>;
+    using u64_1 = typename w_t::template rebind <std::uint64_t, eve::fixed<1>>;
 
     if constexpr ( sizeof(T) >= 4 )
     {
-      return std::pair{ every_4th_byte_arm128(v), eve::lane<sizeof(T) * 2> };
+      return std::pair{ every_4th_byte_arm128(v.bits()), eve::lane<sizeof(T) * 2> };
     }
     else if constexpr ( sizeof(T) == 2 )
     {

--- a/include/eve/detail/function/simd/common/movemask.hpp
+++ b/include/eve/detail/function/simd/common/movemask.hpp
@@ -25,7 +25,10 @@ namespace eve::detail
   EVE_FORCEINLINE auto movemask( eve::logical<eve::wide<T, N, ABI>> const& v ) noexcept
   {
     std::uint64_t res = 0;
-    for (std::uint64_t i = 0; i != (std::uint64_t)N(); ++i) res |= v.get(i) << i;
+    for (std::uint64_t i = 0; i != (std::uint64_t)N(); ++i) {
+      std::uint64_t elem = v.get(i) ? 1 : 0;
+      res |= elem << i;
+    }
     if constexpr (N() < 32) return std::pair{(std::uint32_t) res, eve::lane<1>};
     else                    return std::pair{res, eve::lane<1>};
   }

--- a/include/eve/detail/function/simd/common/movemask.hpp
+++ b/include/eve/detail/function/simd/common/movemask.hpp
@@ -1,0 +1,33 @@
+//==================================================================================================
+/**
+  EVE - Expressive Vector Engine
+  Copyright 2020 Joel FALCOU
+  Copyright 2020 Jean-Thierry LAPRESTE
+  Copyright 2020 Denis YAROSHEVSKIY
+
+  Licensed under the MIT License <http://opensource.org/licenses/MIT>.
+  SPDX-License-Identifier: MIT
+**/
+//==================================================================================================
+
+#pragma once
+
+#include <eve/arch/logical.hpp>
+
+#include <utility>
+
+namespace eve::detail
+{
+  // There is no usecase for aggregated - use top bits.
+  // For emulated, N <= 64 is enforced in top bits.
+
+  template<typename T, typename N, typename ABI>
+  EVE_FORCEINLINE auto movemask( eve::logical<eve::wide<T, N, ABI>> const& v ) noexcept
+  {
+    std::uint64_t res = 0;
+    for (std::uint64_t i = 0; i != (std::uint64_t)N(); ++i) res |= v.get(i) << i;
+    if constexpr (N() < 32) return std::pair{(std::uint32_t) res, eve::lane<1>};
+    else                    return std::pair{res, eve::lane<1>};
+  }
+
+}

--- a/include/eve/detail/function/simd/x86/movemask.hpp
+++ b/include/eve/detail/function/simd/x86/movemask.hpp
@@ -58,4 +58,4 @@ namespace eve::detail
     return std::pair{raw,  eve::lane<sizeof(T) == 2 ? 2: 1>};
   }
 
-}  // namespace eve::detail
+}

--- a/include/eve/detail/function/simd/x86/movemask.hpp
+++ b/include/eve/detail/function/simd/x86/movemask.hpp
@@ -1,0 +1,61 @@
+//==================================================================================================
+/**
+  EVE - Expressive Vector Engine
+  Copyright 2020 Joel FALCOU
+  Copyright 2020 Jean-Thierry LAPRESTE
+
+  Licensed under the MIT License <http://opensource.org/licenses/MIT>.
+  SPDX-License-Identifier: MIT
+**/
+//==================================================================================================
+#pragma once
+
+#include <eve/arch/logical.hpp>
+
+namespace eve::detail
+{
+  template<typename T, typename N, x86_abi ABI>
+  EVE_FORCEINLINE auto movemask( eve::logical<eve::wide<T, N, ABI>> const& v ) noexcept
+    requires ( !ABI::is_wide_logical )
+  {
+    return std::pair{v, eve::lane<1>};
+  }
+
+  template<typename T, typename N, x86_abi ABI>
+  EVE_FORCEINLINE auto movemask( eve::logical<eve::wide<T, N, ABI>> const& v ) noexcept
+    requires ( ABI::is_wide_logical )
+  {
+    auto raw = [&] {
+      if constexpr( std::same_as<ABI, x86_128_> )
+      {
+             if constexpr( std::is_same_v<T, float > ) return (std::uint16_t)_mm_movemask_ps(v);
+        else if constexpr( std::is_same_v<T, double> ) return (std::uint16_t)_mm_movemask_pd(v);
+        else if constexpr( sizeof(T) == 8 )            return (std::uint16_t)_mm_movemask_pd((__m128d)v);
+        else if constexpr( sizeof(T) == 4 )            return (std::uint16_t)_mm_movemask_ps((__m128)v);
+        else                                           return (std::uint16_t)_mm_movemask_epi8(v);
+      }
+      else
+      {
+        if constexpr( std::is_same_v<T, float > )  return (std::uint32_t)_mm256_movemask_ps(v);
+        else if constexpr( std::is_same_v<T, double> ) return (std::uint32_t)_mm256_movemask_pd(v);
+        else if constexpr( sizeof(T) == 8 )            return (std::uint32_t)_mm256_movemask_pd((__m256d)v);
+        else if constexpr( sizeof(T) == 4 )            return (std::uint32_t)_mm256_movemask_ps((__m256)v);
+        else if constexpr( current_api == avx2 )       return (std::uint32_t)_mm256_movemask_epi8(v);
+        else if constexpr( current_api == avx )
+        {
+          auto [l, h] = v.slice();
+          auto s = h.size();
+          if constexpr(sizeof(T) == 2) s *= 2;
+
+          auto top = (std::uint32_t)movemask(h).first;
+          auto bottom = movemask(l).first;
+
+          return (top << s) | bottom;
+        }
+      }
+    }();
+
+    return std::pair{raw,  eve::lane<sizeof(T) == 2 ? 2: 1>};
+  }
+
+}  // namespace eve::detail

--- a/include/eve/detail/function/simd/x86/movemask.hpp
+++ b/include/eve/detail/function/simd/x86/movemask.hpp
@@ -21,7 +21,7 @@ namespace eve::detail
   EVE_FORCEINLINE auto movemask( eve::logical<eve::wide<T, N, ABI>> const &v ) noexcept
     requires ( !ABI::is_wide_logical )
   {
-    return std::pair{v, eve::lane<1>};
+    return std::pair{v.storage(), eve::lane<1>};
   }
 
   template<typename T, typename N, x86_abi ABI>

--- a/include/eve/detail/function/simd/x86/movemask.hpp
+++ b/include/eve/detail/function/simd/x86/movemask.hpp
@@ -1,8 +1,9 @@
 //==================================================================================================
 /**
   EVE - Expressive Vector Engine
-  Copyright 2020 Joel FALCOU
-  Copyright 2020 Jean-Thierry LAPRESTE
+  Copyright 2021 Joel FALCOU
+  Copyright 2021 Jean-Thierry LAPRESTE
+  Copyright 2021 Denis YAROSHEVKIY
 
   Licensed under the MIT License <http://opensource.org/licenses/MIT>.
   SPDX-License-Identifier: MIT
@@ -12,17 +13,19 @@
 
 #include <eve/arch/logical.hpp>
 
+#include <utility>
+
 namespace eve::detail
 {
-  template<typename T, typename N, x86_abi ABI>
-  EVE_FORCEINLINE auto movemask( eve::logical<eve::wide<T, N, ABI>> const& v ) noexcept
+  template<real_scalar_value T, typename N, x86_abi ABI>
+  EVE_FORCEINLINE auto movemask( eve::logical<eve::wide<T, N, ABI>> const &v ) noexcept
     requires ( !ABI::is_wide_logical )
   {
     return std::pair{v, eve::lane<1>};
   }
 
   template<typename T, typename N, x86_abi ABI>
-  EVE_FORCEINLINE auto movemask( eve::logical<eve::wide<T, N, ABI>> const& v ) noexcept
+  EVE_FORCEINLINE auto movemask( eve::logical<eve::wide<T, N, ABI>> const &v ) noexcept
     requires ( ABI::is_wide_logical )
   {
     auto raw = [&] {

--- a/include/eve/detail/top_bits.hpp
+++ b/include/eve/detail/top_bits.hpp
@@ -322,6 +322,14 @@ EVE_FORCEINLINE Logical to_logical(top_bits<Logical> mmask)
 {
        if constexpr ( top_bits<Logical>::is_aggregated )         return Logical{to_logical(mmask.storage[0]), to_logical(mmask.storage[1])};
   else if constexpr ( top_bits<Logical>::is_avx512_logical )     return Logical(mmask.storage);
+  else if constexpr ( has_emulated_abi_v<Logical> )
+  {
+    Logical res;
+    for (std::ptrdiff_t i = 0; i != Logical::static_size; ++i) {
+      res.set(i, mmask.get(i));
+    }
+    return res;
+  }
   else
   {
     // Idea is: put a corresponding part of mmask in each element

--- a/test/unit/internals/top_bits/top_bits/top_bits.hpp
+++ b/test/unit/internals/top_bits/top_bits/top_bits.hpp
@@ -14,10 +14,13 @@
 #include <eve/detail/top_bits.hpp>
 #include <eve/function/is_nez.hpp>
 
+#include <eve/function/all.hpp>
+
 #include <array>
+#include <exception>
 
 # if defined(EVE_NO_SIMD)
-#   define   TOP_BITS_EVE_TYPE eve::wide<std::uint8_t, eve::fixed<128>>
+#   define   TOP_BITS_EVE_TYPE EVE_TYPE,eve::wide<std::uint8_t, eve::fixed<128>>
 # else
 #   define TOP_BITS_EVE_TYPE EVE_TYPE
 # endif
@@ -60,19 +63,12 @@ TTS_CASE_TPL("Check top bits from logical", TOP_BITS_EVE_TYPE)
 
     for (std::ptrdiff_t j = 0; j != test.static_size; ++j)
     {
-      if (test.get(j) != mmask.get(j))
-      {
-        std::cout << "i: " << i << std::endl;
-        std::cout << "mmask: " << std::hex << mmask << std::endl;
-      }
       TTS_EQUAL(test.get(j), mmask.get(j));
     }
 
     test.set(i, false);
   }
 }
-
-#if 0
 
 TTS_CASE_TPL("top_bits, set", TOP_BITS_EVE_TYPE)
 {
@@ -104,14 +100,14 @@ TTS_CASE_TPL("Top bits are little endian", TOP_BITS_EVE_TYPE)
   logical test(false);
   test.set(0, true);
 
-  if constexpr( eve::has_native_abi_v<logical> )
+  if constexpr( top_bits<logical>::is_aggregated )
   {
-    top_bits test_top(test);
-    TTS_EXPECT((test_top.storage & 1u));
+    TTS_PASS("no test for aggregated");
   }
   else
   {
-    TTS_PASS("no test for aggregated");
+    top_bits test_top(test);
+    TTS_EXPECT((test_top.storage & 1u));
   }
 }
 
@@ -145,7 +141,7 @@ TTS_CASE_TPL("bit operations", TOP_BITS_EVE_TYPE)
 
   TTS_EQUAL(top_bits<logical>{eve::ignore_none}, ~top_bits<logical>{eve::ignore_all});
 
-  if constexpr( eve::has_native_abi_v<logical> )
+  if constexpr( !top_bits<logical>::is_aggregated )
   {
     TTS_EQUAL(0u, (~top_bits<logical>{logical{true}}).storage);
   }
@@ -319,5 +315,3 @@ TTS_CASE_TPL("top_bits count_true", TOP_BITS_EVE_TYPE)
     TTS_EQUAL(expected, eve::detail::count_true(mmask));
   });
 }
-
-#endif

--- a/test/unit/internals/top_bits/top_bits/top_bits.hpp
+++ b/test/unit/internals/top_bits/top_bits/top_bits.hpp
@@ -306,3 +306,15 @@ TTS_CASE_TPL("top_bits count_true", EVE_TYPE)
     TTS_EQUAL(expected, eve::detail::count_true(mmask));
   });
 }
+
+TTS_CASE("many chars")
+{
+  // emulated doesn't aggregate even for a big number of elements
+  // but top bits has to.
+  using T = eve::wide<char, eve::fixed<128>>;
+
+  eve::logical<T> x {[] (int i, int) { return i % 2 == 0; }};
+
+  top_bits mmask{x};
+  TTS_EQUAL(x, eve::detail::to_logical(mmask));
+}


### PR DESCRIPTION
Implementation of top_bits for emulated/arm-v7.

On emulated the tricky part is for when I don't fit into the 64 bits of a max number.
I just work with it as emulated.

For arm64 I think this is pretty good. Though chars have a shift, ah well, we need to measure.

For 128 it's roughly the same as for 64 except for chars.

I've tried a ton of different things, but I don't see it - so I left the 64 bit integer - let the compiler deal with the emulation.

The simd everywhere fellows have a movemask implementation for chars
https://github.com/simd-everywhere/simde/blob/12069d720f43830ae9791e8b0f4c4fa3c88012a0/simde/x86/sse2.h#L3607
Maybe that's the way to go - I dunno at the moment.
I guess will see what I write for first true, I only did 64 bits.

