### PR TITLE
Fix bad code generation when returning wide in non-inline context

### DIFF
--- a/include/eve/arch/cpu/logical_wide.hpp
+++ b/include/eve/arch/cpu/logical_wide.hpp
@@ -60,8 +60,7 @@ namespace eve
     //==============================================================================================
     // Constructors
     //==============================================================================================
-    EVE_FORCEINLINE logical() noexcept {}
-    EVE_FORCEINLINE logical(logical const& w) noexcept : storage_base(w.storage()) {}
+    EVE_FORCEINLINE logical() = default;
 
     EVE_FORCEINLINE logical(storage_type const &r) noexcept
       : storage_base( [&]()

--- a/include/eve/arch/cpu/wide.hpp
+++ b/include/eve/arch/cpu/wide.hpp
@@ -30,7 +30,7 @@ namespace eve
   // Wrapper for SIMD registers holding arithmetic types with compile-time size
   //================================================================================================
   template<typename Type, typename Size, typename ABI>
-  struct  EVE_MAY_ALIAS wide
+  struct  EVE_MAY_ALIAS  wide
         : detail::wide_cardinal<Size>
         , detail::wide_ops<wide<Type,Size,ABI>>
         , detail::wide_storage<as_register_t<Type, Size, ABI>>
@@ -52,8 +52,7 @@ namespace eve
     //==============================================================================================
     // Constructors
     //==============================================================================================
-    EVE_FORCEINLINE wide() noexcept : storage_base{} {}
-    EVE_FORCEINLINE wide(wide const& w) noexcept : storage_base(w.storage()) {}
+    EVE_FORCEINLINE wide() = default;
     EVE_FORCEINLINE wide(storage_type const &r) noexcept : storage_base(r) {}
 
     template<std::input_iterator It>


### PR DESCRIPTION
We were a bit too enthusiastic when manually writing copy and default constructor for SIMD value types. Using =default fix the codegen issue.

Code:

```
wide<float> h()
{
  return wide<float>(5.74f);
}
```

Before:
```
h():
        vmovaps xmm0, XMMWORD PTR .LC1[rip]
        mov     rax, rdi
        vmovaps XMMWORD PTR [rdi], xmm0
        ret
```

After:
```
h():
        vmovaps xmm0, XMMWORD PTR .LC0[rip]
        ret
```