### PR TITLE
FIX-455: convert 16 => 8

### DIFF
--- a/include/eve/module/real/core/function/regular/simd/arm/neon/convert.hpp
+++ b/include/eve/module/real/core/function/regular/simd/arm/neon/convert.hpp
@@ -28,16 +28,28 @@ namespace eve::detail
     // Idempotent call
     if constexpr( std::is_same_v<T, U> ) return v0;
 
-#if defined(__aarch64__)
+    if constexpr ( std::signed_integral<T> && std::unsigned_integral<U> )
+    {
+      using s_u = std::make_signed_t<U>;
+      auto s_res = convert(v0, eve::as_<s_u>{});
+      return bit_cast(s_res, eve::as_<wide<U, N>>{});
+    }
+    else if constexpr ( std::unsigned_integral<T> && std::signed_integral<U> )
+    {
+      using u_u = std::make_unsigned_t<U>;
+      auto u_res = convert(v0, eve::as_<u_u>{});
+      return bit_cast(u_res, eve::as_<wide<U, N>>{});
+    }
+
     //==============================================================================================
     // double -> ?
-    if constexpr( catin == category::float64x1 )
+    if constexpr( catin == category::float64x1  && current_api >= asimd )
     {
            if constexpr( catou == category::int64x1  ) return vcvt_s64_f64(v0);
       else if constexpr( catou == category::uint64x1 ) return vcvt_u64_f64(v0);
-      else                                            return convert_(EVE_RETARGET(simd_), v0, tgt);
+      else                                             return convert_(EVE_RETARGET(simd_), v0, tgt);
     }
-    else if constexpr( catin == category::float64x2 )
+    else if constexpr( catin == category::float64x2  && current_api >= asimd )
     {
            if constexpr( catou == category::int64x2  ) return vcvtq_s64_f64(v0);
       else if constexpr( catou == category::uint64x2 ) return vcvtq_u64_f64(v0);
@@ -46,7 +58,6 @@ namespace eve::detail
       else                                             return convert_(EVE_RETARGET(simd_), v0, tgt);
     }
     else
-#endif
     //==============================================================================================
     // float -> ?
     if constexpr( catin == category::float32x2 )
@@ -69,64 +80,42 @@ namespace eve::detail
     // int64 -> ?
     else if constexpr( catin == category::int64x1 )
     {
-#if defined(__aarch64__)
-           if constexpr( catou == category::float64x1 )     return vcvt_f64_s64(v0);
-      else
-#endif
-           if constexpr( catou == category::uint64x1  )     return vreinterpret_u64_s64(v0);
-           else                                             return convert_(EVE_RETARGET(simd_), v0, tgt);
+      if constexpr( catou == category::float64x1 && current_api >= asimd) return vcvt_f64_s64(v0);
+      else                                                                return convert_(EVE_RETARGET(simd_), v0, tgt);
     }
     else if constexpr( catin == category::int64x2 )
     {
-#if defined(__aarch64__)
-           if constexpr( catou == category::float64x2 )     return vcvtq_f64_s64(v0);
-      else
-#endif
-           if constexpr( catou == category::uint64x2  )     return vreinterpretq_u64_s64(v0);
-      else if constexpr( catou == category::float32x2 )     return vcvt_f32_s32(vmovn_s64(v0));
-      else if constexpr( catou == category::int32x2   )     return vmovn_s64(v0);
-      else if constexpr( catou == category::uint32x2  )     return vreinterpret_u32_s32(vmovn_s64(v0));
-      else                                                  return convert_(EVE_RETARGET(simd_), v0, tgt);
+           if constexpr( catou == category::float64x2  && current_api >= asimd)     return vcvtq_f64_s64(v0);
+      else if constexpr( catou == category::float32x2 )                             return vcvt_f32_s32(vmovn_s64(v0));
+      else if constexpr( catou == category::int32x2   )                             return vmovn_s64(v0);
+      else                                                                          return convert_(EVE_RETARGET(simd_), v0, tgt);
     }
     //==============================================================================================
     // uint64 -> ?
     else if constexpr( catin == category::uint64x1 )
     {
-#if defined(__aarch64__)
-      if constexpr( catou == category::float64x1 )          return vcvt_f64_u64(v0);
-      else
-#endif
-           if constexpr( catou == category::int64x1 )       return vreinterpret_s64_u64(v0);
-      else                                                  return convert_(EVE_RETARGET(simd_), v0, tgt);
+      if constexpr( catou == category::float64x1 && current_api >= asimd ) return vcvt_f64_u64(v0);
+      else                                                                 return convert_(EVE_RETARGET(simd_), v0, tgt);
     }
     else if constexpr( catin == category::uint64x2 )
     {
-#if defined(__aarch64__)
-           if constexpr( catou == category::float64x2 )     return vcvtq_f64_u64(v0);
-      else
-#endif
-           if constexpr( catou == category::int64x2 )          return vreinterpretq_s64_u64(v0);
-      else if constexpr( catou == category::float32x2 )        return vcvt_f32_u32(vmovn_u64(v0));
-      else if constexpr( catou == category::uint32x2 )         return vmovn_u64(v0);
-      else if constexpr( catou == category::int32x2 )          return vreinterpret_s32_u32(vmovn_u64(v0));
-      else                                                     return convert_(EVE_RETARGET(simd_), v0, tgt);
+           if constexpr( catou == category::float64x2 && current_api >= asimd ) return vcvtq_f64_u64(v0);
+      else if constexpr( catou == category::float32x2 )                         return vcvt_f32_u32(vmovn_u64(v0));
+      else if constexpr( catou == category::uint32x2 )                          return vmovn_u64(v0);
+      else                                                                      return convert_(EVE_RETARGET(simd_), v0, tgt);
     }
     //==============================================================================================
     // int32 -> ?
     else if constexpr( catin == category::int32x2 )
     {
            if constexpr( catou == category::float32x2 )        return vcvt_f32_s32(v0);
-      else if constexpr( catou == category::uint32x2 )         return vreinterpret_u32_s32(v0);
       else if constexpr( catou == category::int64x2 )          return vmovl_s32(v0);
-      else if constexpr( catou == category::uint64x2 )         return vreinterpretq_u64_s64(vmovl_s32(v0));
       else                                                     return convert_(EVE_RETARGET(simd_), v0, tgt);
     }
     else if constexpr( catin == category::int32x4 )
     {
            if constexpr( catou == category::float32x4 )        return vcvtq_f32_s32(v0);
-      else if constexpr( catou == category::uint32x4 )         return vreinterpretq_u32_s32(v0);
       else if constexpr( catou == category::int16x4 )          return vmovn_s32(v0);
-      else if constexpr( catou == category::uint16x4 )         return vreinterpret_u16_s16(vmovn_s32(v0));
       else                                                     return convert_(EVE_RETARGET(simd_), v0, tgt);
     }
     //==============================================================================================
@@ -134,16 +123,12 @@ namespace eve::detail
     else if constexpr( catin == category::uint32x2 )
     {
            if constexpr( catou == category::float32x2 )        return vcvt_f32_u32(v0);
-      else if constexpr( catou == category::int32x2 )          return vreinterpret_s32_u32(v0);
-      else if constexpr( catou == category::int64x2 )          return vreinterpretq_s64_u64(vmovl_u32(v0));
       else if constexpr( catou == category::uint64x2 )         return vmovl_u32(v0);
       else                                                     return convert_(EVE_RETARGET(simd_), v0, tgt);
     }
     else if constexpr( catin == category::uint32x4 )
     {
            if constexpr( catou == category::float32x4 )        return vcvtq_f32_u32(v0);
-      else if constexpr( catou == category::int32x4 )          return vreinterpretq_s32_u32(v0);
-      else if constexpr( catou == category::int16x4 )          return vreinterpret_s16_u16(vmovn_u32(v0));
       else if constexpr( catou == category::uint16x4 )         return vmovn_u32(v0);
       else                                                     return convert_(EVE_RETARGET(simd_), v0, tgt);
     }
@@ -153,37 +138,42 @@ namespace eve::detail
     {
            if constexpr( catou == category::int32x4 )        return vmovl_s16(v0);
       else if constexpr( catou == category::float32x4 )      return vcvtq_f32_s32(vmovl_s16(v0));
-      else if constexpr( catou == category::uint32x4 )       return vreinterpretq_u32_s32(vmovl_s16(v0));
-      else if constexpr( catou == category::uint16x4 )       return vreinterpret_u16_s16(v0);
       else                                                   return convert_(EVE_RETARGET(simd_), v0, tgt);
+    }
+    else if constexpr ( catin == category::int16x8 )
+    {
+      if constexpr ( catou == category::int8x8 )   return vmovn_s16(v0);
+      else                                         return convert_(EVE_RETARGET(simd_), v0, tgt);
     }
     //==============================================================================================
     // uint16 -> ?
     else if constexpr( catin == category::uint16x4 )
     {
-           if constexpr( catou == category::int32x4 )        return vreinterpretq_s32_u32(vmovl_u16(v0));
-      else if constexpr( catou == category::float32x4 )      return vcvtq_f32_u32(vmovl_u16(v0));
-      else if constexpr( catou == category::uint32x4 )       return vmovl_u16(v0);
-      else if constexpr( catou == category::int16x4 )        return vreinterpret_s16_u16(v0);
-      else                                                   return convert_(EVE_RETARGET(simd_), v0, tgt);
+           if constexpr( catou == category::float32x4 )  return vcvtq_f32_u32(vmovl_u16(v0));
+      else if constexpr( catou == category::uint32x4 )   return vmovl_u16(v0);
+      else if constexpr( catou == category::int16x4 )    return vreinterpret_s16_u16(v0);
+      else                                               return convert_(EVE_RETARGET(simd_), v0, tgt);
     }
+    else if constexpr ( catin == category::uint16x8 )
+    {
+      if constexpr ( catou == category::uint8x8 ) return vmovn_u16(v0);
+      else                                        return convert_(EVE_RETARGET(simd_), v0, tgt);
+    }
+
     //==============================================================================================
     // int8 -> ?
     else if constexpr( catin == category::int8x8 )
     {
-           if constexpr( catou == category::int16x8 )        return vmovl_s8(v0);
-      else if constexpr( catou == category::uint16x8 )       return vreinterpretq_u16_s16(vmovl_s8(v0));
-      else if constexpr( catou == category::uint8x8 )        return vreinterpret_u8_s8(v0);
-      else                                                   return convert_(EVE_RETARGET(simd_), v0, tgt);
+           if constexpr( catou == category::int16x8 ) return vmovl_s8(v0);
+      else                                            return convert_(EVE_RETARGET(simd_), v0, tgt);
     }
     //==============================================================================================
     // uint8 -> ?
     else if constexpr( catin == category::uint8x8 )
     {
-           if constexpr( catou == category::int16x8 )        return vreinterpretq_s16_u16(vmovl_u8(v0));
-      else if constexpr( catou == category::uint16x8 )       return vmovl_u8(v0);
-      else if constexpr( catou == category::int8x8 )         return vreinterpret_s8_u8(v0);
-      else                                                   return convert_(EVE_RETARGET(simd_), v0, tgt);
+           if constexpr( catou == category::uint16x8 )  return vmovl_u8(v0);
+      else if constexpr( catou == category::int8x8 )    return vreinterpret_s8_u8(v0);
+      else                                              return convert_(EVE_RETARGET(simd_), v0, tgt);
     }
     //==============================================================================================
     // other -> ?


### PR DESCRIPTION
Conversions 16 to 8 were missing.

Also simplified the `signed` => `unsigned`.

And replaced macros with api tests.