### PR TITLE
Fix #683 - User-side extension point

### DIFF
--- a/cmake/toolchain/gcc.aarch64.cmake
+++ b/cmake/toolchain/gcc.aarch64.cmake
@@ -11,6 +11,6 @@ set(CMAKE_C_COMPILER    aarch64-linux-gnu-gcc-10  )
 set(CMAKE_CXX_COMPILER  aarch64-linux-gnu-g++-10  )
 set(CMAKE_BUILD_TYPE    Debug                     )
 
-set(CMAKE_CXX_FLAGS     "-DEVE_NO_FORCEINLINE ${EVE_OPTIONS}" )
+set(CMAKE_CXX_FLAGS     "-Wno-psabi -DEVE_NO_FORCEINLINE ${EVE_OPTIONS}" )
 
 set(CMAKE_CROSSCOMPILING_CMD qemu-aarch64)

--- a/include/eve/detail/function/swizzle.hpp
+++ b/include/eve/detail/function/swizzle.hpp
@@ -12,7 +12,7 @@
 
 namespace eve
 {
-  EVE_DECLARE_CALLABLE(basic_swizzle_)
+  EVE_DECLARE_CALLABLE(basic_swizzle_, basic_swizzle)
 
   namespace detail
   {

--- a/include/eve/detail/overload.hpp
+++ b/include/eve/detail/overload.hpp
@@ -57,7 +57,7 @@
                                                                                                    \
         if constexpr( tag_dispatchable<tag_type,Arg,Args...> )                                     \
         {                                                                                          \
-          return dispatcher ( tag_type{}                                                           \
+          return tagged_dispatch ( tag_type{}                                                      \
                             , std::forward<Arg>(d), std::forward<Args>(args)...                    \
                             );                                                                     \
         }                                                                                          \
@@ -181,17 +181,6 @@ namespace eve
     {
       { tagged_dispatch(tag, std::forward<Args>(args)...) };
     };
-
-    // Try to adl lookup the invocation
-    inline struct dispatcher_
-    {
-      template <typename Tag, typename... Args>
-      requires tag_dispatchable<Tag,Args...>
-      decltype(auto) operator()(Tag tag, Args&&... args) const
-      {
-        return tagged_dispatch(tag, std::forward<Args>(args)...);
-      }
-    } constexpr dispatcher;
   }
 
   //==============================================================================================

--- a/include/eve/detail/overload.hpp
+++ b/include/eve/detail/overload.hpp
@@ -78,15 +78,6 @@
         return call(args...);                                                                      \
       }                                                                                            \
                                                                                                    \
-      template<typename Arg, typename... Args>                                                     \
-      requires  (   !tag_dispatchable<tag_type,Arg,Args...>                                        \
-                &&  !supports_ ## TAG<Arg,Args...>                                                 \
-                )                                                                                  \
-      [[deprecated( "[EVE | Invalid Function Call] eve::" #NAME                                    \
-                    " is called with invalids argument types."                                     \
-                  )]]                                                                              \
-      EVE_FORCEINLINE constexpr auto operator()(Arg&& d, Args &&... args) const noexcept;          \
-                                                                                                   \
       template<value Condition>                                                                    \
       EVE_FORCEINLINE constexpr auto operator[](Condition const &c) const noexcept                 \
       requires( eve::supports_conditional<tag_type>::value )                                       \

--- a/include/eve/function/logical_and.hpp
+++ b/include/eve/function/logical_and.hpp
@@ -9,6 +9,7 @@
 #include <eve/detail/implementation.hpp>
 #include <eve/traits/as_logical.hpp>
 #include <eve/concept/value.hpp>
+#include <eve/constant/false.hpp>
 
 namespace eve
 {

--- a/include/eve/function/logical_or.hpp
+++ b/include/eve/function/logical_or.hpp
@@ -9,6 +9,7 @@
 #include <eve/detail/implementation.hpp>
 #include <eve/traits/as_logical.hpp>
 #include <eve/concept/value.hpp>
+#include <eve/constant/true.hpp>
 
 namespace eve
 {

--- a/include/eve/module/real/core/function/regular/generic/hypot.hpp
+++ b/include/eve/module/real/core/function/regular/generic/hypot.hpp
@@ -35,7 +35,7 @@ namespace eve::detail
     }
     else
     {
-      return apply_over(hypot, r_t(a0), r_t(args)...);
+      return apply_over(hypot, r_t{a0}, r_t{args}...);
     }
   }
 }

--- a/include/eve/module/real/math/detail/generic/erf_kernel.hpp
+++ b/include/eve/module/real/math/detail/generic/erf_kernel.hpp
@@ -16,7 +16,6 @@
 #include <eve/module/real/core/detail/generic/horn.hpp>
 #include <eve/module/real/core/detail/generic/horn1.hpp>
 #include <concepts>
-#include <iomanip>
 
 namespace eve::detail
 {

--- a/include/eve/module/real/math/function/pedantic/generic/exp2.hpp
+++ b/include/eve/module/real/math/function/pedantic/generic/exp2.hpp
@@ -40,7 +40,6 @@
 #include <eve/function/sqr.hpp>
 #include <eve/module/real/core/detail/generic/horn.hpp>
 #include <type_traits>
-#include <iomanip>
 
 namespace eve::detail
 {

--- a/include/eve/module/real/math/function/regular/generic/exp2.hpp
+++ b/include/eve/module/real/math/function/regular/generic/exp2.hpp
@@ -41,7 +41,6 @@
 #include <eve/function/sqr.hpp>
 #include <eve/module/real/core/detail/generic/horn.hpp>
 #include <type_traits>
-#include <iomanip>
 
 namespace eve::detail
 {

--- a/include/eve/module/real/polynomial/function/regular/generic/gegenbauer.hpp
+++ b/include/eve/module/real/polynomial/function/regular/generic/gegenbauer.hpp
@@ -22,7 +22,6 @@
 #include <eve/constant/eps.hpp>
 #include <eve/traits/common_compatible.hpp>
 #include <utility>
-#include <iostream>
 
 namespace eve::detail
 {

--- a/include/eve/module/real/polynomial/function/regular/generic/laguerre.hpp
+++ b/include/eve/module/real/polynomial/function/regular/generic/laguerre.hpp
@@ -21,7 +21,6 @@
 #include <eve/function/oneminus.hpp>
 #include <eve/constant/one.hpp>
 #include <utility>
-#include <iostream>
 
 namespace eve::detail
 {

--- a/include/eve/module/real/polynomial/function/regular/generic/legendre.hpp
+++ b/include/eve/module/real/polynomial/function/regular/generic/legendre.hpp
@@ -23,7 +23,6 @@
 #include <eve/constant/one.hpp>
 #include <eve/constant/nan.hpp>
 #include <utility>
-#include <iostream>
 
 namespace eve::detail
 {

--- a/include/eve/module/real/proba/function/regular/generic/binomial_distribution.hpp
+++ b/include/eve/module/real/proba/function/regular/generic/binomial_distribution.hpp
@@ -463,13 +463,13 @@ namespace eve
     {
       auto twopie = T(17.0794684453471341309271017390931489900697770715304);
       if constexpr (floating_value<U> && floating_value<T>)
-        return half(as<T>())*eve::log(twopie*d.n*d.p*d.q); // + �(1/n)
+        return half(as<T>())*eve::log(twopie*d.n*d.p*d.q); // + o(1/n)
       else if constexpr (floating_value<U>)
-        return half(as<U>())*eve::log(twopie*d.n*U(0.25)); // + �(1/n)
+        return half(as<U>())*eve::log(twopie*d.n*U(0.25)); // + o(1/n)
       else if constexpr (floating_value<T>)
-        return half(as<T>())*eve::log(twopie*d.p*d.q); // + �(1/n)
+        return half(as<T>())*eve::log(twopie*d.p*d.q); // + o(1/n)
       else
-        return half(as<I>())*eve::log(twopie*I(0.25)); // + �(1/n)
+        return half(as<I>())*eve::log(twopie*I(0.25)); // + o(1/n)
     }
 
 

--- a/include/eve/module/real/proba/function/regular/generic/binomial_distribution.hpp
+++ b/include/eve/module/real/proba/function/regular/generic/binomial_distribution.hpp
@@ -40,8 +40,6 @@
 #include <eve/constant/inf.hpp>
 #include <eve/constant/one.hpp>
 #include <eve/constant/zero.hpp>
-#include <iostream>
-#include <tts/tts.hpp>
 
 namespace eve
 {
@@ -465,13 +463,13 @@ namespace eve
     {
       auto twopie = T(17.0794684453471341309271017390931489900697770715304);
       if constexpr (floating_value<U> && floating_value<T>)
-        return half(as<T>())*eve::log(twopie*d.n*d.p*d.q); // + ô(1/n)
+        return half(as<T>())*eve::log(twopie*d.n*d.p*d.q); // + ï¿½(1/n)
       else if constexpr (floating_value<U>)
-        return half(as<U>())*eve::log(twopie*d.n*U(0.25)); // + ô(1/n)
+        return half(as<U>())*eve::log(twopie*d.n*U(0.25)); // + ï¿½(1/n)
       else if constexpr (floating_value<T>)
-        return half(as<T>())*eve::log(twopie*d.p*d.q); // + ô(1/n)
+        return half(as<T>())*eve::log(twopie*d.p*d.q); // + ï¿½(1/n)
       else
-        return half(as<I>())*eve::log(twopie*I(0.25)); // + ô(1/n)
+        return half(as<I>())*eve::log(twopie*I(0.25)); // + ï¿½(1/n)
     }
 
 

--- a/include/eve/module/real/proba/function/regular/generic/ev_distribution.hpp
+++ b/include/eve/module/real/proba/function/regular/generic/ev_distribution.hpp
@@ -27,7 +27,6 @@
 #include <eve/constant/zero.hpp>
 #include <eve/constant/one.hpp>
 #include <concepts>
-#include <iostream>
 
 namespace eve
 {

--- a/include/eve/module/real/special/function/diff/generic/gamma_p.hpp
+++ b/include/eve/module/real/special/function/diff/generic/gamma_p.hpp
@@ -16,13 +16,12 @@
 
 namespace eve::detail
 {
-
   template<floating_real_value T>
   EVE_FORCEINLINE constexpr T gamma_p_(EVE_SUPPORTS(cpu_)
                                   , diff_type<1> const &
                                   , T const &x
                                   , T const &k) noexcept
   {
-    return  exp(dec(k) * eve::log(x) - x - lgamma(k));
+    return exp(dec(k) * log(x) - x - lgamma(k));
   }
 }

--- a/include/eve/module/real/special/function/regular/generic/gamma_pinv.hpp
+++ b/include/eve/module/real/special/function/regular/generic/gamma_pinv.hpp
@@ -24,7 +24,6 @@
 #include <eve/function/is_not_nan.hpp>
 #include <eve/function/is_lez.hpp>
 #include <eve/function/is_not_less.hpp>
-#include <eve/function/lgamma.hpp>
 #include <eve/function/log.hpp>
 #include <eve/function/log1p.hpp>
 #include <eve/function/max.hpp>
@@ -41,12 +40,9 @@
 #include <eve/constant/valmax.hpp>
 #include <eve/constant/inf.hpp>
 #include <type_traits>
-#include <boost/math/special_functions/gamma.hpp>
-#include <tts/tts.hpp>
-#include <iomanip>
+
 namespace eve::detail
 {
-
   template<real_value T, real_value U>
   EVE_FORCEINLINE  auto gamma_pinv_(EVE_SUPPORTS(cpu_)
                               , T a

--- a/include/eve/module/real/special/function/regular/generic/lgamma.hpp
+++ b/include/eve/module/real/special/function/regular/generic/lgamma.hpp
@@ -120,7 +120,7 @@ namespace eve::detail
           if( (is_infinite(a0)) ) return inf(as<T>());
           const T Maxlgamma =
               Ieee_constant<T, 0x7bc3f8eaU, 0x7f574c5dd06d2516ULL>(); // 2.035093e36f, 2.556348e305
-          auto lgamma_pos = [Logsqrt2pi](T x)  -> T {
+          auto lgamma_pos = [Logsqrt2pi](T x) {
             if( x < 6.5f )
             {
               T z  = one(as<T>());
@@ -212,7 +212,7 @@ namespace eve::detail
           auto   ltza0 = is_ltz(a0);
           size_t nb    = eve::count_true(ltza0);
           T      r {0};
-          auto   other = [Logsqrt2pi](T x)  -> T {
+          auto   other = [Logsqrt2pi](T x) {
             auto   xlt650 = is_less(x, T(6.50));
             size_t nb     = eve::count_true(xlt650);
             T      r0x    = x;
@@ -296,7 +296,7 @@ namespace eve::detail
           T r1 = other(q);
           if( nb > 0 ) // some are negative
           {
-            auto negative = [](T q, T w)  -> T {
+            auto negative = [](T q, T w) {
               T    p     = floor(q);
               T    z     = q - p;
               auto test2 = (z < half(as<T>()));
@@ -321,7 +321,7 @@ namespace eve::detail
         {
           const T Maxlgamma =
               Ieee_constant<T, 0x7bc3f8eaU, 0x7f574c5dd06d2516ULL>(); // 2.035093e36f, 2.556348e305
-          auto lgamma_pos = [Logsqrt2pi](T x)  -> T {
+          auto lgamma_pos = [Logsqrt2pi](T x) {
             if( x < 13.0 )
             {
               T z = one(as<T>());
@@ -389,7 +389,7 @@ namespace eve::detail
         }
         else if constexpr( simd_value<T> ) // simd double
         {
-          auto other = [Logsqrt2pi](T xx)  -> T {
+          auto other = [Logsqrt2pi](T xx) {
             T      x    = xx;
             auto   test = (x < T(13.0));
             size_t nb   = eve::count_true(test);
@@ -428,7 +428,7 @@ namespace eve::detail
             r2 += lgammaA(p) / xx;
             return if_else(test, r1, r2);
           };
-          auto large_negative = [Logpi](const T &q) -> T {
+          auto large_negative = [Logpi](const T &q) {
             T    w     = lgamma(q);
             T    p     = floor(q);
             T    z     = q - p;

--- a/include/eve/module/real/special/function/regular/generic/lgamma.hpp
+++ b/include/eve/module/real/special/function/regular/generic/lgamma.hpp
@@ -120,7 +120,7 @@ namespace eve::detail
           if( (is_infinite(a0)) ) return inf(as<T>());
           const T Maxlgamma =
               Ieee_constant<T, 0x7bc3f8eaU, 0x7f574c5dd06d2516ULL>(); // 2.035093e36f, 2.556348e305
-          auto lgamma_pos = [Logsqrt2pi](T x) {
+          auto lgamma_pos = [Logsqrt2pi](T x)  -> T {
             if( x < 6.5f )
             {
               T z  = one(as<T>());
@@ -212,7 +212,7 @@ namespace eve::detail
           auto   ltza0 = is_ltz(a0);
           size_t nb    = eve::count_true(ltza0);
           T      r {0};
-          auto   other = [Logsqrt2pi](T x) {
+          auto   other = [Logsqrt2pi](T x)  -> T {
             auto   xlt650 = is_less(x, T(6.50));
             size_t nb     = eve::count_true(xlt650);
             T      r0x    = x;
@@ -296,7 +296,7 @@ namespace eve::detail
           T r1 = other(q);
           if( nb > 0 ) // some are negative
           {
-            auto negative = [](T q, T w) {
+            auto negative = [](T q, T w)  -> T {
               T    p     = floor(q);
               T    z     = q - p;
               auto test2 = (z < half(as<T>()));
@@ -321,7 +321,7 @@ namespace eve::detail
         {
           const T Maxlgamma =
               Ieee_constant<T, 0x7bc3f8eaU, 0x7f574c5dd06d2516ULL>(); // 2.035093e36f, 2.556348e305
-          auto lgamma_pos = [Logsqrt2pi](double x) {
+          auto lgamma_pos = [Logsqrt2pi](T x)  -> T {
             if( x < 13.0 )
             {
               T z = one(as<T>());
@@ -389,7 +389,7 @@ namespace eve::detail
         }
         else if constexpr( simd_value<T> ) // simd double
         {
-          auto other = [Logsqrt2pi](T xx) {
+          auto other = [Logsqrt2pi](T xx)  -> T {
             T      x    = xx;
             auto   test = (x < T(13.0));
             size_t nb   = eve::count_true(test);
@@ -428,7 +428,7 @@ namespace eve::detail
             r2 += lgammaA(p) / xx;
             return if_else(test, r1, r2);
           };
-          auto large_negative = [Logpi](const T &q) {
+          auto large_negative = [Logpi](const T &q) -> T {
             T    w     = lgamma(q);
             T    p     = floor(q);
             T    z     = q - p;

--- a/test/doc/core/gamma_pinv.cpp
+++ b/test/doc/core/gamma_pinv.cpp
@@ -4,7 +4,7 @@
 #include <iostream>
 #include <iomanip>
 
-using wide_ft = eve::wide<double, eve::fixed<4>>;
+using wide_ft = eve::wide<float, eve::fixed<4>>;
 
 int main()
 {
@@ -16,8 +16,8 @@ int main()
              << "<- k                = " << k << '\n'
              << "-> gamma_pinv(p, k) = " << eve::gamma_pinv(p, k) << '\n';
 
-  double kf = 0.1;
-  double pf = 0.3;
+  float kf = 0.1;
+  float pf = 0.3;
   std::cout << "---- scalar" << '\n'
             << "<- kf                 = " << kf << '\n'
             << "<- pf                 = " << pf<< '\n'

--- a/test/generator.hpp
+++ b/test/generator.hpp
@@ -134,9 +134,11 @@ namespace eve::test
             {
               using elt_t = element_type_t<T>;
               auto n = amount<T>()-1;
-              elt_t a = n ? elt_t((v2-v1))/n : elt_t(0);
+              elt_t w1 = as_value(v1,as_<elt_t>{});
+              elt_t w2 = as_value(v2,as_<elt_t>{});
+              elt_t a = n ? elt_t((w2 - w1))/n : elt_t(0);
               std::array<elt_t, amount<T>()> d;
-              for(std::size_t i = 0;i<amount<T>();++i) d[i] = a*i+v1;
+              for(std::size_t i = 0;i<amount<T>();++i) d[i] = std::min( elt_t(a*i+w1), w2);
               return d;
             };
   }

--- a/test/test_distribution.hpp
+++ b/test/test_distribution.hpp
@@ -12,13 +12,13 @@
 #include <eve/constant/valmax.hpp>
 #include <eve/function/saturated/abs.hpp>
 #include <eve/function/average.hpp>
-#include <eve/function/log2.hpp>
-#include <eve/function/exp2.hpp>
 #include <eve/concept/value.hpp>
 #include <eve/platform.hpp>
 #include <type_traits>
-#include <random>
 #include <iostream>
+#include <random>
+#include <cmath>
+
 namespace eve
 {
   template< eve::real_scalar_value T = double > struct tests_real_distribution
@@ -36,8 +36,8 @@ namespace eve
     tests_real_distribution() : tests_real_distribution(0.0, 0.1, 300) { }
 
     tests_real_distribution( T aa, T bb, int nbb = 300)
-      : a(eve::min(aa, bb)),
-        b(eve::max(aa, bb)),
+      : a(std::min(aa, bb)),
+        b(std::max(aa, bb)),
         nb(nbb),
         sd(T(0),T(1)),
         ird(1, nb-1){
@@ -161,8 +161,8 @@ namespace eve
     tests_integral_distribution() : tests_integral_distribution(valmin(as<T>()), valmax(as<T>())) { }
 
     tests_integral_distribution( T aa, T bb, int nbb = 300)
-      : a(eve::min(aa, bb)),
-        b(eve::max(aa, bb)),
+      : a(std::min(aa, bb)),
+        b(std::max(aa, bb)),
         nb(nbb),
         sd(0.0, 1.0),
         ird(a, b),
@@ -193,8 +193,9 @@ namespace eve
       {
         res = ird(gen);
       }
-      auto l2 = [](auto x){return log2(inc(double(x)));   };
-      auto e2 = [](auto x){return dec(T(round(exp2(x)))); };
+
+      auto l2 = [](auto x) { return std::log2(x+1);                         };
+      auto e2 = [](auto x) { return static_cast<T>(round(std::exp2(x)))-1;  };
 
       if(aa == bb) res = aa;
       else

--- a/test/test_distribution.hpp
+++ b/test/test_distribution.hpp
@@ -12,12 +12,15 @@
 #include <eve/constant/valmax.hpp>
 #include <eve/function/saturated/abs.hpp>
 #include <eve/function/average.hpp>
+#include <eve/function/log2.hpp>
+#include <eve/function/exp2.hpp>
+#include <eve/function/dec.hpp>
+#include <eve/function/inc.hpp>
+#include <eve/function/round.hpp>
 #include <eve/concept/value.hpp>
 #include <eve/platform.hpp>
 #include <type_traits>
-#include <iostream>
 #include <random>
-#include <cmath>
 
 namespace eve
 {
@@ -72,11 +75,11 @@ namespace eve
         auto i = ird(gen);
         if (aa >= 1) // bb > aa
         {
-          auto la =  log2(aa);
-          auto f =  log2(bb)-la;
+          auto la =  eve::log2(aa);
+          auto f =  eve::log2(bb)-la;
           auto rand = sd(gen);
           auto x = la+f*(i-1+rand)/nb;
-          res = exp2(x);
+          res = eve::exp2(x);
         }
         else if (bb <= -1) // aa < bb
         {
@@ -157,7 +160,7 @@ namespace eve
       param_type(T aa, T bb, int nbb) : a(aa),  b(bb), nb(nbb){};
 
     };
-
+*
     tests_integral_distribution() : tests_integral_distribution(valmin(as<T>()), valmax(as<T>())) { }
 
     tests_integral_distribution( T aa, T bb, int nbb = 300)
@@ -194,8 +197,8 @@ namespace eve
         res = ird(gen);
       }
 
-      auto l2 = [](auto x) { return std::log2(x+1);                         };
-      auto e2 = [](auto x) { return static_cast<T>(round(std::exp2(x)))-1;  };
+      auto l2 = [](auto x){return eve::log2(eve::inc(double(x)));   };
+      auto e2 = [](auto x){return eve::dec(T(eve::round(eve::exp2(x)))); };
 
       if(aa == bb) res = aa;
       else

--- a/test/types.hpp
+++ b/test/types.hpp
@@ -6,7 +6,6 @@
 **/
 //==================================================================================================
 #pragma once
-#include "test_distribution.hpp"
 #include <eve/detail/meta.hpp>
 #include <tuple>
 

--- a/test/unit/internals/CMakeLists.txt
+++ b/test/unit/internals/CMakeLists.txt
@@ -14,6 +14,7 @@ add_dependencies(unit.simd.exe unit.internals.exe )
 ## List internal tests
 ##==================================================================================================
 make_unit( "unit.internals" aggregation.cpp       )
+make_unit( "unit.internals" dispatch.cpp          )
 make_unit( "unit.internals" optimize_pattern.cpp  )
 make_unit( "unit.internals" to_logical.cpp        )
 make_unit( "unit.internals" top_bits.cpp          )

--- a/test/unit/internals/dispatch.cpp
+++ b/test/unit/internals/dispatch.cpp
@@ -1,0 +1,122 @@
+//==================================================================================================
+/**
+  EVE - Expressive Vector Engine
+  Copyright : EVE Contributors & Maintainers
+  SPDX-License-Identifier: MIT
+**/
+//==================================================================================================
+#include "test.hpp"
+#include <eve/function/add.hpp>
+#include <eve/function/pedantic.hpp>
+#include <eve/constant/valmax.hpp>
+#include <string>
+
+struct use_friend
+{
+  friend std::string tagged_dispatch( eve::tag::valmax_, eve::as_<use_friend> )
+  {
+    return "valmax dispatched via friend";
+  }
+
+  friend std::string tagged_dispatch( eve::tag::add_, use_friend, use_friend )
+  {
+    return "add dispatched via friend";
+  }
+
+  template<eve::conditional_expr Cond>
+  friend std::string tagged_dispatch( eve::tag::add_, Cond, use_friend, use_friend )
+  {
+    return "conditional add dispatched via friend";
+  }
+
+  friend std::string tagged_dispatch( eve::tag::add_, eve::pedantic_type, use_friend, use_friend )
+  {
+    return "pedantic add dispatched via friend";
+  }
+
+  template<eve::conditional_expr Cond>
+  friend std::string tagged_dispatch( eve::tag::add_, Cond, eve::pedantic_type, use_friend, use_friend )
+  {
+    return "conditional pedantic add dispatched via friend";
+  }
+};
+
+namespace other_space
+{
+  struct use_adl {};
+
+  std::string tagged_dispatch( eve::tag::valmax_, eve::as_<use_adl> )
+  {
+    return "valmax dispatched via ADL";
+  }
+
+  std::string tagged_dispatch( eve::tag::add_, use_adl, use_adl  )
+  {
+    return "add dispatched via ADL";
+  }
+
+  auto operator+(use_adl a, use_adl b)
+  {
+    return eve::add(a,b);
+  }
+
+  template<eve::conditional_expr Cond>
+  std::string tagged_dispatch( eve::tag::add_, Cond, use_adl, use_adl )
+  {
+    return "conditional add dispatched via ADL";
+  }
+
+  std::string tagged_dispatch( eve::tag::add_, eve::pedantic_type, use_adl, use_adl )
+  {
+    return "pedantic add dispatched via ADL";
+  }
+
+  template<eve::conditional_expr Cond>
+  std::string tagged_dispatch( eve::tag::add_, Cond, eve::pedantic_type, use_adl, use_adl )
+  {
+    return "conditional pedantic add dispatched via ADL";
+  }
+}
+
+TTS_CASE("Check that constant can be externally defined for user-defined types" )
+{
+  TTS_EQUAL( eve::valmax( eve::as_<use_friend>{}            ), "valmax dispatched via friend" );
+  TTS_EQUAL( eve::valmax( eve::as_<other_space::use_adl>{}  ), "valmax dispatched via ADL"    );
+}
+
+TTS_CASE("Check that function can be externally defined for user-defined types" )
+{
+  use_friend            fa, fb;
+  other_space::use_adl  aa, ab;
+
+  TTS_EQUAL( eve::add(fa, fb) , "add dispatched via friend" );
+  TTS_EQUAL( eve::add(aa, ab) , "add dispatched via ADL"    );
+  TTS_EQUAL( (aa + ab)        , "add dispatched via ADL"    );
+}
+
+TTS_CASE("Check that function + conditional can be externally defined for user-defined types" )
+{
+  use_friend            fa, fb;
+  other_space::use_adl  aa, ab;
+
+  TTS_EQUAL( eve::add[true](fa, fb) , "conditional add dispatched via friend" );
+  TTS_EQUAL( eve::add[true](aa, ab) , "conditional add dispatched via ADL"    );
+}
+
+TTS_CASE("Check that function + decorator can be externally defined for user-defined types" )
+{
+  use_friend            fa, fb;
+  other_space::use_adl  aa, ab;
+
+  TTS_EQUAL( eve::pedantic(eve::add)(fa, fb) , "pedantic add dispatched via friend" );
+  TTS_EQUAL( eve::pedantic(eve::add)(aa, ab) , "pedantic add dispatched via ADL"    );
+}
+
+TTS_CASE("Check that conditional function + decorator can be externally defined for user-defined types" )
+{
+  use_friend            fa, fb;
+  other_space::use_adl  aa, ab;
+
+  TTS_EQUAL( eve::pedantic(eve::add[true])(fa, fb) , "conditional pedantic add dispatched via friend" );
+  TTS_EQUAL( eve::pedantic(eve::add[true])(aa, ab) , "conditional pedantic add dispatched via ADL"    );
+}

--- a/test/unit/memory/load/aligned/logical_if_else.cpp
+++ b/test/unit/memory/load/aligned/logical_if_else.cpp
@@ -11,7 +11,6 @@
 #include <eve/memory/aligned_ptr.hpp>
 #include <eve/function/any.hpp>
 #include <eve/function/load.hpp>
-#include <eve/constant/false.hpp>
 #include <array>
 #include <list>
 
@@ -57,8 +56,6 @@ EVE_TEST( "Check load to logical from aligned pointer with alternatives"
 
     // lanes value
     auto lanes = eve::lane<T::size()>;
-
-    using eve::false_;
 
     TTS_AND_THEN("load is applied on aligned pointer for a specific cardinal")
     {

--- a/test/unit/memory/load/unaligned/arithmetic_if.cpp
+++ b/test/unit/memory/load/unaligned/arithmetic_if.cpp
@@ -11,7 +11,6 @@
 #include <eve/memory/aligned_ptr.hpp>
 #include <eve/function/load.hpp>
 #include <eve/function/any.hpp>
-#include <eve/constant/false.hpp>
 #include <array>
 #include <list>
 
@@ -61,8 +60,6 @@ EVE_TEST_TYPES( "Check load to wides from unaligned pointer", eve::test::simd::a
 
     // lanes value
     auto lanes = eve::lane<T::size()>;
-
-    using eve::false_;
 
     TTS_AND_THEN("load is applied on unaligned pointer for a specific cardinal")
     {

--- a/test/unit/memory/load/unaligned/logical_if_else.cpp
+++ b/test/unit/memory/load/unaligned/logical_if_else.cpp
@@ -11,7 +11,6 @@
 #include <eve/memory/aligned_ptr.hpp>
 #include <eve/function/any.hpp>
 #include <eve/function/load.hpp>
-#include <eve/constant/false.hpp>
 #include <array>
 #include <list>
 
@@ -54,8 +53,6 @@ EVE_TEST( "Check load to logical from unaligned pointer with alternatives"
 
     // lanes value
     auto lanes = eve::lane<T::size()>;
-
-    using eve::false_;
 
     TTS_AND_THEN("load is applied on aligned pointer for a specific cardinal")
     {

--- a/test/unit/module/real/core/clamp.cpp
+++ b/test/unit/module/real/core/clamp.cpp
@@ -35,16 +35,16 @@ EVE_TEST_TYPES( "Check return types of clamp"
 //==================================================================================================
 // clamp simd tests
 //==================================================================================================
-auto val1 = []< typename T>(eve::as_<T> const &){return (eve::valmax(eve::as(eve::element_type_t<T>()))/2); ;};
+auto val1 = []< typename T>(eve::as_<T> const &){return (eve::valmax(eve::as(eve::element_type_t<T>()))/6); ;};
 auto val2 = []< typename T>(eve::as_<T> const &){return (eve::valmax(eve::as(eve::element_type_t<T>()))/6)*2;};
 auto val3 = []< typename T>(eve::as_<T> const &){return (eve::valmax(eve::as(eve::element_type_t<T>()))/6)*3;};
 auto val4 = []< typename T>(eve::as_<T> const &){return (eve::valmax(eve::as(eve::element_type_t<T>()))/6)*4;};
 
 EVE_TEST( "Check behavior of clamp(wide) and diff  on all types"
         , eve::test::simd::all_types
-        , eve::test::generate ( eve::test::randoms(val1, val4)
-                              , eve::test::between(val1, val2)
-                              , eve::test::between(val2, val3)
+        , eve::test::generate ( eve::test::randoms(val1       , val4)
+                              , eve::test::randoms(eve::valmin, val2)
+                              , eve::test::randoms(val3, eve::valmax)
                               )
         )<typename T>( T const& a0, T const& a1, T const& a2 )
 {

--- a/test/unit/module/real/core/clamp.cpp
+++ b/test/unit/module/real/core/clamp.cpp
@@ -35,22 +35,23 @@ EVE_TEST_TYPES( "Check return types of clamp"
 //==================================================================================================
 // clamp simd tests
 //==================================================================================================
-auto val1 = []< typename T>(eve::as_<T> const &){return (eve::valmax(eve::as(eve::element_type_t<T>()))/6); ;};
+auto val1 = []< typename T>(eve::as_<T> const &){return (eve::valmax(eve::as(eve::element_type_t<T>()))/2); ;};
 auto val2 = []< typename T>(eve::as_<T> const &){return (eve::valmax(eve::as(eve::element_type_t<T>()))/6)*2;};
 auto val3 = []< typename T>(eve::as_<T> const &){return (eve::valmax(eve::as(eve::element_type_t<T>()))/6)*3;};
 auto val4 = []< typename T>(eve::as_<T> const &){return (eve::valmax(eve::as(eve::element_type_t<T>()))/6)*4;};
 
 EVE_TEST( "Check behavior of clamp(wide) and diff  on all types"
         , eve::test::simd::all_types
-        , eve::test::generate ( eve::test::randoms(val1       , val4)
-                              , eve::test::randoms(eve::valmin, val2)
-                              , eve::test::randoms(val3, eve::valmax)
+        , eve::test::generate ( eve::test::randoms(val1, val4)
+                              , eve::test::between(val1, val2)
+                              , eve::test::between(val2, val3)
                               )
         )<typename T>( T const& a0, T const& a1, T const& a2 )
 {
   using eve::clamp;
   using eve::diff;
   using v_t = eve::element_type_t<T>;
+
   TTS_EQUAL( clamp(a0, a1, a2), map([&](auto e, auto f, auto g) -> v_t{ return std::clamp(e, f, g); }, a0, a1, a2));
 
   if constexpr(eve::floating_real_value<T>)

--- a/test/unit/module/real/core/geommean.cpp
+++ b/test/unit/module/real/core/geommean.cpp
@@ -59,7 +59,7 @@ EVE_TEST( "Check behavior of geommean(wide)"
   using v_t = eve::element_type_t<T>;
   TTS_ULP_EQUAL( geommean(a0, a1), map([](auto e, auto f) -> v_t { return (eve::sign(e)*eve::sign(f) >= 0) ?
                                            std::sqrt(e*f) :eve::nan(eve::as<v_t>()); }, a0, a1), 2);
-  TTS_ULP_EQUAL( geommean(a0, a1, a2), map([](auto e, auto f,  auto g) { return std::cbrt(e*f*g); }, a0, a1, a2), 2.5);
+  TTS_ULP_EQUAL( geommean(a0, a1, a2), map([](auto e, auto f,  auto g) { return std::cbrt(e*f*g); }, a0, a1, a2), 3);
 };
 
 //==================================================================================================
@@ -80,7 +80,7 @@ EVE_TEST( "Check behavior of diff(geommean)(simd)"
   using v_t =  eve::element_type_t<T>;
   TTS_ULP_EQUAL( eve::diff_1st(geommean)(a0, a2), map([](auto e, auto f) { return (eve::sign(e)*eve::sign(f) >= 0) ? std::sqrt(eve::abs(f))*std::sqrt(eve::abs(e))/e/2 :eve::nan(eve::as<v_t>()); }, a0, a2), 2);
   TTS_ULP_EQUAL( eve::diff_2nd(geommean)(a0, a2), map([](auto e, auto f) { return (eve::sign(e)*eve::sign(f) >= 0) ? std::sqrt(eve::abs(e))*std::sqrt(eve::abs(f))/f/2 :eve::nan(eve::as<v_t>()); }, a0, a2), 2);
-  TTS_ULP_EQUAL( eve::diff_1st(geommean)(a0, a1, a2), map([](auto e, auto f, auto g) { return std::cbrt(f*g)/eve::sqr(std::cbrt(e))/3; }, a0, a1, a2), 3);
-  TTS_ULP_EQUAL( eve::diff_2nd(geommean)(a0, a1, a2), map([](auto e, auto f, auto g) { return std::cbrt(e*g)/eve::sqr(std::cbrt(f))/3; }, a0, a1, a2), 3);
-  TTS_ULP_EQUAL( eve::diff_3rd(geommean)(a0, a1, a2), map([](auto e, auto f, auto g) { return std::cbrt(e*f)/eve::sqr(std::cbrt(g))/3; }, a0, a1, a2), 3);
+  TTS_ULP_EQUAL( eve::diff_1st(geommean)(a0, a1, a2), map([](auto e, auto f, auto g) { return std::cbrt(f*g)/eve::sqr(std::cbrt(e))/3; }, a0, a1, a2), 4);
+  TTS_ULP_EQUAL( eve::diff_2nd(geommean)(a0, a1, a2), map([](auto e, auto f, auto g) { return std::cbrt(e*g)/eve::sqr(std::cbrt(f))/3; }, a0, a1, a2), 4);
+  TTS_ULP_EQUAL( eve::diff_3rd(geommean)(a0, a1, a2), map([](auto e, auto f, auto g) { return std::cbrt(e*f)/eve::sqr(std::cbrt(g))/3; }, a0, a1, a2), 4);
  };

--- a/test/unit/module/real/core/is_finite.cpp
+++ b/test/unit/module/real/core/is_finite.cpp
@@ -8,6 +8,8 @@
 #include "test.hpp"
 #include <eve/constant/valmin.hpp>
 #include <eve/constant/valmax.hpp>
+#include <eve/constant/false.hpp>
+#include <eve/constant/true.hpp>
 #include <eve/function/is_finite.hpp>
 #include <eve/logical.hpp>
 

--- a/test/unit/module/real/core/is_infinite.cpp
+++ b/test/unit/module/real/core/is_infinite.cpp
@@ -8,6 +8,8 @@
 #include "test.hpp"
 #include <eve/constant/valmin.hpp>
 #include <eve/constant/valmax.hpp>
+#include <eve/constant/true.hpp>
+#include <eve/constant/false.hpp>
 #include <eve/function/is_infinite.hpp>
 #include <eve/logical.hpp>
 

--- a/test/unit/module/real/core/is_negative.cpp
+++ b/test/unit/module/real/core/is_negative.cpp
@@ -6,12 +6,14 @@
 **/
 //==================================================================================================
 #include "test.hpp"
-#include <eve/constant/valmin.hpp>
-#include <eve/constant/valmax.hpp>
 #include <eve/function/is_negative.hpp>
 #include <eve/function/bit_or.hpp>
 #include <eve/function/bitofsign.hpp>
 #include <eve/constant/one.hpp>
+#include <eve/constant/true.hpp>
+#include <eve/constant/false.hpp>
+#include <eve/constant/valmin.hpp>
+#include <eve/constant/valmax.hpp>
 #include <eve/logical.hpp>
 
 //==================================================================================================

--- a/test/unit/module/real/core/is_ordered.cpp
+++ b/test/unit/module/real/core/is_ordered.cpp
@@ -7,6 +7,8 @@
 //==================================================================================================
 #include "test.hpp"
 #include <eve/constant/nan.hpp>
+#include <eve/constant/true.hpp>
+#include <eve/constant/false.hpp>
 #include <eve/function/is_ordered.hpp>
 
 //==================================================================================================

--- a/test/unit/module/real/core/is_positive.cpp
+++ b/test/unit/module/real/core/is_positive.cpp
@@ -11,6 +11,7 @@
 #include <eve/function/is_positive.hpp>
 #include <eve/function/bit_or.hpp>
 #include <eve/function/bitofsign.hpp>
+#include <eve/constant/false.hpp>
 #include <eve/constant/one.hpp>
 #include <eve/logical.hpp>
 

--- a/test/unit/module/real/polynomial/gegenbauer.cpp
+++ b/test/unit/module/real/polynomial/gegenbauer.cpp
@@ -33,7 +33,7 @@ EVE_TEST_TYPES( "Check return types of gegenbauer on wide"
 //==================================================================================================
 EVE_TEST( "Check behavior of gegenbauer on wide"
         , eve::test::simd::ieee_reals
-        , eve::test::generate(eve::test::ramp(0.0, 1.0), eve::test::as_integer(eve::test::ramp(0)))
+        , eve::test::generate(eve::test::between(0.0, 1.0), eve::test::as_integer(eve::test::ramp(0)))
         )
   <typename T, typename I>(T const& a0,I const & i0)
 {
@@ -67,7 +67,7 @@ EVE_TEST( "Check behavior of gegenbauer on wide"
 //==================================================================================================
 EVE_TEST( "Check behavior of gegenbauer diff on wide"
         , eve::test::simd::ieee_reals
-        , eve::test::generate(eve::test::ramp(0.0, 1.0), eve::test::as_integer(eve::test::ramp(0)))
+        , eve::test::generate(eve::test::between(0.0, 1.0), eve::test::as_integer(eve::test::ramp(0)))
         )
   <typename T, typename I>(T const& a0,I const & i0)
 {

--- a/test/unit/module/real/polynomial/hermite.cpp
+++ b/test/unit/module/real/polynomial/hermite.cpp
@@ -34,7 +34,7 @@ EVE_TEST_TYPES( "Check return types of hermite on wide"
 //==================================================================================================
 EVE_TEST( "Check behavior of hermite on wide"
         , eve::test::simd::ieee_reals
-        , eve::test::generate(eve::test::ramp(-1.0, 1.0), eve::test::as_integer(eve::test::ramp(0)))
+        , eve::test::generate(eve::test::between(-1.0, 1.0), eve::test::as_integer(eve::test::ramp(0)))
         )
   <typename T, typename I>(T const& a0,I const & i0)
 {
@@ -67,7 +67,7 @@ EVE_TEST( "Check behavior of hermite on wide"
 //==================================================================================================
 EVE_TEST( "Check behavior of diff hermite on wide"
         , eve::test::simd::ieee_reals
-        , eve::test::generate(eve::test::ramp(-1.0, 1.0), eve::test::as_integer(eve::test::ramp(0)))
+        , eve::test::generate(eve::test::between(-1.0, 1.0), eve::test::as_integer(eve::test::ramp(0)))
         )
   <typename T, typename I>(T const& a0,I const & i0)
 {
@@ -94,4 +94,4 @@ EVE_TEST( "Check behavior of diff hermite on wide"
       TTS_ULP_EQUAL(eve__hermitev(i0.get(j) , a0.get(n)), v_t(boost_hermderiv(i0.get(j), a0.get(n))), 100);
     }
   }
-}; 
+};


### PR DESCRIPTION
USe ADL based tag dispatching system to allow users to define specific overload for EVE function without dealing with internals.