### PR TITLE
FIX-670: preparations for an automatic patch

### DIFF
--- a/include/eve/arch/abi.hpp
+++ b/include/eve/arch/abi.hpp
@@ -31,35 +31,34 @@ namespace eve
   template<typename T> concept arithmetic = std::is_arithmetic_v<T>;
 
   // Find proper ABI for wide
-  template<typename Type, typename Size> struct expected_abi {};
+  template<typename Type, typename Size> struct abi {};
 
   template<typename Type, typename Size>
   requires( arithmetic<Type> && detail::require_aggregation<Type, Size> )
-  struct expected_abi<Type, Size>
+  struct abi<Type, Size>
   {
     using type = eve::aggregated_;
   };
 
   template<typename Type, typename Size>
   requires( arithmetic<Type> && !detail::require_aggregation<Type, Size> )
-  struct expected_abi<Type, Size> : abi_of<Type, Size::value>
+  struct abi<Type, Size> : abi_of<Type, Size::value>
   {};
 
   // Wrapper for SIMD registers holding logical type
   template<typename Type, typename Size>
   requires( arithmetic<Type> && detail::require_aggregation<Type, Size> )
-  struct expected_abi<logical<Type>, Size>
+  struct abi<logical<Type>, Size>
   {
     using type = eve::aggregated_;
   };
 
   template<typename Type, typename Size>
   requires( arithmetic<Type> && !detail::require_aggregation<Type, Size> )
-  struct expected_abi<logical<Type>, Size> : abi_of<logical<Type>, Size::value>
+  struct abi<logical<Type>, Size> : abi_of<logical<Type>, Size::value>
   {};
 
   // Type short-cut
   template<typename Type, typename Size>
-  using expected_abi_t = typename expected_abi<Type, Size>::type;
+  using abi_t = typename abi<Type, Size>::type;
 }
-

--- a/include/eve/arch/arm/predef.hpp
+++ b/include/eve/arch/arm/predef.hpp
@@ -13,5 +13,14 @@
 #if defined(SPY_SIMD_IS_ARM) && !defined(EVE_NO_SIMD)
 #  define EVE_SUPPORTS_NATIVE_SIMD
 #  define EVE_HW_ARM
+#  define EVE_INCLUDE_ARM_HEADER
 #endif
 
+#if defined(EVE_HACK_FOR_CLANG_TOOLING)
+#   pragma clang diagnostic ignored "-Wmany-braces-around-scalar-init"
+#   define EVE_INCLUDE_ARM_HEADER
+
+using uint8x8_t   = int;
+using uint8x8x2_t = int;
+
+#endif

--- a/include/eve/arch/ppc/predef.hpp
+++ b/include/eve/arch/ppc/predef.hpp
@@ -13,5 +13,5 @@
 #if defined(SPY_SIMD_IS_PPC) && !defined(EVE_NO_SIMD)
 #  define EVE_SUPPORTS_NATIVE_SIMD
 #  define EVE_HW_POWERPC
+#  define EVE_INCLUDE_POWERPC_HEADER
 #endif
-

--- a/include/eve/arch/x86/predef.hpp
+++ b/include/eve/arch/x86/predef.hpp
@@ -44,5 +44,5 @@
 #if defined(SPY_SIMD_IS_X86) && !defined(EVE_NO_SIMD)
 #  define EVE_SUPPORTS_NATIVE_SIMD
 #  define EVE_HW_X86
+#  define EVE_INCLUDE_X86_HEADER
 #endif
-

--- a/include/eve/detail/function/bitmask.hpp
+++ b/include/eve/detail/function/bitmask.hpp
@@ -10,6 +10,6 @@
 #include <eve/arch.hpp>
 #include <eve/detail/function/simd/common/bitmask.hpp>
 
-#if defined(EVE_HW_X86)
+#if defined(EVE_INCLUDE_X86_HEADER)
 #  include <eve/detail/function/simd/x86/bitmask.hpp>
 #endif

--- a/include/eve/detail/function/broadcast.hpp
+++ b/include/eve/detail/function/broadcast.hpp
@@ -25,6 +25,6 @@ namespace eve
 
 #include <eve/detail/function/simd/common/broadcast.hpp>
 
-#if defined(EVE_HW_POWERPC)
+#if defined(EVE_INCLUDE_POWERPC_HEADER)
 #  include <eve/detail/function/simd/ppc/broadcast.hpp>
 #endif

--- a/include/eve/detail/function/combine.hpp
+++ b/include/eve/detail/function/combine.hpp
@@ -14,7 +14,7 @@
 #  include <eve/detail/function/simd/x86/combine.hpp>
 #endif
 
-#if defined(EVE_HW_POWERPC)
+#if defined(EVE_INCLUDE_POWERPC_HEADER)
 #  include <eve/detail/function/simd/ppc/combine.hpp>
 #endif
 

--- a/include/eve/detail/function/combine.hpp
+++ b/include/eve/detail/function/combine.hpp
@@ -18,6 +18,6 @@
 #  include <eve/detail/function/simd/ppc/combine.hpp>
 #endif
 
-#if defined(EVE_HW_ARM)
+#if defined(EVE_INCLUDE_ARM_HEADER)
 #  include <eve/detail/function/simd/arm/neon/combine.hpp>
 #endif

--- a/include/eve/detail/function/combine.hpp
+++ b/include/eve/detail/function/combine.hpp
@@ -10,7 +10,7 @@
 #include <eve/arch.hpp>
 #include <eve/detail/function/simd/common/combine.hpp>
 
-#if defined(EVE_HW_X86)
+#if defined(EVE_INCLUDE_X86_HEADER)
 #  include <eve/detail/function/simd/x86/combine.hpp>
 #endif
 

--- a/include/eve/detail/function/compounds.hpp
+++ b/include/eve/detail/function/compounds.hpp
@@ -12,7 +12,7 @@
 #include <eve/detail/function/simd/common/arithmetic_compounds.hpp>
 #include <eve/detail/function/operators.hpp>
 
-#if defined(EVE_HW_X86)
+#if defined(EVE_INCLUDE_X86_HEADER)
 #  include <eve/detail/function/simd/x86/bit_compounds.hpp>
 #  include <eve/detail/function/simd/x86/arithmetic_compounds.hpp>
 #endif

--- a/include/eve/detail/function/compounds.hpp
+++ b/include/eve/detail/function/compounds.hpp
@@ -17,7 +17,7 @@
 #  include <eve/detail/function/simd/x86/arithmetic_compounds.hpp>
 #endif
 
-#if defined(EVE_HW_POWERPC)
+#if defined(EVE_INCLUDE_POWERPC_HEADER)
 #  include <eve/detail/function/simd/ppc/bit_compounds.hpp>
 #  include <eve/detail/function/simd/ppc/arithmetic_compounds.hpp>
 #endif

--- a/include/eve/detail/function/compounds.hpp
+++ b/include/eve/detail/function/compounds.hpp
@@ -22,8 +22,7 @@
 #  include <eve/detail/function/simd/ppc/arithmetic_compounds.hpp>
 #endif
 
-#if defined(EVE_HW_ARM)
+#if defined(EVE_INCLUDE_ARM_HEADER)
 #  include <eve/detail/function/simd/arm/neon/bit_compounds.hpp>
 #  include <eve/detail/function/simd/arm/neon/arithmetic_compounds.hpp>
 #endif
-

--- a/include/eve/detail/function/friends.hpp
+++ b/include/eve/detail/function/friends.hpp
@@ -18,6 +18,6 @@
 #  include <eve/detail/function/simd/ppc/friends.hpp>
 #endif
 
-#if defined(EVE_HW_ARM)
+#if defined(EVE_INCLUDE_ARM_HEADER)
 #  include <eve/detail/function/simd/arm/neon/friends.hpp>
 #endif

--- a/include/eve/detail/function/friends.hpp
+++ b/include/eve/detail/function/friends.hpp
@@ -14,7 +14,7 @@
 #  include <eve/detail/function/simd/x86/friends.hpp>
 #endif
 
-#if defined(EVE_HW_POWERPC)
+#if defined(EVE_INCLUDE_POWERPC_HEADER)
 #  include <eve/detail/function/simd/ppc/friends.hpp>
 #endif
 

--- a/include/eve/detail/function/friends.hpp
+++ b/include/eve/detail/function/friends.hpp
@@ -10,7 +10,7 @@
 #include <eve/arch.hpp>
 #include <eve/detail/function/simd/common/friends.hpp>
 
-#if defined(EVE_HW_X86)
+#if defined(EVE_INCLUDE_X86_HEADER)
 #  include <eve/detail/function/simd/x86/friends.hpp>
 #endif
 

--- a/include/eve/detail/function/load.hpp
+++ b/include/eve/detail/function/load.hpp
@@ -18,6 +18,6 @@
 #  include <eve/detail/function/simd/ppc/load.hpp>
 #endif
 
-#if defined(EVE_HW_ARM)
+#if defined(EVE_INCLUDE_ARM_HEADER)
 #  include <eve/detail/function/simd/arm/neon/load.hpp>
 #endif

--- a/include/eve/detail/function/load.hpp
+++ b/include/eve/detail/function/load.hpp
@@ -10,7 +10,7 @@
 #include <eve/arch.hpp>
 #include <eve/detail/function/simd/common/load.hpp>
 
-#if defined(EVE_HW_X86)
+#if defined(EVE_INCLUDE_X86_HEADER)
 #  include <eve/detail/function/simd/x86/load.hpp>
 #endif
 

--- a/include/eve/detail/function/load.hpp
+++ b/include/eve/detail/function/load.hpp
@@ -14,7 +14,7 @@
 #  include <eve/detail/function/simd/x86/load.hpp>
 #endif
 
-#if defined(EVE_HW_POWERPC)
+#if defined(EVE_INCLUDE_POWERPC_HEADER)
 #  include <eve/detail/function/simd/ppc/load.hpp>
 #endif
 

--- a/include/eve/detail/function/lookup.hpp
+++ b/include/eve/detail/function/lookup.hpp
@@ -25,7 +25,6 @@ namespace eve
 #  include <eve/detail/function/simd/ppc/lookup.hpp>
 #endif
 
-#if defined(EVE_HW_ARM)
+#if defined(EVE_INCLUDE_ARM_HEADER)
 #  include <eve/detail/function/simd/arm/neon/lookup.hpp>
 #endif
-

--- a/include/eve/detail/function/lookup.hpp
+++ b/include/eve/detail/function/lookup.hpp
@@ -17,7 +17,7 @@ namespace eve
 
 #include <eve/detail/function/simd/common/lookup.hpp>
 
-#if defined(EVE_HW_X86)
+#if defined(EVE_INCLUDE_X86_HEADER)
 #  include <eve/detail/function/simd/x86/lookup.hpp>
 #endif
 

--- a/include/eve/detail/function/lookup.hpp
+++ b/include/eve/detail/function/lookup.hpp
@@ -21,7 +21,7 @@ namespace eve
 #  include <eve/detail/function/simd/x86/lookup.hpp>
 #endif
 
-#if defined(EVE_HW_POWERPC)
+#if defined(EVE_INCLUDE_POWERPC_HEADER)
 #  include <eve/detail/function/simd/ppc/lookup.hpp>
 #endif
 

--- a/include/eve/detail/function/make.hpp
+++ b/include/eve/detail/function/make.hpp
@@ -18,7 +18,6 @@
 #  include <eve/detail/function/simd/ppc/make.hpp>
 #endif
 
-#if defined(EVE_HW_ARM)
+#if defined(EVE_INCLUDE_ARM_HEADER)
 #  include <eve/detail/function/simd/arm/neon/make.hpp>
 #endif
-

--- a/include/eve/detail/function/make.hpp
+++ b/include/eve/detail/function/make.hpp
@@ -10,7 +10,7 @@
 #include <eve/arch.hpp>
 #include <eve/detail/function/simd/common/make.hpp>
 
-#if defined(EVE_HW_X86)
+#if defined(EVE_INCLUDE_X86_HEADER)
 #  include <eve/detail/function/simd/x86/make.hpp>
 #endif
 

--- a/include/eve/detail/function/make.hpp
+++ b/include/eve/detail/function/make.hpp
@@ -14,7 +14,7 @@
 #  include <eve/detail/function/simd/x86/make.hpp>
 #endif
 
-#if defined(EVE_HW_POWERPC)
+#if defined(EVE_INCLUDE_POWERPC_HEADER)
 #  include <eve/detail/function/simd/ppc/make.hpp>
 #endif
 

--- a/include/eve/detail/function/movemask.hpp
+++ b/include/eve/detail/function/movemask.hpp
@@ -11,7 +11,7 @@
 
 #include <eve/detail/function/simd/common/movemask.hpp>
 
-#if defined(EVE_HW_X86)
+#if defined(EVE_INCLUDE_X86_HEADER)
 #  include <eve/detail/function/simd/x86/movemask.hpp>
 #endif
 

--- a/include/eve/detail/function/movemask.hpp
+++ b/include/eve/detail/function/movemask.hpp
@@ -15,6 +15,6 @@
 #  include <eve/detail/function/simd/x86/movemask.hpp>
 #endif
 
-#if defined(EVE_HW_ARM)
+#if defined(EVE_INCLUDE_ARM_HEADER)
 #  include <eve/detail/function/simd/arm/neon/movemask.hpp>
 #endif

--- a/include/eve/detail/function/reverse.hpp
+++ b/include/eve/detail/function/reverse.hpp
@@ -34,6 +34,6 @@ namespace eve
 #  include <eve/detail/function/simd/x86/reverse.hpp>
 #endif
 
-#if defined(EVE_HW_ARM)
+#if defined(EVE_INCLUDE_ARM_HEADER)
 #  include <eve/detail/function/simd/arm/neon/reverse.hpp>
 #endif

--- a/include/eve/detail/function/reverse.hpp
+++ b/include/eve/detail/function/reverse.hpp
@@ -30,7 +30,7 @@ namespace eve
 
 #include <eve/detail/function/simd/common/reverse.hpp>
 
-#if defined(EVE_HW_X86)
+#if defined(EVE_INCLUDE_X86_HEADER)
 #  include <eve/detail/function/simd/x86/reverse.hpp>
 #endif
 

--- a/include/eve/detail/function/slice.hpp
+++ b/include/eve/detail/function/slice.hpp
@@ -10,7 +10,7 @@
 #include <eve/arch.hpp>
 #include <eve/detail/function/simd/common/slice.hpp>
 
-#if defined(EVE_HW_X86)
+#if defined(EVE_INCLUDE_X86_HEADER)
 #  include <eve/detail/function/simd/x86/slice.hpp>
 #endif
 

--- a/include/eve/detail/function/slice.hpp
+++ b/include/eve/detail/function/slice.hpp
@@ -14,7 +14,7 @@
 #  include <eve/detail/function/simd/x86/slice.hpp>
 #endif
 
-#if defined(EVE_HW_POWERPC)
+#if defined(EVE_INCLUDE_POWERPC_HEADER)
 #  include <eve/detail/function/simd/ppc/slice.hpp>
 #endif
 

--- a/include/eve/detail/function/slice.hpp
+++ b/include/eve/detail/function/slice.hpp
@@ -18,6 +18,6 @@
 #  include <eve/detail/function/simd/ppc/slice.hpp>
 #endif
 
-#if defined(EVE_HW_ARM)
+#if defined(EVE_INCLUDE_ARM_HEADER)
 #  include <eve/detail/function/simd/arm/neon/slice.hpp>
 #endif

--- a/include/eve/detail/function/slide_left.hpp
+++ b/include/eve/detail/function/slide_left.hpp
@@ -42,7 +42,7 @@ namespace eve
 #  include <eve/detail/function/simd/x86/slide_left.hpp>
 #endif
 
-#if defined(EVE_HW_ARM)
+#if defined(EVE_INCLUDE_ARM_HEADER)
 #  include <eve/detail/function/simd/arm/neon/slide_left.hpp>
 #endif
 

--- a/include/eve/detail/function/slide_left.hpp
+++ b/include/eve/detail/function/slide_left.hpp
@@ -38,7 +38,7 @@ namespace eve
 
 #include <eve/detail/function/simd/common/slide_left.hpp>
 
-#if defined(EVE_HW_X86)
+#if defined(EVE_INCLUDE_X86_HEADER)
 #  include <eve/detail/function/simd/x86/slide_left.hpp>
 #endif
 

--- a/include/eve/detail/function/slide_left.hpp
+++ b/include/eve/detail/function/slide_left.hpp
@@ -46,6 +46,6 @@ namespace eve
 #  include <eve/detail/function/simd/arm/neon/slide_left.hpp>
 #endif
 
-#if defined(EVE_HW_POWERPC)
+#if defined(EVE_INCLUDE_POWERPC_HEADER)
 #  include <eve/detail/function/simd/ppc/slide_left.hpp>
 #endif

--- a/include/eve/detail/function/slide_right.hpp
+++ b/include/eve/detail/function/slide_right.hpp
@@ -42,7 +42,7 @@ namespace eve
 #  include <eve/detail/function/simd/x86/slide_right.hpp>
 #endif
 
-#if defined(EVE_HW_ARM)
+#if defined(EVE_INCLUDE_ARM_HEADER)
 #  include <eve/detail/function/simd/arm/neon/slide_right.hpp>
 #endif
 

--- a/include/eve/detail/function/slide_right.hpp
+++ b/include/eve/detail/function/slide_right.hpp
@@ -46,6 +46,6 @@ namespace eve
 #  include <eve/detail/function/simd/arm/neon/slide_right.hpp>
 #endif
 
-#if defined(EVE_HW_POWERPC)
+#if defined(EVE_INCLUDE_POWERPC_HEADER)
 #  include <eve/detail/function/simd/ppc/slide_right.hpp>
 #endif

--- a/include/eve/detail/function/slide_right.hpp
+++ b/include/eve/detail/function/slide_right.hpp
@@ -38,7 +38,7 @@ namespace eve
 
 #include <eve/detail/function/simd/common/slide_right.hpp>
 
-#if defined(EVE_HW_X86)
+#if defined(EVE_INCLUDE_X86_HEADER)
 #  include <eve/detail/function/simd/x86/slide_right.hpp>
 #endif
 

--- a/include/eve/detail/function/subscript.hpp
+++ b/include/eve/detail/function/subscript.hpp
@@ -10,6 +10,6 @@
 #include <eve/arch.hpp>
 #include <eve/detail/function/simd/common/subscript.hpp>
 
-#if defined(EVE_HW_X86)
+#if defined(EVE_INCLUDE_X86_HEADER)
 #  include <eve/detail/function/simd/x86/subscript.hpp>
 #endif

--- a/include/eve/detail/function/swap_adjacent_groups.hpp
+++ b/include/eve/detail/function/swap_adjacent_groups.hpp
@@ -51,7 +51,7 @@ namespace eve
 
 #include <eve/detail/function/simd/common/swap_adjacent_groups.hpp>
 
-#if defined(EVE_HW_X86)
+#if defined(EVE_INCLUDE_X86_HEADER)
 #  include <eve/detail/function/simd/x86/swap_adjacent_groups.hpp>
 #endif
 

--- a/include/eve/detail/function/swap_adjacent_groups.hpp
+++ b/include/eve/detail/function/swap_adjacent_groups.hpp
@@ -59,6 +59,6 @@ namespace eve
 #  include <eve/detail/function/simd/arm/neon/swap_adjacent_groups.hpp>
 #endif
 
-#if defined(EVE_HW_POWERPC)
+#if defined(EVE_INCLUDE_POWERPC_HEADER)
 #  include <eve/detail/function/simd/ppc/swap_adjacent_groups.hpp>
 #endif

--- a/include/eve/detail/function/swap_adjacent_groups.hpp
+++ b/include/eve/detail/function/swap_adjacent_groups.hpp
@@ -55,7 +55,7 @@ namespace eve
 #  include <eve/detail/function/simd/x86/swap_adjacent_groups.hpp>
 #endif
 
-#if defined(EVE_HW_ARM)
+#if defined(EVE_INCLUDE_ARM_HEADER)
 #  include <eve/detail/function/simd/arm/neon/swap_adjacent_groups.hpp>
 #endif
 

--- a/include/eve/detail/function/swizzle.hpp
+++ b/include/eve/detail/function/swizzle.hpp
@@ -32,6 +32,6 @@ namespace eve
 #  include <eve/detail/function/simd/ppc/swizzle.hpp>
 #endif
 
-#if defined(EVE_HW_ARM)
+#if defined(EVE_INCLUDE_ARM_HEADER)
 #  include <eve/detail/function/simd/arm/neon/swizzle.hpp>
 #endif

--- a/include/eve/detail/function/swizzle.hpp
+++ b/include/eve/detail/function/swizzle.hpp
@@ -28,7 +28,7 @@ namespace eve
 #  include <eve/detail/function/simd/x86/swizzle.hpp>
 #endif
 
-#if defined(EVE_HW_POWERPC)
+#if defined(EVE_INCLUDE_POWERPC_HEADER)
 #  include <eve/detail/function/simd/ppc/swizzle.hpp>
 #endif
 

--- a/include/eve/detail/function/swizzle.hpp
+++ b/include/eve/detail/function/swizzle.hpp
@@ -24,7 +24,7 @@ namespace eve
 
 #include <eve/detail/function/simd/common/swizzle.hpp>
 
-#if defined(EVE_HW_X86)
+#if defined(EVE_INCLUDE_X86_HEADER)
 #  include <eve/detail/function/simd/x86/swizzle.hpp>
 #endif
 

--- a/include/eve/detail/function/to_logical.hpp
+++ b/include/eve/detail/function/to_logical.hpp
@@ -10,7 +10,7 @@
 #include <eve/arch.hpp>
 #include <eve/detail/function/simd/common/to_logical.hpp>
 
-#if defined(EVE_HW_X86)
+#if defined(EVE_INCLUDE_X86_HEADER)
 #  include <eve/detail/function/simd/x86/to_logical.hpp>
 #endif
 

--- a/include/eve/detail/function/to_logical.hpp
+++ b/include/eve/detail/function/to_logical.hpp
@@ -14,7 +14,7 @@
 #  include <eve/detail/function/simd/x86/to_logical.hpp>
 #endif
 
-#if defined(EVE_HW_POWERPC)
+#if defined(EVE_INCLUDE_POWERPC_HEADER)
 #  include <eve/detail/function/simd/ppc/to_logical.hpp>
 #endif
 

--- a/include/eve/detail/function/to_logical.hpp
+++ b/include/eve/detail/function/to_logical.hpp
@@ -18,6 +18,6 @@
 #  include <eve/detail/function/simd/ppc/to_logical.hpp>
 #endif
 
-#if defined(EVE_HW_ARM)
+#if defined(EVE_INCLUDE_ARM_HEADER)
 #  include <eve/detail/function/simd/arm/neon/to_logical.hpp>
 #endif

--- a/include/eve/forward.hpp
+++ b/include/eve/forward.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 #include <eve/arch/expected_cardinal.hpp>
-#include <eve/arch/expected_abi.hpp>
+#include <eve/arch/abi.hpp>
 
 namespace eve
 {
@@ -18,6 +18,6 @@ namespace eve
   // Wrapper for SIMD registers holding arithmetic types with compile-time size
   template<typename Type,
            typename Size = expected_cardinal_t<Type>,
-           typename ABI  = expected_abi_t<Type, Size>>
+           typename ABI  = abi_t<Type, Size>>
   struct wide;
 }

--- a/include/eve/function/abs.hpp
+++ b/include/eve/function/abs.hpp
@@ -106,6 +106,6 @@ namespace eve
 #  include <eve/module/real/core/function/regular/simd/ppc/abs.hpp>
 #endif
 
-#if defined(EVE_HW_ARM)
+#if defined(EVE_INCLUDE_ARM_HEADER)
 #  include <eve/module/real/core/function/regular/simd/arm/neon/abs.hpp>
 #endif

--- a/include/eve/function/abs.hpp
+++ b/include/eve/function/abs.hpp
@@ -102,7 +102,7 @@ namespace eve
 #  include <eve/module/real/core/function/regular/simd/x86/abs.hpp>
 #endif
 
-#if defined(EVE_HW_POWERPC)
+#if defined(EVE_INCLUDE_POWERPC_HEADER)
 #  include <eve/module/real/core/function/regular/simd/ppc/abs.hpp>
 #endif
 

--- a/include/eve/function/abs.hpp
+++ b/include/eve/function/abs.hpp
@@ -98,7 +98,7 @@ namespace eve
 
 #include <eve/module/real/core/function/regular/generic/abs.hpp>
 
-#if defined(EVE_HW_X86)
+#if defined(EVE_INCLUDE_X86_HEADER)
 #  include <eve/module/real/core/function/regular/simd/x86/abs.hpp>
 #endif
 

--- a/include/eve/function/all.hpp
+++ b/include/eve/function/all.hpp
@@ -17,7 +17,7 @@ namespace eve
 #include <eve/arch.hpp>
 #include <eve/module/real/algorithm/function/regular/generic/all.hpp>
 
-#if defined(EVE_HW_POWERPC)
+#if defined(EVE_INCLUDE_POWERPC_HEADER)
 #  include <eve/module/real/algorithm/function/regular/simd/ppc/all.hpp>
 #endif
 

--- a/include/eve/function/all.hpp
+++ b/include/eve/function/all.hpp
@@ -21,6 +21,6 @@ namespace eve
 #  include <eve/module/real/algorithm/function/regular/simd/ppc/all.hpp>
 #endif
 
-#if defined(EVE_HW_ARM)
+#if defined(EVE_INCLUDE_ARM_HEADER)
 #  include <eve/module/real/algorithm/function/regular/simd/arm/neon/all.hpp>
 #endif

--- a/include/eve/function/any.hpp
+++ b/include/eve/function/any.hpp
@@ -21,6 +21,6 @@ namespace eve
 #  include <eve/module/real/algorithm/function/regular/simd/ppc/any.hpp>
 #endif
 
-#if defined(EVE_HW_ARM)
+#if defined(EVE_INCLUDE_ARM_HEADER)
 #  include <eve/module/real/algorithm/function/regular/simd/arm/neon/any.hpp>
 #endif

--- a/include/eve/function/any.hpp
+++ b/include/eve/function/any.hpp
@@ -17,7 +17,7 @@ namespace eve
 #include <eve/arch.hpp>
 #include <eve/module/real/algorithm/function/regular/generic/any.hpp>
 
-#if defined(EVE_HW_POWERPC)
+#if defined(EVE_INCLUDE_POWERPC_HEADER)
 #  include <eve/module/real/algorithm/function/regular/simd/ppc/any.hpp>
 #endif
 

--- a/include/eve/function/average.hpp
+++ b/include/eve/function/average.hpp
@@ -20,7 +20,7 @@ namespace eve
 #  include <eve/module/real/core/function/regular/simd/x86/average.hpp>
 #endif
 
-#if defined(EVE_HW_POWERPC)
+#if defined(EVE_INCLUDE_POWERPC_HEADER)
 #  include <eve/module/real/core/function/regular/simd/ppc/average.hpp>
 #endif
 

--- a/include/eve/function/average.hpp
+++ b/include/eve/function/average.hpp
@@ -16,7 +16,7 @@ namespace eve
 
 #include <eve/module/real/core/function/regular/generic/average.hpp>
 
-#if defined(EVE_HW_X86)
+#if defined(EVE_INCLUDE_X86_HEADER)
 #  include <eve/module/real/core/function/regular/simd/x86/average.hpp>
 #endif
 

--- a/include/eve/function/average.hpp
+++ b/include/eve/function/average.hpp
@@ -24,7 +24,6 @@ namespace eve
 #  include <eve/module/real/core/function/regular/simd/ppc/average.hpp>
 #endif
 
-#if defined(EVE_HW_ARM)
+#if defined(EVE_INCLUDE_ARM_HEADER)
 #  include <eve/module/real/core/function/regular/simd/arm/neon/average.hpp>
 #endif
-

--- a/include/eve/function/bit_andnot.hpp
+++ b/include/eve/function/bit_andnot.hpp
@@ -17,7 +17,7 @@ namespace eve
 #include <eve/arch.hpp>
 #include <eve/module/real/core/function/regular/generic/bit_andnot.hpp>
 
-#if defined(EVE_HW_X86)
+#if defined(EVE_INCLUDE_X86_HEADER)
 #  include <eve/module/real/core/function/regular/simd/x86/bit_andnot.hpp>
 #endif
 

--- a/include/eve/function/bit_andnot.hpp
+++ b/include/eve/function/bit_andnot.hpp
@@ -21,7 +21,7 @@ namespace eve
 #  include <eve/module/real/core/function/regular/simd/x86/bit_andnot.hpp>
 #endif
 
-#if defined(EVE_HW_POWERPC)
+#if defined(EVE_INCLUDE_POWERPC_HEADER)
 #  include <eve/module/real/core/function/regular/simd/ppc/bit_andnot.hpp>
 #endif
 

--- a/include/eve/function/bit_andnot.hpp
+++ b/include/eve/function/bit_andnot.hpp
@@ -25,7 +25,6 @@ namespace eve
 #  include <eve/module/real/core/function/regular/simd/ppc/bit_andnot.hpp>
 #endif
 
-#if defined(EVE_HW_ARM)
+#if defined(EVE_INCLUDE_ARM_HEADER)
 #  include <eve/module/real/core/function/regular/simd/arm/neon/bit_andnot.hpp>
 #endif
-

--- a/include/eve/function/bit_notand.hpp
+++ b/include/eve/function/bit_notand.hpp
@@ -17,7 +17,7 @@ namespace eve
 #include <eve/arch.hpp>
 #include <eve/module/real/core/function/regular/generic/bit_notand.hpp>
 
-#if defined(EVE_HW_X86)
+#if defined(EVE_INCLUDE_X86_HEADER)
 #  include <eve/module/real/core/function/regular/simd/x86/bit_notand.hpp>
 #endif
 

--- a/include/eve/function/bit_notand.hpp
+++ b/include/eve/function/bit_notand.hpp
@@ -21,7 +21,7 @@ namespace eve
 #  include <eve/module/real/core/function/regular/simd/x86/bit_notand.hpp>
 #endif
 
-#if defined(EVE_HW_POWERPC)
+#if defined(EVE_INCLUDE_POWERPC_HEADER)
 #  include <eve/module/real/core/function/regular/simd/ppc/bit_notand.hpp>
 #endif
 

--- a/include/eve/function/bit_notand.hpp
+++ b/include/eve/function/bit_notand.hpp
@@ -25,7 +25,6 @@ namespace eve
 #  include <eve/module/real/core/function/regular/simd/ppc/bit_notand.hpp>
 #endif
 
-#if defined(EVE_HW_ARM)
+#if defined(EVE_INCLUDE_ARM_HEADER)
 #  include <eve/module/real/core/function/regular/simd/arm/neon/bit_notand.hpp>
 #endif
-

--- a/include/eve/function/bit_notor.hpp
+++ b/include/eve/function/bit_notor.hpp
@@ -17,7 +17,6 @@ namespace eve
 #include <eve/arch.hpp>
 #include <eve/module/real/core/function/regular/generic/bit_notor.hpp>
 
-#if defined(EVE_HW_ARM)
+#if defined(EVE_INCLUDE_ARM_HEADER)
 #  include <eve/module/real/core/function/regular/simd/arm/neon/bit_notor.hpp>
 #endif
-

--- a/include/eve/function/bit_ornot.hpp
+++ b/include/eve/function/bit_ornot.hpp
@@ -17,8 +17,6 @@ namespace eve
 #include <eve/arch.hpp>
 #include <eve/module/real/core/function/regular/generic/bit_ornot.hpp>
 
-#if defined(EVE_HW_ARM)
+#if defined(EVE_INCLUDE_ARM_HEADER)
 #  include <eve/module/real/core/function/regular/simd/arm/neon/bit_ornot.hpp>
 #endif
-
-

--- a/include/eve/function/bit_select.hpp
+++ b/include/eve/function/bit_select.hpp
@@ -25,7 +25,6 @@ namespace eve
 #  include <eve/module/real/core/function/regular/simd/ppc/bit_select.hpp>
 #endif
 
-#if defined(EVE_HW_ARM)
+#if defined(EVE_INCLUDE_ARM_HEADER)
 #  include <eve/module/real/core/function/regular/simd/arm/neon/bit_select.hpp>
 #endif
-

--- a/include/eve/function/bit_select.hpp
+++ b/include/eve/function/bit_select.hpp
@@ -17,7 +17,7 @@ namespace eve
 #include <eve/arch.hpp>
 #include <eve/module/real/core/function/regular/generic/bit_select.hpp>
 
-#if defined(EVE_HW_X86)
+#if defined(EVE_INCLUDE_X86_HEADER)
 #  include <eve/module/real/core/function/regular/simd/x86/bit_select.hpp>
 #endif
 

--- a/include/eve/function/bit_select.hpp
+++ b/include/eve/function/bit_select.hpp
@@ -21,7 +21,7 @@ namespace eve
 #  include <eve/module/real/core/function/regular/simd/x86/bit_select.hpp>
 #endif
 
-#if defined(EVE_HW_POWERPC)
+#if defined(EVE_INCLUDE_POWERPC_HEADER)
 #  include <eve/module/real/core/function/regular/simd/ppc/bit_select.hpp>
 #endif
 

--- a/include/eve/function/bit_shr.hpp
+++ b/include/eve/function/bit_shr.hpp
@@ -35,6 +35,6 @@ namespace eve
 #include <eve/arch.hpp>
 #include <eve/module/real/core/function/regular/generic/bit_shr.hpp>
 
-#if defined(EVE_HW_POWERPC)
+#if defined(EVE_INCLUDE_POWERPC_HEADER)
 #  include <eve/module/real/core/function/regular/simd/ppc/bit_shr.hpp>
 #endif

--- a/include/eve/function/ceil.hpp
+++ b/include/eve/function/ceil.hpp
@@ -21,7 +21,7 @@ namespace eve
 #  include <eve/module/real/core/function/regular/simd/x86/ceil.hpp>
 #endif
 
-#if defined(EVE_HW_POWERPC)
+#if defined(EVE_INCLUDE_POWERPC_HEADER)
 #  include <eve/module/real/core/function/regular/simd/ppc/ceil.hpp>
 #endif
 

--- a/include/eve/function/ceil.hpp
+++ b/include/eve/function/ceil.hpp
@@ -17,7 +17,7 @@ namespace eve
 #include <eve/arch.hpp>
 #include <eve/module/real/core/function/regular/generic/ceil.hpp>
 
-#if defined(EVE_HW_X86)
+#if defined(EVE_INCLUDE_X86_HEADER)
 #  include <eve/module/real/core/function/regular/simd/x86/ceil.hpp>
 #endif
 

--- a/include/eve/function/ceil.hpp
+++ b/include/eve/function/ceil.hpp
@@ -25,7 +25,6 @@ namespace eve
 #  include <eve/module/real/core/function/regular/simd/ppc/ceil.hpp>
 #endif
 
-#if defined(EVE_HW_ARM)
+#if defined(EVE_INCLUDE_ARM_HEADER)
 #  include <eve/module/real/core/function/regular/simd/arm/neon/ceil.hpp>
 #endif
-

--- a/include/eve/function/convert.hpp
+++ b/include/eve/function/convert.hpp
@@ -17,7 +17,7 @@ namespace eve
 
 #include <eve/module/real/core/function/regular/generic/convert.hpp>
 
-#if defined(EVE_HW_X86)
+#if defined(EVE_INCLUDE_X86_HEADER)
 #  include <eve/module/real/core/function/regular/simd/x86/convert.hpp>
 #endif
 

--- a/include/eve/function/convert.hpp
+++ b/include/eve/function/convert.hpp
@@ -21,7 +21,7 @@ namespace eve
 #  include <eve/module/real/core/function/regular/simd/x86/convert.hpp>
 #endif
 
-#if defined(EVE_HW_POWERPC)
+#if defined(EVE_INCLUDE_POWERPC_HEADER)
 #  include <eve/module/real/core/function/regular/simd/ppc/convert.hpp>
 #endif
 

--- a/include/eve/function/convert.hpp
+++ b/include/eve/function/convert.hpp
@@ -25,7 +25,6 @@ namespace eve
 #  include <eve/module/real/core/function/regular/simd/ppc/convert.hpp>
 #endif
 
-#if defined(EVE_HW_ARM)
+#if defined(EVE_INCLUDE_ARM_HEADER)
 #  include <eve/module/real/core/function/regular/simd/arm/neon/convert.hpp>
 #endif
-

--- a/include/eve/function/div.hpp
+++ b/include/eve/function/div.hpp
@@ -94,7 +94,7 @@ namespace eve
 #include <eve/arch.hpp>
 #include <eve/module/real/core/function/regular/generic/div.hpp>
 
-#if defined(EVE_HW_X86)
+#if defined(EVE_INCLUDE_X86_HEADER)
 #  include <eve/module/real/core/function/regular/simd/x86/div.hpp>
 #endif
 

--- a/include/eve/function/div.hpp
+++ b/include/eve/function/div.hpp
@@ -98,7 +98,7 @@ namespace eve
 #  include <eve/module/real/core/function/regular/simd/x86/div.hpp>
 #endif
 
-#if defined(EVE_HW_POWERPC)
+#if defined(EVE_INCLUDE_POWERPC_HEADER)
 #  include <eve/module/real/core/function/regular/simd/ppc/div.hpp>
 #endif
 

--- a/include/eve/function/div.hpp
+++ b/include/eve/function/div.hpp
@@ -102,6 +102,6 @@ namespace eve
 #  include <eve/module/real/core/function/regular/simd/ppc/div.hpp>
 #endif
 
-#if defined(EVE_HW_ARM)
+#if defined(EVE_INCLUDE_ARM_HEADER)
 #  include <eve/module/real/core/function/regular/simd/arm/neon/div.hpp>
 #endif

--- a/include/eve/function/first_true.hpp
+++ b/include/eve/function/first_true.hpp
@@ -17,6 +17,6 @@ namespace eve
 #include <eve/arch.hpp>
 #include <eve/module/real/algorithm/function/regular/generic/first_true.hpp>
 
-#if defined(EVE_HW_ARM)
+#if defined(EVE_INCLUDE_ARM_HEADER)
 #  include <eve/module/real/algorithm/function/regular/simd/arm/neon/first_true.hpp>
 #endif

--- a/include/eve/function/fma.hpp
+++ b/include/eve/function/fma.hpp
@@ -17,7 +17,7 @@ namespace eve
 #include <eve/arch.hpp>
 #include <eve/module/real/core/function/regular/generic/fma.hpp>
 
-#if defined(EVE_HW_X86)
+#if defined(EVE_INCLUDE_X86_HEADER)
 #  include <eve/module/real/core/function/regular/simd/x86/fma.hpp>
 #endif
 

--- a/include/eve/function/fma.hpp
+++ b/include/eve/function/fma.hpp
@@ -25,6 +25,6 @@ namespace eve
 #  include <eve/module/real/core/function/regular/simd/ppc/fma.hpp>
 #endif
 
-#if defined(EVE_HW_ARM)
+#if defined(EVE_INCLUDE_ARM_HEADER)
 #  include <eve/module/real/core/function/regular/simd/arm/neon/fma.hpp>
 #endif

--- a/include/eve/function/fma.hpp
+++ b/include/eve/function/fma.hpp
@@ -21,7 +21,7 @@ namespace eve
 #  include <eve/module/real/core/function/regular/simd/x86/fma.hpp>
 #endif
 
-#if defined(EVE_HW_POWERPC)
+#if defined(EVE_INCLUDE_POWERPC_HEADER)
 #  include <eve/module/real/core/function/regular/simd/ppc/fma.hpp>
 #endif
 

--- a/include/eve/function/fms.hpp
+++ b/include/eve/function/fms.hpp
@@ -17,7 +17,7 @@ namespace eve
 #include <eve/arch.hpp>
 #include <eve/module/real/core/function/regular/generic/fms.hpp>
 
-#if defined(EVE_HW_X86)
+#if defined(EVE_INCLUDE_X86_HEADER)
 #  include <eve/module/real/core/function/regular/simd/x86/fms.hpp>
 #endif
 

--- a/include/eve/function/fms.hpp
+++ b/include/eve/function/fms.hpp
@@ -21,7 +21,6 @@ namespace eve
 #  include <eve/module/real/core/function/regular/simd/x86/fms.hpp>
 #endif
 
-#if defined(EVE_HW_ARM)
+#if defined(EVE_INCLUDE_ARM_HEADER)
 #  include <eve/module/real/core/function/regular/simd/arm/neon/fms.hpp>
 #endif
-

--- a/include/eve/function/fnma.hpp
+++ b/include/eve/function/fnma.hpp
@@ -21,7 +21,6 @@ namespace eve
 #  include <eve/module/real/core/function/regular/simd/x86/fnma.hpp>
 #endif
 
-#if defined(EVE_HW_ARM)
+#if defined(EVE_INCLUDE_ARM_HEADER)
 #  include <eve/module/real/core/function/regular/simd/arm/neon/fnma.hpp>
 #endif
-

--- a/include/eve/function/fnma.hpp
+++ b/include/eve/function/fnma.hpp
@@ -17,7 +17,7 @@ namespace eve
 #include <eve/arch.hpp>
 #include <eve/module/real/core/function/regular/generic/fnma.hpp>
 
-#if defined(EVE_HW_X86)
+#if defined(EVE_INCLUDE_X86_HEADER)
 #  include <eve/module/real/core/function/regular/simd/x86/fnma.hpp>
 #endif
 

--- a/include/eve/function/fnms.hpp
+++ b/include/eve/function/fnms.hpp
@@ -17,7 +17,7 @@ namespace eve
 #include <eve/arch.hpp>
 #include <eve/module/real/core/function/regular/generic/fnms.hpp>
 
-#if defined(EVE_HW_X86)
+#if defined(EVE_INCLUDE_X86_HEADER)
 #  include <eve/module/real/core/function/regular/simd/x86/fnms.hpp>
 #endif
 

--- a/include/eve/function/fnms.hpp
+++ b/include/eve/function/fnms.hpp
@@ -21,6 +21,6 @@ namespace eve
 #  include <eve/module/real/core/function/regular/simd/x86/fnms.hpp>
 #endif
 
-#if defined(EVE_HW_ARM)
+#if defined(EVE_INCLUDE_ARM_HEADER)
 #  include <eve/module/real/core/function/regular/simd/arm/neon/fnms.hpp>
 #endif

--- a/include/eve/function/frac.hpp
+++ b/include/eve/function/frac.hpp
@@ -16,6 +16,6 @@ namespace eve
 
 #include <eve/module/real/core/function/regular/generic/frac.hpp>
 
-#if defined(EVE_HW_X86)
+#if defined(EVE_INCLUDE_X86_HEADER)
 #  include <eve/module/real/core/function/regular/simd/x86/frac.hpp>
 #endif

--- a/include/eve/function/if_else.hpp
+++ b/include/eve/function/if_else.hpp
@@ -25,6 +25,6 @@ namespace eve
 #  include <eve/module/real/core/function/regular/simd/ppc/if_else.hpp>
 #endif
 
-#if defined(EVE_HW_ARM)
+#if defined(EVE_INCLUDE_ARM_HEADER)
 #  include <eve/module/real/core/function/regular/simd/arm/neon/if_else.hpp>
 #endif

--- a/include/eve/function/if_else.hpp
+++ b/include/eve/function/if_else.hpp
@@ -17,7 +17,7 @@ namespace eve
 #include <eve/arch.hpp>
 #include <eve/module/real/core/function/regular/generic/if_else.hpp>
 
-#if defined(EVE_HW_X86)
+#if defined(EVE_INCLUDE_X86_HEADER)
 #  include <eve/module/real/core/function/regular/simd/x86/if_else.hpp>
 #endif
 

--- a/include/eve/function/if_else.hpp
+++ b/include/eve/function/if_else.hpp
@@ -21,7 +21,7 @@ namespace eve
 #  include <eve/module/real/core/function/regular/simd/x86/if_else.hpp>
 #endif
 
-#if defined(EVE_HW_POWERPC)
+#if defined(EVE_INCLUDE_POWERPC_HEADER)
 #  include <eve/module/real/core/function/regular/simd/ppc/if_else.hpp>
 #endif
 

--- a/include/eve/function/is_lessgreater.hpp
+++ b/include/eve/function/is_lessgreater.hpp
@@ -16,7 +16,6 @@ namespace eve
 
 #include <eve/module/real/core/function/regular/generic/is_lessgreater.hpp>
 
-#if defined(EVE_HW_X86)
+#if defined(EVE_INCLUDE_X86_HEADER)
 #  include <eve/module/real/core/function/regular/simd/x86/is_lessgreater.hpp>
 #endif
-

--- a/include/eve/function/is_not_greater.hpp
+++ b/include/eve/function/is_not_greater.hpp
@@ -17,6 +17,6 @@ namespace eve
 #include <eve/arch.hpp>
 #include <eve/module/real/core/function/regular/generic/is_not_greater.hpp>
 
-#if defined(EVE_HW_X86)
+#if defined(EVE_INCLUDE_X86_HEADER)
 #  include <eve/module/real/core/function/regular/simd/x86/is_not_greater.hpp>
 #endif

--- a/include/eve/function/is_not_greater_equal.hpp
+++ b/include/eve/function/is_not_greater_equal.hpp
@@ -17,7 +17,6 @@ namespace eve
 #include <eve/arch.hpp>
 #include <eve/module/real/core/function/regular/generic/is_not_greater_equal.hpp>
 
-#if defined(EVE_HW_X86)
+#if defined(EVE_INCLUDE_X86_HEADER)
 #  include <eve/module/real/core/function/regular/simd/x86/is_not_greater_equal.hpp>
 #endif
-

--- a/include/eve/function/is_not_less.hpp
+++ b/include/eve/function/is_not_less.hpp
@@ -17,7 +17,6 @@ namespace eve
 #include <eve/arch.hpp>
 #include <eve/module/real/core/function/regular/generic/is_not_less.hpp>
 
-#if defined(EVE_HW_X86)
+#if defined(EVE_INCLUDE_X86_HEADER)
 #  include <eve/module/real/core/function/regular/simd/x86/is_not_less.hpp>
 #endif
-

--- a/include/eve/function/is_not_less_equal.hpp
+++ b/include/eve/function/is_not_less_equal.hpp
@@ -16,7 +16,6 @@ namespace eve
 
 #include <eve/module/real/core/function/regular/generic/is_not_less_equal.hpp>
 
-#if defined(EVE_HW_X86)
+#if defined(EVE_INCLUDE_X86_HEADER)
 #  include <eve/module/real/core/function/regular/simd/x86/is_not_less.hpp>
 #endif
-

--- a/include/eve/function/is_ordered.hpp
+++ b/include/eve/function/is_ordered.hpp
@@ -17,7 +17,6 @@ namespace eve
 #include <eve/arch.hpp>
 #include <eve/module/real/core/function/regular/generic/is_ordered.hpp>
 
-#if defined(EVE_HW_X86)
+#if defined(EVE_INCLUDE_X86_HEADER)
 #  include <eve/module/real/core/function/regular/simd/x86/is_ordered.hpp>
 #endif
-

--- a/include/eve/function/is_unordered.hpp
+++ b/include/eve/function/is_unordered.hpp
@@ -17,6 +17,6 @@ namespace eve
 #include <eve/module/real/core/function/regular/generic/is_unordered.hpp>
 #include <eve/arch.hpp>
 
-#if defined(EVE_HW_X86)
+#if defined(EVE_INCLUDE_X86_HEADER)
 #  include <eve/module/real/core/function/regular/simd/x86/is_unordered.hpp>
 #endif

--- a/include/eve/function/load.hpp
+++ b/include/eve/function/load.hpp
@@ -20,6 +20,6 @@ namespace eve
 
 #include <eve/module/real/core/function/regular/generic/load.hpp>
 
-#if defined(EVE_HW_X86)
+#if defined(EVE_INCLUDE_X86_HEADER)
 #  include <eve/module/real/core/function/regular/simd/x86/load.hpp>
 #endif

--- a/include/eve/function/log.hpp
+++ b/include/eve/function/log.hpp
@@ -17,7 +17,6 @@ namespace eve
 
 #include <eve/module/real/math/function/regular/generic/log.hpp>
 
-#if defined(EVE_HW_X86)
+#if defined(EVE_INCLUDE_X86_HEADER)
 #  include <eve/module/real/math/function/regular/simd/x86/log.hpp>
 #endif
-

--- a/include/eve/function/log10.hpp
+++ b/include/eve/function/log10.hpp
@@ -17,7 +17,6 @@ namespace eve
 
 #include <eve/module/real/math/function/regular/generic/log10.hpp>
 
-#if defined(EVE_HW_X86)
+#if defined(EVE_INCLUDE_X86_HEADER)
 #  include <eve/module/real/math/function/regular/simd/x86/log10.hpp>
 #endif
-

--- a/include/eve/function/log1p.hpp
+++ b/include/eve/function/log1p.hpp
@@ -17,7 +17,6 @@ namespace eve
 
 #include <eve/module/real/math/function/regular/generic/log1p.hpp>
 
-#if defined(EVE_HW_X86)
+#if defined(EVE_INCLUDE_X86_HEADER)
 #  include <eve/module/real/math/function/regular/simd/x86/log1p.hpp>
 #endif
-

--- a/include/eve/function/log2.hpp
+++ b/include/eve/function/log2.hpp
@@ -17,7 +17,6 @@ namespace eve
 
 #include <eve/module/real/math/function/regular/generic/log2.hpp>
 
-#if defined(EVE_HW_X86)
+#if defined(EVE_INCLUDE_X86_HEADER)
 #  include <eve/module/real/math/function/regular/simd/x86/log2.hpp>
 #endif
-

--- a/include/eve/function/max.hpp
+++ b/include/eve/function/max.hpp
@@ -17,7 +17,7 @@ namespace eve
 #include <eve/arch.hpp>
 #include <eve/module/real/core/function/regular/generic/max.hpp>
 
-#if defined(EVE_HW_X86)
+#if defined(EVE_INCLUDE_X86_HEADER)
 #  include <eve/module/real/core/function/regular/simd/x86/max.hpp>
 #endif
 

--- a/include/eve/function/max.hpp
+++ b/include/eve/function/max.hpp
@@ -25,7 +25,6 @@ namespace eve
 #  include <eve/module/real/core/function/regular/simd/ppc/max.hpp>
 #endif
 
-#if defined(EVE_HW_ARM)
+#if defined(EVE_INCLUDE_ARM_HEADER)
 #  include <eve/module/real/core/function/regular/simd/arm/neon/max.hpp>
 #endif
-

--- a/include/eve/function/max.hpp
+++ b/include/eve/function/max.hpp
@@ -21,7 +21,7 @@ namespace eve
 #  include <eve/module/real/core/function/regular/simd/x86/max.hpp>
 #endif
 
-#if defined(EVE_HW_POWERPC)
+#if defined(EVE_INCLUDE_POWERPC_HEADER)
 #  include <eve/module/real/core/function/regular/simd/ppc/max.hpp>
 #endif
 

--- a/include/eve/function/maximum.hpp
+++ b/include/eve/function/maximum.hpp
@@ -17,6 +17,6 @@ namespace eve
 #include <eve/arch.hpp>
 #include <eve/module/real/algorithm/function/regular/generic/maximum.hpp>
 
-#if defined(EVE_HW_ARM)
+#if defined(EVE_INCLUDE_ARM_HEADER)
 #  include <eve/module/real/algorithm/function/regular/simd/arm/neon/maximum.hpp>
 #endif

--- a/include/eve/function/min.hpp
+++ b/include/eve/function/min.hpp
@@ -21,7 +21,7 @@ namespace eve
 #  include <eve/module/real/core/function/regular/simd/x86/min.hpp>
 #endif
 
-#if defined(EVE_HW_POWERPC)
+#if defined(EVE_INCLUDE_POWERPC_HEADER)
 #  include <eve/module/real/core/function/regular/simd/ppc/min.hpp>
 #endif
 

--- a/include/eve/function/min.hpp
+++ b/include/eve/function/min.hpp
@@ -25,7 +25,6 @@ namespace eve
 #  include <eve/module/real/core/function/regular/simd/ppc/min.hpp>
 #endif
 
-#if defined(EVE_HW_ARM)
+#if defined(EVE_INCLUDE_ARM_HEADER)
 #  include <eve/module/real/core/function/regular/simd/arm/neon/min.hpp>
 #endif
-

--- a/include/eve/function/min.hpp
+++ b/include/eve/function/min.hpp
@@ -17,7 +17,7 @@ namespace eve
 #include <eve/arch.hpp>
 #include <eve/module/real/core/function/regular/generic/min.hpp>
 
-#if defined(EVE_HW_X86)
+#if defined(EVE_INCLUDE_X86_HEADER)
 #  include <eve/module/real/core/function/regular/simd/x86/min.hpp>
 #endif
 

--- a/include/eve/function/minimum.hpp
+++ b/include/eve/function/minimum.hpp
@@ -21,6 +21,6 @@ namespace eve
 #  include <eve/module/real/algorithm/function/regular/simd/arm/neon/minimum.hpp>
 #endif
 
-#if defined(EVE_HW_X86)
+#if defined(EVE_INCLUDE_X86_HEADER)
 #  include <eve/module/real/algorithm/function/regular/simd/x86/minimum.hpp>
 #endif

--- a/include/eve/function/minimum.hpp
+++ b/include/eve/function/minimum.hpp
@@ -17,7 +17,7 @@ namespace eve
 #include <eve/arch.hpp>
 #include <eve/module/real/algorithm/function/regular/generic/minimum.hpp>
 
-#if defined(EVE_HW_ARM)
+#if defined(EVE_INCLUDE_ARM_HEADER)
 #  include <eve/module/real/algorithm/function/regular/simd/arm/neon/minimum.hpp>
 #endif
 

--- a/include/eve/function/mul.hpp
+++ b/include/eve/function/mul.hpp
@@ -25,6 +25,6 @@ namespace eve
 #  include <eve/module/real/core/function/regular/simd/ppc/mul.hpp>
 #endif
 
-#if defined(EVE_HW_ARM)
+#if defined(EVE_INCLUDE_ARM_HEADER)
 #  include <eve/module/real/core/function/regular/simd/arm/neon/mul.hpp>
 #endif

--- a/include/eve/function/mul.hpp
+++ b/include/eve/function/mul.hpp
@@ -21,7 +21,7 @@ namespace eve
 #  include <eve/module/real/core/function/regular/simd/x86/mul.hpp>
 #endif
 
-#if defined(EVE_HW_POWERPC)
+#if defined(EVE_INCLUDE_POWERPC_HEADER)
 #  include <eve/module/real/core/function/regular/simd/ppc/mul.hpp>
 #endif
 

--- a/include/eve/function/mul.hpp
+++ b/include/eve/function/mul.hpp
@@ -17,7 +17,7 @@ namespace eve
 
 #include <eve/module/real/core/function/regular/generic/mul.hpp>
 
-#if defined(EVE_HW_X86)
+#if defined(EVE_INCLUDE_X86_HEADER)
 #  include <eve/module/real/core/function/regular/simd/x86/mul.hpp>
 #endif
 

--- a/include/eve/function/nearest.hpp
+++ b/include/eve/function/nearest.hpp
@@ -17,15 +17,14 @@ namespace eve
 
 #include <eve/module/real/core/function/regular/generic/nearest.hpp>
 
-#  if defined(EVE_HW_X86)
-#    include <eve/module/real/core/function/regular/simd/x86/nearest.hpp>
-#  endif
+#if defined(EVE_HW_X86)
+#  include <eve/module/real/core/function/regular/simd/x86/nearest.hpp>
+#endif
 
-#  if defined(EVE_HW_POWERPC)
-#    include <eve/module/real/core/function/regular/simd/ppc/nearest.hpp>
-#  endif
+#if defined(EVE_INCLUDE_POWERPC_HEADER)
+#  include <eve/module/real/core/function/regular/simd/ppc/nearest.hpp>
+#endif
 
-#  if defined(EVE_HW_ARM)
-#    include <eve/module/real/core/function/regular/simd/arm/neon/nearest.hpp>
-#  endif
-
+#if defined(EVE_INCLUDE_ARM_HEADER)
+#  include <eve/module/real/core/function/regular/simd/arm/neon/nearest.hpp>
+#endif

--- a/include/eve/function/nearest.hpp
+++ b/include/eve/function/nearest.hpp
@@ -17,7 +17,7 @@ namespace eve
 
 #include <eve/module/real/core/function/regular/generic/nearest.hpp>
 
-#if defined(EVE_HW_X86)
+#if defined(EVE_INCLUDE_X86_HEADER)
 #  include <eve/module/real/core/function/regular/simd/x86/nearest.hpp>
 #endif
 

--- a/include/eve/function/negate.hpp
+++ b/include/eve/function/negate.hpp
@@ -17,7 +17,6 @@ namespace eve
 #include <eve/arch.hpp>
 #include <eve/module/real/core/function/regular/generic/negate.hpp>
 
-#if defined(EVE_HW_X86)
+#if defined(EVE_INCLUDE_X86_HEADER)
 #  include <eve/module/real/core/function/regular/simd/x86/negate.hpp>
 #endif
-

--- a/include/eve/function/numeric/fma.hpp
+++ b/include/eve/function/numeric/fma.hpp
@@ -10,6 +10,6 @@
 #include <eve/function/fma.hpp>
 #include <eve/module/real/core/function/numeric/generic/fma.hpp>
 
-#if defined(EVE_HW_X86)
+#if defined(EVE_INCLUDE_X86_HEADER)
 #  include <eve/module/real/core/function/numeric/simd/x86/fma.hpp>
 #endif

--- a/include/eve/function/numeric/fms.hpp
+++ b/include/eve/function/numeric/fms.hpp
@@ -10,6 +10,6 @@
 #include <eve/function/fms.hpp>
 #include <eve/module/real/core/function/numeric/generic/fms.hpp>
 
-#if defined(EVE_HW_X86)
+#if defined(EVE_INCLUDE_X86_HEADER)
 #  include <eve/module/real/core/function/numeric/simd/x86/fms.hpp>
 #endif

--- a/include/eve/function/numeric/fnma.hpp
+++ b/include/eve/function/numeric/fnma.hpp
@@ -10,6 +10,6 @@
 #include <eve/function/fnma.hpp>
 #include <eve/module/real/core/function/numeric/generic/fnma.hpp>
 
-#if defined(EVE_HW_X86)
+#if defined(EVE_INCLUDE_X86_HEADER)
 #  include <eve/module/real/core/function/numeric/simd/x86/fnma.hpp>
 #endif

--- a/include/eve/function/numeric/fnms.hpp
+++ b/include/eve/function/numeric/fnms.hpp
@@ -10,6 +10,6 @@
 #include <eve/function/fnms.hpp>
 #include <eve/module/real/core/function/numeric/generic/fnms.hpp>
 
-#if defined(EVE_HW_X86)
+#if defined(EVE_INCLUDE_X86_HEADER)
 #  include <eve/module/real/core/function/numeric/simd/x86/fnms.hpp>
 #endif

--- a/include/eve/function/pedantic/fma.hpp
+++ b/include/eve/function/pedantic/fma.hpp
@@ -10,6 +10,6 @@
 #include <eve/function/fma.hpp>
 #include <eve/module/real/core/function/pedantic/generic/fma.hpp>
 
-#if defined(EVE_HW_X86)
+#if defined(EVE_INCLUDE_X86_HEADER)
 #  include <eve/module/real/core/function/pedantic/simd/x86/fma.hpp>
 #endif

--- a/include/eve/function/pedantic/fms.hpp
+++ b/include/eve/function/pedantic/fms.hpp
@@ -10,6 +10,6 @@
 #include <eve/function/fms.hpp>
 #include <eve/module/real/core/function/pedantic/generic/fms.hpp>
 
-#if defined(EVE_HW_X86)
+#if defined(EVE_INCLUDE_X86_HEADER)
 #  include <eve/module/real/core/function/pedantic/simd/x86/fms.hpp>
 #endif

--- a/include/eve/function/pedantic/fnma.hpp
+++ b/include/eve/function/pedantic/fnma.hpp
@@ -10,6 +10,6 @@
 #include <eve/function/fnma.hpp>
 #include <eve/module/real/core/function/pedantic/generic/fnma.hpp>
 
-#if defined(EVE_HW_X86)
+#if defined(EVE_INCLUDE_X86_HEADER)
 #  include <eve/module/real/core/function/pedantic/simd/x86/fnma.hpp>
 #endif

--- a/include/eve/function/pedantic/fnms.hpp
+++ b/include/eve/function/pedantic/fnms.hpp
@@ -10,6 +10,6 @@
 #include <eve/function/fnms.hpp>
 #include <eve/module/real/core/function/pedantic/generic/fnms.hpp>
 
-#if defined(EVE_HW_X86)
+#if defined(EVE_INCLUDE_X86_HEADER)
 #  include <eve/module/real/core/function/pedantic/simd/x86/fnms.hpp>
 #endif

--- a/include/eve/function/pedantic/max.hpp
+++ b/include/eve/function/pedantic/max.hpp
@@ -11,6 +11,6 @@
 #include <eve/module/real/core/function/pedantic/generic/max.hpp>
 
 
-#if defined(EVE_HW_ARM)
+#if defined(EVE_INCLUDE_ARM_HEADER)
 #  include <eve/module/real/core/function/pedantic/simd/arm/neon/max.hpp>
 #endif

--- a/include/eve/function/pedantic/min.hpp
+++ b/include/eve/function/pedantic/min.hpp
@@ -10,6 +10,6 @@
 #include <eve/function/min.hpp>
 #include <eve/module/real/core/function/pedantic/generic/min.hpp>
 
-#if defined(EVE_HW_ARM)
+#if defined(EVE_INCLUDE_ARM_HEADER)
 #  include <eve/module/real/core/function/pedantic/simd/arm/neon/min.hpp>
 #endif

--- a/include/eve/function/pedantic/rsqrt.hpp
+++ b/include/eve/function/pedantic/rsqrt.hpp
@@ -10,6 +10,6 @@
 #include <eve/function/rsqrt.hpp>
 #include <eve/module/real/core/function/pedantic/generic/rsqrt.hpp>
 
-#if defined(EVE_HW_X86)
+#if defined(EVE_INCLUDE_X86_HEADER)
 #  include <eve/module/real/core/function/pedantic/simd/x86/rsqrt.hpp>
 #endif

--- a/include/eve/function/popcount.hpp
+++ b/include/eve/function/popcount.hpp
@@ -16,6 +16,6 @@ namespace eve
 
 #include <eve/module/real/core/function/regular/generic/popcount.hpp>
 
-#if defined(EVE_HW_X86)
+#if defined(EVE_INCLUDE_X86_HEADER)
 #  include <eve/module/real/core/function/regular/simd/x86/popcount.hpp>
 #endif

--- a/include/eve/function/rec.hpp
+++ b/include/eve/function/rec.hpp
@@ -21,7 +21,7 @@ namespace eve
 #  include <eve/module/real/core/function/regular/simd/x86/rec.hpp>
 #endif
 
-#if defined(EVE_HW_POWERPC)
+#if defined(EVE_INCLUDE_POWERPC_HEADER)
 #  include <eve/module/real/core/function/regular/simd/ppc/rec.hpp>
 #endif
 

--- a/include/eve/function/rec.hpp
+++ b/include/eve/function/rec.hpp
@@ -25,7 +25,6 @@ namespace eve
 #  include <eve/module/real/core/function/regular/simd/ppc/rec.hpp>
 #endif
 
-#if defined(EVE_HW_ARM)
+#if defined(EVE_INCLUDE_ARM_HEADER)
 #  include <eve/module/real/core/function/regular/simd/arm/neon/rec.hpp>
 #endif
-

--- a/include/eve/function/rec.hpp
+++ b/include/eve/function/rec.hpp
@@ -17,7 +17,7 @@ namespace eve
 #include <eve/arch.hpp>
 #include <eve/module/real/core/function/regular/generic/rec.hpp>
 
-#if defined(EVE_HW_X86)
+#if defined(EVE_INCLUDE_X86_HEADER)
 #  include <eve/module/real/core/function/regular/simd/x86/rec.hpp>
 #endif
 

--- a/include/eve/function/refine_rec.hpp
+++ b/include/eve/function/refine_rec.hpp
@@ -17,7 +17,6 @@ namespace eve
 #include <eve/arch.hpp>
 #include <eve/module/real/core/function/regular/generic/refine_rec.hpp>
 
-#if defined(EVE_HW_ARM)
+#if defined(EVE_INCLUDE_ARM_HEADER)
 #  include <eve/module/real/core/function/regular/simd/arm/neon/refine_rec.hpp>
 #endif
-

--- a/include/eve/function/rotl.hpp
+++ b/include/eve/function/rotl.hpp
@@ -37,6 +37,6 @@ namespace eve
 #include <eve/arch.hpp>
 #include <eve/module/real/core/function/regular/generic/rotl.hpp>
 
-#if defined(EVE_HW_X86)
+#if defined(EVE_INCLUDE_X86_HEADER)
 #  include <eve/module/real/core/function/regular/simd/x86/rotl.hpp>
 #endif

--- a/include/eve/function/rshl.hpp
+++ b/include/eve/function/rshl.hpp
@@ -43,6 +43,6 @@ namespace eve
 #  include <eve/module/real/core/function/regular/simd/x86/rshl.hpp>
 #endif
 
-#if defined(EVE_HW_ARM)
+#if defined(EVE_INCLUDE_ARM_HEADER)
 #  include <eve/module/real/core/function/regular/simd/arm/neon/rshl.hpp>
 #endif

--- a/include/eve/function/rshl.hpp
+++ b/include/eve/function/rshl.hpp
@@ -39,7 +39,7 @@ namespace eve
 #include <eve/arch.hpp>
 #include <eve/module/real/core/function/regular/generic/rshl.hpp>
 
-#if defined(EVE_HW_X86)
+#if defined(EVE_INCLUDE_X86_HEADER)
 #  include <eve/module/real/core/function/regular/simd/x86/rshl.hpp>
 #endif
 

--- a/include/eve/function/rshr.hpp
+++ b/include/eve/function/rshr.hpp
@@ -44,6 +44,6 @@ namespace eve
 #  include <eve/module/real/core/function/regular/simd/x86/rshr.hpp>
 #endif
 
-#if defined(EVE_HW_ARM)
+#if defined(EVE_INCLUDE_ARM_HEADER)
 #  include <eve/module/real/core/function/regular/simd/arm/neon/rshr.hpp>
 #endif

--- a/include/eve/function/rshr.hpp
+++ b/include/eve/function/rshr.hpp
@@ -40,7 +40,7 @@ namespace eve
 #include <eve/arch.hpp>
 #include <eve/module/real/core/function/regular/generic/rshr.hpp>
 
-#if defined(EVE_HW_X86)
+#if defined(EVE_INCLUDE_X86_HEADER)
 #  include <eve/module/real/core/function/regular/simd/x86/rshr.hpp>
 #endif
 

--- a/include/eve/function/rsqrt.hpp
+++ b/include/eve/function/rsqrt.hpp
@@ -21,7 +21,7 @@ namespace eve
 #  include <eve/module/real/core/function/regular/simd/x86/rsqrt.hpp>
 #endif
 
-#if defined(EVE_HW_POWERPC)
+#if defined(EVE_INCLUDE_POWERPC_HEADER)
 #  include <eve/module/real/core/function/regular/simd/ppc/rsqrt.hpp>
 #endif
 

--- a/include/eve/function/rsqrt.hpp
+++ b/include/eve/function/rsqrt.hpp
@@ -25,7 +25,6 @@ namespace eve
 #  include <eve/module/real/core/function/regular/simd/ppc/rsqrt.hpp>
 #endif
 
-#if defined(EVE_HW_ARM)
+#if defined(EVE_INCLUDE_ARM_HEADER)
 #  include <eve/module/real/core/function/regular/simd/arm/neon/rsqrt.hpp>
 #endif
-

--- a/include/eve/function/rsqrt.hpp
+++ b/include/eve/function/rsqrt.hpp
@@ -17,7 +17,7 @@ namespace eve
 #include <eve/arch.hpp>
 #include <eve/module/real/core/function/regular/generic/rsqrt.hpp>
 
-#if defined(EVE_HW_X86)
+#if defined(EVE_INCLUDE_X86_HEADER)
 #  include <eve/module/real/core/function/regular/simd/x86/rsqrt.hpp>
 #endif
 

--- a/include/eve/function/saturated/add.hpp
+++ b/include/eve/function/saturated/add.hpp
@@ -10,6 +10,6 @@
 #include <eve/function/add.hpp>
 #include <eve/module/real/core/function/saturated/generic/add.hpp>
 
-#if defined(EVE_HW_X86)
+#if defined(EVE_INCLUDE_X86_HEADER)
 #  include <eve/module/real/core/function/saturated/simd/x86/add.hpp>
 #endif

--- a/include/eve/function/saturated/mul.hpp
+++ b/include/eve/function/saturated/mul.hpp
@@ -10,6 +10,6 @@
 #include <eve/function/mul.hpp>
 #include <eve/module/real/core/function/saturated/generic/mul.hpp>
 
-#if defined(EVE_HW_X86)
+#if defined(EVE_INCLUDE_X86_HEADER)
 #  include <eve/module/real/core/function/saturated/simd/x86/mul.hpp>
 #endif

--- a/include/eve/function/sign.hpp
+++ b/include/eve/function/sign.hpp
@@ -17,7 +17,6 @@ namespace eve
 #include <eve/arch.hpp>
 #include <eve/module/real/core/function/regular/generic/sign.hpp>
 
-#if defined(EVE_HW_X86)
+#if defined(EVE_INCLUDE_X86_HEADER)
 #  include <eve/module/real/core/function/regular/simd/x86/sign.hpp>
 #endif
-

--- a/include/eve/function/sqrt.hpp
+++ b/include/eve/function/sqrt.hpp
@@ -39,7 +39,7 @@ namespace eve
 #  include <eve/module/real/core/function/regular/simd/x86/sqrt.hpp>
 #endif
 
-#if defined(EVE_HW_POWERPC)
+#if defined(EVE_INCLUDE_POWERPC_HEADER)
 #  include <eve/module/real/core/function/regular/simd/ppc/sqrt.hpp>
 #endif
 

--- a/include/eve/function/sqrt.hpp
+++ b/include/eve/function/sqrt.hpp
@@ -43,6 +43,6 @@ namespace eve
 #  include <eve/module/real/core/function/regular/simd/ppc/sqrt.hpp>
 #endif
 
-#if defined(EVE_HW_ARM)
+#if defined(EVE_INCLUDE_ARM_HEADER)
 #  include <eve/module/real/core/function/regular/simd/arm/neon/sqrt.hpp>
 #endif

--- a/include/eve/function/sqrt.hpp
+++ b/include/eve/function/sqrt.hpp
@@ -35,7 +35,7 @@ namespace eve
 #include <eve/arch.hpp>
 #include <eve/module/real/core/function/regular/generic/sqrt.hpp>
 
-#if defined(EVE_HW_X86)
+#if defined(EVE_INCLUDE_X86_HEADER)
 #  include <eve/module/real/core/function/regular/simd/x86/sqrt.hpp>
 #endif
 

--- a/include/eve/function/store.hpp
+++ b/include/eve/function/store.hpp
@@ -17,7 +17,7 @@ namespace eve
 
 #include <eve/module/real/core/function/regular/generic/store.hpp>
 
-#if defined(EVE_HW_X86)
+#if defined(EVE_INCLUDE_X86_HEADER)
 #  include <eve/module/real/core/function/regular/simd/x86/store.hpp>
 #endif
 

--- a/include/eve/function/store.hpp
+++ b/include/eve/function/store.hpp
@@ -21,7 +21,7 @@ namespace eve
 #  include <eve/module/real/core/function/regular/simd/x86/store.hpp>
 #endif
 
-#if defined(EVE_HW_POWERPC)
+#if defined(EVE_INCLUDE_POWERPC_HEADER)
 #  include <eve/module/real/core/function/regular/simd/ppc/store.hpp>
 #endif
 

--- a/include/eve/function/store.hpp
+++ b/include/eve/function/store.hpp
@@ -25,7 +25,6 @@ namespace eve
 #  include <eve/module/real/core/function/regular/simd/ppc/store.hpp>
 #endif
 
-#if defined(EVE_HW_ARM)
+#if defined(EVE_INCLUDE_ARM_HEADER)
 #  include <eve/module/real/core/function/regular/simd/arm/neon/store.hpp>
 #endif
-

--- a/include/eve/function/sub.hpp
+++ b/include/eve/function/sub.hpp
@@ -94,7 +94,7 @@ namespace eve
 
 #include <eve/module/real/core/function/regular/generic/sub.hpp>
 
-#if defined(EVE_HW_X86)
+#if defined(EVE_INCLUDE_X86_HEADER)
 #  include <eve/module/real/core/function/regular/simd/x86/sub.hpp>
 #endif
 

--- a/include/eve/function/sub.hpp
+++ b/include/eve/function/sub.hpp
@@ -98,7 +98,7 @@ namespace eve
 #  include <eve/module/real/core/function/regular/simd/x86/sub.hpp>
 #endif
 
-#if defined(EVE_HW_POWERPC)
+#if defined(EVE_INCLUDE_POWERPC_HEADER)
 #  include <eve/module/real/core/function/regular/simd/ppc/sub.hpp>
 #endif
 

--- a/include/eve/function/sub.hpp
+++ b/include/eve/function/sub.hpp
@@ -102,6 +102,6 @@ namespace eve
 #  include <eve/module/real/core/function/regular/simd/ppc/sub.hpp>
 #endif
 
-#if defined(EVE_HW_ARM)
+#if defined(EVE_INCLUDE_ARM_HEADER)
 #  include <eve/module/real/core/function/regular/simd/arm/neon/sub.hpp>
 #endif

--- a/include/eve/function/trunc.hpp
+++ b/include/eve/function/trunc.hpp
@@ -21,7 +21,7 @@ namespace eve
 #  include <eve/module/real/core/function/regular/simd/x86/trunc.hpp>
 #endif
 
-#if defined(EVE_HW_POWERPC)
+#if defined(EVE_INCLUDE_POWERPC_HEADER)
 #  include <eve/module/real/core/function/regular/simd/ppc/trunc.hpp>
 #endif
 

--- a/include/eve/function/trunc.hpp
+++ b/include/eve/function/trunc.hpp
@@ -17,7 +17,7 @@ namespace eve
 #include <eve/arch.hpp>
 #include <eve/module/real/core/function/regular/generic/trunc.hpp>
 
-#if defined(EVE_HW_X86)
+#if defined(EVE_INCLUDE_X86_HEADER)
 #  include <eve/module/real/core/function/regular/simd/x86/trunc.hpp>
 #endif
 

--- a/include/eve/function/trunc.hpp
+++ b/include/eve/function/trunc.hpp
@@ -25,8 +25,6 @@ namespace eve
 #  include <eve/module/real/core/function/regular/simd/ppc/trunc.hpp>
 #endif
 
-#if defined(EVE_HW_ARM)
+#if defined(EVE_INCLUDE_ARM_HEADER)
 #  include <eve/module/real/core/function/regular/simd/arm/neon/trunc.hpp>
 #endif
-
-


### PR DESCRIPTION
* Adding  EVE_HACK_FOR_CLANG_TOOLING to patch arm with clang tooling on x86.

Introduce a special header guard macros. This allows me to include `arm` header files on x86 build and make.
This required me to change all of the header inclusion guards for arm.
Changed for x86 and power as well for completeness.

* `expected_abi` to `abi` 

We'd need to get ABI somehow. So `abi_t<T, N>` is the new ABI.
