### PR TITLE
Fix #463 - Update to use new SPY detection of neon/asimd discrimination

### DIFF
--- a/include/eve/arch/abi_of.hpp
+++ b/include/eve/arch/abi_of.hpp
@@ -47,7 +47,7 @@ namespace eve
         }
         else if constexpr( spy::simd_instruction_set == spy::arm_simd_ )
         {
-          if constexpr( spy::supports::aarch64_ )
+          if constexpr( spy::simd_instruction_set == spy::asimd_ )
           {
             if constexpr(width <= 8)       return arm_64_{};
             else if constexpr(width == 16) return arm_128_{};

--- a/include/eve/arch/arm/as_register.hpp
+++ b/include/eve/arch/arm/as_register.hpp
@@ -18,7 +18,6 @@ namespace eve
 {
   template<typename T>
   struct logical;
-  struct neon64_;
   struct neon128_;
 }
 
@@ -37,8 +36,11 @@ namespace eve
       }
       else if constexpr( std::is_same_v<T,double> && Size::value <= 1 )
       {
-        if constexpr(spy::supports::aarch64_) return float64x1_t{};
-        else                                  return emulated_{};
+        #if defined(SPY_SIMD_IS_ARM_ASIMD)
+        return float64x1_t{};
+        #else
+        return emulated_{};
+        #endif
       }
       else if constexpr( std::is_integral_v<T> )
       {
@@ -72,8 +74,11 @@ namespace eve
       }
       else if constexpr( std::is_same_v<T,double> )
       {
-        if constexpr(spy::supports::aarch64_) return float64x2_t{};
-        else                                  return emulated_{};
+        #if defined(SPY_SIMD_IS_ARM_ASIMD)
+        return float64x2_t{};
+        #else
+        return emulated_{};
+        #endif
       }
       else if constexpr( std::is_integral_v<T> )
       {

--- a/include/eve/arch/arm/detection.hpp
+++ b/include/eve/arch/arm/detection.hpp
@@ -34,9 +34,9 @@ namespace eve
     #endif
   }
 
-  inline bool is_supported(aarch64_ const &) noexcept
+  inline bool is_supported(spy::arm_simd_info<spy::detail::simd_version::asimd_ > const &) noexcept
   {
-    #if defined( SPY_SIMD_IS_ARM )
+    #if defined( SPY_SIMD_IS_ARM_ASIMD )
     auto hwcaps = getauxval(AT_HWCAP);
     return (hwcaps & HWCAP_ASIMD) != 0;
     #else

--- a/include/eve/arch/arm/spec.hpp
+++ b/include/eve/arch/arm/spec.hpp
@@ -30,6 +30,10 @@ namespace eve
 // NEON SIMD ABI
 # if !defined(EVE_CURRENT_API) && defined(SPY_SIMD_IS_ARM)
 #  include <arm_neon.h>
+#  if !defined(EVE_CURRENT_ABI) && defined(SPY_SIMD_IS_ARM_ASIMD)
+#   define EVE_CURRENT_ABI ::eve::arm_128_
+#   define EVE_CURRENT_API ::eve::asimd_
+#  endif
 #  if !defined(EVE_CURRENT_ABI) && defined(SPY_SIMD_IS_ARM_NEON)
 #   define EVE_CURRENT_ABI ::eve::arm_128_
 #   define EVE_CURRENT_API ::eve::neon128_
@@ -43,4 +47,3 @@ namespace eve
 # endif
 
 #endif
-

--- a/include/eve/arch/arm/tags.hpp
+++ b/include/eve/arch/arm/tags.hpp
@@ -14,13 +14,6 @@
 #include <eve/arch/cpu/tags.hpp>
 #include <eve/detail/meta.hpp>
 
-#if defined( SPY_SIMD_IS_ARM )
-  #if defined( SPY_OS_IS_LINUX )
-    #include <asm/hwcap.h>
-    #include <sys/auxv.h>
-  #endif
-#endif
-
 namespace eve
 {
   // clang-format off
@@ -43,16 +36,14 @@ namespace eve
   //================================================================================================
   // Dispatching tag for ARM SIMD implementation
   //================================================================================================
-  struct neon64_  : simd_ {};
-  struct neon128_ : simd_ {};
+  struct neon128_ : simd_     {};
+  struct asimd_   : neon128_  {};
 
   //================================================================================================
   // NEON extension tag objects
   //================================================================================================
-  inline constexpr auto neon = spy::neon_;
-
-  struct aarch64_   {};
-  inline constexpr auto aarch64 = aarch64_{};
+  inline constexpr auto neon  = spy::neon_;
+  inline constexpr auto asimd = spy::asimd_;
 
   //================================================================================================
   // ARM ABI concept

--- a/include/eve/arch/cpu/logical_wide.hpp
+++ b/include/eve/arch/cpu/logical_wide.hpp
@@ -68,7 +68,7 @@ namespace eve
 #if !defined(__aarch64__)
       : storage_base( [&]()
                       { constexpr auto  c =   Size::value == 1 && sizeof(Type) == 8
-                                          &&  std::is_same_v<ABI, neon64_>;
+                                          &&  std::is_same_v<ABI, arm_64_>;
                         if constexpr(c) return value_type(r); else  return r;
                       }()
                     )

--- a/include/eve/arch/cpu/spec.hpp
+++ b/include/eve/arch/cpu/spec.hpp
@@ -25,7 +25,6 @@ namespace eve
   inline constexpr bool supports_fma3               = spy::supports::fma_;
   inline constexpr bool supports_fma4               = spy::supports::fma4_;
   inline constexpr bool supports_xop                = spy::supports::xop_;
-  inline constexpr bool supports_aarch64            = spy::supports::aarch64_;
   inline constexpr bool supports_avx512bw           = spy::supports::avx512::bw_;
   inline constexpr bool supports_avx512cd           = spy::supports::avx512::cd_;
   inline constexpr bool supports_avx512dq           = spy::supports::avx512::dq_;

--- a/include/eve/detail/function/simd/arm/neon/combine.hpp
+++ b/include/eve/detail/function/simd/arm/neon/combine.hpp
@@ -34,12 +34,10 @@ namespace eve::detail
       {
         return vcombine_f32(l, h);
       }
-#if defined(__aarch64__)
-      else if constexpr( std::is_same_v<T, double> )
+      else if constexpr( current_api >= asimd && std::is_same_v<T, double> )
       {
         return vcombine_f64(l, h);
       }
-#endif
       else if constexpr( std::signed_integral<T> )
       {
         if constexpr( sizeof(T) == 8 )

--- a/include/eve/detail/spy.hpp
+++ b/include/eve/detail/spy.hpp
@@ -1,12 +1,13 @@
 //==================================================================================================
 /*
   SPY - C++ Informations Broker
-  Copyright 2020 Joel FALCOU
+  Copyright 2020-2021 Joel FALCOU
   Licensed under the MIT License <http://opensource.org/licenses/MIT>.
   SPDX-License-Identifier: MIT
  */
 //==================================================================================================
-#pragma once
+#ifndef SPY_SPY_HPP_INCLUDED
+#define SPY_SPY_HPP_INCLUDED
 #include <ostream>
 namespace spy::detail
 {
@@ -74,7 +75,7 @@ namespace spy
   constexpr inline auto ppc_    = detail::arch_info<detail::archs::ppc_>{};
   constexpr inline auto arm_    = detail::arch_info<detail::archs::arm_>{};
 }
-#include <ostream>
+#include <iosfwd>
 #include <ostream>
 namespace spy::detail
 {
@@ -278,7 +279,7 @@ namespace spy::literal
     return detail::literal_wrap<detail::gcc_t,c...>();
   }
 }
-#include <ostream>
+#include <iosfwd>
 namespace spy::detail
 {
   template<int Short, int Integer, int Long, int Pointer>
@@ -328,7 +329,7 @@ namespace spy
   constexpr inline auto lp64_   = detail::data_model_info<2,4,8,8>{};
 }
 #include <cstddef>
-#include <ostream>
+#include <iosfwd>
 namespace spy::detail
 {
   enum class libC  { undefined_  = - 1, cloudabi_, uc_, vms_, zos_, gnu_ };
@@ -431,7 +432,7 @@ namespace spy::literal
   }
 }
 #include <cstddef>
-#include <ostream>
+#include <iosfwd>
 namespace spy::detail
 {
   enum class stdlib { undefined_  = - 1, libcpp_, gnucpp_ };
@@ -706,7 +707,11 @@ namespace avx512
 #endif
 }
 }
-#if !defined(SPY_SIMD_DETECTED) && (defined(__ARM_NEON__) || defined(_M_ARM) || defined(__aarch64__))
+#if !defined(SPY_SIMD_DETECTED) && defined(__aarch64__)
+#  define SPY_SIMD_IS_ARM_ASIMD
+#  define SPY_SIMD_DETECTED ::spy::detail::simd_version::asimd_
+#endif
+#if !defined(SPY_SIMD_DETECTED) && ((defined(__ARM_NEON__) || defined(_M_ARM)) && (__ARM_ARCH == 7))
 #  define SPY_SIMD_IS_ARM_NEON
 #  define SPY_SIMD_DETECTED ::spy::detail::simd_version::neon_
 #endif
@@ -714,15 +719,6 @@ namespace avx512
 #  define SPY_SIMD_IS_ARM
 #  define SPY_SIMD_VENDOR ::spy::detail::simd_isa::arm_
 #endif
-namespace spy::supports
-{
-#if defined(__aarch64__)
-#  define SPY_SIMD_SUPPORTS_AARCH64
-  constexpr inline auto aarch64_ = true;
-#else
-  constexpr inline auto aarch64_ = false;
-#endif
-}
 #if !defined(SPY_SIMD_DETECTED) && defined(__VSX__)
 #  define SPY_SIMD_IS_PPC_VSX
 #  define SPY_SIMD_DETECTED ::spy::detail::simd_version::vsx_
@@ -743,7 +739,7 @@ namespace spy::detail
                           , sse41_  = 1141, sse42_ = 1142, avx_  = 1201, avx2_  = 1202
                           , avx512_ = 1300
                           , vmx_    = 2001, vsx_   = 2002
-                          , neon_   = 3001
+                          , neon_   = 3001, asimd_ = 3002
                           };
   template<simd_isa InsSetArch = simd_isa::undefined_, simd_version Version = simd_version::undefined_>
   struct simd_info
@@ -764,8 +760,8 @@ namespace spy::detail
       else  if constexpr ( Version == simd_version::vmx_    ) os << "PPC VMX";
       else  if constexpr ( Version == simd_version::vsx_    ) os << "PPC VSX";
       else  if constexpr ( Version == simd_version::neon_   ) os << "ARM NEON";
+      else  if constexpr ( Version == simd_version::asimd_  ) os << "ARM ASIMD";
       else return os << "Undefined SIMD instructions set";
-      if constexpr (spy::supports::aarch64_) os << " (with AARCH64 support)";
       if constexpr (spy::supports::fma_)     os << " (with FMA3 support)";
       if constexpr (spy::supports::fma4_)    os << " (with FMA4 support)";
       if constexpr (spy::supports::xop_)     os << " (with XOP support)";
@@ -836,8 +832,9 @@ namespace spy
   using arm_simd_info = detail::simd_info<detail::simd_isa::arm_,V>;
   constexpr inline auto arm_simd_ = arm_simd_info<>{};
   constexpr inline auto neon_     = arm_simd_info<detail::simd_version::neon_ >{};
+  constexpr inline auto asimd_    = arm_simd_info<detail::simd_version::asimd_>{};
 }
-#include <ostream>
+#include <iosfwd>
 #if defined(__APPLE__) || defined(__APPLE_CC__) || defined(macintosh)
 #  include <AvailabilityMacros.h>
 #endif
@@ -930,3 +927,4 @@ namespace spy::supports
   constexpr inline auto posix_ = false;
 #endif
 }
+#endif

--- a/include/eve/module/real/core/function/regular/simd/arm/neon/bit_select.hpp
+++ b/include/eve/module/real/core/function/regular/simd/arm/neon/bit_select.hpp
@@ -24,10 +24,8 @@ namespace eve::detail
   {
     constexpr auto cat = categorize<wide<T, N, ABI>>();
 
-#if defined(__aarch64__)
          if constexpr(cat == category::float64x1) return vbsl_f64(vreinterpret_u64_f64(m), v0, v1);
     else if constexpr(cat == category::float64x2) return vbslq_f64(vreinterpretq_u64_f64(m), v0, v1);
-#endif
     else if constexpr(cat == category::float32x2) return vbsl_f32(vreinterpret_u32_f32(m), v0, v1);
     else if constexpr(cat == category::int64x1)   return vbsl_s64(vreinterpret_u64_s64(m), v0, v1);
     else if constexpr(cat == category::int32x2)   return vbsl_s32(vreinterpret_u32_s32(m), v0, v1);

--- a/test/unit/api/wide/load/arithmetic/load.hpp
+++ b/test/unit/api/wide/load/arithmetic/load.hpp
@@ -131,9 +131,10 @@ TTS_CASE_TPL("Check conditional load from pointer for wide", EVE_TYPE)
     auto i1 = eve::ignore_first(EVE_CARDINAL/4);
     auto kf = eve::keep_first(EVE_CARDINAL/4);
     auto kl = eve::keep_last(EVE_CARDINAL/4);
-    auto kb = eve::keep_between ( std::min<std::ptrdiff_t>(0L,EVE_CARDINAL/3)
-                                , std::max<std::ptrdiff_t>(0L,(EVE_CARDINAL*2)/3)
+    auto kb = eve::keep_between ( std::min(std::ptrdiff_t(0),std::ptrdiff_t(EVE_CARDINAL/3))
+                                , std::max(std::ptrdiff_t(0),std::ptrdiff_t((EVE_CARDINAL*2)/3))
                                 );
+
     auto ie = i1 && il;
 
     // Conditional selectors' masks

--- a/test/unit/api/wide/load/arithmetic/load.hpp
+++ b/test/unit/api/wide/load/arithmetic/load.hpp
@@ -131,8 +131,8 @@ TTS_CASE_TPL("Check conditional load from pointer for wide", EVE_TYPE)
     auto i1 = eve::ignore_first(EVE_CARDINAL/4);
     auto kf = eve::keep_first(EVE_CARDINAL/4);
     auto kl = eve::keep_last(EVE_CARDINAL/4);
-    auto kb = eve::keep_between ( std::min(0L,EVE_CARDINAL/3)
-                                , std::max(0L,(EVE_CARDINAL*2)/3)
+    auto kb = eve::keep_between ( std::min<std::ptrdiff_t>(0L,EVE_CARDINAL/3)
+                                , std::max<std::ptrdiff_t>(0L,(EVE_CARDINAL*2)/3)
                                 );
     auto ie = i1 && il;
 

--- a/test/unit/api/wide/load/logical/load.hpp
+++ b/test/unit/api/wide/load/logical/load.hpp
@@ -128,8 +128,8 @@ TTS_CASE_TPL("Check conditional load from  pointer for logical<wide>", EVE_TYPE)
     auto i1 = eve::ignore_first(EVE_CARDINAL/4);
     auto kf = eve::keep_first(EVE_CARDINAL/4);
     auto kl = eve::keep_last(EVE_CARDINAL/4);
-    auto kb = eve::keep_between ( std::min(0L,EVE_CARDINAL/3)
-                                , std::max(0L,(EVE_CARDINAL*2)/3)
+    auto kb = eve::keep_between ( std::min<std::ptrdiff_t>(0L,EVE_CARDINAL/3)
+                                , std::max<std::ptrdiff_t>(0L,(EVE_CARDINAL*2)/3)
                                 );
     auto ie = i1 && il;
 

--- a/test/unit/api/wide/load/logical/load.hpp
+++ b/test/unit/api/wide/load/logical/load.hpp
@@ -128,9 +128,10 @@ TTS_CASE_TPL("Check conditional load from  pointer for logical<wide>", EVE_TYPE)
     auto i1 = eve::ignore_first(EVE_CARDINAL/4);
     auto kf = eve::keep_first(EVE_CARDINAL/4);
     auto kl = eve::keep_last(EVE_CARDINAL/4);
-    auto kb = eve::keep_between ( std::min<std::ptrdiff_t>(0L,EVE_CARDINAL/3)
-                                , std::max<std::ptrdiff_t>(0L,(EVE_CARDINAL*2)/3)
+    auto kb = eve::keep_between ( std::min(std::ptrdiff_t(0),std::ptrdiff_t(EVE_CARDINAL/3))
+                                , std::max(std::ptrdiff_t(0),std::ptrdiff_t((EVE_CARDINAL*2)/3))
                                 );
+
     auto ie = i1 && il;
 
     // Conditional selectors' masks

--- a/test/unit/arch/is_supported.cpp
+++ b/test/unit/arch/is_supported.cpp
@@ -53,8 +53,8 @@ TTS_CASE("Static detections of API")
   std::cout << "\n";
   std::cout << "========================\n";
   std::cout << "ARM SIMD extensions\n";
-  std::cout << "NEON   : " << std::boolalpha << (eve::current_api >= eve::neon   ) << "\n";
-  std::cout << "AARCH64: " << std::boolalpha << eve::supports_aarch64              << "\n";
+  std::cout << "NEON  : " << std::boolalpha << (eve::current_api >= eve::neon   ) << "\n";
+  std::cout << "ASIMD : " << std::boolalpha << (eve::current_api >= eve::asimd  )  << "\n";
   std::cout << "\n";
 
   TTS_PASS("All static detections - done");
@@ -86,7 +86,7 @@ TTS_CASE("Dynamic detections of API")
   std::cout << "========================\n";
   std::cout << "ARM SIMD extensions\n";
   std::cout << "NEON  : " << std::boolalpha << eve::is_supported(eve::neon) << "\n";
-  std::cout << "ASIMD : " << std::boolalpha << eve::is_supported(eve::aarch64) << "\n";
+  std::cout << "ASIMD : " << std::boolalpha << eve::is_supported(eve::asimd) << "\n";
 
   TTS_PASS("All dynamic detections - done");
 }


### PR DESCRIPTION
This patch adapts existing infrastructure to properly discriminate neon and asimd extensions set as such.
It fixes urgent issue when trying to compile for cortex A15 but doesn't remove all the #ifdef on aarch64 yet.
