### PR TITLE
FIX-670: clang-tooling: replacing every usage of the ABI parameter with `abi_t<T, N>` in functions.

### DIFF
--- a/include/eve/detail/function/simd/arm/neon/make.hpp
+++ b/include/eve/detail/function/simd/arm/neon/make.hpp
@@ -41,7 +41,7 @@ namespace eve::detail
   template<real_scalar_value T, typename N, arm_abi ABI, typename... Vs>
   EVE_FORCEINLINE auto make(eve::as_<wide<T,N,ABI>> const &, Vs... vs) noexcept
   {
-    return neon_maker<T, ABI> {}(vs...);
+    return neon_maker<T, abi_t<T, N>> {}(vs...);
   }
 
   //================================================================================================
@@ -74,6 +74,6 @@ namespace eve::detail
   template<real_scalar_value T, typename N, arm_abi ABI, typename... Vs>
   EVE_FORCEINLINE auto make(eve::as_<logical<wide<T,N,ABI>>> const &, Vs... vs) noexcept
   {
-    return neon_maker<logical<T>, ABI> {}(vs...);
+    return neon_maker<logical<T>, abi_t<T, N>> {}(vs...);
   }
 }

--- a/include/eve/detail/function/simd/arm/neon/reverse.hpp
+++ b/include/eve/detail/function/simd/arm/neon/reverse.hpp
@@ -15,7 +15,7 @@ namespace eve::detail
   template<typename T, typename N, arm_abi ABI>
   EVE_FORCEINLINE wide<T,N,ABI> reverse_( EVE_SUPPORTS(neon128_), wide<T,N,ABI> v) noexcept
   {
-    constexpr bool one_instruction_basic_swizzle = (current_api >= asimd) || std::same_as<ABI, arm_64_>;
+    constexpr bool one_instruction_basic_swizzle = (current_api >= asimd) || std::same_as<abi_t<T, N>, arm_64_>;
 
     // two reverse instructions seem better than one table lookup.
     if constexpr ( N() >= 8 && one_instruction_basic_swizzle) return reverse_(EVE_RETARGET(cpu_), v);

--- a/include/eve/detail/function/simd/arm/neon/slide_right.hpp
+++ b/include/eve/detail/function/simd/arm/neon/slide_right.hpp
@@ -35,7 +35,7 @@ namespace eve::detail
 
       // The actual shift uses the expected cardinal so it has enough
       // to push through the unused space.
-      constexpr auto shf  = expected_cardinal_v<T,ABI> - Shift;
+      constexpr auto shf  = expected_cardinal_v<T,abi_t<T, N>> - Shift;
 
             if constexpr( c == category::int64x2    ) return vextq_s64(z,v,shf);
       else  if constexpr( c == category::uint64x2   ) return vextq_u64(z,v,shf);

--- a/include/eve/detail/function/simd/arm/neon/swizzle.hpp
+++ b/include/eve/detail/function/simd/arm/neon/swizzle.hpp
@@ -29,7 +29,7 @@ namespace eve::detail
     }
     else
     {
-      if constexpr( std::same_as<ABI, arm_64_> )
+      if constexpr( std::same_as<abi_t<T, N>, arm_64_> )
       {
         using that_abi_t  = typename that_t::abi_type;
         using bytes_t     = typename that_t::template rebind<std::uint8_t,fixed<8>>;
@@ -51,7 +51,7 @@ namespace eve::detail
           return bit_cast(out_t{l,h}, as_<that_t>());
         }
       }
-      else if constexpr( std::same_as<ABI, arm_128_> )
+      else if constexpr( std::same_as<abi_t<T, N>, arm_128_> )
       {
         using bytes_t     = typename that_t::template rebind<std::uint8_t,fixed<16>>;
         bytes_t     b0    = bit_cast(v,as_<bytes_t>());

--- a/include/eve/detail/function/simd/common/arithmetic_compounds.hpp
+++ b/include/eve/detail/function/simd/common/arithmetic_compounds.hpp
@@ -32,12 +32,12 @@ namespace eve::detail
     }
     else if constexpr( std::same_as<type, U> )
     {
-      if constexpr( is_emulated_v<ABI> )
+      if constexpr( is_emulated_v<abi_t<T, N>> )
       {
         apply<N::value>([&](auto... I) { (self.set(I, self.get(I) + other.get(I)), ...); });
         return self;
       }
-      else if constexpr( is_aggregated_v<ABI> )
+      else if constexpr( is_aggregated_v<abi_t<T, N>> )
       {
         self.storage().for_each( [&](auto& s, auto const& o)  { s += o; }, other );
         return self;
@@ -59,12 +59,12 @@ namespace eve::detail
       return self_sub(self, type {other});
     else if constexpr( std::same_as<type, U> )
     {
-      if constexpr( is_emulated_v<ABI> )
+      if constexpr( is_emulated_v<abi_t<T, N>> )
       {
         apply<N::value>([&](auto... I) { (self.set(I, self.get(I) - other.get(I)), ...); });
         return self;
       }
-      else if constexpr( is_aggregated_v<ABI> )
+      else if constexpr( is_aggregated_v<abi_t<T, N>> )
       {
         self.storage().for_each( [&](auto& s, auto const& o)  { s -= o; }, other );
         return self;
@@ -86,12 +86,12 @@ namespace eve::detail
       return self_mul(self, type {other});
     else if constexpr( std::same_as<type, U> )
     {
-      if constexpr( is_emulated_v<ABI> )
+      if constexpr( is_emulated_v<abi_t<T, N>> )
       {
         apply<N::value>([&](auto... I) { (self.set(I, self.get(I) * other.get(I)), ...); });
         return self;
       }
-      else if constexpr( is_aggregated_v<ABI> )
+      else if constexpr( is_aggregated_v<abi_t<T, N>> )
       {
         self.storage().for_each( [&](auto& s, auto const& o)  { s *= o; }, other );
         return self;
@@ -113,12 +113,12 @@ namespace eve::detail
       return self_div(self, type {other});
     else if constexpr( std::same_as<type, U> )
     {
-      if constexpr( is_emulated_v<ABI> )
+      if constexpr( is_emulated_v<abi_t<T, N>> )
       {
         apply<N::value>([&](auto... I) { (self.set(I, self.get(I) / other.get(I)), ...); });
         return self;
       }
-      else if constexpr( is_aggregated_v<ABI> )
+      else if constexpr( is_aggregated_v<abi_t<T, N>> )
       {
         self.storage().for_each( [&](auto& s, auto const& o)  { s /= o; }, other );
         return self;
@@ -142,7 +142,7 @@ namespace eve::detail
     }
     else if constexpr( std::same_as<type, U> )
     {
-      if constexpr( is_aggregated_v<ABI> )
+      if constexpr( is_aggregated_v<abi_t<T, N>> )
       {
         self.storage().for_each( [&](auto& s, auto const& o)  { s %= o; }, other );
         return self;

--- a/include/eve/detail/function/simd/common/bit_compounds.hpp
+++ b/include/eve/detail/function/simd/common/bit_compounds.hpp
@@ -82,7 +82,7 @@ namespace eve::detail
     }
     else
     {
-      if constexpr( is_emulated_v<ABI> )
+      if constexpr( is_emulated_v<abi_t<T, N>> )
       {
         auto& data = self.storage();
 
@@ -92,7 +92,7 @@ namespace eve::detail
 
         return self;
       }
-      else if constexpr( is_aggregated_v<ABI> )
+      else if constexpr( is_aggregated_v<abi_t<T, N>> )
       {
         self.storage().for_each( [&](auto& s, auto const& o)  { s &= o; }, other );
         return self;
@@ -117,7 +117,7 @@ namespace eve::detail
     }
     else
     {
-      if constexpr( is_emulated_v<ABI> )
+      if constexpr( is_emulated_v<abi_t<T, N>> )
       {
         auto& data = self.storage();
 
@@ -127,7 +127,7 @@ namespace eve::detail
 
         return self;
       }
-      else if constexpr( is_aggregated_v<ABI> )
+      else if constexpr( is_aggregated_v<abi_t<T, N>> )
       {
         self.storage().for_each( [&](auto& s, auto const& o)  { s |= o; }, other );
         return self;
@@ -152,7 +152,7 @@ namespace eve::detail
     }
     else
     {
-      if constexpr( is_emulated_v<ABI> )
+      if constexpr( is_emulated_v<abi_t<T, N>> )
       {
         auto& data = self.storage();
 
@@ -162,7 +162,7 @@ namespace eve::detail
 
         return self;
       }
-      else if constexpr( is_aggregated_v<ABI> )
+      else if constexpr( is_aggregated_v<abi_t<T, N>> )
       {
         self.storage().for_each( [&](auto& s, auto const& o)  { s ^= o; }, other );
         return self;

--- a/include/eve/detail/function/simd/common/combine.hpp
+++ b/include/eve/detail/function/simd/common/combine.hpp
@@ -21,11 +21,11 @@ namespace eve::detail
   {
     using that_t = wide<T, typename N::combined_type>;
 
-    if constexpr( is_emulated_v<ABI> )
+    if constexpr( is_emulated_v<abi_t<T, N>> )
     {
       return apply<N::value>([&](auto... I) { return that_t {l.get(I)..., h.get(I)...}; });
     }
-    else if constexpr( is_aggregated_v<ABI> )
+    else if constexpr( is_aggregated_v<abi_t<T, N>> )
     {
       that_t that;
 
@@ -42,11 +42,11 @@ namespace eve::detail
   {
     using that_t = logical<wide<T, typename N::combined_type>>;
 
-    if constexpr( is_emulated_v<ABI> )
+    if constexpr( is_emulated_v<abi_t<T, N>> )
     {
       return apply<N::value>([&](auto... I) { return that_t {l.get(I)..., h.get(I)...}; });
     }
-    else if constexpr( is_aggregated_v<ABI> )
+    else if constexpr( is_aggregated_v<abi_t<T, N>> )
     {
       that_t that;
 

--- a/include/eve/detail/function/simd/common/friends.hpp
+++ b/include/eve/detail/function/simd/common/friends.hpp
@@ -38,7 +38,7 @@ namespace eve::detail
   template<real_scalar_value T, typename N, typename ABI>
   EVE_FORCEINLINE auto self_bitnot(wide<T,N,ABI> const& v) noexcept
   {
-    if constexpr(is_native_v<ABI>)
+    if constexpr(is_native_v<abi_t<T, N>>)
     {
       auto that = v;
       that ^= allbits(eve::as(v));

--- a/include/eve/detail/function/simd/common/load.hpp
+++ b/include/eve/detail/function/simd/common/load.hpp
@@ -98,7 +98,7 @@ namespace eve::detail
   template<typename T, typename N, typename Ptr, typename ABI>
   EVE_FORCEINLINE
   auto load(eve::as_<logical<wide<T, N, ABI>>> const & tgt, Ptr p)
-  requires( dereference_as<logical<T>, Ptr>::value && !x86_abi<ABI>)
+  requires( dereference_as<logical<T>, Ptr>::value && !x86_abi<abi_t<T, N>>)
   {
     return  bit_cast
             ( [&]() -> wide<T, N, ABI>

--- a/include/eve/detail/function/simd/common/slice.hpp
+++ b/include/eve/detail/function/simd/common/slice.hpp
@@ -99,7 +99,7 @@ namespace eve::detail
   template<typename T, typename N, typename ABI>
   EVE_FORCEINLINE auto slice(logical<wide<T, N, ABI>> const &a) noexcept
   {
-    if constexpr( is_native_v<ABI> )
+    if constexpr( is_native_v<abi_t<T, N>> )
     {
       using l_t   = logical<wide<T, typename N::split_type>>;
       using s_t   = typename l_t::storage_type;
@@ -118,7 +118,7 @@ namespace eve::detail
   template<typename T, typename N, typename ABI, typename Slice>
   EVE_FORCEINLINE auto slice(logical<wide<T, N, ABI>> const &a, Slice const &s) noexcept
   {
-    if constexpr( is_native_v<ABI> )
+    if constexpr( is_native_v<abi_t<T, N>> )
     {
       using l_t = logical<wide<T, typename N::split_type>>;
       using s_t = typename l_t::storage_type;

--- a/include/eve/detail/function/simd/common/to_logical.hpp
+++ b/include/eve/detail/function/simd/common/to_logical.hpp
@@ -21,7 +21,7 @@ namespace eve::detail
   template<typename T, typename N, typename ABI>
   EVE_FORCEINLINE auto to_logical( wide<T,N,ABI> const& v ) noexcept
   {
-    if constexpr( is_aggregated_v<ABI> )
+    if constexpr( is_aggregated_v<abi_t<T, N>> )
     {
       as_logical_t<wide<T,N,ABI>> that;
       that.storage().for_each( [](auto& s, auto const& o)  { s = to_logical(o); }, v );

--- a/include/eve/detail/function/simd/x86/bit_compounds.hpp
+++ b/include/eve/detail/function/simd/x86/bit_compounds.hpp
@@ -240,8 +240,8 @@ namespace eve::detail
       else  if constexpr( c == category::float32x16       ) self = _mm512_and_ps(self, bits);
       else  if constexpr( c == category::float32x8        ) self = _mm256_and_ps(self, bits);
       else  if constexpr( c == category::float32x4        ) self = _mm_and_ps   (self, bits);
-      else  if constexpr( i && std::same_as<ABI,x86_512_> ) self = _mm512_and_si512(self, bits);
-      else  if constexpr( i && std::same_as<ABI,x86_256_> )
+      else  if constexpr( i && std::same_as<abi_t<T, N>,x86_512_> ) self = _mm512_and_si512(self, bits);
+      else  if constexpr( i && std::same_as<abi_t<T, N>,x86_256_> )
       {
         if constexpr  ( current_api >= avx2 ) self =  _mm256_and_si256(self, bits);
         else                                  self =  _mm256_castps_si256
@@ -250,7 +250,7 @@ namespace eve::detail
                                                                       )
                                                       );
       }
-      else  if constexpr  ( i && std::same_as<ABI,x86_128_> ) self = _mm_and_si128(self, bits);
+      else  if constexpr  ( i && std::same_as<abi_t<T, N>,x86_128_> ) self = _mm_and_si128(self, bits);
 
       return self;
     }
@@ -282,8 +282,8 @@ namespace eve::detail
       else  if constexpr  ( c == category::float32x16       ) self = _mm512_or_ps(self, bits);
       else  if constexpr  ( c == category::float32x8        ) self = _mm256_or_ps(self, bits);
       else  if constexpr  ( c == category::float32x4        ) self = _mm_or_ps   (self, bits);
-      else  if constexpr  ( i && std::same_as<ABI,x86_512_> ) self = _mm512_or_si512(self, bits);
-      else  if constexpr  ( i && std::same_as<ABI,x86_256_> )
+      else  if constexpr  ( i && std::same_as<abi_t<T, N>,x86_512_> ) self = _mm512_or_si512(self, bits);
+      else  if constexpr  ( i && std::same_as<abi_t<T, N>,x86_256_> )
       {
         if constexpr  ( current_api >= avx2 ) self =  _mm256_or_si256(self, bits);
         else                                  self =  _mm256_castps_si256
@@ -292,7 +292,7 @@ namespace eve::detail
                                                                       )
                                                       );
       }
-      else  if constexpr  ( i && std::same_as<ABI,x86_128_> ) self = _mm_or_si128(self, bits);
+      else  if constexpr  ( i && std::same_as<abi_t<T, N>,x86_128_> ) self = _mm_or_si128(self, bits);
 
       return self;
     }
@@ -324,8 +324,8 @@ namespace eve::detail
       else  if constexpr  ( c == category::float32x16       ) self = _mm512_xor_ps(self, bits);
       else  if constexpr  ( c == category::float32x8        ) self = _mm256_xor_ps(self, bits);
       else  if constexpr  ( c == category::float32x4        ) self = _mm_xor_ps   (self, bits);
-      else  if constexpr  ( i && std::same_as<ABI,x86_512_> ) self = _mm512_xor_si512(self, bits);
-      else  if constexpr  ( i && std::same_as<ABI,x86_256_> )
+      else  if constexpr  ( i && std::same_as<abi_t<T, N>,x86_512_> ) self = _mm512_xor_si512(self, bits);
+      else  if constexpr  ( i && std::same_as<abi_t<T, N>,x86_256_> )
       {
         if constexpr  ( current_api >= avx2 ) self =  _mm256_xor_si256(self, bits);
         else                                  self =  _mm256_castps_si256
@@ -334,7 +334,7 @@ namespace eve::detail
                                                                       )
                                                       );
       }
-      else  if constexpr  ( i && std::same_as<ABI,x86_128_> ) self = _mm_xor_si128(self, bits);
+      else  if constexpr  ( i && std::same_as<abi_t<T, N>,x86_128_> ) self = _mm_xor_si128(self, bits);
 
       return self;
     }

--- a/include/eve/detail/function/simd/x86/bitmask.hpp
+++ b/include/eve/detail/function/simd/x86/bitmask.hpp
@@ -34,7 +34,7 @@ namespace eve::detail
       auto a = allbits(as_<wide<T, N, ABI>>());
       auto m = p.storage().value;
 
-      if constexpr( std::same_as<ABI,x86_128_>)
+      if constexpr( std::same_as<abi_t<T, N>,x86_128_>)
       {
               if constexpr( std::same_as<T,double > ) return _mm_mask_blend_pd(m,z,a);
         else  if constexpr( std::same_as<T,float  > ) return _mm_mask_blend_ps(m,z,a);
@@ -53,7 +53,7 @@ namespace eve::detail
           return _mm_mask_blend_epi8(m,z.storage(),a.storage());
         }
       }
-      else if constexpr( std::same_as<ABI,x86_256_>)
+      else if constexpr( std::same_as<abi_t<T, N>,x86_256_>)
       {
               if constexpr( std::same_as<T,double > ) return _mm256_mask_blend_pd(m,z,a);
         else  if constexpr( std::same_as<T,float  > ) return _mm256_mask_blend_ps(m,z,a);
@@ -72,7 +72,7 @@ namespace eve::detail
           return _mm256_mask_blend_epi8(m,z.storage(),a.storage());
         }
       }
-      else if constexpr( std::same_as<ABI,x86_512_>)
+      else if constexpr( std::same_as<abi_t<T, N>,x86_512_>)
       {
               if constexpr( std::same_as<T,double > ) return _mm512_mask_blend_pd(m,z,a);
         else  if constexpr( std::same_as<T,float  > ) return _mm512_mask_blend_ps(m,z,a);
@@ -101,11 +101,11 @@ namespace eve::detail
   template<typename T, typename N, x86_abi ABI> EVE_FORCEINLINE
   std::bitset<N::value> to_bitmap(sse2_ const&, logical<wide<T, N, ABI>> const& p ) noexcept
   {
-    if constexpr( !ABI::is_wide_logical )
+    if constexpr( !abi_t<T, N>::is_wide_logical )
     {
       return p.storage().value;
     }
-    else if constexpr( std::same_as<ABI,x86_128_>)
+    else if constexpr( std::same_as<abi_t<T, N>,x86_128_>)
     {
             if constexpr(std::is_same_v<T, float >) return _mm_movemask_ps(p.storage());
       else  if constexpr(std::is_same_v<T, double>) return _mm_movemask_pd(p.storage());
@@ -117,7 +117,7 @@ namespace eve::detail
       }
       else  if constexpr(sizeof(T) == 1)            return _mm_movemask_epi8(p.storage());
     }
-    else if constexpr( std::same_as<ABI,x86_256_>)
+    else if constexpr( std::same_as<abi_t<T, N>,x86_256_>)
     {
             if constexpr(std::is_same_v<T, float >) return _mm256_movemask_ps(p.storage());
       else  if constexpr(std::is_same_v<T, double>) return _mm256_movemask_pd(p.storage());

--- a/include/eve/detail/function/simd/x86/friends.hpp
+++ b/include/eve/detail/function/simd/x86/friends.hpp
@@ -22,7 +22,7 @@ namespace eve::detail
                                   , logical<wide<T,N,ABI>> v, logical<wide<U,N,ABI>> w
                                   ) noexcept
   {
-    if constexpr( !use_is_wide_logical<ABI>::value )
+    if constexpr( !use_is_wide_logical<abi_t<T, N>>::value )
     {
       using storage_t = typename logical<wide<T, N, ABI>>::storage_type;
       using m_t       = typename storage_t::type;
@@ -41,7 +41,7 @@ namespace eve::detail
                                   , logical<wide<T,N,ABI>> v, logical<wide<U,N,ABI>> w
                                   ) noexcept
   {
-    if constexpr( !use_is_wide_logical<ABI>::value )
+    if constexpr( !use_is_wide_logical<abi_t<T, N>>::value )
     {
       using storage_t = typename logical<wide<T, N, ABI>>::storage_type;
       using m_t       = typename storage_t::type;
@@ -58,7 +58,7 @@ namespace eve::detail
   template<real_value T, typename N, x86_abi ABI>
   EVE_FORCEINLINE auto self_lognot(logical<wide<T, N, ABI>> v) noexcept
   {
-    if constexpr( !ABI::is_wide_logical )
+    if constexpr( !abi_t<T, N>::is_wide_logical )
     {
       using l_t = logical<wide<T, N, ABI>>;
       return l_t{~v.storage()};
@@ -157,7 +157,7 @@ namespace eve::detail
   template<real_value T, typename N, x86_abi ABI>
   EVE_FORCEINLINE auto self_eq(logical<wide<T,N,ABI>> v, logical<wide<T,N,ABI>> w) noexcept
   {
-    if constexpr( !ABI::is_wide_logical )
+    if constexpr( !abi_t<T, N>::is_wide_logical )
     {
       return logical<wide<T,N,ABI>>{ ~(v.storage() ^ w.storage()) };
     }
@@ -231,7 +231,7 @@ namespace eve::detail
   template<real_value T, typename N, x86_abi ABI>
   EVE_FORCEINLINE auto self_neq(logical<wide<T,N,ABI>> v, logical<wide<T,N,ABI>> w) noexcept
   {
-    if constexpr( !ABI::is_wide_logical )
+    if constexpr( !abi_t<T, N>::is_wide_logical )
     {
       return logical<wide<T,N,ABI>>{ v.storage() ^ w.storage() };
     }

--- a/include/eve/detail/function/simd/x86/make.hpp
+++ b/include/eve/detail/function/simd/x86/make.hpp
@@ -195,7 +195,7 @@ namespace eve::detail
   template<real_scalar_value T, typename S, x86_abi ABI, typename... Vs>
   EVE_FORCEINLINE auto make(as_<logical<wide<T,S,ABI>>> const &, Vs... vs) noexcept
   {
-    if constexpr( !ABI::is_wide_logical )
+    if constexpr( !abi_t<T, S>::is_wide_logical )
     {
       typename logical<wide<T,S,ABI>>::storage_type that{};
       [&]<std::size_t... N>(auto& v, std::index_sequence<N...>){ (( v |= vs?(1ULL<<N):0),...); }
@@ -212,7 +212,7 @@ namespace eve::detail
   template<real_scalar_value T, typename S, x86_abi ABI,typename V>
   EVE_FORCEINLINE auto make(as_<logical<wide<T,S,ABI>>> const &, V v) noexcept
   {
-    if constexpr( !ABI::is_wide_logical )
+    if constexpr( !abi_t<T, S>::is_wide_logical )
     {
       using s_t = typename logical<wide<T,S,ABI>>::storage_type;
       using i_t = typename s_t::type;

--- a/include/eve/detail/function/simd/x86/movemask.hpp
+++ b/include/eve/detail/function/simd/x86/movemask.hpp
@@ -15,17 +15,17 @@ namespace eve::detail
 {
   template<real_scalar_value T, typename N, x86_abi ABI>
   EVE_FORCEINLINE auto movemask( eve::logical<eve::wide<T, N, ABI>> const &v ) noexcept
-    requires ( !ABI::is_wide_logical )
+    requires ( !abi_t<T, N>::is_wide_logical )
   {
     return std::pair{v.storage(), eve::lane<1>};
   }
 
   template<typename T, typename N, x86_abi ABI>
   EVE_FORCEINLINE auto movemask( eve::logical<eve::wide<T, N, ABI>> const &v ) noexcept
-    requires ( ABI::is_wide_logical )
+    requires ( abi_t<T, N>::is_wide_logical )
   {
     auto raw = [&] {
-      if constexpr( std::same_as<ABI, x86_128_> )
+      if constexpr( std::same_as<abi_t<T, N>, x86_128_> )
       {
              if constexpr( std::is_same_v<T, float > ) return (std::uint16_t)_mm_movemask_ps(v);
         else if constexpr( std::is_same_v<T, double> ) return (std::uint16_t)_mm_movemask_pd(v);

--- a/include/eve/detail/function/simd/x86/reverse.hpp
+++ b/include/eve/detail/function/simd/x86/reverse.hpp
@@ -26,7 +26,7 @@ namespace eve::detail
       as_ints = reverse(as_ints);
       return eve::bit_cast(as_ints, eve::as(v));
     }
-    else if constexpr( std::same_as<ABI, eve::x86_128_> )
+    else if constexpr( std::same_as<abi_t<T, N>, eve::x86_128_> )
     {
            if constexpr ( sizeof(T) == 8 )            return _mm_shuffle_epi32(v, _MM_SHUFFLE(1, 0, 3, 2));
       else if constexpr ( sizeof(T) == 4 && N() == 2) return _mm_shuffle_epi32(v, _MM_SHUFFLE(3, 2, 0, 1));
@@ -81,7 +81,7 @@ namespace eve::detail
       h = reverse(h);
       return {h, l};
     }
-    else if constexpr ( std::same_as<ABI, eve::x86_256_> )
+    else if constexpr ( std::same_as<abi_t<T, N>, eve::x86_256_> )
     {
            if constexpr ( sizeof(T) == 8 ) return _mm256_permute4x64_epi64(v, _MM_SHUFFLE(0, 1, 2, 3));
       else if constexpr ( sizeof(T) == 4 ) return _mm256_permutevar8x32_epi32(v, _mm256_set_epi32(0, 1, 2, 3, 4, 5, 6, 7));
@@ -99,7 +99,7 @@ namespace eve::detail
         return _mm256_permute4x64_epi64(halves, _MM_SHUFFLE(1, 0, 3, 2));
       }
     }
-    else if constexpr ( std::same_as<ABI, eve::x86_512_> )
+    else if constexpr ( std::same_as<abi_t<T, N>, eve::x86_512_> )
     {
       if constexpr ( sizeof(T) >= 2 )
       {

--- a/include/eve/detail/function/simd/x86/slice.hpp
+++ b/include/eve/detail/function/simd/x86/slice.hpp
@@ -21,7 +21,7 @@ namespace eve::detail
   {
     constexpr auto s = Slice::value;
 
-    if constexpr( std::same_as<ABI,x86_128_> )
+    if constexpr( std::same_as<abi_t<T, N>,x86_128_> )
     {
       if constexpr( !s )
       {
@@ -40,19 +40,19 @@ namespace eve::detail
           constexpr auto size = N::value * sizeof(T);
 
           if constexpr( N::value == 2          )  return wide<T, typename N::split_type>{a.get(1)};
-          if constexpr( size == ABI::bytes     )  return _mm_shuffle_epi32(a, 0xEE);
-          if constexpr( 2 * size == ABI::bytes )  return _mm_shuffle_epi32(a, 0x01);
+          if constexpr( size == abi_t<T, N>::bytes     )  return _mm_shuffle_epi32(a, 0xEE);
+          if constexpr( 2 * size == abi_t<T, N>::bytes )  return _mm_shuffle_epi32(a, 0x01);
           else                                    return _mm_shufflelo_epi16(a, 0x01);
         }
       }
     }
-    else if constexpr( std::same_as<ABI,x86_256_> )
+    else if constexpr( std::same_as<abi_t<T, N>,x86_256_> )
     {
             if constexpr( std::same_as<T, double> ) return _mm256_extractf128_pd(a, s);
       else  if constexpr( std::same_as<T, float>  ) return _mm256_extractf128_ps(a, s);
       else                                          return _mm256_extractf128_si256(a, s);
     }
-    else if constexpr( std::same_as<ABI,x86_512_> )
+    else if constexpr( std::same_as<abi_t<T, N>,x86_512_> )
     {
             if constexpr( std::same_as<T, double> )         return _mm512_extractf64x4_pd(a, s);
       else  if constexpr( std::integral<T> && sizeof(T)==8) return _mm512_extracti64x4_epi64(a, s);
@@ -76,7 +76,7 @@ namespace eve::detail
   EVE_FORCEINLINE logical<wide<T, typename N::split_type>>
   slice(logical<wide<T,N,ABI>> const &a, Slice const &) noexcept
   {
-    if constexpr( !ABI::is_wide_logical )
+    if constexpr( !abi_t<T, N>::is_wide_logical )
     {
       using type  = logical<wide<T, typename N::split_type>>;
       using mask  = typename type::storage_type;

--- a/include/eve/detail/function/simd/x86/slide_left.hpp
+++ b/include/eve/detail/function/simd/x86/slide_left.hpp
@@ -23,7 +23,7 @@ namespace eve::detail
     else  if constexpr(Shift == N::value) return wide<T,N,ABI>{0};
     else
     {
-      if constexpr( std::same_as<ABI,x86_128_>)
+      if constexpr( std::same_as<abi_t<T, N>,x86_128_>)
       {
         constexpr auto shift = Shift*sizeof(T);
         using i_t = as_integer_t<wide<T,N,ABI>, unsigned>;
@@ -39,7 +39,7 @@ namespace eve::detail
 
         return result;
       }
-      else if constexpr( std::same_as<ABI,x86_256_>)
+      else if constexpr( std::same_as<abi_t<T, N>,x86_256_>)
       {
         if constexpr( current_api >= avx2)
         {
@@ -127,7 +127,7 @@ namespace eve::detail
           }
         }
       }
-      else if constexpr( std::same_as<ABI,x86_512_>)
+      else if constexpr( std::same_as<abi_t<T, N>,x86_512_>)
       {
         // Generates vperm + pand, good enough for now
         return basic_swizzle(v, slide_left_pattern<Shift,N::value>);

--- a/include/eve/detail/function/simd/x86/slide_right.hpp
+++ b/include/eve/detail/function/simd/x86/slide_right.hpp
@@ -21,7 +21,7 @@ namespace eve::detail
     else  if constexpr(Shift == N::value) return wide<T,N,ABI>{0};
     else
     {
-      if constexpr( std::same_as<ABI,x86_128_>)
+      if constexpr( std::same_as<abi_t<T, N>,x86_128_>)
       {
         constexpr auto shift = Shift*sizeof(T);
         using i_t = as_integer_t<wide<T,N,ABI>, unsigned>;
@@ -29,7 +29,7 @@ namespace eve::detail
         auto const b  = bit_cast(v, as_<i_t>());
         return bit_cast(i_t(_mm_bslli_si128( b, shift)), as(v));
       }
-      else if constexpr( std::same_as<ABI,x86_256_>)
+      else if constexpr( std::same_as<abi_t<T, N>,x86_256_>)
       {
         if constexpr( current_api >= avx2)
         {
@@ -120,7 +120,7 @@ namespace eve::detail
           }
         }
       }
-      else if constexpr( std::same_as<ABI,x86_512_>)
+      else if constexpr( std::same_as<abi_t<T, N>,x86_512_>)
       {
         // Generates vperm + pand, good enough for now
         return basic_swizzle(v, slide_right_pattern<Shift,N::value>);

--- a/include/eve/detail/function/simd/x86/subscript.hpp
+++ b/include/eve/detail/function/simd/x86/subscript.hpp
@@ -17,7 +17,7 @@ namespace eve::detail
   template<typename T, typename N, x86_abi ABI>
   EVE_FORCEINLINE logical<T> extract(logical<wide<T,N,ABI>> const& p, std::size_t i) noexcept
   {
-    if constexpr( !ABI::is_wide_logical )
+    if constexpr( !abi_t<T, N>::is_wide_logical )
     {
       using i_t = typename logical<wide<T,N,ABI>>::storage_type::type;
       return p.storage().value & (i_t(1) << i);
@@ -34,7 +34,7 @@ namespace eve::detail
   template<typename T, typename N, x86_abi ABI>
   EVE_FORCEINLINE void insert(logical<wide<T,N,ABI>>& p, std::size_t i, auto v) noexcept
   {
-    if constexpr( !ABI::is_wide_logical )
+    if constexpr( !abi_t<T, N>::is_wide_logical )
     {
       using i_t = typename logical<wide<T,N,ABI>>::storage_type::type;
       p.storage().value = (p.storage().value & ~(i_t(1)<<i)) | ((v ? i_t(1) : 0)<<i);

--- a/include/eve/detail/function/simd/x86/swap_adjacent_groups.hpp
+++ b/include/eve/detail/function/simd/x86/swap_adjacent_groups.hpp
@@ -30,7 +30,7 @@ namespace eve::detail
     {
       constexpr auto size = G * sizeof(T);
 
-      if constexpr( std::same_as<ABI,x86_128_> )
+      if constexpr( std::same_as<abi_t<T, N>,x86_128_> )
       {
         if constexpr( size == 1 )
         {
@@ -86,7 +86,7 @@ namespace eve::detail
           }
         }
       }
-      else  if constexpr( std::same_as<ABI,x86_256_> )
+      else  if constexpr( std::same_as<abi_t<T, N>,x86_256_> )
       {
         if constexpr( size == 1 )
         {
@@ -174,7 +174,7 @@ namespace eve::detail
           }
         }
       }
-      else  if constexpr( std::same_as<ABI,x86_512_> )
+      else  if constexpr( std::same_as<abi_t<T, N>,x86_512_> )
       {
         // We have perfect swizzle so LET'S ROCK'N'ROLL
         return basic_swizzle(v, swap_adjacent_groups_pattern<G,N::value> );
@@ -192,7 +192,7 @@ namespace eve::detail
     {
       return v;
     }
-    else  if constexpr( !ABI::is_wide_logical )
+    else  if constexpr( !abi_t<T, N>::is_wide_logical )
     {
       // Reconstruct mask, swag then turn to mask again
       auto const m = v.mask();

--- a/include/eve/module/real/algorithm/function/regular/generic/maximum.hpp
+++ b/include/eve/module/real/algorithm/function/regular/generic/maximum.hpp
@@ -22,7 +22,7 @@ namespace eve::detail
                                 ) noexcept
   {
           if constexpr( N::value == 1 )         return v;
-    else  if constexpr( !is_aggregated_v<ABI> ) return butterfly_reduction(v, eve::max);
+    else  if constexpr( !is_aggregated_v<abi_t<T, N>> ) return butterfly_reduction(v, eve::max);
     else
     {
       auto[l,h] = v.slice();
@@ -49,7 +49,7 @@ namespace eve::detail
   EVE_FORCEINLINE auto maximum_(EVE_SUPPORTS(cpu_), wide<T,N,ABI> const &v) noexcept
   {
           if constexpr( N::value == 1 )         return v.get(0);
-    else  if constexpr( !is_aggregated_v<ABI> ) return butterfly_reduction(v, eve::max).get(0);
+    else  if constexpr( !is_aggregated_v<abi_t<T, N>> ) return butterfly_reduction(v, eve::max).get(0);
     else
     {
       auto[l,h] = v.slice();

--- a/include/eve/module/real/algorithm/function/regular/generic/minimum.hpp
+++ b/include/eve/module/real/algorithm/function/regular/generic/minimum.hpp
@@ -22,7 +22,7 @@ namespace eve::detail
                                 ) noexcept
   {
           if constexpr( N::value == 1 )         return v;
-    else  if constexpr( !is_aggregated_v<ABI> ) return butterfly_reduction(v, eve::min);
+    else  if constexpr( !is_aggregated_v<abi_t<T, N>> ) return butterfly_reduction(v, eve::min);
     else
     {
       auto[l,h] = v.slice();
@@ -49,7 +49,7 @@ namespace eve::detail
   EVE_FORCEINLINE auto minimum_(EVE_SUPPORTS(cpu_), wide<T,N,ABI> const &v) noexcept
   {
           if constexpr( N::value == 1 )         return v.get(0);
-    else  if constexpr( !is_aggregated_v<ABI> ) return butterfly_reduction(v, eve::min).get(0);
+    else  if constexpr( !is_aggregated_v<abi_t<T, N>> ) return butterfly_reduction(v, eve::min).get(0);
     else
     {
       auto[l,h] = v.slice();

--- a/include/eve/module/real/algorithm/function/regular/simd/arm/neon/maximum.hpp
+++ b/include/eve/module/real/algorithm/function/regular/simd/arm/neon/maximum.hpp
@@ -75,9 +75,9 @@ namespace eve::detail
 
             if constexpr( N::value == 1 ) return v;
       else  if constexpr( N::value == 2 ) return type(eve::max(v.get(0),v.get(1)));
-      else  if constexpr( std::same_as<ABI,arm_64_> )
+      else  if constexpr( std::same_as<abi_t<T, N>,arm_64_> )
       {
-        if(N::value == expected_cardinal_v<T,ABI>)
+        if(N::value == expected_cardinal_v<T,abi_t<T, N>>)
         {
           wide<T,N,ABI> s = pairwise_max(v,v);
           if constexpr(N::value >= 2  ) s = pairwise_max(s,s);
@@ -90,7 +90,7 @@ namespace eve::detail
           return butterfly_reduction(v, eve::max);
         }
       }
-      else  if constexpr( std::same_as<ABI,arm_128_> )
+      else  if constexpr( std::same_as<abi_t<T, N>,arm_128_> )
       {
         auto [l,h] = v.slice();
         if constexpr(N::value >= 4  ) l = pairwise_max(l,h);

--- a/include/eve/module/real/algorithm/function/regular/simd/arm/neon/minimum.hpp
+++ b/include/eve/module/real/algorithm/function/regular/simd/arm/neon/minimum.hpp
@@ -75,9 +75,9 @@ namespace eve::detail
 
             if constexpr( N::value == 1 ) return v;
       else  if constexpr( N::value == 2 ) return type(eve::min(v.get(0),v.get(1)));
-      else  if constexpr( std::same_as<ABI,arm_64_> )
+      else  if constexpr( std::same_as<abi_t<T, N>,arm_64_> )
       {
-        if(N::value == expected_cardinal_v<T,ABI>)
+        if(N::value == expected_cardinal_v<T,abi_t<T, N>>)
         {
           wide<T,N,ABI> s = pairwise_min(v,v);
           if constexpr(N::value >= 2  ) s = pairwise_min(s,s);
@@ -90,7 +90,7 @@ namespace eve::detail
           return butterfly_reduction(v, eve::min);
         }
       }
-      else  if constexpr( std::same_as<ABI,arm_128_> )
+      else  if constexpr( std::same_as<abi_t<T, N>,arm_128_> )
       {
         auto [l,h] = v.slice();
         if constexpr(N::value >= 4  ) l = pairwise_min(l,h);

--- a/include/eve/module/real/algorithm/function/regular/simd/x86/minimum.hpp
+++ b/include/eve/module/real/algorithm/function/regular/simd/x86/minimum.hpp
@@ -29,7 +29,7 @@ namespace eve::detail
     {
       return v.get(0);
     }
-    else if constexpr( !std::same_as<ABI,x86_128_> )
+    else if constexpr( !std::same_as<abi_t<T, N>,x86_128_> )
     {
       // Larger X86 ABI slices and try to optimize down the road
       auto [lw,hw] = v.slice();

--- a/include/eve/module/real/core/function/regular/simd/arm/neon/store.hpp
+++ b/include/eve/module/real/core/function/regular/simd/arm/neon/store.hpp
@@ -19,7 +19,7 @@ namespace eve::detail
                              , wide<T, N, ABI> const &value
                              , T *ptr) noexcept
   {
-    if constexpr( std::is_same_v<ABI,arm_64_> &&  (N::value * sizeof(T) != arm_64_::bytes ))
+    if constexpr( std::is_same_v<abi_t<T, N>,arm_64_> &&  (N::value * sizeof(T) != arm_64_::bytes ))
     {
       memcpy(ptr, (T const*)(&value), N::value * sizeof(T));
     }

--- a/include/eve/module/real/core/function/regular/simd/x86/abs.hpp
+++ b/include/eve/module/real/core/function/regular/simd/x86/abs.hpp
@@ -74,7 +74,7 @@ namespace eve::detail
   {
     constexpr auto c = categorize<wide<T, N, ABI>>();
 
-    if constexpr( C::is_complete || ABI::is_wide_logical )
+    if constexpr( C::is_complete || abi_t<T, N>::is_wide_logical )
     {
       return abs_(EVE_RETARGET(cpu_),cx,v);
     }

--- a/include/eve/module/real/core/function/regular/simd/x86/bit_andnot.hpp
+++ b/include/eve/module/real/core/function/regular/simd/x86/bit_andnot.hpp
@@ -33,8 +33,8 @@ namespace eve ::detail
     else  if constexpr( c == category::float32x16)            return _mm512_andnot_ps(v1, v0);
     else  if constexpr( c == category::float32x8 )            return _mm256_andnot_ps(v1, v0);
     else  if constexpr( c == category::float32x4 )            return _mm_andnot_ps(v1, v0);
-    else  if constexpr( i && std::same_as<ABI,x86_128_> )     return _mm_andnot_si128(v1, v0);
-    else  if constexpr( i && std::same_as<ABI,x86_256_> )
+    else  if constexpr( i && std::same_as<abi_t<T, N>,x86_128_> )     return _mm_andnot_si128(v1, v0);
+    else  if constexpr( i && std::same_as<abi_t<T, N>,x86_256_> )
     {
       if constexpr( current_api >= avx2 ) return  _mm256_andnot_si256(v1, v0);
       else                                return  _mm256_castps_si256
@@ -43,6 +43,6 @@ namespace eve ::detail
                                                                     )
                                                   );
     }
-    else  if constexpr( i && std::same_as<ABI,x86_512_> )     return _mm512_andnot_si512(v1, v0);
+    else  if constexpr( i && std::same_as<abi_t<T, N>,x86_512_> )     return _mm512_andnot_si512(v1, v0);
   }
 }

--- a/include/eve/module/real/core/function/regular/simd/x86/if_else.hpp
+++ b/include/eve/module/real/core/function/regular/simd/x86/if_else.hpp
@@ -27,7 +27,7 @@ namespace eve::detail
   {
     constexpr auto c = categorize<wide<T,N,ABI>>();
 
-    if constexpr( !ABI::is_wide_logical )
+    if constexpr( !abi_t<T, N>::is_wide_logical )
     {
       auto const msk =v0.storage().value;
       auto const s1 =v1.storage();
@@ -74,7 +74,7 @@ namespace eve::detail
       else  if constexpr( c == category::float32x4   ) return _mm_blendv_ps   (v2, v1, msk);
       else
       {
-        if constexpr( std::same_as<ABI,x86_128_> ) return _mm_blendv_epi8(v2, v1, msk);
+        if constexpr( std::same_as<abi_t<T, N>,x86_128_> ) return _mm_blendv_epi8(v2, v1, msk);
         else if constexpr(current_api >= avx2)
         {
           using a_t = wide<as_integer_t<T>, N>;
@@ -102,7 +102,7 @@ namespace eve::detail
                                 , logical<wide<T, N, ABI>> const &v2
                                 ) noexcept
   {
-    if constexpr( !ABI::is_wide_logical )
+    if constexpr( !abi_t<T, N>::is_wide_logical )
     {
       using s_t = typename logical<wide<T,N,ABI>>::storage_type;
       auto    r = bit_select(v0.storage().value,v1.storage().value,v2.storage().value);


### PR DESCRIPTION
First automated patch.

This will help with the next fixes, because now I don't have to look at ABI and figure where it's used at least.