### PR TITLE
FIX-455: arm-v7, all

### DIFF
--- a/include/eve/conditional.hpp
+++ b/include/eve/conditional.hpp
@@ -123,6 +123,11 @@ namespace eve
       return eve::as_logical_t<T>(false);
     }
 
+    template<typename T> EVE_FORCEINLINE auto mask_inverted(eve::as_<T> const&) const
+    {
+      return eve::as_logical_t<T>(true);
+    }
+
     template<typename T> EVE_FORCEINLINE auto bitmap(eve::as_<T> const&) const
     {
       constexpr auto sz = cardinal_v<T> < 8 ? 8 : cardinal_v<T>;
@@ -162,6 +167,11 @@ namespace eve
     template<typename T> EVE_FORCEINLINE auto mask(eve::as_<T> const&) const
     {
       return eve::as_logical_t<T>(true);
+    }
+
+    template<typename T> EVE_FORCEINLINE auto mask_inverted(eve::as_<T> const&) const
+    {
+      return eve::as_logical_t<T>(false);
     }
 
     template<typename T> EVE_FORCEINLINE auto bitmap(eve::as_<T> const&) const
@@ -216,6 +226,15 @@ namespace eve
       return bit_cast(m, as_<as_logical_t<T>>());
     }
 
+    template<typename T> EVE_FORCEINLINE auto mask_inverted(eve::as_<T> const&) const
+    {
+      constexpr std::ptrdiff_t card = cardinal_v<T>;
+      using i_t = as_arithmetic_t<detail::as_integer_t<T>>;
+
+      auto const m = detail::linear_ramp(eve::as_<i_t>()) >= (card-count_);
+      return bit_cast(m, as_<as_logical_t<T>>());
+    }
+
     template<typename T> EVE_FORCEINLINE auto bitmap(eve::as_<T> const&) const
     {
       constexpr auto sz = cardinal_v<T> < 8 ? 8 : cardinal_v<T>;
@@ -264,12 +283,22 @@ namespace eve
 
     template<typename V> EVE_FORCEINLINE auto else_(V v) const  {  return or_(*this,v);  }
 
-    template<typename T> auto mask(eve::as_<T> const&) const
+    template<typename T> EVE_FORCEINLINE auto mask(eve::as_<T> const&) const
     {
       using i_t = as_arithmetic_t<detail::as_integer_t<T>>;
       constexpr std::ptrdiff_t card = cardinal_v<T>;
 
       auto const m = detail::linear_ramp(eve::as_<i_t>()) >= i_t(card-count_);
+
+      return bit_cast(m, as_<as_logical_t<T>>());
+    }
+
+    template<typename T> EVE_FORCEINLINE auto mask_inverted(eve::as_<T> const&) const
+    {
+      using i_t = as_arithmetic_t<detail::as_integer_t<T>>;
+      constexpr std::ptrdiff_t card = cardinal_v<T>;
+
+      auto const m = detail::linear_ramp(eve::as_<i_t>()) < i_t(card-count_);
 
       return bit_cast(m, as_<as_logical_t<T>>());
     }
@@ -330,6 +359,14 @@ namespace eve
       return bit_cast(m, as_<as_logical_t<T>>());
     }
 
+    template<typename T> EVE_FORCEINLINE auto mask_inverted(eve::as_<T> const&) const
+    {
+      using i_t = as_arithmetic_t<detail::as_integer_t<T>>;
+      auto const m = detail::linear_ramp(eve::as_<i_t>()) < i_t(count_);
+
+      return bit_cast(m, as_<as_logical_t<T>>());
+    }
+
     template<typename T> EVE_FORCEINLINE auto bitmap(eve::as_<T> const&) const
     {
       constexpr auto sz = cardinal_v<T> < 8 ? 8 : cardinal_v<T>;
@@ -382,6 +419,14 @@ namespace eve
     {
       using i_t = as_arithmetic_t<detail::as_integer_t<T>>;
       auto const m = detail::linear_ramp(eve::as_<i_t>()) < i_t(count_);
+
+      return bit_cast(m, as_<as_logical_t<T>>());
+    }
+
+    template<typename T> EVE_FORCEINLINE auto mask_inverted(eve::as_<T> const&) const
+    {
+      using i_t = as_arithmetic_t<detail::as_integer_t<T>>;
+      auto const m = detail::linear_ramp(eve::as_<i_t>()) >= i_t(count_);
 
       return bit_cast(m, as_<as_logical_t<T>>());
     }
@@ -446,6 +491,15 @@ namespace eve
       return bit_cast(m, as_<as_logical_t<T>>());
     }
 
+    template<typename T> EVE_FORCEINLINE auto mask_inverted(eve::as_<T> const&) const
+    {
+      using i_t = as_arithmetic_t<detail::as_integer_t<T>>;
+      auto const i = detail::linear_ramp(eve::as_<i_t>());
+      auto const m = (i < begin_) || (i >= end_);
+
+      return bit_cast(m, as_<as_logical_t<T>>());
+    }
+
     template<typename T> EVE_FORCEINLINE auto bitmap(eve::as_<T> const&) const
     {
       constexpr auto sz = cardinal_v<T> < 8 ? 8 : cardinal_v<T>;
@@ -502,6 +556,15 @@ namespace eve
       using i_t = as_arithmetic_t<detail::as_integer_t<T>>;
       auto const i = detail::linear_ramp(eve::as_<i_t>());
       auto const m = (i >= first_count_) && (i < (cardinal_v<T>-last_count_));
+
+      return bit_cast(m, as_<as_logical_t<T>>());
+    }
+
+    template<typename T> EVE_FORCEINLINE auto mask_inverted(eve::as_<T> const&) const
+    {
+      using i_t = as_arithmetic_t<detail::as_integer_t<T>>;
+      auto const i = detail::linear_ramp(eve::as_<i_t>());
+      auto const m = (i < first_count_) || (i >= (cardinal_v<T>-last_count_));
 
       return bit_cast(m, as_<as_logical_t<T>>());
     }

--- a/include/eve/module/real/algorithm/function/regular/simd/arm/neon/all.hpp
+++ b/include/eve/module/real/algorithm/function/regular/simd/arm/neon/all.hpp
@@ -14,7 +14,6 @@
 #include <eve/conditional.hpp>
 #include <eve/function/bit_cast.hpp>
 #include <eve/function/convert.hpp>
-#include <eve/arch/logical.hpp>
 
 namespace eve::detail
 {
@@ -59,6 +58,6 @@ namespace eve::detail
   template<real_scalar_value T, typename N, arm_abi ABI>
   EVE_FORCEINLINE bool all_(EVE_SUPPORTS(neon128_), logical<wide<T, N, ABI>> const &v0) noexcept
   {
-    return all[ignore_none](v0);
+    return all_arm_impl(v0, ignore_none);
   }
 }

--- a/test/unit/module/real/algorithm/all/regular/all.hpp
+++ b/test/unit/module/real/algorithm/all/regular/all.hpp
@@ -19,13 +19,15 @@
 #include <eve/platform.hpp>
 #include <type_traits>
 
-TTS_CASE_TPL("Check eve::all return type", EVE_TYPE)
+#define EVE_ALL_TYPE eve::wide<std::uint32_t, eve::fixed<2>>
+
+TTS_CASE_TPL("Check eve::all return type", EVE_ALL_TYPE)
 {
   TTS_EXPR_IS( (eve::all(eve::logical<T>())) , bool);
   TTS_EXPR_IS( (eve::all(T()))               , bool);
 }
 
-TTS_CASE_TPL("Check eve::all behavior on arithmetic", EVE_TYPE)
+TTS_CASE_TPL("Check eve::all behavior on arithmetic", EVE_ALL_TYPE)
 {
   TTS_EXPECT    ( (eve::all(T{1})) );
   TTS_EXPECT_NOT( (eve::all(T{0})) );
@@ -63,7 +65,7 @@ TTS_CASE_TPL("Check eve::all behavior on arithmetic", EVE_TYPE)
 #endif
 }
 
-TTS_CASE_TPL("Check eve::all behavior on logical", EVE_TYPE)
+TTS_CASE_TPL("Check eve::all behavior on logical", EVE_ALL_TYPE)
 {
   TTS_EXPECT    (eve::all(eve::true_(eve::as<T>())));
   TTS_EXPECT_NOT(eve::all(eve::false_(eve::as<T>())));
@@ -71,7 +73,7 @@ TTS_CASE_TPL("Check eve::all behavior on logical", EVE_TYPE)
 
 #if defined(EVE_SIMD_TESTS)
 
-TTS_CASE_TPL("Check eve::all[ignore]", EVE_TYPE)
+TTS_CASE_TPL("Check eve::all[ignore]", EVE_ALL_TYPE)
 {
   // complete
   {

--- a/test/unit/module/real/algorithm/all/regular/all.hpp
+++ b/test/unit/module/real/algorithm/all/regular/all.hpp
@@ -19,15 +19,13 @@
 #include <eve/platform.hpp>
 #include <type_traits>
 
-#define EVE_ALL_TYPE eve::wide<std::uint32_t, eve::fixed<2>>
-
-TTS_CASE_TPL("Check eve::all return type", EVE_ALL_TYPE)
+TTS_CASE_TPL("Check eve::all return type", EVE_TYPE)
 {
   TTS_EXPR_IS( (eve::all(eve::logical<T>())) , bool);
   TTS_EXPR_IS( (eve::all(T()))               , bool);
 }
 
-TTS_CASE_TPL("Check eve::all behavior on arithmetic", EVE_ALL_TYPE)
+TTS_CASE_TPL("Check eve::all behavior on arithmetic", EVE_TYPE)
 {
   TTS_EXPECT    ( (eve::all(T{1})) );
   TTS_EXPECT_NOT( (eve::all(T{0})) );
@@ -65,7 +63,7 @@ TTS_CASE_TPL("Check eve::all behavior on arithmetic", EVE_ALL_TYPE)
 #endif
 }
 
-TTS_CASE_TPL("Check eve::all behavior on logical", EVE_ALL_TYPE)
+TTS_CASE_TPL("Check eve::all behavior on logical", EVE_TYPE)
 {
   TTS_EXPECT    (eve::all(eve::true_(eve::as<T>())));
   TTS_EXPECT_NOT(eve::all(eve::false_(eve::as<T>())));
@@ -73,7 +71,7 @@ TTS_CASE_TPL("Check eve::all behavior on logical", EVE_ALL_TYPE)
 
 #if defined(EVE_SIMD_TESTS)
 
-TTS_CASE_TPL("Check eve::all[ignore]", EVE_ALL_TYPE)
+TTS_CASE_TPL("Check eve::all[ignore]", EVE_TYPE)
 {
   // complete
   {
@@ -98,7 +96,7 @@ TTS_CASE_TPL("Check eve::all[ignore]", EVE_ALL_TYPE)
     TTS_EXPECT_NOT(eve::all[eve::ignore_last(T::static_size - 1)](mask));
   }
 
-  // ignore_first
+  // ignore_first, keep_last
   {
     eve::logical<T> mask(true);
 
@@ -108,6 +106,9 @@ TTS_CASE_TPL("Check eve::all[ignore]", EVE_ALL_TYPE)
       mask.set(i, false);
       TTS_EXPECT_NOT(eve::all[eve::ignore_first(i)](mask));
       TTS_EXPECT(eve::all[eve::ignore_first(i + 1)](mask));
+
+      TTS_EXPECT_NOT(eve::all[eve::keep_last(T::static_size - i)](mask));
+      TTS_EXPECT(eve::all[eve::keep_last(T::static_size - i - 1)](mask));
     }
   }
 
@@ -121,10 +122,13 @@ TTS_CASE_TPL("Check eve::all[ignore]", EVE_ALL_TYPE)
       mask.set(T::static_size - i - 1, false);
       TTS_EXPECT_NOT(eve::all[eve::ignore_last(i)](mask));
       TTS_EXPECT(eve::all[eve::ignore_last(i + 1)](mask));
+
+      TTS_EXPECT_NOT(eve::all[eve::keep_first(T::static_size - i)](mask));
+      TTS_EXPECT(eve::all[eve::keep_first(T::static_size - i - 1)](mask));
     }
   }
 
-  // ignore_extrema_
+  // ignore_extrema_, keep_between
   {
     for (int i = 0; i < T::static_size + 1; ++i)
     {
@@ -139,11 +143,18 @@ TTS_CASE_TPL("Check eve::all[ignore]", EVE_ALL_TYPE)
 
         TTS_EXPECT_NOT(eve::all[eve::ignore_extrema_(i, j)](mask));
         TTS_EXPECT(eve::all[eve::ignore_extrema_(i + 1, j)](mask));
+
+        TTS_EXPECT_NOT(eve::all[eve::keep_between(i, T::static_size - j)](mask));
+        TTS_EXPECT(eve::all[eve::keep_between(i + 1, T::static_size - j)](mask));
+
         mask.set(i, true);
 
         mask.set(T::static_size - j - 1, false);
         TTS_EXPECT_NOT(eve::all[eve::ignore_extrema_(i, j)](mask));
         TTS_EXPECT(eve::all[eve::ignore_extrema_(i, j + 1)](mask));
+
+        TTS_EXPECT_NOT(eve::all[eve::keep_between(i, T::static_size - j)](mask));
+        TTS_EXPECT(eve::all[eve::keep_between(i, T::static_size - j - 1)](mask));
       }
     }
   }


### PR DESCRIPTION
A better implementation of all on arm-v7.
For 64 bit the trick is `vpmin_u32` - the smallest uint32 should be still all ones (within the number of bits).
So min + get + test

I dunno enough about arm, maybe get just goes away since I get 0's element

For arm128 for anything but chars we just convert down a size.
So convert + min + get + test.
On x86 this is mmask + test so less by 2 instructions, but I don't see how I can do anything cooler on v7.

Unfortunately, for chars I didn't come up with anything smart, so split and merge.
Which also means I have to deal with ignore at the 16 byte level.

So split + and + min + get + test

I thought about using shift with insert to combine two halves
https://developer.arm.com/documentation/dui0472/m/using-neon-support/neon-intrinsics-for-shifts-with-insert

But it seems for that I need to split a vector, in which case I might just `and` it all.

I had to add a `mask_invert` to conditionals. Should be tested OK using `all` tests.
! doesn't seem to clear out the top half of the logical, + I am very much not sure compiler will see through it.
