### PR TITLE
FIX-#538 support unsafe(load[ignore])

### DIFF
--- a/include/eve/module/real/core/function/regular/simd/x86/load.hpp
+++ b/include/eve/module/real/core/function/regular/simd/x86/load.hpp
@@ -53,6 +53,8 @@ namespace eve::detail
       if constexpr( current_api >= avx512 ) return to_logical(block).storage();
       else                                  return bit_cast(block, as_<r_t>{});
     }
+    // Hack until a proper FIX-#572
+    else if constexpr ( has_aggregated_abi_v<r_t> ) return load_(EVE_RETARGET(cpu_), cond, p, Cardinal{});
     else if constexpr( current_api >= avx512 )
     {
       if constexpr( C::is_complete )

--- a/test/unit/api/wide/load/arithmetic/load.hpp
+++ b/test/unit/api/wide/load/arithmetic/load.hpp
@@ -350,6 +350,12 @@ TTS_CASE_TPL("Check load unsafe, wide", EVE_TYPE)
 
     loaded = eve::unsafe(eve::load)(ptr.get());
     TTS_EXPECT(eve::any(loaded == x));
+
+    for (auto ignore_ptr = ptr.get(); (&x - ignore_ptr) < T::static_size; --ignore_ptr)
+    {
+      loaded = eve::unsafe(eve::load[eve::ignore_first(ptr.get() - ignore_ptr)])(ignore_ptr);
+      TTS_EXPECT(eve::any(loaded == x));
+    }
   }
 
   auto test_n = [&](auto n) {
@@ -357,6 +363,12 @@ TTS_CASE_TPL("Check load unsafe, wide", EVE_TYPE)
     auto loaded = eve::unsafe(eve::load)(ptr, n);
 
     TTS_EXPECT(eve::any(loaded == x));
+
+    for (auto ignore_ptr = ptr.get(); (&x - ignore_ptr) < n(); --ignore_ptr)
+    {
+      loaded = eve::unsafe(eve::load[eve::ignore_first(ptr.get() - ignore_ptr)])(ignore_ptr, n);
+      TTS_EXPECT(eve::any(loaded == x));
+    }
   };
 
   test_n(eve::lane<1>);

--- a/test/unit/api/wide/load/logical/load.hpp
+++ b/test/unit/api/wide/load/logical/load.hpp
@@ -345,6 +345,12 @@ TTS_CASE_TPL("Check load unsafe, logical", EVE_TYPE)
 
     loaded = eve::unsafe(eve::load)(ptr.get());
     TTS_EXPECT(eve::any(loaded == x));
+
+    for (auto ignore_ptr = ptr.get(); (&x - ignore_ptr) < T::static_size; --ignore_ptr)
+    {
+      loaded = eve::unsafe(eve::load[eve::ignore_first(ptr.get() - ignore_ptr)])(ignore_ptr);
+      TTS_EXPECT(eve::any(loaded));
+    }
   }
 
   auto more_data_test = [&] (auto n)
@@ -359,6 +365,13 @@ TTS_CASE_TPL("Check load unsafe, logical", EVE_TYPE)
       auto loaded = eve::unsafe(eve::load)(ptr, n);
 
       TTS_EXPECT(eve::any(loaded));
+
+      for (auto ignore_ptr = ptr.get(); (&e - ignore_ptr) < n(); --ignore_ptr)
+      {
+        auto ignore = eve::ignore_first(ptr.get() - ignore_ptr);
+        loaded = eve::unsafe(eve::load[ignore])(ignore_ptr, n);
+        TTS_EXPECT(eve::any(loaded));
+      }
 
       e = false;
     }
@@ -375,6 +388,12 @@ TTS_CASE_TPL("Check load unsafe, logical", EVE_TYPE)
 
     loaded = eve::unsafe(eve::load)(ptr.get(), n);
     TTS_EXPECT(eve::any(loaded));
+
+    for (auto ignore_ptr = ptr.get(); (&x - ignore_ptr) < n(); --ignore_ptr)
+    {
+      loaded = eve::unsafe(eve::load[eve::ignore_first(ptr.get() - ignore_ptr)])(ignore_ptr, n);
+      TTS_EXPECT(eve::any(loaded));
+    }
   };
 
   test_n(eve::lane<1>);


### PR DESCRIPTION
Fixing the api gap.

We can argue wether this testing is good enough but it seems to be able to catch most of the bugs I can think off.

Generally speaking this API is a bit weird and I don't know when you'd need it, but it makes some sense in the context of just thread sanitizer.

`load[ignore]` for aggregated does not work on avx-512 and avx2 as well I suspect. I put an forward to memcpy for now and reported a bug.