### PR TITLE
Proof of Concept : Using AVX512 masked operations

### DIFF
--- a/include/eve/concept/conditional.hpp
+++ b/include/eve/concept/conditional.hpp
@@ -24,7 +24,6 @@ namespace eve
 
   template<typename T> concept relative_conditional_expr = conditional_expr<T> && requires(T a)
   {
-    { a.bitmap(eve::as_<eve::wide<int>>()) };
     { a.count(eve::as_<eve::wide<int>>())  };
     { a.offset(eve::as_<eve::wide<int>>()) };
     { a.roffset(eve::as_<eve::wide<int>>()) };

--- a/include/eve/conditional.hpp
+++ b/include/eve/conditional.hpp
@@ -46,31 +46,6 @@ namespace eve
   };
 
   //================================================================================================
-  // Helper structure to encode negated conditional expression with alternative
-  //================================================================================================
-  template<typename C, typename V> struct not_or_ : C
-  {
-    static constexpr bool has_alternative = true;
-    static constexpr bool is_inverted     = true;
-    using alternative_type = V;
-
-    not_or_(C c, V v) : C(c), alternative(v) {}
-
-    template<typename T> auto rebase(T v) const
-    {
-      return or_<C,T>{static_cast<C const&>(*this), v};
-    }
-
-    friend std::ostream& operator<<(std::ostream& os, not_or_ const& c)
-    {
-      os << "( " << c.alternative << " ) else ";
-      return os << static_cast<C const&>(c);
-    }
-
-    V alternative;
-  };
-
-  //================================================================================================
   // Helper structure to encode conditional expression without alternative
   //================================================================================================
   template<typename C> struct if_
@@ -87,28 +62,6 @@ namespace eve
     friend std::ostream& operator<<(std::ostream& os, if_ const& c)
     {
       return os << "if( " << c.condition_ << " )";
-    }
-
-    C condition_;
-  };
-
-  //================================================================================================
-  // Helper structure to encode negated conditional expression without alternative
-  //================================================================================================
-  template<typename C> struct if_not_
-  {
-    static constexpr bool has_alternative = false;
-    static constexpr bool is_inverted     = true;
-    static constexpr bool is_complete     = false;
-
-    if_not_(C const& c) : condition_(c) {}
-
-    template<typename V> EVE_FORCEINLINE auto else_(V v) const { return not_or_(*this,v); }
-    template<typename T> EVE_FORCEINLINE auto mask(eve::as_<T> const&)  const { return condition_;  }
-
-    friend std::ostream& operator<<(std::ostream& os, if_not_ const& c)
-    {
-      return os << "if( !" << c.condition_ << " )";
     }
 
     C condition_;

--- a/include/eve/conditional.hpp
+++ b/include/eve/conditional.hpp
@@ -29,14 +29,7 @@ namespace eve
     static constexpr bool has_alternative = true;
     using alternative_type = V;
 
-    or_(C const& c, V const& v) : C(c), alternative(v) {}
-
-    using C::mask;
-    using C::mask_inverted;
-    using C::bitmap;
-    using C::offset;
-    using C::roffset;
-    using C::count;
+    or_(C c, V v) : C(c), alternative(v) {}
 
     template<typename T> auto rebase(T v) const
     {
@@ -61,14 +54,7 @@ namespace eve
     static constexpr bool is_inverted     = true;
     using alternative_type = V;
 
-    not_or_(C const& c, V const& v) : C(c), alternative(v) {}
-
-    using C::mask;
-    using C::mask_inverted;
-    using C::bitmap;
-    using C::offset;
-    using C::roffset;
-    using C::count;
+    not_or_(C c, V v) : C(c), alternative(v) {}
 
     template<typename T> auto rebase(T v) const
     {
@@ -93,10 +79,15 @@ namespace eve
     static constexpr bool is_inverted     = false;
     static constexpr bool is_complete     = false;
 
-    if_(C const& c) : condition_(c) {}
+    if_(C c) : condition_(c) {}
 
     template<typename V> EVE_FORCEINLINE auto else_(V v) const  {  return or_(*this,v);  }
     template<typename T> EVE_FORCEINLINE auto mask(eve::as_<T> const&)  const { return condition_; }
+
+    template<typename T> EVE_FORCEINLINE auto bitmap(eve::as_<T> const&) const
+    {
+      return condition_.bitmap().to_ullong();
+    }
 
     friend std::ostream& operator<<(std::ostream& os, if_ const& c)
     {
@@ -119,6 +110,11 @@ namespace eve
 
     template<typename V> EVE_FORCEINLINE auto else_(V v) const { return not_or_(*this,v); }
     template<typename T> EVE_FORCEINLINE auto mask(eve::as_<T> const&)  const { return condition_;  }
+
+    template<typename T> EVE_FORCEINLINE auto bitmap(eve::as_<T> const&) const
+    {
+      return ~(condition_.bitmap()).to_ullong();
+    }
 
     friend std::ostream& operator<<(std::ostream& os, if_not_ const& c)
     {

--- a/include/eve/detail/function/conditional.hpp
+++ b/include/eve/detail/function/conditional.hpp
@@ -10,8 +10,3 @@
 #include <eve/arch.hpp>
 #include <eve/conditional.hpp>
 #include <eve/detail/function/simd/common/conditional.hpp>
-
-#if defined(EVE_HW_X86)
-// TODO: AVX512 will probably uses special optimisation for the ignore conditional
-//#  include <eve/detail/function/simd/x86/conditional.hpp>
-#endif

--- a/include/eve/detail/function/simd/common/conditional.hpp
+++ b/include/eve/detail/function/simd/common/conditional.hpp
@@ -13,79 +13,49 @@
 namespace eve::detail
 {
   //================================================================================================
-  // Handle the basic if{not}{_else} cases
+  // What's the alternative for this case ?
   //================================================================================================
-  template<typename ABI, conditional_expr C, typename Op, typename Arg0, typename... Args>
-  EVE_FORCEINLINE auto mask_op( ABI const&, C const& c
+  template<conditional_expr C, typename Target, typename Arg>
+  EVE_FORCEINLINE auto alternative(C const& c, Arg a0, as_<Target> const&)
+  {
+    if constexpr( C::has_alternative )  return Target{c.alternative};
+    else                                return a0;
+  }
+
+  //================================================================================================
+  // Turn a conditional into a mask
+  //================================================================================================
+  template<conditional_expr C, typename Target>
+  EVE_FORCEINLINE auto expand_mask(C const& c, as_<Target> const&)
+  {
+    auto m = [](auto cx)
+    {
+      auto msk = cx.mask( as_<Target>{} );
+      return as_wide_t<decltype(msk), cardinal_t<Target>>(msk);
+    }(c);
+
+    if constexpr( C::is_inverted ) m = !m;
+    return m;
+  }
+
+  //================================================================================================
+  // Handle the basic if/if_else cases
+  //================================================================================================
+  template<conditional_expr C, typename Op, typename Arg0, typename... Args>
+  EVE_FORCEINLINE auto mask_op( C const& c
                               , [[maybe_unused]] Op f
                               , [[maybe_unused]] Arg0 const& a0
                               , [[maybe_unused]] Args const&... as
                               )
   {
-    using r_t             = decltype(f(a0,as...));
-    auto const condition  = c.mask(eve::as<r_t>());
+    using r_t       = decltype(f(a0,as...));
+    auto const cond = c.mask(eve::as<r_t>());
 
-    // If the ignore/keep is complete we can jump over if_else
-    if constexpr( C::is_complete )
-    {
-      if constexpr(C::is_inverted)  { return f(a0,as...); }
-      else                          { return r_t(a0);     }
-    }
-    else
-    {
-      // If no optimizations are mandated by the conditional type, we just go over all mask cases.
-      if constexpr( C::has_alternative && C::is_inverted)
-      {
-        return if_else(condition, c.alternative, f(a0,as...) );
-      }
-      else if constexpr( C::has_alternative && !C::is_inverted)
-      {
-        return if_else(condition, f(a0,as...), c.alternative );
-      }
-      else if constexpr( !C::has_alternative && C::is_inverted)
-      {
-        return if_else(condition, a0, f(a0,as...) );
-      }
-      else if constexpr( !C::has_alternative && !C::is_inverted)
-      {
-        return if_else(condition, f(a0,as...), a0 );
-      }
-    }
-  }
-
-  template<conditional_expr C, typename BaseOp, typename MaskOp, typename Arg0, typename... Args>
-  EVE_FORCEINLINE auto mask_op( x86_512_ const&, C const& c
-                              , [[maybe_unused]] BaseOp f
-                              , [[maybe_unused]] MaskOp g
-                              , [[maybe_unused]] Arg0 const& a0
-                              , [[maybe_unused]] Args const&... as
-                              )
-  {
-    using r_t = decltype(f(a0,as...));
-
-    // If the ignore/keep is complete we can jump over calling the masked operations
-    if constexpr( C::is_complete )
-    {
-      if constexpr(C::is_inverted)  { return f(a0,as...); }
-      else                          { return r_t(a0);     }
-    }
-    else
-    {
-      // Extract bitmap then use the function with mask support
-      auto mask = [&](auto const& cx)
-      {
-        auto m = cx.mask( as_<r_t>{} ).bitmap();
-        if constexpr( C::is_inverted )  return ~m;
-        else                            return  m;
-      };
-
-      // Prepare the source value
-      auto src = [&](auto const& cx, auto const& s)
-      {
-        if constexpr( C::has_alternative )  return r_t{cx.alternative}; else return s;
-      };
-
-      return g( mask(c), src(c,a0), a0, as...);
-    }
+          if constexpr( C::is_complete && !C::is_inverted ) return alternative(c,a0,as_<r_t>{});
+    else  if constexpr( C::is_complete &&  C::is_inverted ) return f(a0,as...);
+    else                                                    return if_else( cond
+                                                                          , f(a0,as...)
+                                                                          , alternative(c,a0,as_<r_t>{})
+                                                                          );
   }
 }

--- a/include/eve/detail/function/simd/common/conditional.hpp
+++ b/include/eve/detail/function/simd/common/conditional.hpp
@@ -52,4 +52,40 @@ namespace eve::detail
       }
     }
   }
+
+  template<conditional_expr C, typename BaseOp, typename MaskOp, typename Arg0, typename... Args>
+  EVE_FORCEINLINE auto mask_op( x86_512_ const&, C const& c
+                              , [[maybe_unused]] BaseOp f
+                              , [[maybe_unused]] MaskOp g
+                              , [[maybe_unused]] Arg0 const& a0
+                              , [[maybe_unused]] Args const&... as
+                              )
+  {
+    using r_t = decltype(f(a0,as...));
+
+    // If the ignore/keep is complete we can jump over calling the masked operations
+    if constexpr( C::is_complete )
+    {
+      if constexpr(C::is_inverted)  { return f(a0,as...); }
+      else                          { return r_t(a0);     }
+    }
+    else
+    {
+      // Extract bitmap then use the function with mask support
+      auto mask = [&](auto const& cx)
+      {
+        auto m = cx.bitmap( as_<r_t>{} );
+        if constexpr( C::is_inverted )  return ~m;
+        else                            return m;
+      };
+
+      // Prepare the source value
+      auto src = [&](auto const& cx, auto const& s)
+      {
+        if constexpr( C::has_alternative )  return r_t{cx.alternative}; else return s;
+      };
+
+      return g( mask(c), src(c,a0), a0, as...);
+    }
+  }
 }

--- a/include/eve/detail/function/simd/common/conditional.hpp
+++ b/include/eve/detail/function/simd/common/conditional.hpp
@@ -74,9 +74,9 @@ namespace eve::detail
       // Extract bitmap then use the function with mask support
       auto mask = [&](auto const& cx)
       {
-        auto m = cx.bitmap( as_<r_t>{} );
+        auto m = cx.mask( as_<r_t>{} ).bitmap();
         if constexpr( C::is_inverted )  return ~m;
-        else                            return m;
+        else                            return  m;
       };
 
       // Prepare the source value

--- a/include/eve/module/real/core/function/fuzzy/generic/ceil.hpp
+++ b/include/eve/module/real/core/function/fuzzy/generic/ceil.hpp
@@ -46,6 +46,6 @@ namespace eve::detail
   template<conditional_expr C, real_value U>
   EVE_FORCEINLINE auto ceil_(EVE_SUPPORTS(cpu_), C const &cond, tolerant_type const &, U const &t) noexcept
   {
-    return mask_op( EVE_CURRENT_API{}, cond, tolerant(eve::ceil), t);
+    return mask_op(  cond, tolerant(eve::ceil), t);
   }
 }

--- a/include/eve/module/real/core/function/fuzzy/generic/floor.hpp
+++ b/include/eve/module/real/core/function/fuzzy/generic/floor.hpp
@@ -85,7 +85,7 @@ namespace eve::detail
   template<conditional_expr C, real_value U>
   EVE_FORCEINLINE auto floor_(EVE_SUPPORTS(cpu_), C const &cond, tolerant_type const &, U const &t) noexcept
   {
-    return mask_op( EVE_CURRENT_API{}, cond, tolerant(eve::floor), t);
+    return mask_op(  cond, tolerant(eve::floor), t);
   }
 
 }

--- a/include/eve/module/real/core/function/fuzzy/generic/trunc.hpp
+++ b/include/eve/module/real/core/function/fuzzy/generic/trunc.hpp
@@ -76,6 +76,6 @@ namespace eve::detail
   template<conditional_expr C, real_value U>
   EVE_FORCEINLINE auto trunc_(EVE_SUPPORTS(cpu_), C const &cond, tolerant_type const &, U const &t) noexcept
   {
-    return mask_op( EVE_CURRENT_API{}, cond, tolerant(eve::trunc), t);
+    return mask_op(  cond, tolerant(eve::trunc), t);
   }
 }

--- a/include/eve/module/real/core/function/pedantic/generic/geommean.hpp
+++ b/include/eve/module/real/core/function/pedantic/generic/geommean.hpp
@@ -53,7 +53,7 @@ namespace eve::detail
                                 , U const &t, V const &f) noexcept
       requires compatible_values<U, V>
   {
-    return mask_op( EVE_CURRENT_API{}, cond, pedantic(eve::geommean), t, f);
+    return mask_op(  cond, pedantic(eve::geommean), t, f);
   }
 
 }

--- a/include/eve/module/real/core/function/pedantic/generic/rem.hpp
+++ b/include/eve/module/real/core/function/pedantic/generic/rem.hpp
@@ -34,6 +34,6 @@ namespace eve::detail
   rem_(EVE_SUPPORTS(cpu_), C const &cond, pedantic_type const &, U const &t, V const &f) noexcept
       requires compatible_values<U, V>
   {
-    return mask_op( EVE_CURRENT_API{}, cond, pedantic(rem), t, f);
+    return mask_op(  cond, pedantic(rem), t, f);
   }
 }

--- a/include/eve/module/real/core/function/regular/generic/abs.hpp
+++ b/include/eve/module/real/core/function/regular/generic/abs.hpp
@@ -38,6 +38,6 @@ namespace eve::detail
   template<conditional_expr C, real_value U>
   EVE_FORCEINLINE auto abs_(EVE_SUPPORTS(cpu_), C const &cond, U const &t) noexcept
   {
-    return mask_op( EVE_CURRENT_API{}, cond, eve::abs, t);
+    return mask_op( cond, eve::abs, t);
   }
 }

--- a/include/eve/module/real/core/function/regular/generic/add.hpp
+++ b/include/eve/module/real/core/function/regular/generic/add.hpp
@@ -21,7 +21,7 @@ namespace eve::detail
   EVE_FORCEINLINE auto add_(EVE_SUPPORTS(cpu_), C const &cond, U const &t, V const &f) noexcept
       requires compatible_values<U, V>
   {
-    return mask_op( EVE_CURRENT_API{}, cond, eve::add, t, f);
+    return mask_op(  cond, eve::add, t, f);
   }
 
   //================================================================================================

--- a/include/eve/module/real/core/function/regular/generic/average.hpp
+++ b/include/eve/module/real/core/function/regular/generic/average.hpp
@@ -62,7 +62,7 @@ namespace eve::detail
   EVE_FORCEINLINE auto average_(EVE_SUPPORTS(cpu_), C const &cond, U const &t, V const &f) noexcept
       requires compatible_values<U, V>
   {
-    return mask_op( EVE_CURRENT_API{}, cond, eve::average, t, f);
+    return mask_op(  cond, eve::average, t, f);
   }
 
   //================================================================================================

--- a/include/eve/module/real/core/function/regular/generic/bit_and.hpp
+++ b/include/eve/module/real/core/function/regular/generic/bit_and.hpp
@@ -23,7 +23,7 @@ namespace eve::detail
   EVE_FORCEINLINE auto bit_and_(EVE_SUPPORTS(cpu_), C const &cond, U const &t, V const &f) noexcept
       requires bit_compatible_values<U, V>
   {
-    return mask_op( EVE_CURRENT_API{}, cond, eve::bit_and, t, f);
+    return mask_op(  cond, eve::bit_and, t, f);
   }
 
   //================================================================================================

--- a/include/eve/module/real/core/function/regular/generic/bit_andnot.hpp
+++ b/include/eve/module/real/core/function/regular/generic/bit_andnot.hpp
@@ -55,7 +55,7 @@ namespace eve::detail
   EVE_FORCEINLINE auto bit_andnot_(EVE_SUPPORTS(cpu_), C const &cond, U const &t, V const &f) noexcept
       requires bit_compatible_values<U, V>
   {
-    return mask_op( EVE_CURRENT_API{}, cond, eve::bit_andnot, t, f);
+    return mask_op(  cond, eve::bit_andnot, t, f);
   }
 
   //================================================================================================

--- a/include/eve/module/real/core/function/regular/generic/bit_not.hpp
+++ b/include/eve/module/real/core/function/regular/generic/bit_not.hpp
@@ -26,6 +26,6 @@ namespace eve::detail
   template<conditional_expr C, real_value U>
   EVE_FORCEINLINE auto bit_not_(EVE_SUPPORTS(cpu_), C const &cond, U const &t) noexcept
   {
-    return mask_op( EVE_CURRENT_API{}, cond, eve::bit_not, t);
+    return mask_op(  cond, eve::bit_not, t);
   }
 }

--- a/include/eve/module/real/core/function/regular/generic/bit_notand.hpp
+++ b/include/eve/module/real/core/function/regular/generic/bit_notand.hpp
@@ -54,7 +54,7 @@ namespace eve::detail
   EVE_FORCEINLINE auto bit_notand_(EVE_SUPPORTS(cpu_), C const &cond, U const &t, V const &f) noexcept
       requires bit_compatible_values<U, V>
   {
-    return mask_op( EVE_CURRENT_API{}, cond, eve::bit_notand, t, f);
+    return mask_op(  cond, eve::bit_notand, t, f);
   }
 
   //================================================================================================

--- a/include/eve/module/real/core/function/regular/generic/bit_notor.hpp
+++ b/include/eve/module/real/core/function/regular/generic/bit_notor.hpp
@@ -53,7 +53,7 @@ namespace eve::detail
   EVE_FORCEINLINE auto bit_notor_(EVE_SUPPORTS(cpu_), C const &cond, U const &t, V const &f) noexcept
       requires bit_compatible_values<U, V>
   {
-    return mask_op( EVE_CURRENT_API{}, cond, eve::bit_notor, t, f);
+    return mask_op(  cond, eve::bit_notor, t, f);
   }
 
   //================================================================================================

--- a/include/eve/module/real/core/function/regular/generic/bit_or.hpp
+++ b/include/eve/module/real/core/function/regular/generic/bit_or.hpp
@@ -30,7 +30,7 @@ namespace eve::detail
   EVE_FORCEINLINE auto bit_or_(EVE_SUPPORTS(cpu_), C const &cond, U const &t, V const &f) noexcept
       requires bit_compatible_values<U, V>
   {
-    return mask_op( EVE_CURRENT_API{}, cond, eve::bit_or, t, f);
+    return mask_op(  cond, eve::bit_or, t, f);
   }
 
   //================================================================================================

--- a/include/eve/module/real/core/function/regular/generic/bit_ornot.hpp
+++ b/include/eve/module/real/core/function/regular/generic/bit_ornot.hpp
@@ -55,7 +55,7 @@ namespace eve::detail
   EVE_FORCEINLINE auto bit_ornot_(EVE_SUPPORTS(cpu_), C const &cond, U const &t, V const &f) noexcept
       requires bit_compatible_values<U, V>
   {
-    return mask_op( EVE_CURRENT_API{}, cond, eve::bit_ornot, t, f);
+    return mask_op(  cond, eve::bit_ornot, t, f);
   }
 
   //================================================================================================

--- a/include/eve/module/real/core/function/regular/generic/bit_shr.hpp
+++ b/include/eve/module/real/core/function/regular/generic/bit_shr.hpp
@@ -54,7 +54,7 @@ namespace eve::detail
   template<conditional_expr C, integral_value T, integral_value U>
   EVE_FORCEINLINE auto bit_shr_(EVE_SUPPORTS(cpu_), C const &cond, T const &a, U const &b) noexcept
   {
-    return mask_op( EVE_CURRENT_API{}, cond, eve::bit_shr, a, b);
+    return mask_op(  cond, eve::bit_shr, a, b);
   }
 
 }

--- a/include/eve/module/real/core/function/regular/generic/bit_xor.hpp
+++ b/include/eve/module/real/core/function/regular/generic/bit_xor.hpp
@@ -24,7 +24,7 @@ namespace eve::detail
   EVE_FORCEINLINE auto bit_xor_(EVE_SUPPORTS(cpu_), C const &cond, U const &t, V const &f) noexcept
       requires bit_compatible_values<U, V>
   {
-    return mask_op( EVE_CURRENT_API{}, cond, eve::bit_xor, t, f);
+    return mask_op(  cond, eve::bit_xor, t, f);
   }
 
   //================================================================================================

--- a/include/eve/module/real/core/function/regular/generic/bitofsign.hpp
+++ b/include/eve/module/real/core/function/regular/generic/bitofsign.hpp
@@ -29,7 +29,7 @@ namespace eve::detail
   template<conditional_expr C, real_value U>
   EVE_FORCEINLINE auto bitofsign_(EVE_SUPPORTS(cpu_), C const &cond, U const &t) noexcept
   {
-    return mask_op( EVE_CURRENT_API{}, cond, eve::bitofsign, t);
+    return mask_op(  cond, eve::bitofsign, t);
   }
 
 }

--- a/include/eve/module/real/core/function/regular/generic/cbrt.hpp
+++ b/include/eve/module/real/core/function/regular/generic/cbrt.hpp
@@ -76,7 +76,7 @@ namespace eve::detail
   template<conditional_expr C, floating_real_value U>
   EVE_FORCEINLINE auto cbrt_(EVE_SUPPORTS(cpu_), C const &cond, U const &t) noexcept
   {
-    return mask_op( EVE_CURRENT_API{}, cond, eve::cbrt, t);
+    return mask_op(  cond, eve::cbrt, t);
   }
 
 }

--- a/include/eve/module/real/core/function/regular/generic/dec.hpp
+++ b/include/eve/module/real/core/function/regular/generic/dec.hpp
@@ -29,6 +29,6 @@ namespace eve::detail
   template<conditional_expr C, real_value U>
   EVE_FORCEINLINE auto dec_(EVE_SUPPORTS(cpu_), C const &cond, U const &t) noexcept
   {
-    return mask_op( EVE_CURRENT_API{}, cond, eve::dec, t);
+    return mask_op(  cond, eve::dec, t);
   }
 }

--- a/include/eve/module/real/core/function/regular/generic/div.hpp
+++ b/include/eve/module/real/core/function/regular/generic/div.hpp
@@ -59,7 +59,7 @@ namespace eve::detail
   EVE_FORCEINLINE auto div_(EVE_SUPPORTS(cpu_), C const &cond, U const &t, V const &f) noexcept
       requires compatible_values<U, V>
   {
-    return mask_op( EVE_CURRENT_API{}, cond, eve::div, t, f);
+    return mask_op(  cond, eve::div, t, f);
   }
 
   template<conditional_expr C, decorator D, real_value U, real_value V>
@@ -67,7 +67,7 @@ namespace eve::detail
   div_(EVE_SUPPORTS(cpu_), C const &cond, D const &, U const &t, V const &f) noexcept
       requires compatible_values<U, V>
   {
-    return mask_op( EVE_CURRENT_API{}, cond, D()(div), t, f);
+    return mask_op(  cond, D()(div), t, f);
   }
 }
 

--- a/include/eve/module/real/core/function/regular/generic/geommean.hpp
+++ b/include/eve/module/real/core/function/regular/generic/geommean.hpp
@@ -44,7 +44,7 @@ namespace eve::detail
   EVE_FORCEINLINE auto geommean_(EVE_SUPPORTS(cpu_), C const &cond, U const &t, V const &f) noexcept
       requires compatible_values<U, V>
   {
-    return mask_op( EVE_CURRENT_API{}, cond, eve::geommean, t, f);
+    return mask_op(  cond, eve::geommean, t, f);
   }
 
 }

--- a/include/eve/module/real/core/function/regular/generic/inc.hpp
+++ b/include/eve/module/real/core/function/regular/generic/inc.hpp
@@ -29,6 +29,6 @@ namespace eve::detail
   template<conditional_expr C, real_value U>
   EVE_FORCEINLINE auto inc_(EVE_SUPPORTS(cpu_), C const &cond, U const &t) noexcept
   {
-    return mask_op( EVE_CURRENT_API{}, cond, eve::inc, t);
+    return mask_op(  cond, eve::inc, t);
   }
 }

--- a/include/eve/module/real/core/function/regular/generic/minus.hpp
+++ b/include/eve/module/real/core/function/regular/generic/minus.hpp
@@ -29,7 +29,7 @@ namespace eve::detail
   template<conditional_expr C, real_value U>
   EVE_FORCEINLINE auto minus_(EVE_SUPPORTS(cpu_), C const &cond, U const &t) noexcept
   {
-    return mask_op( EVE_CURRENT_API{}, cond, eve::minus, t);
+    return mask_op(  cond, eve::minus, t);
   }
 
   template<conditional_expr C, real_value U, real_value V>
@@ -37,6 +37,6 @@ namespace eve::detail
       requires compatible_values<U, V>
   {
     auto substract =  [](auto x, auto y){return x-y;};
-    return mask_op( EVE_CURRENT_API{}, cond, substract, t, f);
+    return mask_op(  cond, substract, t, f);
   }
 }

--- a/include/eve/module/real/core/function/regular/generic/mul.hpp
+++ b/include/eve/module/real/core/function/regular/generic/mul.hpp
@@ -23,7 +23,7 @@ namespace eve::detail
   EVE_FORCEINLINE auto mul_(EVE_SUPPORTS(cpu_), C const &cond, U const &t, V const &f) noexcept
       requires compatible_values<U, V>
   {
-    return mask_op( EVE_CURRENT_API{}, cond, eve::mul, t, f);
+    return mask_op(  cond, eve::mul, t, f);
   }
 
   //================================================================================================

--- a/include/eve/module/real/core/function/regular/generic/oneminus.hpp
+++ b/include/eve/module/real/core/function/regular/generic/oneminus.hpp
@@ -26,6 +26,6 @@ namespace eve::detail
   template<conditional_expr C, real_value U>
   EVE_FORCEINLINE auto oneminus_(EVE_SUPPORTS(cpu_), C const &cond, U const &t) noexcept
   {
-    return mask_op( EVE_CURRENT_API{}, cond, eve::oneminus, t);
+    return mask_op(  cond, eve::oneminus, t);
   }
 }

--- a/include/eve/module/real/core/function/regular/generic/plus.hpp
+++ b/include/eve/module/real/core/function/regular/generic/plus.hpp
@@ -35,6 +35,6 @@ namespace eve::detail
   EVE_FORCEINLINE auto plus_(EVE_SUPPORTS(cpu_), C const &cond, U const &t, V const &f) noexcept
       requires compatible_values<U, V>
   {
-    return mask_op( EVE_CURRENT_API{}, cond, eve::add, t, f);
+    return mask_op(  cond, eve::add, t, f);
   }
 }

--- a/include/eve/module/real/core/function/regular/generic/rem.hpp
+++ b/include/eve/module/real/core/function/regular/generic/rem.hpp
@@ -58,7 +58,7 @@ namespace eve::detail
   EVE_FORCEINLINE auto rem_(EVE_SUPPORTS(cpu_), C const &cond, U const &t, V const &f) noexcept
       requires compatible_values<U, V>
   {
-    return mask_op( EVE_CURRENT_API{}, cond, eve::rem, t, f);
+    return mask_op(  cond, eve::rem, t, f);
   }
 
   template<conditional_expr C, decorator D, real_value U, real_value V>
@@ -66,6 +66,6 @@ namespace eve::detail
   rem_(EVE_SUPPORTS(cpu_), C const &cond, D const &, U const &t, V const &f) noexcept
       requires compatible_values<U, V>
   {
-    return mask_op( EVE_CURRENT_API{}, cond, D()(rem), t, f);
+    return mask_op(  cond, D()(rem), t, f);
   }
 }

--- a/include/eve/module/real/core/function/regular/generic/sqrt.hpp
+++ b/include/eve/module/real/core/function/regular/generic/sqrt.hpp
@@ -48,6 +48,6 @@ namespace eve::detail
   template<conditional_expr C, real_value U>
   EVE_FORCEINLINE auto sqrt_(EVE_SUPPORTS(cpu_), C const &cond, U const &t) noexcept
   {
-    return mask_op( EVE_CURRENT_API{}, cond, eve::sqrt, t);
+    return mask_op(  cond, eve::sqrt, t);
   }
 }

--- a/include/eve/module/real/core/function/regular/generic/sub.hpp
+++ b/include/eve/module/real/core/function/regular/generic/sub.hpp
@@ -23,6 +23,6 @@ namespace eve::detail
   EVE_FORCEINLINE auto sub_(EVE_SUPPORTS(cpu_), C const &cond, U const &t, V const &f) noexcept
       requires compatible_values<U, V>
   {
-    return mask_op( EVE_CURRENT_API{}, cond, eve::sub, t, f);
+    return mask_op(  cond, eve::sub, t, f);
   }
 }

--- a/include/eve/module/real/core/function/regular/simd/x86/load.hpp
+++ b/include/eve/module/real/core/function/regular/simd/x86/load.hpp
@@ -71,7 +71,7 @@ namespace eve::detail
         else                                return s;
       };
 
-      auto mask = cond.bitmap( as_<r_t>{} );
+      auto mask = cond.mask( as_<r_t>{} ).storage().value;
       constexpr auto c = categorize<r_t>();
 
             if constexpr( c == category::float64x8 ) return _mm512_mask_loadu_pd(src(that),mask,p);

--- a/include/eve/module/real/core/function/saturated/generic/abs.hpp
+++ b/include/eve/module/real/core/function/saturated/generic/abs.hpp
@@ -51,6 +51,6 @@ namespace eve::detail
   template<conditional_expr C, real_value U>
   EVE_FORCEINLINE auto abs_(EVE_SUPPORTS(cpu_), C const &cond, saturated_type const &, U const &t) noexcept
   {
-    return mask_op( EVE_CURRENT_API{}, cond, saturated(eve::abs), t);
+    return mask_op( cond, saturated(eve::abs), t);
   }
 }

--- a/include/eve/module/real/core/function/saturated/generic/add.hpp
+++ b/include/eve/module/real/core/function/saturated/generic/add.hpp
@@ -143,7 +143,7 @@ namespace eve::detail
   add_(EVE_SUPPORTS(cpu_), C const &cond, saturated_type const &, U const &t, V const &f) noexcept
       requires compatible_values<U, V>
   {
-    return mask_op( EVE_CURRENT_API{}, cond, saturated(add), t, f);
+    return mask_op(  cond, saturated(add), t, f);
   }
 
 }

--- a/include/eve/module/real/core/function/saturated/generic/dec.hpp
+++ b/include/eve/module/real/core/function/saturated/generic/dec.hpp
@@ -35,6 +35,6 @@ namespace eve::detail
   template<conditional_expr C, real_value U>
   EVE_FORCEINLINE auto dec_(EVE_SUPPORTS(cpu_), C const &cond, saturated_type const &, U const &t) noexcept
   {
-    return mask_op( EVE_CURRENT_API{}, cond, saturated(eve::dec), t);
+    return mask_op(  cond, saturated(eve::dec), t);
   }
 }

--- a/include/eve/module/real/core/function/saturated/generic/div.hpp
+++ b/include/eve/module/real/core/function/saturated/generic/div.hpp
@@ -100,7 +100,7 @@ namespace eve::detail
   div_(EVE_SUPPORTS(cpu_), C const &cond, saturated_type const &, U const &t, V const &f) noexcept
       requires compatible_values<U, V>
   {
-    return mask_op( EVE_CURRENT_API{}, cond, saturated(div), t, f);
+    return mask_op(  cond, saturated(div), t, f);
   }
 }
 

--- a/include/eve/module/real/core/function/saturated/generic/inc.hpp
+++ b/include/eve/module/real/core/function/saturated/generic/inc.hpp
@@ -46,6 +46,6 @@ namespace eve::detail
   EVE_FORCEINLINE auto inc_(EVE_SUPPORTS(cpu_), C const &cond
                            , saturated_type const &, U const &t) noexcept
   {
-    return mask_op( EVE_CURRENT_API{}, cond, saturated(eve::inc), t);
+    return mask_op(  cond, saturated(eve::inc), t);
   }
 }

--- a/include/eve/module/real/core/function/saturated/generic/mul.hpp
+++ b/include/eve/module/real/core/function/saturated/generic/mul.hpp
@@ -148,6 +148,6 @@ namespace eve::detail
   mul_(EVE_SUPPORTS(cpu_), C const &cond, saturated_type const &, U const &t, V const &f) noexcept
       requires compatible_values<U, V>
   {
-    return mask_op( EVE_CURRENT_API{}, cond, saturated(mul), t, f);
+    return mask_op(  cond, saturated(mul), t, f);
   }
 }

--- a/include/eve/module/real/core/function/saturated/generic/oneminus.hpp
+++ b/include/eve/module/real/core/function/saturated/generic/oneminus.hpp
@@ -59,6 +59,6 @@ namespace eve::detail
   EVE_FORCEINLINE auto oneminus_(EVE_SUPPORTS(cpu_), C const &cond
                                 , saturated_type const &, U const &t) noexcept
   {
-    return mask_op( EVE_CURRENT_API{}, cond, saturated(eve::oneminus), t);
+    return mask_op(  cond, saturated(eve::oneminus), t);
   }
 }

--- a/include/eve/module/real/core/function/saturated/generic/plus.hpp
+++ b/include/eve/module/real/core/function/saturated/generic/plus.hpp
@@ -30,6 +30,6 @@ namespace eve::detail
   plus_(EVE_SUPPORTS(cpu_), C const &cond, saturated_type const &, U const &t, V const &f) noexcept
       requires compatible_values<U, V>
   {
-    return mask_op( EVE_CURRENT_API{}, cond, saturated(add), t, f);
+    return mask_op(  cond, saturated(add), t, f);
   }
 }

--- a/include/eve/module/real/core/function/saturated/generic/sub.hpp
+++ b/include/eve/module/real/core/function/saturated/generic/sub.hpp
@@ -134,6 +134,6 @@ namespace eve::detail
   sub_(EVE_SUPPORTS(cpu_), C const &cond, saturated_type const &, U const &t, V const &f) noexcept
       requires compatible_values<U, V>
   {
-    return mask_op( EVE_CURRENT_API{}, cond, saturated(sub), t, f);
+    return mask_op(  cond, saturated(sub), t, f);
   }
 }

--- a/include/eve/module/real/math/detail/generic/atan_kernel.hpp
+++ b/include/eve/module/real/math/detail/generic/atan_kernel.hpp
@@ -69,7 +69,7 @@ namespace eve::detail
     }
     z = eve::fma(xx, z, xx);
     z = add[flag2]     (z, Ieee_constant<T, 0XB2BBBD2EU, 0X3C81A62633145C07ULL>());  //pio_4lo
-    z = add[if_not_(flag1)](z, Ieee_constant<T,0XB33BBD2EU, 0X3C91A62633145C07ULL>());   //pio_2lo
+    z = add[!flag1](z, Ieee_constant<T,0XB33BBD2EU, 0X3C91A62633145C07ULL>());   //pio_2lo
     return yy + z;
   }
 }

--- a/include/eve/module/real/math/function/regular/generic/logspace_add.hpp
+++ b/include/eve/module/real/math/function/regular/generic/logspace_add.hpp
@@ -80,7 +80,7 @@ namespace eve::detail
   EVE_FORCEINLINE auto logspace_add_(EVE_SUPPORTS(cpu_), C const &cond, U const &t, V const &f) noexcept
       requires compatible_values<U, V>
   {
-    return mask_op( EVE_CURRENT_API{}, cond, eve::logspace_add, t, f);
+    return mask_op(  cond, eve::logspace_add, t, f);
   }
 
 }

--- a/include/eve/module/real/math/function/regular/generic/logspace_sub.hpp
+++ b/include/eve/module/real/math/function/regular/generic/logspace_sub.hpp
@@ -83,7 +83,7 @@ namespace eve::detail
   EVE_FORCEINLINE auto logspace_sub_(EVE_SUPPORTS(cpu_), C const &cond, U const &t, V const &f) noexcept
       requires compatible_values<U, V>
   {
-    return mask_op( EVE_CURRENT_API{}, cond, eve::logspace_sub, t, f);
+    return mask_op(  cond, eve::logspace_sub, t, f);
   }
 
 }

--- a/include/eve/module/real/polynomial/function/diff/generic/gegenbauer.hpp
+++ b/include/eve/module/real/polynomial/function/diff/generic/gegenbauer.hpp
@@ -25,7 +25,7 @@ namespace eve::detail
                                             , U const &x) noexcept
   requires index_compatible_values<N, T> && compatible_values<T, U>
   {
-    auto iseqzn = is_eqz(n); 
-    return if_else(iseqzn, zero, 2*l*gegenbauer(dec[if_not_(iseqzn)](n), inc(l), x));
+    auto iseqzn = is_eqz(n);
+    return if_else(iseqzn, zero, 2*l*gegenbauer(dec[!iseqzn](n), inc(l), x));
   }
 }

--- a/include/eve/module/real/polynomial/function/regular/generic/hermite.hpp
+++ b/include/eve/module/real/polynomial/function/regular/generic/hermite.hpp
@@ -81,7 +81,7 @@ namespace eve::detail
     auto p0 = one(as(x));
     auto iseqzn = is_eqz(nn);
     if(eve::all(iseqzn)) return p0;
-    auto p1 = add[if_not_(iseqzn)](x, x);
+    auto p1 = add[!iseqzn](x, x);
     auto n =  convert(nn, as<elt_t>());
     auto c = one(as(n));
     auto hermite_next = [](auto c,  auto x,  auto hn,  auto hnm1)

--- a/test/unit/api/conditional.cpp
+++ b/test/unit/api/conditional.cpp
@@ -14,9 +14,9 @@
 #include <eve/function/if_else.hpp>
 #include <eve/wide.hpp>
 
-TTS_CASE_TPL("ignore_all behavior", TTS_NUMERIC_TYPES)
+EVE_TEST_TYPES( "ignore_all behavior", eve::test::simd::all_types)
+<typename type>(eve::as_<type>)
 {
-  using eve::wide;
   using eve::logical;
   using eve::relative_conditional_expr;
   using eve::ignore_all;
@@ -25,17 +25,15 @@ TTS_CASE_TPL("ignore_all behavior", TTS_NUMERIC_TYPES)
 
   TTS_EXPECT( relative_conditional_expr<eve::ignore_all_>  );
 
-  using type = wide<T>;
-
   TTS_EXPR_IS(ignore_all.mask( as_<type>() ), logical<type> );
 
-  TTS_EQUAL( ignore_all.mask( as_<type>() )           , eve::false_( as_<type>() ) );
+  TTS_EQUAL( ignore_all.mask( as_<type>() )           , eve::false_( as_<type>()) );
   TTS_EQUAL( (if_else(ignore_all,type(42), type(69))) , type(69)                  );
-}
+};
 
-TTS_CASE_TPL("ignore_none behavior", TTS_NUMERIC_TYPES)
+EVE_TEST_TYPES( "ignore_none behavior", eve::test::simd::all_types)
+<typename type>(eve::as_<type>)
 {
-  using eve::wide;
   using eve::logical;
   using eve::relative_conditional_expr;
   using eve::ignore_none;
@@ -44,17 +42,15 @@ TTS_CASE_TPL("ignore_none behavior", TTS_NUMERIC_TYPES)
 
   TTS_EXPECT( relative_conditional_expr<eve::ignore_none_>  );
 
-  using type = wide<T>;
-
   TTS_EXPR_IS(ignore_none.mask( as_<type>() ), logical<type> );
 
   TTS_EQUAL( ignore_none.mask( as_<type>() )            , eve::true_( as_<type>() )  );
   TTS_EQUAL( (if_else(ignore_none,type(42), type(69)))  , type(42)                  );
-}
+};
 
-TTS_CASE_TPL("ignore_last behavior", TTS_NUMERIC_TYPES)
+EVE_TEST_TYPES( "ignore_last behavior", eve::test::simd::all_types)
+<typename type>(eve::as_<type>)
 {
-  using eve::wide;
   using eve::logical;
   using eve::relative_conditional_expr;
   using eve::ignore_last;
@@ -63,7 +59,6 @@ TTS_CASE_TPL("ignore_last behavior", TTS_NUMERIC_TYPES)
 
   TTS_EXPECT( relative_conditional_expr<eve::ignore_last>  );
 
-  using type = wide<T>;
   type value = [](auto i, auto) { return 1+i; };
 
   TTS_EXPR_IS(ignore_last(0).mask( as_<type>() ), logical<type> );
@@ -71,7 +66,7 @@ TTS_CASE_TPL("ignore_last behavior", TTS_NUMERIC_TYPES)
   TTS_EQUAL( ignore_last(0).mask(as_<type>()).bits(), eve::true_(as_<type>()).bits());
   TTS_EQUAL( (if_else(ignore_last(0),value, type(69))), value                   );
 
-  for(std::size_t i = 1;i <= type::static_size;i++)
+  for(std::size_t i = 1;i < type::static_size;i++)
   {
     logical<type> mref  = [i](std::size_t j, std::size_t c) { return j < c-i; };
     type          ref   = [i,&value](std::size_t j, std::size_t c) { return (j < c-i) ? value.get(j) : 69; };
@@ -82,11 +77,11 @@ TTS_CASE_TPL("ignore_last behavior", TTS_NUMERIC_TYPES)
 
   TTS_EQUAL( ignore_last(type::static_size).mask(as_<type>())          , eve::false_( as_<type>() ) );
   TTS_EQUAL( (if_else(ignore_last(type::static_size),value, type(69))) , type(69)                  );
-}
+};
 
-TTS_CASE_TPL("keep_last behavior", TTS_NUMERIC_TYPES)
+EVE_TEST_TYPES( "keep_last behavior", eve::test::simd::all_types)
+<typename type>(eve::as_<type>)
 {
-  using eve::wide;
   using eve::logical;
   using eve::relative_conditional_expr;
   using eve::keep_last;
@@ -95,7 +90,6 @@ TTS_CASE_TPL("keep_last behavior", TTS_NUMERIC_TYPES)
 
   TTS_EXPECT( relative_conditional_expr<eve::keep_last>  );
 
-  using type = wide<T>;
   type value = [](auto i, auto) { return 1+i; };
 
   TTS_EXPR_IS(keep_last(0).mask( as_<type>() ), logical<type> );
@@ -114,11 +108,11 @@ TTS_CASE_TPL("keep_last behavior", TTS_NUMERIC_TYPES)
 
   TTS_EQUAL( keep_last(0).mask(as_<type>()).bits(), eve::false_(as_<type>()).bits() );
   TTS_EQUAL( (if_else(keep_last(0),value, type(69))) , type(69)                     );
-}
+};
 
-TTS_CASE_TPL("ignore_first behavior", TTS_NUMERIC_TYPES)
+EVE_TEST_TYPES( "ignore_first behavior", eve::test::simd::all_types)
+<typename type>(eve::as_<type>)
 {
-  using eve::wide;
   using eve::logical;
   using eve::relative_conditional_expr;
   using eve::ignore_first;
@@ -127,7 +121,6 @@ TTS_CASE_TPL("ignore_first behavior", TTS_NUMERIC_TYPES)
 
   TTS_EXPECT( relative_conditional_expr<eve::ignore_first>  );
 
-  using type = wide<T>;
   type value = [](auto i, auto) { return 1+i; };
 
   TTS_EXPR_IS(ignore_first(0).mask( as_<type>() ), logical<type> );
@@ -146,11 +139,11 @@ TTS_CASE_TPL("ignore_first behavior", TTS_NUMERIC_TYPES)
 
   TTS_EQUAL( ignore_first(type::static_size).mask(as_<type>()).bits(), eve::false_(as_<type>()).bits());
   TTS_EQUAL( (if_else(ignore_first(type::static_size),value, type(69))) , type(69)                );
-}
+};
 
-TTS_CASE_TPL("keep_first behavior", TTS_NUMERIC_TYPES)
+EVE_TEST_TYPES( "keep_first behavior", eve::test::simd::all_types)
+<typename type>(eve::as_<type>)
 {
-  using eve::wide;
   using eve::logical;
   using eve::relative_conditional_expr;
   using eve::keep_first;
@@ -159,7 +152,6 @@ TTS_CASE_TPL("keep_first behavior", TTS_NUMERIC_TYPES)
 
   TTS_EXPECT( relative_conditional_expr<eve::keep_first>  );
 
-  using type = wide<T>;
   type value = [](auto i, auto) { return 1+i; };
 
   TTS_EXPR_IS(keep_first(0).mask( as_<type>() ), logical<type> );
@@ -178,11 +170,11 @@ TTS_CASE_TPL("keep_first behavior", TTS_NUMERIC_TYPES)
 
   TTS_EQUAL( keep_first(0).mask(as_<type>()).bits(), eve::false_(as_<type>()).bits());
   TTS_EQUAL( (if_else(keep_first(0),value, type(69))) , type(69)                    );
-}
+};
 
-TTS_CASE_TPL("keep_between behavior", TTS_NUMERIC_TYPES)
+EVE_TEST_TYPES( "keep_between behavior", eve::test::simd::all_types)
+<typename type>(eve::as_<type>)
 {
-  using eve::wide;
   using eve::logical;
   using eve::relative_conditional_expr;
   using eve::keep_between;
@@ -191,7 +183,6 @@ TTS_CASE_TPL("keep_between behavior", TTS_NUMERIC_TYPES)
 
   TTS_EXPECT( relative_conditional_expr<eve::keep_between>  );
 
-  using type = wide<T>;
   type value = [](auto i, auto) { return 1+i; };
 
   TTS_EXPR_IS(keep_between(0,1).mask( as_<type>() ), logical<type> );
@@ -210,11 +201,11 @@ TTS_CASE_TPL("keep_between behavior", TTS_NUMERIC_TYPES)
       }
     }
   }
-}
+};
 
-TTS_CASE_TPL("ignore_first/last combination", TTS_NUMERIC_TYPES)
+EVE_TEST_TYPES( "ignore_first/last behavior", eve::test::simd::all_types)
+<typename type>(eve::as_<type>)
 {
-  using eve::wide;
   using eve::logical;
   using eve::relative_conditional_expr;
   using eve::ignore_first;
@@ -224,7 +215,6 @@ TTS_CASE_TPL("ignore_first/last combination", TTS_NUMERIC_TYPES)
 
   TTS_EXPECT( relative_conditional_expr<eve::ignore_extrema>  );
 
-  using type = wide<T>;
   type value = [](auto i, auto) { return 1+i; };
 
   TTS_EXPR_IS( ((ignore_first(1) && ignore_last(0)).mask( as_<type>() )), logical<type> );
@@ -233,7 +223,7 @@ TTS_CASE_TPL("ignore_first/last combination", TTS_NUMERIC_TYPES)
   for(std::size_t i = 0;i <= type::static_size; i++)
   {
     auto mref  = ignore_first(i).mask(as_<type>());
-    type ref   = if_else(ignore_first(i), value, T(69));
+    type ref   = if_else(ignore_first(i), value, type(69));
 
     TTS_EQUAL( (ignore_first(i) && ignore_last(0)).mask(as_<type>()).bits(), mref.bits() );
     TTS_EQUAL( (if_else(ignore_first(i) && ignore_last(0),value, type(69))), ref);
@@ -243,7 +233,7 @@ TTS_CASE_TPL("ignore_first/last combination", TTS_NUMERIC_TYPES)
   for(std::size_t i = 0;i <= type::static_size; i++)
   {
     auto mref  = ignore_last(i).mask(as_<type>());
-    type ref   = if_else(ignore_last(i), value, T(69));
+    type ref   = if_else(ignore_last(i), value, type(69));
 
     TTS_EQUAL( (ignore_first(0) && ignore_last(i)).mask(as_<type>()).bits(), mref.bits() );
     TTS_EQUAL( (if_else(ignore_first(0) && ignore_last(i),value, type(69))), ref);
@@ -255,10 +245,10 @@ TTS_CASE_TPL("ignore_first/last combination", TTS_NUMERIC_TYPES)
     for(std::size_t li = 1;li <= type::static_size;li++)
     {
       auto mref  = ignore_first(fi).mask(as_<type>()) && ignore_last(li).mask(as_<type>());
-      type ref   = if_else(mref, value, T(69));
+      type ref   = if_else(mref, value,  type(69));
 
       TTS_EQUAL( (ignore_first(fi) && ignore_last(li)).mask(as_<type>()).bits(), mref.bits() );
       TTS_EQUAL( (if_else(ignore_first(fi) && ignore_last(li),value, type(69))), ref);
     }
   }
-}
+};

--- a/test/unit/module/real/core/abs.cpp
+++ b/test/unit/module/real/core/abs.cpp
@@ -6,97 +6,176 @@
 **/
 //==================================================================================================
 #include "test.hpp"
-#include <eve/concept/value.hpp>
 #include <eve/constant/valmin.hpp>
 #include <eve/constant/valmax.hpp>
 #include <eve/function/abs.hpp>
-#include <eve/function/inc.hpp>
 #include <eve/function/diff/abs.hpp>
 #include <eve/function/saturated/abs.hpp>
 #include <eve/logical.hpp>
-#include <type_traits>
 #include <cmath>
+
+//==================================================================================================
+// Specific generator - valmin or valmin+1 if T is signed
+//==================================================================================================
+auto minimal = []<typename T>(eve::as_<T> const & tgt)
+{
+  constexpr auto sign = std::is_signed_v<T> ? 1 : 0;
+  return eve::valmin(tgt) + sign;
+};
 
 //==================================================================================================
 // Types tests
 //==================================================================================================
-EVE_TEST_TYPES( "Check return types of abs"
-            , eve::test::simd::all_types
-            )
+EVE_TEST_TYPES( "Check return types of eve::abs(scalar)", eve::test::scalar::all_types)
+<typename T>(eve::as_<T>)
+{
+  TTS_EXPR_IS( eve::abs(T())                    , T   );
+  TTS_EXPR_IS( eve::abs[eve::logical<T>()](T()) , T   );
+  TTS_EXPR_IS( eve::abs[bool()](T())            , T   );
+
+  TTS_EXPR_IS( eve::saturated(eve::abs)(T())                   , T   );
+  TTS_EXPR_IS( eve::saturated(eve::abs[eve::logical<T>()])(T()), T   );
+  TTS_EXPR_IS( eve::saturated(eve::abs[bool()])(T())           , T   );
+
+  if constexpr(eve::floating_real_value<T>)
+  {
+    TTS_EXPR_IS( eve::diff(eve::abs)(T()) , T );
+  }
+};
+
+EVE_TEST_TYPES( "Check return types of eve::abs(wide)", eve::test::simd::all_types)
 <typename T>(eve::as_<T>)
 {
   using v_t = eve::element_type_t<T>;
 
-  TTS_EXPR_IS( eve::abs(T())  , T);
-  TTS_EXPR_IS( eve::abs(v_t()), v_t);
-  TTS_EXPR_IS( eve::abs[eve::logical<T>()](T())  , T);
-  TTS_EXPR_IS( eve::abs[eve::logical<T>()](v_t()), T);
-  TTS_EXPR_IS( eve::abs[eve::logical<v_t>()](T())  , T);
-  TTS_EXPR_IS( eve::abs[eve::logical<v_t>()](v_t()), v_t);
-  TTS_EXPR_IS( eve::abs[bool()](T())  , T);
-  TTS_EXPR_IS( eve::abs[bool()](v_t()), v_t);
+  TTS_EXPR_IS( eve::abs(T())                      , T );
+  TTS_EXPR_IS( eve::abs[eve::logical<T>()](T())   , T );
+  TTS_EXPR_IS( eve::abs[eve::logical<v_t>()](T()) , T );
+  TTS_EXPR_IS( eve::abs[bool()](T())              , T );
 
-
-  TTS_EXPR_IS( eve::saturated(eve::abs)(T())  , T);
-  TTS_EXPR_IS( eve::saturated(eve::abs)(v_t()), v_t);
-  TTS_EXPR_IS( eve::saturated(eve::abs[eve::logical<T>()])(T())  , T);
-  TTS_EXPR_IS( eve::saturated(eve::abs[eve::logical<T>()])(v_t()), T);
-  TTS_EXPR_IS( eve::saturated(eve::abs[eve::logical<v_t>()])(T())  , T);
-  TTS_EXPR_IS( eve::saturated(eve::abs[eve::logical<v_t>()])(v_t()), v_t);
-  TTS_EXPR_IS( eve::saturated(eve::abs[bool()])(T())  , T);
-  TTS_EXPR_IS( eve::saturated(eve::abs[bool()])(v_t()), v_t);
+  TTS_EXPR_IS( eve::saturated(eve::abs)(T())                      , T );
+  TTS_EXPR_IS( eve::saturated(eve::abs[eve::logical<T>()])(T())   , T );
+  TTS_EXPR_IS( eve::saturated(eve::abs[eve::logical<v_t>()])(T()) , T );
+  TTS_EXPR_IS( eve::saturated(eve::abs[bool()])(T())              , T );
 
   if constexpr(eve::floating_real_value<T>)
   {
-    TTS_EXPR_IS( eve::diff(eve::abs)(T())  , T);
-    TTS_EXPR_IS( eve::diff(eve::abs)(v_t()), v_t);
+    TTS_EXPR_IS( eve::diff(eve::abs)(T()) , T );
   }
 };
 
-
-
 //==================================================================================================
-// abs signed tests
+// Tests for eve::abs
 //==================================================================================================
-auto valminp1 = []< typename T>(eve::as_<T> const &){return eve::inc(eve::valmin(eve::as(eve::element_type_t<T>())));};
+EVE_TEST( "Check behavior of eve::abs(eve::wide)"
+        , eve::test::simd::all_types
+        , eve::test::generate ( eve::test::randoms(minimal, eve::valmax)
+                              , eve::test::logicals(0,3)
+                              )
+        )
+<typename T, typename M>(T const& a0, M const& mask )
+{
+  using eve::detail::map;
+  using v_t = eve::element_type_t<T>;
 
-EVE_TEST( "Check behavior of abs on signed wide"
-        , eve::test::simd::signed_types
-        , eve::test::generate(eve::test::randoms(valminp1, eve::valmax))
+  TTS_EQUAL(eve::abs(a0)      , map([](auto e) -> v_t { return e > 0 ? e : -e; }, a0) );
+  TTS_EQUAL(eve::abs[mask](a0), eve::if_else(mask,eve::abs(a0),a0)                    );
+};
+
+EVE_TEST( "Check behavior of eve::abs(scalar) - signed types"
+        , eve::test::scalar::all_types
+        , eve::test::generate(eve::test::randoms(minimal, eve::valmax))
         )
 <typename T>(T const& a0 )
 {
-  using v_t = eve::element_type_t<T>;
-  TTS_EQUAL( eve::abs(a0), T([&](auto i, auto) { return a0.get(i) > 0 ? v_t(a0.get(i)) : -v_t(a0.get(i)); }));
-  if constexpr(eve::floating_real_value<T>)
-    TTS_EQUAL( eve::diff(eve::abs)(a0)
-             , (T([&](auto i, auto) {
-                   auto z = a0.get(i); return (z > 0 ? v_t(1)
-                                               : (z <  0) ? v_t(-1) : v_t(0));
-                  }))
-             );
+  TTS_EQUAL(eve::abs(a0), (a0 > 0 ? T(a0) : T(-a0)) );
+  TTS_EQUAL(eve::abs[true ](a0), eve::abs(a0)       );
+  TTS_EQUAL(eve::abs[false](a0), a0                 );
 };
 
-EVE_TEST( "Check behavior of saturated(abs) on signed integral wide"
-        , eve::test::simd::signed_integers
+//==================================================================================================
+// Tests for eve::saturated(eve::abs)
+//==================================================================================================
+EVE_TEST( "Check behavior of eve::saturated(eve::abs)(eve::wide)"
+        , eve::test::simd::all_types
+        , eve::test::generate ( eve::test::randoms(minimal, eve::valmax)
+                              , eve::test::logicals(0,3)
+                              )
+        )
+<typename T, typename M>(T const& a0, M const& mask )
+{
+  using v_t = eve::element_type_t<T>;
+  using eve::detail::map;
+
+  if constexpr(std::is_signed_v<v_t>)
+  {
+    TTS_EQUAL ( eve::saturated(eve::abs)(a0)
+              , map ( [](auto e)
+                      {
+                        return e == eve::valmin(eve::as(e)) ? eve::valmax(eve::as(e))
+                                                            : eve::abs(e);
+                      }
+                    , a0
+                    )
+              );
+  }
+  else
+  {
+    TTS_EQUAL(eve::saturated(eve::abs)(a0), a0);
+  }
+
+  TTS_EQUAL ( eve::saturated(eve::abs[mask])(a0)
+            , eve::if_else(mask,eve::saturated(eve::abs)(a0),a0)
+            );
+};
+
+EVE_TEST( "Check behavior of eve::saturated(eve::abs)(scalar)"
+        , eve::test::scalar::all_types
+        , eve::test::generate ( eve::test::randoms(minimal, eve::valmax))
+        )
+<typename T>(T const& a0)
+{
+  if constexpr(std::is_signed_v<T>)
+  {
+    TTS_EQUAL ( eve::saturated(eve::abs)(a0)
+              , (a0 == eve::valmin(eve::as(a0)) ? eve::valmax(eve::as(a0)) : eve::abs(a0))
+              );
+  }
+  else
+  {
+    TTS_EQUAL(eve::saturated(eve::abs)(a0), a0);
+  }
+
+  TTS_EQUAL(eve::saturated(eve::abs[true ])(a0), eve::saturated(eve::abs)(a0) );
+  TTS_EQUAL(eve::saturated(eve::abs[false])(a0), a0                           );
+};
+
+//==================================================================================================
+// Test for eve::diff(eve::abs)
+//==================================================================================================
+EVE_TEST( "Check behavior of eve::diff(eve::abs) on wide"
+        , eve::test::simd::ieee_reals
+        , eve::test::generate ( eve::test::randoms(eve::valmin, eve::valmax))
+        )
+<typename T>(T const& a0)
+{
+  using eve::detail::map;
+  using v_t = eve::element_type_t<T>;
+
+  TTS_EQUAL ( eve::diff(eve::abs)(a0)
+            , map([](auto e) -> v_t { return e > 0 ? 1 : ((e <  0) ? -1 : 0); }, a0)
+            );
+};
+
+EVE_TEST( "Check behavior of eve::diff(eve::abs) on scalar"
+        , eve::test::scalar::ieee_reals
         , eve::test::generate(eve::test::randoms(eve::valmin, eve::valmax))
         )
 <typename T>(T const& a0 )
 {
-  using eve::as;
-  TTS_EQUAL( eve::abs(a0), T([&](auto i, auto) { auto a0i = a0.get(i); return a0i == eve::valmin(as(a0i)) ? eve::valmax(as(a0i)) : std::abs(a0i); }));
-};
+  using eve::detail::map;
 
-
-//==================================================================================================
-// abs unsigned tests
-//==================================================================================================
-EVE_TEST( "Check behavior of abs on unsigned wide"
-            , eve::test::simd::unsigned_types
-            , eve::test::generate ( eve::test::randoms(0, eve::valmax))
-            )
-<typename T>(T const& a0 )
-{
-  TTS_EQUAL( eve::abs(a0), a0);
-  TTS_EQUAL( eve::saturated(eve::abs)(a0), a0);
+  TTS_EQUAL ( eve::diff(eve::abs)(a0)
+            , (a0 > 0 ? T(1) : (a0 < 0 ? T(-1) : T(0)))
+            );
 };


### PR DESCRIPTION
This PR is a PoC of how I think we should handle the masked AVX512 operations.
By amending mask_ops to take a callable containing the masked intrinsic, we are able to factor a lot of code around the ignore_*

I am awaiting comments more than validation on this one