### PR TITLE
Doc typos 1

### DIFF
--- a/docs/glossary.html
+++ b/docs/glossary.html
@@ -24,7 +24,7 @@ This sections explains some common definitions used throughout this documentatio
 Let `x`, `y` and `z` be three values of respective types `T, U, V`.
 
 For any callable object `f`, the expression `f(x,y)` has an **arithmetic operations semantic**
-if `T` and `U`  are [compatible](../../concepts.html#compatible) [values](../../concepts.html#value)
+if `T` and `U`  are [compatible](reference/concepts/compatible.html#eve::compatible) [values](reference/concepts/value.html#value)
 and the call is semantically equivalent to:
 
 <script type="preformatted">
@@ -55,7 +55,8 @@ Let `x`, `y` be two values of respective types `T` and `U`.
 
 When invoking the function-call operator of an object `f`,  the calls `f(x,y)`
 will be reputed to respond to the **bitwise operations semantic**
-if the two types are bit_compatible and the call is semantically equivalent to:
+if the two types are  [bit_compatible](reference/concepts/bit_compatible.html#eve::bit_compatible_values)
+ [values](reference/concepts/value.html#value) and the call is semantically equivalent to:
 
 <script type="preformatted">
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ c++

--- a/docs/reference/concepts/bit_compatible.html
+++ b/docs/reference/concepts/bit_compatible.html
@@ -29,7 +29,7 @@ namespace eve
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 </script>
 
-The concept `element_bit_compatible_to<T,U>` is satisfied if and only if `T` is a
+The concept <script type="preformatted">`element_bit_compatible_to<T,U>`</script> is satisfied if and only if `T` is a
 [`scalar_value`](scalar_value.html) which has the same size in bytes as the [element type](../types/traits.html#element_type)
 of the [`simd_value`](simd_value.html) U.
 
@@ -59,7 +59,7 @@ namespace eve
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 </script>
 
-The concept `bit_compatible_values<T,U>` is satisfied if either `T` and `U` satisfies
+The concept <script type="preformatted">`bit_compatible_values<T,U>`</script> is satisfied if either `T` and `U` satisfies
 `element_bit_compatible_to` with one another or if the size in bytes of `T` is equal
 to the size in bytes of `U`.
 

--- a/docs/reference/concepts/compatible.html
+++ b/docs/reference/concepts/compatible.html
@@ -29,7 +29,7 @@ namespace eve
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 </script>
 
-The concept `element_compatible_to<T,U>` is satisfied if and only if `T` is a
+The concept <script type="preformatted">`element_compatible_to<T,U>`</script> is satisfied if and only if `T` is a
 [`scalar_value`](scalar_value.html) which is convertible to the [element type](../types/traits.html#element_type)
 of the [`simd_value`](simd_value.html) U.
 
@@ -59,8 +59,8 @@ namespace eve
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 </script>
 
-The concept `compatible_values<T,U>` is satisfied if either `T` and `U` satisfies `element_compatible_to`
-with one another or if `T` and`U` satisfies `std::same_as`.
+The concept <script type="preformatted">`compatible_values<T,U>`</script> is satisfied if either `T` and `U` satisfies `element_compatible_to`
+with one another or if `T` and `U` satisfies `std::same_as`.
 
 ----------------------------------------------------------------------------------------------------
 <!-- Shortcuts -->

--- a/docs/reference/concepts/rebindable.html
+++ b/docs/reference/concepts/rebindable.html
@@ -27,7 +27,7 @@ namespace eve
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 </script>
 
-The concept `rebindable<T>` is satisfied if and only if T can be used in a
+The concept <script type="preformatted">`rebindable<T>`</script> is satisfied if and only if T can be used in a
 [structured binding declaration](https://en.cppreference.com/w/cpp/language/structured_binding).
 
 ## Examples

--- a/docs/reference/concepts/scalar_value.html
+++ b/docs/reference/concepts/scalar_value.html
@@ -27,7 +27,7 @@ namespace eve
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 </script>
 
-The concept `scalar_value<T>` is satisfied if and only if T is an
+The concept <script type="preformatted">`scalar_value<T>`</script> is satisfied if and only if T is an
 [arithmetic type](https://en.cppreference.com/w/cpp/types/is_arithmetic) or satisfies
 [`eve::rebindable`](./rebindable.html) while all its subobjetcts satisfy <script type="preformatted">`scalar_value<T>`</script>
 themselves.

--- a/docs/reference/types/helpers/as.html
+++ b/docs/reference/types/helpers/as.html
@@ -28,11 +28,11 @@ namespace eve
 </script>
 
 Various **EVE** functions require to be configured by a type. This type
-argument is used for selecting or configuring the output type of the functions (i.e the various
-[conversions functions](../reference/functions/conversion.html)).
+argument is used for selecting or configuring the output type of the functions (for example, the various
+[conversions functions](../../functions/conversion/convert.html)).
 
 Instead of requiring users to pass unwieldy template parameters that may clash with the [function objects
-paradigm](../rationale.html#functionobjectsasapi) **EVE** uses, Instances of [`eve::as`](#as) can be passed
+paradigm](../../rationale.html#functionobjectsasapi) **EVE** uses, Instances of [`eve::as`](#as) can be passed
 as objects and the type they wrap can be retrieved later via their member type.
 
 **Member types:**

--- a/docs/reference/types/helpers/cardinal.html
+++ b/docs/reference/types/helpers/cardinal.html
@@ -26,7 +26,7 @@ namespace eve
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 </script>
 
-Type used to represent the [cardinal][] of [scalar values](../../concepts.html#scalar_value).
+Type used to represent the [cardinal][] of [scalar values](../../concepts/scalar_value.html#scalar_value).
 
 **Member Constants:**
 
@@ -53,11 +53,11 @@ namespace eve
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 </script>
 
-Type used to represent the [cardinal][] of [SIMD values](../../concepts.html#scalar_value).
+Type used to represent the [cardinal][] of [SIMD values](../../concepts/simd_value.html#scalar_value).
 
 **Parameters:**
 `N`
-:   desired [cardinal][] value. Must be equal to 1 or any power of 2.
+:   desired [cardinal][] value. Must be equal to any unsigned power of 2.
 
 **Member Constants:**
 

--- a/docs/reference/types/traits.html
+++ b/docs/reference/types/traits.html
@@ -19,12 +19,12 @@ types that are accessible through the following traits.
 
 [`eve::alignment`<br>`eve::alignment_v` ](traits/alignment.html)
 :   computes the proper alignment of a given type
-[`eve::cardinal`<br>`eve::cardinal_t`<br>`eve::cardinal-v`](traits/cardinal.html)
-:   computes the cardinal of a given type
+[`eve::cardinal`<br>`eve::cardinal_t`<br>`eve::cardinal_v`](traits/cardinal.html)
+:   computes the cardinal (number of lanes) of a given type<br><br>
 [`eve::element_type`<br>`eve::element_type_t`](traits/element_type.html)
-:   retrieves the most fundamental type of a given type
+:   retrieves the fundamental type of a given type
 [`eve::as_wide`<br>`eve::as_wide_t`](traits/as_wide.html)
-:   converts a type into the proper SIMD type
+:   converts a type into the proper associated SIMD type
 
 <!-- End of Document -->
 <style class="fallback">body{visibility:hidden}</style><script>markdeepOptions={tocStyle:'none'};</script>

--- a/docs/reference/types/traits/as_wide.html
+++ b/docs/reference/types/traits/as_wide.html
@@ -29,21 +29,21 @@ namespace eve
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 </script>
 
-Build a [SIMD type](../../../concept.html#simd_value) from a given [element type](traits.html#element_type)
-`Type` and an optional [cardinal](traits.html#cardinal) `Size`.
+Build a [SIMD type](../../concepts/simd_value.html#simd_value) from a given [element type](element_type.html#element_type)
+`Type` and an optional [cardinal](cardinal.html#cardinal) `Size`.
 
- - If `Type` satisfies [scalar_value](../../../concept.html#scalar_value), `eve::as_wide&lt;Type,Cardinal>::type`
+ - If `Type` satisfies [scalar_value](../../concepts/scalar_value.html#scalar_value), `eve::as_wide&lt;Type,Cardinal>::type`
    evaluates to `wide&lt;Type,Cardinal>`.
 
- - If `Type` satisfies [simd_value](../../../concept.html#simd_value), `eve::as_wide&lt;Type,Cardinal>::type`
-   evaluates to `wide&lt;eve::element_t&lt;Type>,Cardinal>`, i.e it overwrites the initial type's cardinal.
+ - If `Type` satisfies [simd_value](../../simd_value.html#simd_value), `eve::as_wide&lt;Type,Cardinal>::type`
+   evaluates to `wide&lt;eve::element_t&lt;Type>,Cardinal>`, i.e. it overwrites the initial type's cardinal.
 
- - If `Type` is a template type satisfies Rebindable, `eve::as_wide&lt;Type,Cardinal>::type`
+ - If `Type` is a template type satisfies [rebindable](../../concepts/rebindable.html), `eve::as_wide&lt;Type,Cardinal>::type`
    evaluates to `std::tuple&lt;eve::as_wide_t&lt;Ts,Cardinal>...>`.
 
- - If `Type` is an instance of `std::pair&lt;T,U>`, evaluates `std::pair&lt;eve::as_wide_t&lt;T>,eve::as_wide_t&lt;U>>`.
+ - If `Type` is an instance of <script type="preformatted">`std::pair&lt;T,U>`</script>, evaluates <script type="preformatted">`std::pair<eve::as_wide_t<T>,eve::as_wide_t&lt;U>>`</script>.
 
- - If `Type` is an instance of `std::array&lt;T,N>`, evaluates `std::array&lt;eve::as_wide_t&lt;T>,N>`.
+ - If `Type` is an instance of <script type="preformatted">`std::array&lt;T,N></script>`, evaluates <script type="preformatted">`std::array<eve::as_wide_t&lt;T>,N>`.</script>
 
 
 
@@ -51,7 +51,7 @@ Build a [SIMD type](../../../concept.html#simd_value) from a given [element type
 
 Member type  | Definition
 ------------ | ----------
-`type`       | The [SIMD type](../../../concept.html#simd_value) build from `Type` and `Cardinal`
+`type`       | The [SIMD type](../../concepts/simd_value.html#simd_value) build from `Type` and `Cardinal`
 
 **Helper Types:**
 <script type="preformatted">

--- a/docs/tutorial/masking.html
+++ b/docs/tutorial/masking.html
@@ -367,6 +367,7 @@ The output is the same obviously:
 </script>
 
 Conclusion
+====================================================================================================
 
 Conditional operations on [SIMD values](../reference/concepts/simd_value.html#simd_value) is a good way to
 keep a high level code over some complex computations. **EVE** provides different levels of abstraction

--- a/docs/tutorial/masking.html
+++ b/docs/tutorial/masking.html
@@ -12,7 +12,7 @@
 
 [doc_if_else]: ../reference/functions/logical/if_else.html
 
-When you call a function on one or more [SIMD values](reference/concepts.html#simd_value), you
+When you call a function on one or more [SIMD values](../reference/concepts/simd_value.html#simd_value), you
 expect the computation to be performed on every elements of its parameters. Sometimes, you may want
 to make the application of a given function dependent on some condition. Let's explore the
 functionalities **EVE** provides for this kind of task.
@@ -248,9 +248,9 @@ The output is then:
 Context-sensitive mask
 ----------------------------------------------------------------------------------------------------
 Some algorithms require conditional function calls but use logical expression relative to the
-element index inside a [SIMD value](reference/concepts.html#simd_value) rather than its value.
+element index inside a [SIMD value](../reference/concepts/simd_value.html#simd_value) rather than its value.
 One may want for example to not compute an expression on the first and last element of such
-[SIMD values](reference/concepts.html#simd_value).
+[SIMD values](../reference/concepts/simd_value.html#simd_value).
 
 Let's write a function that computes the differences between two vectors in multiple scenarios: not
 using the first elements and not using the last elements.
@@ -296,7 +296,7 @@ The output is then:
 !!! Tip
     The [ignore_first](../reference/types/mask.html#eve::ignore_first) and
     [ignore_last](../reference/types/mask.html#eve::ignore_last) conditional takes a number of elements
-    as parameter so they can be applied generically on any size of [SIMD value](reference/concepts.html#simd_value)
+    as parameter so they can be applied generically on any size of [SIMD value](../reference/concepts/simd_value.html#simd_value)
 
 But what if we want to apply our operation to every element but the first and last one ? Clearly,
 calling two operations with two different conditional masks is sub-optimal. **EVE** provides some
@@ -367,8 +367,8 @@ The output is the same obviously:
 </script>
 
 Conclusion
-====================================================================================================
-Conditional operations on [SIMD values](reference/concepts.html#simd_value) is a good way to
+
+Conditional operations on [SIMD values](../reference/concepts/simd_value.html#simd_value) is a good way to
 keep a high level code over some complex computations. **EVE** provides different levels of abstraction
 for such operations as well as various helpers to specify how the conditions can be computed based
 either on values or indexes.

--- a/docs/tutorial/strlen.html
+++ b/docs/tutorial/strlen.html
@@ -12,7 +12,10 @@
 *NOTE: this documentation was valid at [commit](https://github.com/jfalcou/eve/commit/98b73427f16e580853202000d87c0eb0b6739905)*
 
 In this tutorial we will introduce some of the basic EVE concepts and see how they come together to implement strlen. <br/>
-The strlen we will implement is discussed in this [stackoverflow](https://stackoverflow.com/questions/25566302/vectorized-strlen-getting-away-with-reading-unallocated-memory) and is very close to [MacOs x86](https://opensource.apple.com/source/Libc/Libc-997.90.3/x86_64/string/strlen.s) and [glibc arm-v8](https://code.woboq.org/userspace/glibc/sysdeps/aarch64/multiarch/strlen_asimd.S.html) implemenations. <br/>
+The strlen we will implement is discussed in this
+[stackoverflow](https://stackoverflow.com/questions/25566302/vectorized-strlen-getting-away-with-reading-unallocated-memory)
+and is very close to [MacOs x86](https://opensource.apple.com/source/Libc/Libc-997.90.3/x86_64/string/strlen.s)
+and [glibc arm-v8](https://code.woboq.org/userspace/glibc/sysdeps/aarch64/multiarch/strlen_asimd.S.html) implemenations. <br/>
 You can also find this tutorial in [this talk](https://youtu.be/d6NcnyXjc3I) though the syntax was updated.
 
 *NOTE: we are not advocating rewriting `strlen` with EVE - this was just an example
@@ -20,9 +23,13 @@ to show the interfaces and to prove that we have high quality codegen.*
 
 # Key idea
 
-SIMD allows us to test multiple chars at once for zero and that what will do with EVE. However, how can we read multiple bytes is the string can be less that what we try to read?
-We are just going to state the solution here: **reading a register from an address aligned to the size of the register is safe due to allocations happening in pages**. <br/>
-You can find a detailed discussion on [stackoverflow](https://stackoverflow.com/questions/25566302/vectorized-strlen-getting-away-with-reading-unallocated-memory) or in [this talk](https://youtu.be/d6NcnyXjc3I).
+SIMD allows us to test multiple chars at once for zero and that what will do with EVE.
+However, how can we read multiple bytes if the string can be less that what we try to read?
+We are just going to state the solution here: **reading a register from an address aligned to the size of the register
+is safe due to allocations happening in pages**. <br/>
+You can find a detailed discussion on
+[stackoverflow](https://stackoverflow.com/questions/25566302/vectorized-strlen-getting-away-with-reading-unallocated-memory)
+or in [this talk](https://youtu.be/d6NcnyXjc3I).
 
   (insert src/strlen.src.html here)
 
@@ -43,8 +50,10 @@ You can construct a wide from a constant or a variable.
 
 ### `eve::previous_aligned_address(s);`
 This returns the previous address aligned to the default width of the register.
-You can specify an `eve::fixed<N>{}` as a second parameter if you wanted to override how many elements you needed to align to (for non-default width).
-There is a convenience template variable `eve::lane<N>` that has `eve::fixed<N>` type. It returns a special type eve::aligned_ptr[T, size_t] - second parameter is alignment in bytes. (there is a default = native register size),
+You can specify an `eve::fixed<N>{}` as a second parameter if you wanted to override how many elements you
+needed to align to (for non-default width).
+There is a convenience template variable `eve::lane<N>` that has `eve::fixed<N>` type.
+It returns a special type eve::aligned_ptr[T, size_t] - second parameter is alignment in bytes. (there is a default = native register size),
 Here we want the library to take care of all of that, so we just rely on CTAD.
 
 ### `eve::unsafe(eve::load)(aligned_s);`
@@ -59,24 +68,24 @@ EVE detects build with these sanitizers and disable them for this load.
 `wide(ptr)` constructor does not have a way to do this.
 
 ### `cur == zeroes`
-This is a pairwise comparison for equality between `cur` and `zero`.
-The result is `eve::logical<wide>` - a class representing N booleans where N is the width of our wide.
+This is an elementwise comparison for equality between `cur` and `zeroes`.
+The result is `eve::logical<wide>` - a class representing N booleans where N is the cardinal (number of lanes) of our wide.
 
 ### `eve::ignore_first ignore / eve::first_true[ignore]`
 `first_true` takes a `logical` and returns the optional position of the first `true` element.
-However we took a `previous_aligned_address` and not just `s` - so there might be some 0s we are not interested in. <br/>
+However we took a `previous_aligned_address(s)` and not just `s`, so there might be some 0s we are not interested in. <br/>
 For this purpose `eve` provides some conditional mutators, most commonly used ones are:
 `ignore_first`, `ignore_last`, `ignore_extrema` (ignores from both sides).
 
 ### `while (!match) / aligned_s += wide::static_size`
-While we didn't find the 0 - go to the next chunk. `wide::static_size` is the number of elements in the `wide`. Alternatively we could've used `wide.size()`.
-`static_size` has the advantage of being `constexpr` friendly.
+While we didn't find the 0, we go to the next chunk. `wide::static_size` is the cardinal of the `wide`.
+Alternatively we could have used `wide.size()`. but `static_size` has the advantage of being `constexpr` friendly.
 
 ### `match = eve::first_true(cur == zeroes);`
 This is the same `first_true` but we no longer need to ignore anything.
 
 ### `aligned_s.get() + *match - s`
-Finally - compute where we finished.
+Finally, compute where we finished.
 
 # Comparison with real strlens
 
@@ -87,13 +96,16 @@ The differences are minimal: clang handles the bit and address manipulations sli
 When comparing against [glibc arm-v8 (aarch64)](https://code.woboq.org/userspace/glibc/sysdeps/aarch64/multiarch/strlen_asimd.S.html) <br/>
 With eve we get: [eve, aarch64](https://godbolt.org/z/nz5eWe). <br/>
 The interesting differences are:
-* they do not immideatly load from the previous aligned address for the first block. Instead they check if they can load from s, and only if not - they start dealing with the previous address.
-* they compute position of the first match differently.
-* we compare with 0 and then look for `true` using `umaxv` instruction.
-  They rely on 0 being unsigned minimum and use `uminv` on the register directly.
-  Unfortunatly this trick only works for looking for 0 and we can look for arbitraty value.
+  * they do not immediatly load from the previous aligned address for the first block. Instead they check if they can load from s,
+    and only if not, they start dealing with the previous address.
+  * they compute position of the first match differently.
+  * we compare with 0 and then look for `true` using `umaxv` instruction.
+    They rely on 0 being unsigned minimum and use `uminv` on the register directly.
+    Unfortunatly this trick only works for looking for 0 and we can look for arbitraty value.
 
-There are some substantial improvements one can make to this `strlen`, like unrolling which can be found in [glibc avx2 implementation](https://code.woboq.org/userspace/glibc/sysdeps/x86_64/multiarch/strlen-avx2.S.html).
+There are some substantial improvements one can make to this `strlen`,
+like unrolling which can be found in [glibc avx2
+implementation](https://code.woboq.org/userspace/glibc/sysdeps/x86_64/multiarch/strlen-avx2.S.html).
 
 <!-- Footnotes -->
 

--- a/docs/tutorial/strlen.html
+++ b/docs/tutorial/strlen.html
@@ -69,16 +69,16 @@ EVE detects build with these sanitizers and disable them for this load.
 
 ### `cur == zeroes`
 This is an elementwise comparison for equality between `cur` and `zeroes`.
-The result is `eve::logical<wide>` - a class representing N booleans where N is the cardinal (number of lanes) of our wide.
+The result is `eve::logical<wide>` - a class representing N booleans where N is the cardinal of our wide.
 
 ### `eve::ignore_first ignore / eve::first_true[ignore]`
 `first_true` takes a `logical` and returns the optional position of the first `true` element.
-However we took a `previous_aligned_address(s)` and not just `s`, so there might be some 0s we are not interested in. <br/>
+However we compute `previous_aligned_address(s)` and not just `s`, so there might be some 0s we are not interested in. <br/>
 For this purpose `eve` provides some conditional mutators, most commonly used ones are:
 `ignore_first`, `ignore_last`, `ignore_extrema` (ignores from both sides).
 
 ### `while (!match) / aligned_s += wide::static_size`
-While we didn't find the 0, we go to the next chunk. `wide::static_size` is the cardinal of the `wide`.
+While we didn't find the 0, we go to the next chunk. `wide::static_size` is the cardinal of the  `wide`.
 Alternatively we could have used `wide.size()`. but `static_size` has the advantage of being `constexpr` friendly.
 
 ### `match = eve::first_true(cur == zeroes);`
@@ -96,7 +96,7 @@ The differences are minimal: clang handles the bit and address manipulations sli
 When comparing against [glibc arm-v8 (aarch64)](https://code.woboq.org/userspace/glibc/sysdeps/aarch64/multiarch/strlen_asimd.S.html) <br/>
 With eve we get: [eve, aarch64](https://godbolt.org/z/nz5eWe). <br/>
 The interesting differences are:
-  * they do not immediatly load from the previous aligned address for the first block. Instead they check if they can load from s,
+  * they do not immediatly load from the previous aligned address for the first block. Instead they check if they load from s,
     and only if not, they start dealing with the previous address.
   * they compute position of the first match differently.
   * we compare with 0 and then look for `true` using `umaxv` instruction.


### PR DESCRIPTION
this correct most references links in non functions docs
also small typos
and try to unify vocabulary sometimes
only html are touched so cycle is quite meaningless, only the review counts