### PR TITLE
Fix #592 - Better SSE2 abs implementation 

### DIFF
--- a/include/eve/module/real/core/function/regular/simd/x86/abs.hpp
+++ b/include/eve/module/real/core/function/regular/simd/x86/abs.hpp
@@ -36,7 +36,7 @@ namespace eve::detail
     else  if constexpr(c == category::int32x4 )
     {
       if constexpr(current_api >= ssse3 )           return _mm_abs_epi32(v);
-      else                                          return map(eve::abs, v);
+      else                                          return (v ^ (v >> 31)) - (v >> 31);
     }
     else  if constexpr(c == category::int16x32)     return _mm512_abs_epi16(v);
     else  if constexpr(c == category::int16x16 )
@@ -47,7 +47,7 @@ namespace eve::detail
     else  if constexpr(c == category::int16x8 )
     {
       if constexpr(current_api >= ssse3 )           return _mm_abs_epi16(v);
-      else                                          return map(eve::abs, v);
+      else                                          return (v ^ (v >> 15)) - (v >> 15);
     }
     else  if constexpr(c == category::int8x64 )     return _mm512_abs_epi8(v);
     else  if constexpr(c == category::int8x32 )
@@ -58,7 +58,7 @@ namespace eve::detail
     else  if constexpr(c == category::int8x16 )
     {
       if constexpr(current_api >= ssse3 )           return _mm_abs_epi8(v);
-      else                                          return map(eve::abs, v);
+      else                                          return _mm_min_epu8(v,-v);
     }
   }
 

--- a/include/eve/module/real/core/function/regular/simd/x86/abs.hpp
+++ b/include/eve/module/real/core/function/regular/simd/x86/abs.hpp
@@ -36,7 +36,11 @@ namespace eve::detail
     else  if constexpr(c == category::int32x4 )
     {
       if constexpr(current_api >= ssse3 )           return _mm_abs_epi32(v);
-      else                                          return (v ^ (v >> 31)) - (v >> 31);
+      else
+      {
+        auto s = _mm_srai_epi32(v,31);
+        return wide<T, N, ABI>{_mm_sub_epi32(_mm_xor_si128(v,s),s)};
+      }
     }
     else  if constexpr(c == category::int16x32)     return _mm512_abs_epi16(v);
     else  if constexpr(c == category::int16x16 )
@@ -47,7 +51,7 @@ namespace eve::detail
     else  if constexpr(c == category::int16x8 )
     {
       if constexpr(current_api >= ssse3 )           return _mm_abs_epi16(v);
-      else                                          return (v ^ (v >> 15)) - (v >> 15);
+      else                                          return _mm_max_epi16(v,-v);
     }
     else  if constexpr(c == category::int8x64 )     return _mm512_abs_epi8(v);
     else  if constexpr(c == category::int8x32 )

--- a/test/unit/module/real/core/abs.cpp
+++ b/test/unit/module/real/core/abs.cpp
@@ -73,7 +73,7 @@ EVE_TEST( "Check behavior of eve::abs(eve::wide)"
                               , eve::test::logicals(0,3)
                               )
         )
-<typename T, typename M>(T const& a0, M const& mask )
+<typename T, typename M>(T const& a0, M const& mask)
 {
   using eve::detail::map;
   using v_t = eve::element_type_t<T>;
@@ -98,7 +98,7 @@ EVE_TEST( "Check behavior of eve::abs(scalar) - signed types"
 //==================================================================================================
 EVE_TEST( "Check behavior of eve::saturated(eve::abs)(eve::wide)"
         , eve::test::simd::all_types
-        , eve::test::generate ( eve::test::randoms(minimal, eve::valmax)
+        , eve::test::generate ( eve::test::randoms(eve::valmin, eve::valmax)
                               , eve::test::logicals(0,3)
                               )
         )
@@ -131,7 +131,7 @@ EVE_TEST( "Check behavior of eve::saturated(eve::abs)(eve::wide)"
 
 EVE_TEST( "Check behavior of eve::saturated(eve::abs)(scalar)"
         , eve::test::scalar::all_types
-        , eve::test::generate ( eve::test::randoms(minimal, eve::valmax))
+        , eve::test::generate ( eve::test::randoms(eve::valmin, eve::valmax))
         )
 <typename T>(T const& a0)
 {
@@ -178,4 +178,44 @@ EVE_TEST( "Check behavior of eve::diff(eve::abs) on scalar"
   TTS_EQUAL ( eve::diff(eve::abs)(a0)
             , (a0 > 0 ? T(1) : (a0 < 0 ? T(-1) : T(0)))
             );
+};
+
+//==================================================================================================
+// Test for corner-cases values
+//==================================================================================================
+EVE_TEST( "Check corner-cases behavior of eve::abs variants on wide"
+        , eve::test::simd::all_types
+        , eve::test::generate(eve::test::limits())
+        )
+<typename T>(T const& cases)
+{
+  using type = typename T::type;
+
+  if constexpr( eve::floating_real_value<type> )
+  {
+    TTS_IEEE_EQUAL( eve::abs(cases.nan    ) , cases.nan   );
+    TTS_IEEE_EQUAL( eve::abs(cases.minf   ) , cases.inf   );
+    TTS_EQUAL     ( eve::abs(cases.mzero  ) , type(0)     );
+    TTS_EQUAL     ( eve::abs(cases.valmin ) , cases.valmax);
+    TTS_EQUAL     ( eve::abs(cases.valmax ) , cases.valmax);
+
+    TTS_IEEE_EQUAL( eve::saturated(eve::abs)(cases.nan    ) , cases.nan   );
+    TTS_IEEE_EQUAL( eve::saturated(eve::abs)(cases.minf   ) , cases.inf   );
+    TTS_EQUAL     ( eve::saturated(eve::abs)(cases.mzero  ) , type(0)     );
+    TTS_EQUAL     ( eve::saturated(eve::abs)(cases.valmin ) , cases.valmax);
+    TTS_EQUAL     ( eve::saturated(eve::abs)(cases.valmax ) , cases.valmax);
+  }
+  else
+  {
+    TTS_EQUAL( eve::abs(cases.valmin ) , cases.valmin);
+    TTS_EQUAL( eve::abs(cases.valmax ) , cases.valmax);
+
+    if constexpr( eve::signed_value<type> )
+      TTS_EQUAL( eve::saturated(eve::abs)(cases.valmin ) , cases.valmax);
+    else
+      TTS_EQUAL( eve::saturated(eve::abs)(cases.valmin ) , cases.valmin);
+
+    TTS_EQUAL( eve::saturated(eve::abs)(cases.valmax ) , cases.valmax);
+
+  }
 };


### PR DESCRIPTION
Strategies used are derived from autovectorizer output:
    
* For int8, we compute the unsigned minimum of v and -v.
   If v is positive, the unsigned bits of -v is greater than v, so we select v.
   If v is negative, its unsigned bits are greather than bits of -v, so we compute -v.
    
* For other integral, we use the 2-complement abs algorithm involving
   XOR and propagated bit of sign: 
    abs(x) =  (x XOR (x >> 31)) - (x >> 31);  (for 32bits integral)
