### PR TITLE
Fix #548: better arm v7 codegen for first_true/any and somewhat all

### DIFF
--- a/include/eve/module/real/algorithm/function/regular/generic/first_true.hpp
+++ b/include/eve/module/real/algorithm/function/regular/generic/first_true.hpp
@@ -42,8 +42,11 @@ namespace eve::detail
     {
       // No ignore, we might luck out even if some elements should not be counted.
       if ( !eve::any(v) ) return {};
+
       top_bits mmask{v, cond};
-      return eve::detail::first_true(mmask);
+      if constexpr ( C::is_complete ) return *detail::first_true(mmask); // optimizes a check on clang
+      else                            return detail::first_true(mmask);
+
     }
   }
 

--- a/include/eve/module/real/algorithm/function/regular/simd/arm/neon/any.hpp
+++ b/include/eve/module/real/algorithm/function/regular/simd/arm/neon/any.hpp
@@ -25,7 +25,7 @@ namespace eve::detail
     else
     {
       if constexpr ( !C::is_complete ) v0 = v0 && cond.mask(eve::as_<l_t>{});
-      using wide_u32 = wide<std::uint32_t, fixed<2>, arm_64_>;
+      using wide_u32 = typename wide<T, N, arm_64_>::template rebind<std::uint32_t, eve::fixed<2>>;
       auto as_uint32 = eve::bit_cast(v0, eve::as_<eve::logical<wide_u32>>{});
 
       if constexpr( sizeof(T) * N() > 4u ) as_uint32 = vpmax_u32(as_uint32, as_uint32);
@@ -48,8 +48,11 @@ namespace eve::detail
     else
     {
       if constexpr ( !C::is_complete ) v0 = v0 && cond.mask(eve::as_<l_t>{});
-      auto [l, h] = v0.slice();
-      return any_arm_impl(l || h, ignore_none);
+
+      using u32_4 = typename wide<T, N, arm_128_>::template rebind<std::uint32_t, eve::fixed<4>>;
+
+      auto dwords = eve::bit_cast(v0, eve::as<u32_4>());
+      return any_arm_impl(detail::to_logical(dwords), ignore_none);
     }
   }
 


### PR DESCRIPTION
####  first_true

Turns out the issue with `first_true` unsafe is not so simple: `std::countr_zero` already checks for zero.
Also on gcc the codegen is either way OK, it's all clang problems.
(we could go to intrinsics but there is another way)

Clang can optimise that check away based on me doing a dereference: https://godbolt.org/z/W5b1vY
So I just added that.

gcc asm btw: https://github.com/DenisYaroshevskiy/unsq_eve/blob/93f862cd3c0f2e6cd6ff904118c293551b263bdc/disassemble/disassemble_arm.s#L49

####  any/ all

The split in two registers is a lot of asm. Much better option seems to be cast to `uint32_t` and test that against zero.
A much similar option is available for all but I need to test against FFFFF.


