### PR TITLE
FIX-414: enable asan for sse2 builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -219,7 +219,7 @@ workflows:
     ## X86 - 128 bits
     ##==============================================================================================
       - x86_sse2:
-          tool:     "../cmake/toolchain/clang.x86.cmake"
+          tool:     "../cmake/toolchain/clang.x86.asan.cmake"
           options:  "-msse2"
           filters:
             branches:

--- a/cmake/toolchain/clang.x86.asan.cmake
+++ b/cmake/toolchain/clang.x86.asan.cmake
@@ -1,0 +1,14 @@
+##==================================================================================================
+##  EVE - Expressive Vector Engine
+##  Copyright 2018-2021 Joel FALCOU
+##  Copyright 2018-2021 Jean-Thierry LAPRESTE
+##
+##  Licensed under the MIT License <http://opensource.org/licenses/MIT>.
+##  SPDX-License-Identifier: MIT
+##==================================================================================================
+set(CMAKE_C_COMPILER    clang-10   )
+set(CMAKE_CXX_COMPILER  clang++-10 )
+set(CMAKE_BUILD_TYPE    Debug      )
+
+set(CMAKE_CXX_FLAGS        "-DEVE_NO_FORCEINLINE -fsanitize=address ${EVE_OPTIONS}")
+set(CMAKE_EXE_LINKER_FLAGS "-fsanitize=address")


### PR DESCRIPTION
As we discussed, enabling asan on sse2 should be good for us.
I checked  - unsafe(load) it tests correctly, removing the attribute fails the test.