### PR TITLE
FIX-#716: aligning in algorithms MVP.

### DIFF
--- a/include/eve/algo/README.txt
+++ b/include/eve/algo/README.txt
@@ -37,15 +37,33 @@ The minimum requirements are:
 
 The main model is `aligned_ptr_iterator`
 
-The concept around a general purpose `aligned_ptr`. We can only step in `I::cardinal{}()` divisible steps. We guarantee that all loads stores will happen from an aligned address.
+This is a `partially_aligned_iterator` but has an extra feature: we can do `unsafe` load.
+When we get to unbounded algorithms it will become important.
+
+### partially_aligned_iterator(concept)
+
+I and partially_aligned_t<I> are the same.
+
+The main model is `aligned_ptr_iterator`, `zip_iterator<aligned_ptr_iterator, unaligned_ptr_iterator>`
+
+Loading/Storign is more efficient than doing the same from `unaligned`. We can only step in `I::cardinal{}()` divisible steps.
 
 ### unaligned_iterator(concept)
 
-*TODO*
+I and unaligned_t<I> are the same.
 
 The main model is `unaligned_ptr_iterator`
 
 iterator that can represent any position in the underlying range.
+
+### always_aligned_iterator (concept)
+
+I is the same as `partially_aligned_t<I>` and `unaligned_t<I>`
+
+Main model: iota_iterator.
+
+These are not phisical iterators but rather some mechanisms that pretend to be iterators.
+alignment does not matter to them, every position is just as efficient as any other.
 
 ### iteration pattern (concept)
 
@@ -60,6 +78,7 @@ However for some algorithms, like `reverse` and maybe `partition` it's not a goo
 
 * `traits`
 * `unroll`
+* `no_aligning`
 * `divisible_by_cardinal`
 
 traits is a way to customise the behaviour of the algorithm.
@@ -68,7 +87,13 @@ Different algorithms support different customizations.
 ### concepts
 
 * `unaligned_t` -> a convinience to get the unaligned type.
+* `partially_aligned_t` -> a convinience to get the type of `previous_partially_aligned`
 * `same_unaligned_iterator<T, U>` -> checks if two iterators have the same unaligned types.
+* `iterator_basics` -> checks everything about iterator except for load and store
+* `readable_iterator`
+* `unaligned_iterator`
+* `partially_aligned_iterator`
+* `always_aligned_iterator`
 
 ### iterator helpers
 

--- a/include/eve/algo/README.txt
+++ b/include/eve/algo/README.txt
@@ -29,6 +29,7 @@ The minimum requirements are:
 * I is totally ordered
 * `I.unaligned()` - returns an `unaligned_iterator` pointing to the same place.
 * `I.unaligned()` and `I` are comparible
+* `I.previous_partially_aligned()` - returns our best attempt to align this iterator.
 
 ### aligned_iterator(concept)
 

--- a/include/eve/algo/any_of.hpp
+++ b/include/eve/algo/any_of.hpp
@@ -55,7 +55,7 @@ namespace eve::algo
 
       delegate d{p};
 
-      auto [traits, f, l] = preprocess_range(_traits, _f, _l);
+      auto [traits, f, l] = preprocess_range(default_to(_traits, default_traits), _f, _l);
       for_each_iteration(traits, f, l, d);
       return d.res;
     }

--- a/include/eve/algo/concepts.hpp
+++ b/include/eve/algo/concepts.hpp
@@ -16,13 +16,13 @@ namespace eve::algo
   namespace detail
   {
     template <typename>
-    struct is_eve_fixed  : std::false_type {};
+    struct is_fixed  : std::false_type {};
 
     template <std::ptrdiff_t N>
-    struct is_eve_fixed<eve::fixed<N>> : std::true_type {};
+    struct is_fixed<eve::fixed<N>> : std::true_type {};
 
     template <typename T>
-    concept is_eve_fixed_v = is_eve_fixed<T>::value;
+    concept is_fixed_v = is_fixed<T>::value;
   }
 
   template <typename T>
@@ -36,30 +36,40 @@ namespace eve::algo
   };
 
   template <typename T>
-  using partialy_unaligned_t = decltype(std::declval<T>().previous_partially_aligned());
+  using partially_aligned_t = decltype(std::declval<T>().previous_partially_aligned());
+
+  template <typename T>
+  struct partially_aligned
+  {
+    using type = partially_aligned_t<T>;
+  };
+
+  namespace detail
+  {
+
+    template <typename I>
+    concept unaligned_check = std::same_as<unaligned_t<I>, I>;
+
+    template <typename I>
+    concept partially_aligned_check = std::same_as<partially_aligned_t<I>, I>;
+  }
 
   template <typename I>
-  concept unaligned_check = std::same_as<unaligned_t<I>, I>;
-
-  template <typename I>
-  concept partially_aligned_check = std::same_as<partialy_unaligned_t<I>, I>;
-
-  template <typename I>
-  concept iterator_basics =
-    detail::is_eve_fixed_v<typename I::cardinal> &&
+  concept iterator =
+    detail::is_fixed_v<typename I::cardinal> &&
     std::regular<I> &&
     std::totally_ordered<I> &&
     std::totally_ordered_with<I, unaligned_t<I>> &&
-    std::totally_ordered_with<I, partialy_unaligned_t<I>> &&
+    std::totally_ordered_with<I, partially_aligned_t<I>> &&
     requires(I i, std::ptrdiff_t n) {
        { i += n } -> std::same_as<I&>;
        { i - i }  -> std::same_as<std::ptrdiff_t>;
-       { i.unaligned() } -> unaligned_check;
-       { i.previous_partially_aligned() } -> partially_aligned_check;
+       { i.unaligned() } -> detail::unaligned_check;
+       { i.previous_partially_aligned() } -> detail::partially_aligned_check;
     };
 
   template <typename I>
-  concept readable_iterator = iterator_basics<I> &&
+  concept readable_iterator = iterator<I> &&
     requires(I i) {
       { eve::load(i) };
       { eve::load[eve::ignore_first(1)](i) };
@@ -67,17 +77,17 @@ namespace eve::algo
     };
 
   template <typename I>
-  concept unaligned_iterator = iterator_basics<I> && unaligned_check<I>;
+  concept unaligned_iterator = iterator<I> && detail::unaligned_check<I>;
 
   template <typename I>
-  concept partially_aligned_iterator = iterator_basics<I> && partially_aligned_check<I>;
+  concept partially_aligned_iterator = iterator<I> && detail::partially_aligned_check<I>;
 
   // We don't yet have examples;
   template <typename I>
   concept always_aligned_iterator = partially_aligned_iterator<I> && unaligned_iterator<I>;
 
   template <typename S, typename I>
-  concept sentinel_for = std::totally_ordered_with<S, I> &&
+  concept sentinel_for = iterator<I> && std::totally_ordered_with<S, I> &&
     requires(I i, S s) {
       { s - i } -> std::same_as<std::ptrdiff_t>;
     };

--- a/include/eve/algo/concepts.hpp
+++ b/include/eve/algo/concepts.hpp
@@ -8,9 +8,23 @@
 #pragma once
 
 #include <concepts>
+#include <type_traits>
+#include <eve/function/load.hpp>
 
 namespace eve::algo
 {
+  namespace detail
+  {
+    template <typename>
+    struct is_eve_fixed  : std::false_type {};
+
+    template <std::ptrdiff_t N>
+    struct is_eve_fixed<eve::fixed<N>> : std::true_type {};
+
+    template <typename T>
+    concept is_eve_fixed_v = is_eve_fixed<T>::value;
+  }
+
   template <typename T>
   using unaligned_t = decltype(std::declval<T>().unaligned());
 
@@ -20,6 +34,50 @@ namespace eve::algo
   {
     using type = unaligned_t<T>;
   };
+
+  template <typename T>
+  using partialy_unaligned_t = decltype(std::declval<T>().previous_partially_aligned());
+
+  template <typename I>
+  concept unaligned_check = std::same_as<unaligned_t<I>, I>;
+
+  template <typename I>
+  concept partially_aligned_check = std::same_as<partialy_unaligned_t<I>, I>;
+
+  template <typename I>
+  concept iterator_basics =
+    detail::is_eve_fixed_v<typename I::cardinal> &&
+    std::regular<I> &&
+    std::totally_ordered<I> &&
+    std::totally_ordered_with<I, unaligned_t<I>> &&
+    std::totally_ordered_with<I, partialy_unaligned_t<I>> &&
+    requires(I i, std::ptrdiff_t n) {
+       { i += n } -> std::same_as<I&>;
+       { i - i }  -> std::same_as<std::ptrdiff_t>;
+       { i.unaligned() } -> unaligned_check;
+       { i.previous_partially_aligned() } -> partially_aligned_check;
+    };
+
+  template <typename I>
+  concept readable_iterator = iterator_basics<I> &&
+    requires(I i) {
+      { eve::load(i) };
+      { eve::load[eve::ignore_first(1)](i) };
+      { eve::load[eve::ignore_extrema(1, 0)](i) };
+    };
+
+  template <typename I>
+  concept unaligned_iterator = iterator_basics<I> && unaligned_check<I>;
+
+  template <typename I>
+  concept partially_aligned_iterator = iterator_basics<I> && partially_aligned_check<I>;
+
+
+  template <typename S, typename I>
+  concept sentinel_for = std::totally_ordered_with<S, I> &&
+    requires(I i, S s) {
+      { s - i } -> std::same_as<std::ptrdiff_t>;
+    };
 
 
   template <typename T, typename U>

--- a/include/eve/algo/concepts.hpp
+++ b/include/eve/algo/concepts.hpp
@@ -72,6 +72,7 @@ namespace eve::algo
   template <typename I>
   concept partially_aligned_iterator = iterator_basics<I> && partially_aligned_check<I>;
 
+  // We don't yet have examples;
   template <typename I>
   concept always_aligned_iterator = partially_aligned_iterator<I> && unaligned_iterator<I>;
 

--- a/include/eve/algo/concepts.hpp
+++ b/include/eve/algo/concepts.hpp
@@ -72,6 +72,8 @@ namespace eve::algo
   template <typename I>
   concept partially_aligned_iterator = iterator_basics<I> && partially_aligned_check<I>;
 
+  template <typename I>
+  concept always_aligned_iterator = partially_aligned_iterator<I> && unaligned_iterator<I>;
 
   template <typename S, typename I>
   concept sentinel_for = std::totally_ordered_with<S, I> &&

--- a/include/eve/algo/for_each_iteration.hpp
+++ b/include/eve/algo/for_each_iteration.hpp
@@ -20,10 +20,12 @@ namespace eve::algo
 {
   struct for_each_iteration_
   {
-    template <typename Traits, iterator_basics I, sentinel_for<I> S, typename Delegate>
+    template <typename Traits, iterator I, sentinel_for<I> S, typename Delegate>
     EVE_FORCEINLINE void operator()(Traits traits, I f, S l, Delegate& delegate) const
       requires (Traits::contains(no_aligning)())
     {
+      EVE_ASSERT(f != l, "for_each_iteration requires a non-empty range");
+
       static constexpr std::ptrdiff_t step = typename I::cardinal{}();
 
       I precise_l = f + ((l - f) / step * step);
@@ -40,6 +42,8 @@ namespace eve::algo
     EVE_FORCEINLINE void operator()(Traits traits, I f, S l, Delegate& delegate) const
       requires (!Traits::contains(no_aligning)())
     {
+      EVE_ASSERT(f != l, "for_each_iteration requires a non-empty range");
+
       static constexpr std::ptrdiff_t step = typename I::cardinal{}();
 
       auto aligned_f = f.previous_partially_aligned();

--- a/include/eve/algo/iterator_helpers.hpp
+++ b/include/eve/algo/iterator_helpers.hpp
@@ -48,7 +48,6 @@ namespace eve::algo
     {
       return x.unaligned() <=> y.unaligned();
     }
-
     template <typename T, typename U>
     friend std::ptrdiff_t operator-(T const& x, U const& y) requires detail::should_enable_forward_to_unaligned<T, U>
     {

--- a/include/eve/algo/preprocess_range.hpp
+++ b/include/eve/algo/preprocess_range.hpp
@@ -59,7 +59,7 @@ namespace eve::algo
     }
 
     // Base case. Should validate that I, S are a valid iterator pair
-    template <typename Traits, iterator_basics I, sentinel_for<I> S>
+    template <typename Traits, iterator I, sentinel_for<I> S>
     auto operator()(Traits traits_, I f, S l) const
     {
       EVE_ASSERT(f != l, "preprocess_range requires a non-empty range");

--- a/include/eve/algo/preprocess_range.hpp
+++ b/include/eve/algo/preprocess_range.hpp
@@ -46,6 +46,18 @@ namespace eve::algo
       return operator()(traits_, it{raw_f}, it{raw_l});
     }
 
+    template <typename Traits, typename T>
+    auto operator()(Traits traits_, eve::aligned_ptr<T> f, T* l) const
+    {
+      EVE_ASSERT(f != l, "preprocess_range requires a non-empty range");
+
+      using N            = eve::fixed<eve::expected_cardinal_v<T>>;
+      using aligned_it   = aligned_ptr_iterator<T, N>;
+      using unaligned_it = unaligned_ptr_iterator<T, N>;
+
+      return operator()(traits_, aligned_it(f), unaligned_it(l));
+    }
+
     // Base case. Should validate that I, S are a valid iterator pair
     template <typename Traits, iterator_basics I, sentinel_for<I> S>
     auto operator()(Traits traits_, I f, S l) const

--- a/include/eve/algo/preprocess_range.hpp
+++ b/include/eve/algo/preprocess_range.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <eve/algo/ptr_iterator.hpp>
+#include <eve/algo/traits.hpp>
 
 #include <eve/assert.hpp>
 
@@ -33,7 +34,7 @@ namespace eve::algo
   struct preprocess_range_
   {
     template <typename Traits, std::contiguous_iterator I, typename S>
-    auto operator()(Traits traits, I f, S l) const
+    auto operator()(Traits traits_, I f, S l) const
     {
       EVE_ASSERT(f != l, "preprocess_range requires a non-empty range");
 
@@ -42,15 +43,27 @@ namespace eve::algo
       using T = std::remove_reference_t<decltype(*raw_f)>;
       using it = unaligned_ptr_iterator<T, eve::fixed<eve::expected_cardinal_v<T>>>;
 
-      return detail::preprocess_range_result{traits, it{raw_f}, it{raw_l}};
+      return operator()(traits_, it{raw_f}, it{raw_l});
     }
 
     // Base case. Should validate that I, S are a valid iterator pair
-    template <typename Traits, typename I, typename S>
-    auto operator()(Traits traits, I f, S l) const
+    template <typename Traits, iterator_basics I, sentinel_for<I> S>
+    auto operator()(Traits traits_, I f, S l) const
     {
       EVE_ASSERT(f != l, "preprocess_range requires a non-empty range");
-      return detail::preprocess_range_result{traits, f, l};
+
+      auto deduced = [] {
+        if constexpr (partially_aligned_iterator<I>)
+        {
+          if constexpr ( std::same_as<I, S> && !always_aligned_iterator<I> ) return algo::traits(no_aligning, divisible_by_cardinal);
+          else                                                               return algo::traits(no_aligning);
+        }
+        else
+        {
+          return algo::traits();
+        }
+      }();
+      return detail::preprocess_range_result{default_to(traits_, deduced), f, l};
     }
 
   } inline constexpr preprocess_range;

--- a/include/eve/algo/ptr_iterator.hpp
+++ b/include/eve/algo/ptr_iterator.hpp
@@ -16,6 +16,9 @@
 namespace eve::algo
 {
   template <typename T, typename Cardinal>
+  struct aligned_ptr_iterator;
+
+  template <typename T, typename Cardinal>
   struct unaligned_ptr_iterator : operations_with_distance
   {
     using cardinal = Cardinal;
@@ -25,6 +28,11 @@ namespace eve::algo
     explicit unaligned_ptr_iterator(T* ptr) : ptr(ptr) {}
 
     unaligned_ptr_iterator unaligned() const { return *this; }
+
+    auto previous_partially_aligned() const
+    {
+      return aligned_ptr_iterator<T, cardinal>{eve::previous_aligned_address(ptr, cardinal{})};
+    }
 
     unaligned_ptr_iterator& operator+=(std::ptrdiff_t n) { ptr += n; return *this; }
     friend std::ptrdiff_t   operator-(unaligned_ptr_iterator x, unaligned_ptr_iterator y) { return x.ptr - y.ptr; }
@@ -70,7 +78,14 @@ namespace eve::algo
     aligned_ptr_iterator();
     explicit aligned_ptr_iterator(aligned_ptr_type ptr) : ptr{ptr} {}
 
+    // Need this for totally ordered.
+    operator unaligned_ptr_iterator<T, Cardinal>() const {
+      return unaligned_ptr_iterator<T, Cardinal>{ptr.get()};
+    }
+
     auto unaligned() const { return unaligned_ptr_iterator<T, Cardinal>{ptr.get()}; }
+    auto previous_partially_aligned() const { return *this; }
+
     aligned_ptr_iterator& operator+=(std::ptrdiff_t n) { ptr += n; return *this; }
 
     template <relative_conditional_expr C>

--- a/include/eve/algo/ptr_iterator.hpp
+++ b/include/eve/algo/ptr_iterator.hpp
@@ -75,7 +75,7 @@ namespace eve::algo
 
     using aligned_ptr_type = eve::aligned_ptr<T, Cardinal{}() * sizeof(T)>;
 
-    aligned_ptr_iterator();
+    aligned_ptr_iterator() = default;
     explicit aligned_ptr_iterator(aligned_ptr_type ptr) : ptr{ptr} {}
 
     // Need this for totally ordered.

--- a/include/eve/algo/traits.hpp
+++ b/include/eve/algo/traits.hpp
@@ -30,11 +30,54 @@ namespace eve::algo
 
   template<int N>
   inline constexpr auto unroll = (unrolling = eve::index<N>);
-  inline constexpr auto divisible_by_cardinal = rbr::keyword<struct divisible_by_cardinal_tag>;
+
+  inline constexpr auto divisible_by_cardinal = rbr::flag<struct divisible_by_cardinal_tag>;
+
+  inline constexpr auto no_aligning = rbr::flag<struct disable_aligning_tag>;
+
 
   template <typename Traits>
   constexpr std::ptrdiff_t get_unrolling() {
     if constexpr (!Traits::contains(eve::algo::unrolling)) return 1;
     else return std::remove_cvref_t<decltype(std::declval<Traits>()[unrolling])>{}();
+  }
+
+  // Temp hack while https://github.com/jfalcou/ofw/issues/25 is not done
+  template <typename ... User, typename ... Default>
+  constexpr auto default_to(traits<User...>, traits<Default...>) {
+    using o_t = traits<User...>;
+    using d_t = traits<Default...>;
+
+    auto unroll_ = [&] (auto ...other){
+           if constexpr (o_t::contains(unrolling)) return traits(unroll<get_unrolling<o_t>()>, other...);
+      else if constexpr (d_t::contains(unrolling)) return traits(unroll<get_unrolling<d_t>()>, other...);
+      else                                         return traits(other...);
+    };
+
+    auto divisible_ = [&] (auto ...other){
+      if constexpr (o_t::contains(divisible_by_cardinal) ||
+                    d_t::contains(divisible_by_cardinal))
+      {
+        return unroll_(divisible_by_cardinal, other...);
+      }
+      else
+      {
+        return unroll_(other...);
+      }
+    };
+
+    auto no_aligning_ = [&] (auto ...other){
+      if constexpr (o_t::contains(no_aligning) ||
+                    d_t::contains(no_aligning))
+      {
+        return divisible_(no_aligning, other...);
+      }
+      else
+      {
+        return unroll_(other...);
+      }
+    };
+
+    return no_aligning_();
   }
 }

--- a/include/eve/algo/traits.hpp
+++ b/include/eve/algo/traits.hpp
@@ -74,7 +74,7 @@ namespace eve::algo
       }
       else
       {
-        return unroll_(other...);
+        return divisible_(other...);
       }
     };
 

--- a/test/unit/algo/find_generic_test.hpp
+++ b/test/unit/algo/find_generic_test.hpp
@@ -13,6 +13,7 @@
 
 #include <eve/memory/aligned_allocator.hpp>
 
+#include <algorithm>
 #include <vector>
 
 namespace algo_test
@@ -36,10 +37,10 @@ namespace algo_test
     using e_t = eve::element_type_t<T>;
     std::vector<e_t, eve::aligned_allocator<e_t, 4096>> page(4096 / sizeof(e_t), e_t{0});
 
-    const std::ptrdiff_t elemenents_to_test = T::static_size * 6;
+    constexpr int elements_to_test  = std::min(T::static_size * 10, 300l);
 
     auto f = page.data();
-    auto l = f + elemenents_to_test;
+    auto l = f + elements_to_test;
 
     auto run = [&] {
       for (auto it = f; it < l; ++it) {
@@ -54,7 +55,7 @@ namespace algo_test
     // from the beginning
     while (f < l) {
       run();
-      *l = 1;
+      if (l != (page.data() + page.size())) { *l = 1; }
       --l;
       *f = 1;
       ++f;
@@ -62,10 +63,13 @@ namespace algo_test
 
     std::fill(page.begin(), page.end(), 0);
 
+    l = page.data() + page.size();
+    f = l - elements_to_test;
+
     // from the end
     while (f < l) {
       run();
-      *l = 1;
+      if (l != (page.data() + page.size())) { *l = 1; }
       --l;
       *f = 1;
       ++f;

--- a/test/unit/algo/iterator_concept_test.hpp
+++ b/test/unit/algo/iterator_concept_test.hpp
@@ -81,11 +81,16 @@ namespace algo_test
     TTS_EQUAL(f, l);
   }
 
-  template <typename I, typename S, typename T, typename ReplaceIgnored>
+  template <eve::algo::readable_iterator I, eve::algo::sentinel_for<I> S, typename T, typename ReplaceIgnored>
   void iterator_sentinel_test(I f, S l, T v, ReplaceIgnored replace)
   {
     iterator_sentinel_test_one_pair(f, l, v, replace);
     unaligned_iteration_test(f.unaligned(), l);
+
+    TTS_CONSTEXPR_EXPECT(
+      eve::algo::partially_aligned_iterator<decltype(f.previous_partially_aligned())>);
+    TTS_CONSTEXPR_EXPECT(
+      eve::algo::unaligned_iterator<decltype(f.unaligned())>);
 
     iterator_sentinel_test_one_pair(f.unaligned(), l, v, replace);
     iterator_sentinel_test_one_pair(f, l.unaligned(), v, replace);

--- a/test/unit/algo/preprocess_range.cpp
+++ b/test/unit/algo/preprocess_range.cpp
@@ -15,10 +15,6 @@
 #include <array>
 #include <vector>
 
-namespace
-{
-  struct no_traits {};
-}
 
 EVE_TEST_TYPES("Check preprocess_range for contiguous iterators", algo_test::selected_types)
 <typename T>(eve::as_<T>)
@@ -32,8 +28,8 @@ EVE_TEST_TYPES("Check preprocess_range for contiguous iterators", algo_test::sel
 
   // pointers
   {
-    auto [traits, f, l] = eve::algo::preprocess_range(no_traits{}, arr.begin(), arr.end());
-    TTS_TYPE_IS(decltype(traits), no_traits);
+    auto [traits, f, l] = eve::algo::preprocess_range(eve::algo::traits(eve::algo::unroll<2>), arr.begin(), arr.end());
+    TTS_CONSTEXPR_EXPECT(eve::algo::get_unrolling<decltype(traits)>() == 2);
     TTS_TYPE_IS(decltype(f), (eve::algo::unaligned_ptr_iterator<e_t, N>));
     TTS_TYPE_IS(decltype(l), (eve::algo::unaligned_ptr_iterator<e_t, N>));
     TTS_EQUAL((void*)f.ptr, (void*)arr.begin());
@@ -42,8 +38,8 @@ EVE_TEST_TYPES("Check preprocess_range for contiguous iterators", algo_test::sel
 
   // const pointers
   {
-    auto [traits, f, l] = eve::algo::preprocess_range(no_traits{}, arr.cbegin(), arr.cend());
-    TTS_TYPE_IS(decltype(traits), no_traits);
+    auto [traits, f, l] = eve::algo::preprocess_range(eve::algo::traits(eve::algo::unroll<2>), arr.cbegin(), arr.cend());
+    TTS_CONSTEXPR_EXPECT(eve::algo::get_unrolling<decltype(traits)>() == 2);
     TTS_TYPE_IS(decltype(f), (eve::algo::unaligned_ptr_iterator<const e_t, N>));
     TTS_TYPE_IS(decltype(l), (eve::algo::unaligned_ptr_iterator<const e_t, N>));
     TTS_EQUAL((void*)f.ptr, (void*)arr.cbegin());
@@ -52,8 +48,8 @@ EVE_TEST_TYPES("Check preprocess_range for contiguous iterators", algo_test::sel
 
   // vector::iterator
   {
-    auto [traits, f, l] = eve::algo::preprocess_range(no_traits{}, vec.begin(), vec.end());
-    TTS_TYPE_IS(decltype(traits), no_traits);
+    auto [traits, f, l] = eve::algo::preprocess_range(eve::algo::traits(eve::algo::unroll<2>), vec.begin(), vec.end());
+    TTS_CONSTEXPR_EXPECT(eve::algo::get_unrolling<decltype(traits)>() == 2);
     TTS_TYPE_IS(decltype(f), (eve::algo::unaligned_ptr_iterator<e_t, N>));
     TTS_TYPE_IS(decltype(l), (eve::algo::unaligned_ptr_iterator<e_t, N>));
     TTS_EQUAL((void*)f.ptr, (void*)vec.data());
@@ -62,8 +58,8 @@ EVE_TEST_TYPES("Check preprocess_range for contiguous iterators", algo_test::sel
 
   // vector::const_iterator
   {
-    auto [traits, f, l] = eve::algo::preprocess_range(no_traits{}, vec.cbegin(), vec.cend());
-    TTS_TYPE_IS(decltype(traits), no_traits);
+    auto [traits, f, l] = eve::algo::preprocess_range(eve::algo::traits(eve::algo::unroll<2>), vec.cbegin(), vec.cend());
+    TTS_CONSTEXPR_EXPECT(eve::algo::get_unrolling<decltype(traits)>() == 2);
     TTS_TYPE_IS(decltype(f), (eve::algo::unaligned_ptr_iterator<const e_t, N>));
     TTS_TYPE_IS(decltype(l), (eve::algo::unaligned_ptr_iterator<const e_t, N>));
     TTS_EQUAL((void*)f.ptr, (void*)vec.data());
@@ -79,10 +75,10 @@ EVE_TEST_TYPES("Check preprocess_range for eve ptr iterators", algo_test::select
 
   alignas(sizeof(T)) std::array<e_t, T::static_size> arr;
 
-  auto run_one_test = [&]<typename I, typename S>(I _f, S _l)
+  auto run_one_test = [&]<typename I, typename S, typename ExpectedTraits>(I _f, S _l, ExpectedTraits)
   {
-    auto [traits, f, l] = eve::algo::preprocess_range(no_traits{}, _f, _l);
-    TTS_TYPE_IS(decltype(traits), no_traits);
+    auto [traits, f, l] = eve::algo::preprocess_range(eve::algo::traits(eve::algo::unroll<2>), _f, _l);
+    TTS_TYPE_IS(decltype(traits), ExpectedTraits);
     TTS_TYPE_IS(decltype(f), I);
     TTS_TYPE_IS(decltype(l), S);
     TTS_EQUAL(f, _f);
@@ -98,10 +94,10 @@ EVE_TEST_TYPES("Check preprocess_range for eve ptr iterators", algo_test::select
     eve::algo::aligned_ptr_iterator<U, N>   a_f(aligned_p{f});
     eve::algo::aligned_ptr_iterator<U, N>   a_l(aligned_p{l});
 
-    run_one_test(u_f, u_l);
-    run_one_test(u_f, a_l);
-    run_one_test(a_f, a_l);
-    run_one_test(a_f, u_l);
+    run_one_test(u_f, u_l, eve::algo::traits(eve::algo::unroll<2>));
+    run_one_test(u_f, a_l, eve::algo::traits(eve::algo::unroll<2>));
+    run_one_test(a_f, a_l, eve::algo::traits(eve::algo::unroll<2>, eve::algo::divisible_by_cardinal, eve::algo::no_aligning));
+    run_one_test(a_f, u_l, eve::algo::traits(eve::algo::unroll<2>, eve::algo::no_aligning));
   };
 
   run_test(arr.begin(), arr.end());

--- a/test/unit/algo/preprocess_range.cpp
+++ b/test/unit/algo/preprocess_range.cpp
@@ -22,7 +22,7 @@ EVE_TEST_TYPES("Check preprocess_range for contiguous iterators", algo_test::sel
   using e_t = eve::element_type_t<T>;
   using N = eve::fixed<eve::expected_cardinal_v<e_t>>;
 
-  alignas(sizeof(T)) std::array<e_t, T::static_size> arr{};
+  alignas(sizeof(eve::wide<e_t, N>)) std::array<e_t, T::static_size> arr{};
 
   std::vector<e_t> vec(100u, 0);
 

--- a/test/unit/algo/preprocess_range.cpp
+++ b/test/unit/algo/preprocess_range.cpp
@@ -46,6 +46,26 @@ EVE_TEST_TYPES("Check preprocess_range for contiguous iterators", algo_test::sel
     TTS_EQUAL((void*)l.ptr, (void*)arr.cend());
   }
 
+  // aligned_pointer
+  {
+    auto [traits, f, l] = eve::algo::preprocess_range(eve::algo::traits(eve::algo::unroll<2>), eve::aligned_ptr<e_t>{arr.begin()}, arr.end());
+    TTS_TYPE_IS(decltype(traits), decltype(eve::algo::traits(eve::algo::unroll<2>, eve::algo::no_aligning)));
+    TTS_TYPE_IS(decltype(f), (eve::algo::aligned_ptr_iterator<e_t, N>));
+    TTS_TYPE_IS(decltype(l), (eve::algo::unaligned_ptr_iterator<e_t, N>));
+    TTS_EQUAL((void*)f.ptr.get(), (void*)arr.begin());
+    TTS_EQUAL((void*)l.ptr, (void*)arr.end());
+  }
+
+  // const aligned_pointer
+  {
+    auto [traits, f, l] = eve::algo::preprocess_range(eve::algo::traits(eve::algo::unroll<2>), eve::aligned_ptr<const e_t>{arr.cbegin()}, arr.cend());
+    TTS_TYPE_IS(decltype(traits), decltype(eve::algo::traits(eve::algo::unroll<2>, eve::algo::no_aligning)));
+    TTS_TYPE_IS(decltype(f), (eve::algo::aligned_ptr_iterator<const e_t, N>));
+    TTS_TYPE_IS(decltype(l), (eve::algo::unaligned_ptr_iterator<const e_t, N>));
+    TTS_EQUAL((void*)f.ptr.get(), (void*)arr.begin());
+    TTS_EQUAL((void*)l.ptr, (void*)arr.end());
+  }
+
   // vector::iterator
   {
     auto [traits, f, l] = eve::algo::preprocess_range(eve::algo::traits(eve::algo::unroll<2>), vec.begin(), vec.end());

--- a/test/unit/algo/traits.cpp
+++ b/test/unit/algo/traits.cpp
@@ -50,4 +50,10 @@ TTS_CASE("eve.algo defaulting")
     TTS_CONSTEXPR_EXPECT(decltype(out)::contains((eve::algo::divisible_by_cardinal)));
     TTS_CONSTEXPR_EXPECT(decltype(out)::contains((eve::algo::no_aligning)));
   }
+  {
+    constexpr auto expected = eve::algo::traits(eve::algo::divisible_by_cardinal);
+    constexpr auto actual = eve::algo::default_to(eve::algo::traits(), expected);
+
+    TTS_TYPE_IS(decltype(expected), decltype(actual));
+  }
 }

--- a/test/unit/algo/traits.cpp
+++ b/test/unit/algo/traits.cpp
@@ -25,9 +25,29 @@ TTS_CASE("eve.algo basic traits testing")
     }(just_unroll);
   }
   {
-    auto divisible_by_cardinal = eve::algo::traits(eve::algo::divisible_by_cardinal = true);
+    auto divisible_by_cardinal = eve::algo::traits(eve::algo::divisible_by_cardinal);
     []<typename Traits>(Traits){
       TTS_CONSTEXPR_EXPECT(Traits::contains(eve::algo::divisible_by_cardinal));
     }(divisible_by_cardinal);
+  }
+}
+
+TTS_CASE("eve.algo defaulting")
+{
+  {
+    eve::algo::traits out =
+      eve::algo::default_to(eve::algo::traits(eve::algo::unroll<1>), eve::algo::traits(eve::algo::unroll<4>));
+    TTS_CONSTEXPR_EXPECT(eve::algo::get_unrolling<decltype(out)>() == 1);
+    TTS_CONSTEXPR_EXPECT(!decltype(out)::contains((eve::algo::divisible_by_cardinal)));
+    TTS_CONSTEXPR_EXPECT(!decltype(out)::contains((eve::algo::no_aligning)));
+  }
+  {
+    eve::algo::traits out = eve::algo::default_to(
+      eve::algo::traits(eve::algo::divisible_by_cardinal),
+      eve::algo::traits(eve::algo::unroll<4>,
+                        eve::algo::no_aligning));
+    TTS_CONSTEXPR_EXPECT(eve::algo::get_unrolling<decltype(out)>() == 4);
+    TTS_CONSTEXPR_EXPECT(decltype(out)::contains((eve::algo::divisible_by_cardinal)));
+    TTS_CONSTEXPR_EXPECT(decltype(out)::contains((eve::algo::no_aligning)));
   }
 }


### PR DESCRIPTION
* Iterators now have `previous_partially_aligned` method. I am not sure if every iterator should have it (efficiency of it is a different question).

* Introduced some of the basic concepts. Unfortunately a bit struggle with `writeable_iterator` so `iterator_basics` and `readable_iterator` for now. Also they are not fully implemented.

* Introduced `no_aligning` the tell us not to use any of the `prervious_partially_aligned` business.

* Hacked together defaulting logic for traits since I need it.

* `preprocess_range` now can deduce some of the traits: like that `no_aligning` and `divisible_by_cardinal`. I'm not actually using `divisible_by_cardinal` yet.

* `preprocess_range` now can accept `aligned_ptr` as a first parameter.

* `for_each_iteration` now checks that the range it calls the last iteration with is not empty. The reason why it's important is that we require to `load` from an actually valid address. But `l` can be the end of the page in which case calling with `load(l)` is not cool.

* `for_each_iteration` now checks traits to figure wether it should try to align or not.