### PR TITLE
FIX-670: decls and wides default automatic

### DIFF
--- a/include/eve/detail/function/simd/arm/neon/reverse.hpp
+++ b/include/eve/detail/function/simd/arm/neon/reverse.hpp
@@ -12,8 +12,9 @@
 
 namespace eve::detail
 {
-  template<typename T, typename N, arm_abi ABI>
-  EVE_FORCEINLINE wide<T,N,ABI> reverse_( EVE_SUPPORTS(neon128_), wide<T,N,ABI> v) noexcept
+  template<typename T, typename N>
+  EVE_FORCEINLINE wide<T,N> reverse_( EVE_SUPPORTS(neon128_), wide<T,N> v) noexcept
+      requires arm_abi<abi_t<T, N>>
   {
     constexpr bool one_instruction_basic_swizzle = (current_api >= asimd) || std::same_as<abi_t<T, N>, arm_64_>;
 

--- a/include/eve/detail/function/simd/arm/neon/swizzle.hpp
+++ b/include/eve/detail/function/simd/arm/neon/swizzle.hpp
@@ -14,11 +14,12 @@
 
 namespace eve::detail
 {
-  template<typename T, typename N, arm_abi ABI, shuffle_pattern Pattern>
-  EVE_FORCEINLINE auto basic_swizzle_( EVE_SUPPORTS(neon128_), wide<T,N,ABI> const& v, Pattern const&)
+  template<typename T, typename N, shuffle_pattern Pattern>
+  EVE_FORCEINLINE auto basic_swizzle_( EVE_SUPPORTS(neon128_), wide<T,N> const& v, Pattern const&)
+      requires arm_abi<abi_t<T, N>>
   {
     constexpr auto sz = Pattern::size();
-    using that_t      = as_wide_t<wide<T,N,ABI>,fixed<sz>>;
+    using that_t      = as_wide_t<wide<T,N>,fixed<sz>>;
 
     constexpr Pattern q = {};
 
@@ -37,7 +38,7 @@ namespace eve::detail
 
         if constexpr( std::same_as<that_abi_t, arm_64_> )
         {
-          bytes_t that = vtbl1_u8(b0,as_bytes<wide<T,N,ABI>>(q,as_<bytes_t>()));
+          bytes_t that = vtbl1_u8(b0,as_bytes<wide<T,N>>(q,as_<bytes_t>()));
           return bit_cast(that,as_<that_t>());
         }
         else
@@ -45,8 +46,8 @@ namespace eve::detail
           using out_t = typename that_t::template rebind<std::uint8_t,fixed<16>>;
 
           auto sp     = pattern_view<sz/2,sz,sz/2>(q);
-          bytes_t h   = vtbl1_u8(b0,as_bytes<wide<T,N,ABI>>(sp,as_<bytes_t>()));
-          bytes_t l   = vtbl1_u8(b0,as_bytes<wide<T,N,ABI>>(q,as_<bytes_t>()));
+          bytes_t h   = vtbl1_u8(b0,as_bytes<wide<T,N>>(sp,as_<bytes_t>()));
+          bytes_t l   = vtbl1_u8(b0,as_bytes<wide<T,N>>(q,as_<bytes_t>()));
 
           return bit_cast(out_t{l,h}, as_<that_t>());
         }

--- a/include/eve/detail/function/simd/common/swizzle.hpp
+++ b/include/eve/detail/function/simd/common/swizzle.hpp
@@ -29,9 +29,9 @@ namespace eve::detail
   //================================================================================================
   // Unary swizzle - logical
   //================================================================================================
-  template<typename T, typename N, typename ABI, shuffle_pattern Pattern>
+  template<typename T, typename N, shuffle_pattern Pattern>
   EVE_FORCEINLINE auto basic_swizzle_ ( EVE_SUPPORTS(cpu_)
-                                      , logical<wide<T,N,ABI>> const& v, Pattern p
+                                      , logical<wide<T,N>> const& v, Pattern p
                                       ) noexcept
   {
     constexpr auto sz = Pattern::size();
@@ -41,12 +41,12 @@ namespace eve::detail
   //================================================================================================
   // Emulation
   //================================================================================================
-  template<typename T, typename N, typename ABI, shuffle_pattern Pattern>
-  EVE_FORCEINLINE auto basic_swizzle_(EVE_SUPPORTS(cpu_), wide<T,N,ABI> const& v, Pattern const&)
+  template<typename T, typename N, shuffle_pattern Pattern>
+  EVE_FORCEINLINE auto basic_swizzle_(EVE_SUPPORTS(cpu_), wide<T,N> const& v, Pattern const&)
   {
     constexpr auto cd = N::value;
     constexpr auto sz = Pattern::size();
-    using that_t      = as_wide_t<wide<T,N,ABI>,fixed<sz>>;
+    using that_t      = as_wide_t<wide<T,N>,fixed<sz>>;
 
     constexpr Pattern q = {};
 
@@ -56,7 +56,7 @@ namespace eve::detail
     };
 
     // We're swizzling so much we aggregate the output
-    if constexpr( has_aggregated_abi_v<that_t> && !has_aggregated_abi_v<wide<T,N,ABI>> )
+    if constexpr( has_aggregated_abi_v<that_t> && !has_aggregated_abi_v<wide<T,N>> )
     {
       return aggregate_swizzle(v,q);
     }
@@ -64,17 +64,17 @@ namespace eve::detail
     else if constexpr( !has_aggregated_abi_v<that_t> )
     {
       // We're swizzling the first half of an aggregate
-      if constexpr( has_aggregated_abi_v<wide<T,N,ABI>> && q.strictly_under(cd/2) )
+      if constexpr( has_aggregated_abi_v<wide<T,N>> && q.strictly_under(cd/2) )
       {
         return v.slice(lower_)[q];
       }
       // We're swizzling the second half of an aggregate
-      else if constexpr( has_aggregated_abi_v<wide<T,N,ABI>> && q.over(cd/2) )
+      else if constexpr( has_aggregated_abi_v<wide<T,N>> && q.over(cd/2) )
       {
         return v.slice(upper_)[ slide_pattern<cd/2,sz>(q) ];
       }
       // We're swizzling an aggregate in steplock [lo | hi]
-      else if constexpr (   has_aggregated_abi_v<wide<T,N,ABI>>
+      else if constexpr (   has_aggregated_abi_v<wide<T,N>>
                         && pattern_view<0   ,sz/2,sz>(q).strictly_under(cd/2)
                         && pattern_view<sz/2,sz  ,sz>(q).over(cd/2)
                         )
@@ -82,7 +82,7 @@ namespace eve::detail
         return that_t{ v[pattern_view<0,sz/2,sz>(q)], v[pattern_view<sz/2,sz,sz>(q)] };
       }
       // We're swizzling an aggregate in steplock [hi | lo]
-      else if constexpr (   has_aggregated_abi_v<wide<T,N,ABI>>
+      else if constexpr (   has_aggregated_abi_v<wide<T,N>>
                         && pattern_view<0   ,sz/2,sz>(q).over(cd/2)
                         && pattern_view<sz/2,sz  ,sz>(q).strictly_under(cd/2)
                         )

--- a/include/eve/detail/function/simd/x86/reverse.hpp
+++ b/include/eve/detail/function/simd/x86/reverse.hpp
@@ -11,8 +11,9 @@
 
 namespace eve::detail
 {
-  template<real_scalar_value T, typename N, x86_abi ABI>
-  EVE_FORCEINLINE wide<T,N,ABI> reverse_( EVE_SUPPORTS(sse2_), wide<T,N,ABI> v) noexcept
+  template<real_scalar_value T, typename N>
+  EVE_FORCEINLINE wide<T,N> reverse_( EVE_SUPPORTS(sse2_), wide<T,N> v) noexcept
+      requires x86_abi<abi_t<T, N>>
   {
     const __m128i reverse_8_shorts = _mm_set_epi8(1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14);
 
@@ -104,7 +105,7 @@ namespace eve::detail
       if constexpr ( sizeof(T) >= 2 )
       {
         // spelling out the indexes will be a lot.
-        wide<T, N, ABI> idx([](int i, int size) { return size - i - 1; });
+        wide<T, N> idx([](int i, int size) { return size - i - 1; });
              if constexpr ( sizeof(T) == 8 ) return _mm512_permutexvar_epi64(idx, v);
         else if constexpr ( sizeof(T) == 4 ) return _mm512_permutexvar_epi32(idx, v);
         else                                 return _mm512_permutexvar_epi16(idx, v);

--- a/include/eve/module/real/algorithm/function/regular/generic/maximum.hpp
+++ b/include/eve/module/real/algorithm/function/regular/generic/maximum.hpp
@@ -16,9 +16,9 @@
 
 namespace eve::detail
 {
-  template<real_scalar_value T, typename N, typename ABI>
+  template<real_scalar_value T, typename N>
   EVE_FORCEINLINE auto maximum_ ( EVE_SUPPORTS(cpu_)
-                                , splat_type const&, wide<T,N,ABI> const &v
+                                , splat_type const&, wide<T,N> const &v
                                 ) noexcept
   {
           if constexpr( N::value == 1 )         return v;
@@ -45,8 +45,8 @@ namespace eve::detail
     return v;
   }
 
-  template<real_scalar_value T, typename N, typename ABI>
-  EVE_FORCEINLINE auto maximum_(EVE_SUPPORTS(cpu_), wide<T,N,ABI> const &v) noexcept
+  template<real_scalar_value T, typename N>
+  EVE_FORCEINLINE auto maximum_(EVE_SUPPORTS(cpu_), wide<T,N> const &v) noexcept
   {
           if constexpr( N::value == 1 )         return v.get(0);
     else  if constexpr( !is_aggregated_v<abi_t<T, N>> ) return butterfly_reduction(v, eve::max).get(0);

--- a/include/eve/module/real/algorithm/function/regular/generic/minimum.hpp
+++ b/include/eve/module/real/algorithm/function/regular/generic/minimum.hpp
@@ -16,9 +16,9 @@
 
 namespace eve::detail
 {
-  template<real_scalar_value T, typename N, typename ABI>
+  template<real_scalar_value T, typename N>
   EVE_FORCEINLINE auto minimum_ ( EVE_SUPPORTS(cpu_)
-                                , splat_type const&, wide<T,N,ABI> const &v
+                                , splat_type const&, wide<T,N> const &v
                                 ) noexcept
   {
           if constexpr( N::value == 1 )         return v;
@@ -45,8 +45,8 @@ namespace eve::detail
     return v;
   }
 
-  template<real_scalar_value T, typename N, typename ABI>
-  EVE_FORCEINLINE auto minimum_(EVE_SUPPORTS(cpu_), wide<T,N,ABI> const &v) noexcept
+  template<real_scalar_value T, typename N>
+  EVE_FORCEINLINE auto minimum_(EVE_SUPPORTS(cpu_), wide<T,N> const &v) noexcept
   {
           if constexpr( N::value == 1 )         return v.get(0);
     else  if constexpr( !is_aggregated_v<abi_t<T, N>> ) return butterfly_reduction(v, eve::min).get(0);

--- a/include/eve/module/real/algorithm/function/regular/generic/reduce.hpp
+++ b/include/eve/module/real/algorithm/function/regular/generic/reduce.hpp
@@ -40,24 +40,24 @@ namespace eve::detail
     }
   }
 
-  template<real_scalar_value T, typename N, typename ABI, typename Callable>
+  template<real_scalar_value T, typename N, typename Callable>
   EVE_FORCEINLINE auto reduce_( EVE_SUPPORTS(cpu_), splat_type const& s
-                              , wide<T,N,ABI> v, Callable f
+                              , wide<T,N> v, Callable f
                               ) noexcept
   {
     auto op = find_reduction(f,s);
     return op(s, v);
   }
 
-  template<real_scalar_value T, typename N, typename ABI, typename Callable>
-  EVE_FORCEINLINE auto reduce_(EVE_SUPPORTS(cpu_), wide<T,N,ABI> v, Callable f) noexcept
+  template<real_scalar_value T, typename N, typename Callable>
+  EVE_FORCEINLINE auto reduce_(EVE_SUPPORTS(cpu_), wide<T,N> v, Callable f) noexcept
   {
     auto op = find_reduction(f);
     return op(v);
   }
 
-  template<real_scalar_value T, typename N, typename ABI, typename Callable>
-  EVE_FORCEINLINE auto reduce_(EVE_SUPPORTS(cpu_), logical<wide<T,N,ABI>> v, Callable f) noexcept
+  template<real_scalar_value T, typename N, typename Callable>
+  EVE_FORCEINLINE auto reduce_(EVE_SUPPORTS(cpu_), logical<wide<T,N>> v, Callable f) noexcept
   {
     auto op = find_reduction(f);
     return op(v);

--- a/include/eve/module/real/algorithm/function/regular/simd/arm/neon/maximum.hpp
+++ b/include/eve/module/real/algorithm/function/regular/simd/arm/neon/maximum.hpp
@@ -14,12 +14,13 @@
 
 namespace eve::detail
 {
-  template<real_scalar_value T, typename N, arm_abi ABI>
+  template<real_scalar_value T, typename N>
   EVE_FORCEINLINE T maximum_( EVE_SUPPORTS(neon128_)
-                            , wide<T,N,ABI> v
+                            , wide<T,N> v
                             ) noexcept
+      requires arm_abi<abi_t<T, N>>
   {
-    constexpr auto c = categorize<wide<T,N,ABI>>();
+    constexpr auto c = categorize<wide<T,N>>();
 
     if constexpr ( eve::current_api >= eve::asimd )
     {
@@ -47,14 +48,15 @@ namespace eve::detail
     }
   }
 
-  template<real_scalar_value T, typename N, arm_abi ABI>
-  EVE_FORCEINLINE wide<T,N,ABI> maximum_( EVE_SUPPORTS(neon128_)
-                                        , splat_type const&, wide<T,N,ABI> const& v
+  template<real_scalar_value T, typename N>
+  EVE_FORCEINLINE wide<T,N> maximum_( EVE_SUPPORTS(neon128_)
+                                        , splat_type const&, wide<T,N> const& v
                                         ) noexcept
+      requires arm_abi<abi_t<T, N>>
   {
     if constexpr ( eve::current_api >= eve::asimd )
     {
-      return wide<T,N,ABI>( maximum(v) );
+      return wide<T,N>( maximum(v) );
     }
     else
     {
@@ -71,7 +73,7 @@ namespace eve::detail
         else  if constexpr( c == category::uint8x8  ) return vpmax_u8(a,b);
       };
 
-      using type = wide<T,N,ABI>;
+      using type = wide<T,N>;
 
             if constexpr( N::value == 1 ) return v;
       else  if constexpr( N::value == 2 ) return type(eve::max(v.get(0),v.get(1)));
@@ -79,7 +81,7 @@ namespace eve::detail
       {
         if(N::value == expected_cardinal_v<T,abi_t<T, N>>)
         {
-          wide<T,N,ABI> s = pairwise_max(v,v);
+          wide<T,N> s = pairwise_max(v,v);
           if constexpr(N::value >= 2  ) s = pairwise_max(s,s);
           if constexpr(N::value >= 4  ) s = pairwise_max(s,s);
           if constexpr(N::value >= 8  ) s = pairwise_max(s,s);
@@ -98,7 +100,7 @@ namespace eve::detail
         if constexpr(N::value >= 16 ) l = pairwise_max(l,l);
         l = pairwise_max(l,l);
 
-        return wide<T,N,ABI>(l,l);
+        return wide<T,N>(l,l);
       }
     }
   }

--- a/include/eve/module/real/algorithm/function/regular/simd/arm/neon/minimum.hpp
+++ b/include/eve/module/real/algorithm/function/regular/simd/arm/neon/minimum.hpp
@@ -14,12 +14,13 @@
 
 namespace eve::detail
 {
-  template<real_scalar_value T, typename N, arm_abi ABI>
+  template<real_scalar_value T, typename N>
   EVE_FORCEINLINE T minimum_( EVE_SUPPORTS(neon128_)
-                            , wide<T,N,ABI> v
+                            , wide<T,N> v
                             ) noexcept
+      requires arm_abi<abi_t<T, N>>
   {
-    constexpr auto c = categorize<wide<T,N,ABI>>();
+    constexpr auto c = categorize<wide<T,N>>();
 
     if constexpr ( eve::current_api >= eve::asimd )
     {
@@ -47,14 +48,15 @@ namespace eve::detail
     }
   }
 
-  template<real_scalar_value T, typename N, arm_abi ABI>
-  EVE_FORCEINLINE wide<T,N,ABI> minimum_( EVE_SUPPORTS(neon128_)
-                                        , splat_type const&, wide<T,N,ABI> const& v
+  template<real_scalar_value T, typename N>
+  EVE_FORCEINLINE wide<T,N> minimum_( EVE_SUPPORTS(neon128_)
+                                        , splat_type const&, wide<T,N> const& v
                                         ) noexcept
+      requires arm_abi<abi_t<T, N>>
   {
     if constexpr ( eve::current_api >= eve::asimd )
     {
-      return wide<T,N,ABI>( minimum(v) );
+      return wide<T,N>( minimum(v) );
     }
     else
     {
@@ -71,7 +73,7 @@ namespace eve::detail
         else  if constexpr( c == category::uint8x8  ) return vpmin_u8(a,b);
       };
 
-      using type = wide<T,N,ABI>;
+      using type = wide<T,N>;
 
             if constexpr( N::value == 1 ) return v;
       else  if constexpr( N::value == 2 ) return type(eve::min(v.get(0),v.get(1)));
@@ -79,7 +81,7 @@ namespace eve::detail
       {
         if(N::value == expected_cardinal_v<T,abi_t<T, N>>)
         {
-          wide<T,N,ABI> s = pairwise_min(v,v);
+          wide<T,N> s = pairwise_min(v,v);
           if constexpr(N::value >= 2  ) s = pairwise_min(s,s);
           if constexpr(N::value >= 4  ) s = pairwise_min(s,s);
           if constexpr(N::value >= 8  ) s = pairwise_min(s,s);
@@ -98,7 +100,7 @@ namespace eve::detail
         if constexpr(N::value >= 16 ) l = pairwise_min(l,l);
         l = pairwise_min(l,l);
 
-        return wide<T,N,ABI>(l,l);
+        return wide<T,N>(l,l);
       }
     }
   }

--- a/include/eve/module/real/algorithm/function/regular/simd/x86/minimum.hpp
+++ b/include/eve/module/real/algorithm/function/regular/simd/x86/minimum.hpp
@@ -17,13 +17,14 @@
 
 namespace eve::detail
 {
-  template<real_scalar_value T, typename N, x86_abi ABI>
+  template<real_scalar_value T, typename N>
   requires(sizeof(T) <= 2)
   EVE_FORCEINLINE auto minimum_ ( EVE_SUPPORTS(sse4_1_)
-                                , wide<T,N,ABI> v
+                                , wide<T,N> v
                                 ) noexcept
+      requires x86_abi<abi_t<T, N>>
   {
-    constexpr auto c = categorize<wide<T,N,ABI>>();
+    constexpr auto c = categorize<wide<T,N>>();
 
     if constexpr( N::value == 1 )
     {
@@ -50,12 +51,12 @@ namespace eve::detail
 
         // minupos return a vector like [0 0 0 0 0 0 p m] where m is the minimum and p its position
         // We extract only the minimum.
-        using type = wide<T,N,ABI>;
+        using type = wide<T,N>;
         return type(_mm_minpos_epu16(fix(v))).get(0);
       }
       else if constexpr ( c == category::int16x8 )
       {
-        auto usv = eve::bit_cast(v, as_<wide<std::uint16_t,N,ABI>>{});
+        auto usv = eve::bit_cast(v, as_<wide<std::uint16_t,N>>{});
         auto const sm = signmask(as_<T>());
         usv += sm;
         return static_cast<T>(minimum(usv)-sm);
@@ -75,12 +76,13 @@ namespace eve::detail
     }
   }
 
-  template<real_scalar_value T, typename N, x86_abi ABI>
+  template<real_scalar_value T, typename N>
   requires(sizeof(T) <= 2)
   EVE_FORCEINLINE auto minimum_ ( EVE_SUPPORTS(sse4_1_)
-                                , splat_type const&, wide<T,N,ABI> const &v
+                                , splat_type const&, wide<T,N> const &v
                                 ) noexcept
+      requires x86_abi<abi_t<T, N>>
   {
-    return wide<T,N,ABI>(minimum(v));
+    return wide<T,N>(minimum(v));
   }
 }

--- a/include/eve/module/real/core/function/numeric/simd/x86/fma.hpp
+++ b/include/eve/module/real/core/function/numeric/simd/x86/fma.hpp
@@ -18,12 +18,13 @@
 
 namespace eve::detail
 {
-  template<real_scalar_value T, typename N, x86_abi ABI>
-  EVE_FORCEINLINE wide<T, N, ABI> fma_(EVE_SUPPORTS(avx2_),
+  template<real_scalar_value T, typename N>
+  EVE_FORCEINLINE wide<T, N> fma_(EVE_SUPPORTS(avx2_),
                                         numeric_type const &,
-                                        wide<T, N, ABI> const &a,
-                                        wide<T, N, ABI> const &b,
-                                        wide<T, N, ABI> const &c) noexcept
+                                        wide<T, N> const &a,
+                                        wide<T, N> const &b,
+                                        wide<T, N> const &c) noexcept
+      requires x86_abi<abi_t<T, N>>
   {
     if constexpr( supports_fma3 || supports_fma4  )
     {

--- a/include/eve/module/real/core/function/numeric/simd/x86/fms.hpp
+++ b/include/eve/module/real/core/function/numeric/simd/x86/fms.hpp
@@ -18,12 +18,13 @@
 
 namespace eve::detail
 {
-  template<real_scalar_value T, typename N, x86_abi ABI>
-  EVE_FORCEINLINE wide<T, N, ABI> fms_(EVE_SUPPORTS(avx2_),
+  template<real_scalar_value T, typename N>
+  EVE_FORCEINLINE wide<T, N> fms_(EVE_SUPPORTS(avx2_),
                                        numeric_type const &,
-                                       wide<T, N, ABI> const &a,
-                                       wide<T, N, ABI> const &b,
-                                       wide<T, N, ABI> const &c) noexcept
+                                       wide<T, N> const &a,
+                                       wide<T, N> const &b,
+                                       wide<T, N> const &c) noexcept
+      requires x86_abi<abi_t<T, N>>
   {
     if constexpr( supports_fma3 || supports_fma4  )
     {

--- a/include/eve/module/real/core/function/numeric/simd/x86/fnma.hpp
+++ b/include/eve/module/real/core/function/numeric/simd/x86/fnma.hpp
@@ -17,12 +17,13 @@
 
 namespace eve::detail
 {
-  template<real_scalar_value T, typename N, x86_abi ABI>
-  EVE_FORCEINLINE wide<T, N, ABI> fnma_(EVE_SUPPORTS(avx2_),
+  template<real_scalar_value T, typename N>
+  EVE_FORCEINLINE wide<T, N> fnma_(EVE_SUPPORTS(avx2_),
                                         numeric_type const &,
-                                        wide<T, N, ABI> const &a,
-                                        wide<T, N, ABI> const &b,
-                                        wide<T, N, ABI> const &c) noexcept
+                                        wide<T, N> const &a,
+                                        wide<T, N> const &b,
+                                        wide<T, N> const &c) noexcept
+      requires x86_abi<abi_t<T, N>>
   {
     if constexpr( supports_fma3 || supports_fma4  )
     {

--- a/include/eve/module/real/core/function/numeric/simd/x86/fnms.hpp
+++ b/include/eve/module/real/core/function/numeric/simd/x86/fnms.hpp
@@ -18,12 +18,13 @@
 
 namespace eve::detail
 {
-  template<real_scalar_value T, typename N, x86_abi ABI>
-  EVE_FORCEINLINE wide<T, N, ABI> fnms_(EVE_SUPPORTS(avx2_),
+  template<real_scalar_value T, typename N>
+  EVE_FORCEINLINE wide<T, N> fnms_(EVE_SUPPORTS(avx2_),
                                         numeric_type const &,
-                                        wide<T, N, ABI> const &a,
-                                        wide<T, N, ABI> const &b,
-                                        wide<T, N, ABI> const &c) noexcept
+                                        wide<T, N> const &a,
+                                        wide<T, N> const &b,
+                                        wide<T, N> const &c) noexcept
+      requires x86_abi<abi_t<T, N>>
   {
     if constexpr( supports_fma3 || supports_fma4  )
     {

--- a/include/eve/module/real/core/function/pedantic/simd/arm/neon/max.hpp
+++ b/include/eve/module/real/core/function/pedantic/simd/arm/neon/max.hpp
@@ -14,12 +14,13 @@
 
 namespace eve::detail
 {
-  template<typename T, typename N, arm_abi ABI>
-  EVE_FORCEINLINE wide<T, N, ABI> max_( EVE_SUPPORTS(neon128_)
+  template<typename T, typename N>
+  EVE_FORCEINLINE wide<T, N> max_( EVE_SUPPORTS(neon128_)
                                       , pedantic_type const &
-                                      , wide<T, N, ABI> const &a0
-                                      , wide<T, N, ABI> const &a1
+                                      , wide<T, N> const &a0
+                                      , wide<T, N> const &a1
                                       ) noexcept
+      requires arm_abi<abi_t<T, N>>
   {
     auto tmp = eve::max(a0, a1);
     if constexpr(eve::platform::supports_invalids) tmp = if_else(is_nan(a1), a0, tmp);

--- a/include/eve/module/real/core/function/pedantic/simd/arm/neon/min.hpp
+++ b/include/eve/module/real/core/function/pedantic/simd/arm/neon/min.hpp
@@ -14,12 +14,13 @@
 
 namespace eve::detail
 {
-  template<typename T, typename N, arm_abi ABI>
-  EVE_FORCEINLINE wide<T, N, ABI> min_( EVE_SUPPORTS(neon128_)
+  template<typename T, typename N>
+  EVE_FORCEINLINE wide<T, N> min_( EVE_SUPPORTS(neon128_)
                                       , pedantic_type const &
-                                      , wide<T, N, ABI> const &a0
-                                      , wide<T, N, ABI> const &a1
+                                      , wide<T, N> const &a0
+                                      , wide<T, N> const &a1
                                       ) noexcept
+      requires arm_abi<abi_t<T, N>>
   {
     auto tmp = eve::min(a0, a1);
     if constexpr(eve::platform::supports_invalids) tmp = if_else(is_nan(a1), a0, tmp);

--- a/include/eve/module/real/core/function/pedantic/simd/x86/fma.hpp
+++ b/include/eve/module/real/core/function/pedantic/simd/x86/fma.hpp
@@ -18,12 +18,13 @@
 
 namespace eve::detail
 {
-  template<real_scalar_value T, typename N, x86_abi ABI>
-  EVE_FORCEINLINE wide<T, N, ABI> fma_(EVE_SUPPORTS(avx2_),
+  template<real_scalar_value T, typename N>
+  EVE_FORCEINLINE wide<T, N> fma_(EVE_SUPPORTS(avx2_),
                                         pedantic_type const &,
-                                        wide<T, N, ABI> const &a,
-                                        wide<T, N, ABI> const &b,
-                                        wide<T, N, ABI> const &c) noexcept
+                                        wide<T, N> const &a,
+                                        wide<T, N> const &b,
+                                        wide<T, N> const &c) noexcept
+      requires x86_abi<abi_t<T, N>>
   {
     if constexpr( supports_fma3 || supports_fma4  )
     {

--- a/include/eve/module/real/core/function/pedantic/simd/x86/fms.hpp
+++ b/include/eve/module/real/core/function/pedantic/simd/x86/fms.hpp
@@ -18,12 +18,13 @@
 
 namespace eve::detail
 {
-  template<real_scalar_value T, typename N, x86_abi ABI>
-  EVE_FORCEINLINE wide<T, N, ABI> fms_(EVE_SUPPORTS(avx2_),
+  template<real_scalar_value T, typename N>
+  EVE_FORCEINLINE wide<T, N> fms_(EVE_SUPPORTS(avx2_),
                                        pedantic_type const &,
-                                       wide<T, N, ABI> const &a,
-                                       wide<T, N, ABI> const &b,
-                                       wide<T, N, ABI> const &c) noexcept
+                                       wide<T, N> const &a,
+                                       wide<T, N> const &b,
+                                       wide<T, N> const &c) noexcept
+      requires x86_abi<abi_t<T, N>>
   {
     if constexpr( supports_fma3 || supports_fma4  )
     {

--- a/include/eve/module/real/core/function/pedantic/simd/x86/fnma.hpp
+++ b/include/eve/module/real/core/function/pedantic/simd/x86/fnma.hpp
@@ -18,12 +18,13 @@
 
 namespace eve::detail
 {
-  template<real_scalar_value T, typename N, x86_abi ABI>
-  EVE_FORCEINLINE wide<T, N, ABI> fnma_(EVE_SUPPORTS(avx2_),
+  template<real_scalar_value T, typename N>
+  EVE_FORCEINLINE wide<T, N> fnma_(EVE_SUPPORTS(avx2_),
                                         pedantic_type const &,
-                                        wide<T, N, ABI> const &a,
-                                        wide<T, N, ABI> const &b,
-                                        wide<T, N, ABI> const &c) noexcept
+                                        wide<T, N> const &a,
+                                        wide<T, N> const &b,
+                                        wide<T, N> const &c) noexcept
+      requires x86_abi<abi_t<T, N>>
   {
     if constexpr( supports_fma3 || supports_fma4  )
     {

--- a/include/eve/module/real/core/function/pedantic/simd/x86/fnms.hpp
+++ b/include/eve/module/real/core/function/pedantic/simd/x86/fnms.hpp
@@ -17,12 +17,13 @@
 
 namespace eve::detail
 {
-  template<real_scalar_value T, typename N, x86_abi ABI>
-  EVE_FORCEINLINE wide<T, N, ABI> fnms_(EVE_SUPPORTS(avx2_),
+  template<real_scalar_value T, typename N>
+  EVE_FORCEINLINE wide<T, N> fnms_(EVE_SUPPORTS(avx2_),
                                         pedantic_type const &,
-                                        wide<T, N, ABI> const &a,
-                                        wide<T, N, ABI> const &b,
-                                        wide<T, N, ABI> const &c) noexcept
+                                        wide<T, N> const &a,
+                                        wide<T, N> const &b,
+                                        wide<T, N> const &c) noexcept
+      requires x86_abi<abi_t<T, N>>
   {
     if constexpr( supports_fma3 || supports_fma4  )
     {

--- a/include/eve/module/real/core/function/regular/generic/gather.hpp
+++ b/include/eve/module/real/core/function/regular/generic/gather.hpp
@@ -17,37 +17,37 @@ namespace eve::detail
 {
   //================================================================================================
   // Unaligned pointer
-  template<typename U, integral_scalar_value T, typename N, typename ABI>
-  EVE_FORCEINLINE auto gather_(EVE_SUPPORTS(cpu_), U const *ptr, wide<T, N, ABI> const &v) noexcept
+  template<typename U, integral_scalar_value T, typename N>
+  EVE_FORCEINLINE auto gather_(EVE_SUPPORTS(cpu_), U const *ptr, wide<T, N> const &v) noexcept
   {
     wide<U, N> that;
     apply<N::value>([&](auto... I) { (that.set(I,ptr[v.get(I)]),...); });
     return that;
   }
 
-  template<typename U, value X, integral_scalar_value T, typename N, typename ABI>
+  template<typename U, value X, integral_scalar_value T, typename N>
   EVE_FORCEINLINE auto gather_(EVE_SUPPORTS(cpu_),
                                logical<X> const &     cond,
                                U const *              ptr,
-                               wide<T, N, ABI> const &v) noexcept
+                               wide<T, N> const &v) noexcept
   {
     return if_else(cond, gather(ptr, v), zero_);
   }
 
   //================================================================================================
   // Aligned pointer
-  template<typename U, std::size_t S, integral_scalar_value T, typename N, typename ABI>
+  template<typename U, std::size_t S, integral_scalar_value T, typename N>
   EVE_FORCEINLINE auto
-  gather_(EVE_SUPPORTS(cpu_), aligned_ptr<U, S> ptr, wide<T, N, ABI> const &v) noexcept
+  gather_(EVE_SUPPORTS(cpu_), aligned_ptr<U, S> ptr, wide<T, N> const &v) noexcept
   {
     return gather(ptr.get(), v);
   }
 
-  template<typename U, std::size_t S, value X, integral_scalar_value T, typename N, typename ABI>
+  template<typename U, std::size_t S, value X, integral_scalar_value T, typename N>
   EVE_FORCEINLINE auto gather_(EVE_SUPPORTS(cpu_),
                                logical<X> const &     cond,
                                aligned_ptr<U, S>      ptr,
-                               wide<T, N, ABI> const &v) noexcept
+                               wide<T, N> const &v) noexcept
   {
     return if_else(cond, gather(ptr.get(), v), zero_);
   }

--- a/include/eve/module/real/core/function/regular/generic/store.hpp
+++ b/include/eve/module/real/core/function/regular/generic/store.hpp
@@ -122,17 +122,17 @@ namespace eve::detail
     }
   }
 
-  template<real_scalar_value T, typename S, typename ABI>
+  template<real_scalar_value T, typename S>
   EVE_FORCEINLINE void store_(EVE_SUPPORTS(cpu_),
-                              logical<wide<T, S, ABI>> const &value,
+                              logical<wide<T, S>> const &value,
                               logical<T>* ptr) noexcept
   {
     store(value.mask(), (typename logical<T>::mask_type*) ptr);
   }
 
-  template<real_scalar_value T, typename S, std::size_t A, typename ABI>
+  template<real_scalar_value T, typename S, std::size_t A>
   EVE_FORCEINLINE void store_(EVE_SUPPORTS(cpu_),
-                              logical<wide<T, S, ABI>> const &value,
+                              logical<wide<T, S>> const &value,
                               aligned_ptr<logical<T>, A> ptr) noexcept
     requires (
       requires {store(value.mask(), aligned_ptr<typename logical<T>::mask_type, A>{}); } )

--- a/include/eve/module/real/core/function/regular/simd/arm/neon/abs.hpp
+++ b/include/eve/module/real/core/function/regular/simd/arm/neon/abs.hpp
@@ -13,10 +13,11 @@
 
 namespace eve::detail
 {
-  template<real_scalar_value T, typename N, arm_abi ABI>
-  EVE_FORCEINLINE wide<T, N, ABI> abs_(EVE_SUPPORTS(neon128_), wide<T, N, ABI> const& v) noexcept
+  template<real_scalar_value T, typename N>
+  EVE_FORCEINLINE wide<T, N> abs_(EVE_SUPPORTS(neon128_), wide<T, N> const& v) noexcept
+      requires arm_abi<abi_t<T, N>>
   {
-    constexpr auto cat = categorize<wide<T, N, ABI>>();
+    constexpr auto cat = categorize<wide<T, N>>();
 
           if constexpr( cat && category::unsigned_) return v;
     else  if constexpr( cat && category::size64_  ) return map(eve::abs, v);

--- a/include/eve/module/real/core/function/regular/simd/arm/neon/average.hpp
+++ b/include/eve/module/real/core/function/regular/simd/arm/neon/average.hpp
@@ -18,12 +18,13 @@
 
 namespace eve::detail
 {
-  template<real_scalar_value T, typename N, arm_abi ABI>
-  EVE_FORCEINLINE wide<T, N, ABI> average_(EVE_SUPPORTS(neon128_),
-                                           wide<T, N, ABI> const &v0,
-                                           wide<T, N, ABI> const &v1) noexcept
+  template<real_scalar_value T, typename N>
+  EVE_FORCEINLINE wide<T, N> average_(EVE_SUPPORTS(neon128_),
+                                           wide<T, N> const &v0,
+                                           wide<T, N> const &v1) noexcept
+      requires arm_abi<abi_t<T, N>>
   {
-    constexpr auto cat = categorize<wide<T, N, ABI>>();
+    constexpr auto cat = categorize<wide<T, N>>();
 
           if constexpr(std::is_floating_point_v<T>) return fma(v0, half(eve::as(v0)), v1 * half(eve::as(v1)));
     else  if constexpr( sizeof(T) == 8 )            return map(average, v0, v1);

--- a/include/eve/module/real/core/function/regular/simd/arm/neon/bit_andnot.hpp
+++ b/include/eve/module/real/core/function/regular/simd/arm/neon/bit_andnot.hpp
@@ -13,12 +13,13 @@
 
 namespace eve::detail
 {
-  template<real_scalar_value T, typename N, arm_abi ABI>
-  EVE_FORCEINLINE wide<T, N, ABI> bit_andnot_(EVE_SUPPORTS(neon128_),
-                                              wide<T, N, ABI> const &v0,
-                                              wide<T, N, ABI> const &v1) noexcept
+  template<real_scalar_value T, typename N>
+  EVE_FORCEINLINE wide<T, N> bit_andnot_(EVE_SUPPORTS(neon128_),
+                                              wide<T, N> const &v0,
+                                              wide<T, N> const &v1) noexcept
+      requires arm_abi<abi_t<T, N>>
   {
-    constexpr auto cat = categorize<wide<T, N, ABI>>();
+    constexpr auto cat = categorize<wide<T, N>>();
 
     if constexpr(cat == category::float32x4)
       return vreinterpretq_f32_u32(vbicq_u32(vreinterpretq_u32_f32(v0), vreinterpretq_u32_f32(v1)));

--- a/include/eve/module/real/core/function/regular/simd/arm/neon/bit_notand.hpp
+++ b/include/eve/module/real/core/function/regular/simd/arm/neon/bit_notand.hpp
@@ -13,12 +13,13 @@
 
 namespace eve::detail
 {
-  template<real_scalar_value T, typename N, arm_abi ABI>
-  EVE_FORCEINLINE wide<T, N, ABI> bit_notand_(EVE_SUPPORTS(neon128_),
-                                              wide<T, N, ABI> const &v0,
-                                              wide<T, N, ABI> const &v1) noexcept
+  template<real_scalar_value T, typename N>
+  EVE_FORCEINLINE wide<T, N> bit_notand_(EVE_SUPPORTS(neon128_),
+                                              wide<T, N> const &v0,
+                                              wide<T, N> const &v1) noexcept
+      requires arm_abi<abi_t<T, N>>
   {
-    constexpr auto cat = categorize<wide<T, N, ABI>>();
+    constexpr auto cat = categorize<wide<T, N>>();
 
     if constexpr(cat == category::float32x4)
       return vreinterpretq_f32_u32(vbicq_u32(vreinterpretq_u32_f32(v1), vreinterpretq_u32_f32(v0)));

--- a/include/eve/module/real/core/function/regular/simd/arm/neon/bit_notor.hpp
+++ b/include/eve/module/real/core/function/regular/simd/arm/neon/bit_notor.hpp
@@ -13,12 +13,13 @@
 
 namespace eve::detail
 {
-  template<real_scalar_value T, typename N, arm_abi ABI>
-  EVE_FORCEINLINE wide<T, N, ABI> bit_notor_(EVE_SUPPORTS(neon128_),
-                                             wide<T, N, ABI> const &v0,
-                                             wide<T, N, ABI> const &v1) noexcept
+  template<real_scalar_value T, typename N>
+  EVE_FORCEINLINE wide<T, N> bit_notor_(EVE_SUPPORTS(neon128_),
+                                             wide<T, N> const &v0,
+                                             wide<T, N> const &v1) noexcept
+      requires arm_abi<abi_t<T, N>>
   {
-    constexpr auto cat = categorize<wide<T, N, ABI>>();
+    constexpr auto cat = categorize<wide<T, N>>();
 
     if constexpr(cat == category::float32x4)
       return vreinterpretq_f32_u32(vornq_u32(vreinterpretq_u32_f32(v1), vreinterpretq_u32_f32(v0)));

--- a/include/eve/module/real/core/function/regular/simd/arm/neon/bit_ornot.hpp
+++ b/include/eve/module/real/core/function/regular/simd/arm/neon/bit_ornot.hpp
@@ -13,12 +13,13 @@
 
 namespace eve::detail
 {
-  template<real_scalar_value T, typename N, arm_abi ABI>
-  EVE_FORCEINLINE wide<T, N, ABI> bit_ornot_(EVE_SUPPORTS(neon128_),
-                                             wide<T, N, ABI> const &v0,
-                                             wide<T, N, ABI> const &v1) noexcept
+  template<real_scalar_value T, typename N>
+  EVE_FORCEINLINE wide<T, N> bit_ornot_(EVE_SUPPORTS(neon128_),
+                                             wide<T, N> const &v0,
+                                             wide<T, N> const &v1) noexcept
+      requires arm_abi<abi_t<T, N>>
   {
-    constexpr auto cat = categorize<wide<T, N, ABI>>();
+    constexpr auto cat = categorize<wide<T, N>>();
 
     if constexpr(cat == category::float32x4)
       return vreinterpretq_f32_u32(vornq_u32(vreinterpretq_u32_f32(v0), vreinterpretq_u32_f32(v1)));

--- a/include/eve/module/real/core/function/regular/simd/arm/neon/bit_select.hpp
+++ b/include/eve/module/real/core/function/regular/simd/arm/neon/bit_select.hpp
@@ -13,13 +13,14 @@
 
 namespace eve::detail
 {
-  template<real_scalar_value T, typename N, arm_abi ABI>
-  EVE_FORCEINLINE wide<T, N, ABI> bit_select_(EVE_SUPPORTS(neon128_),
-                                               wide<T, N, ABI> const &m,
-                                               wide<T, N, ABI> const &v0,
-                                               wide<T, N, ABI> const &v1) noexcept
+  template<real_scalar_value T, typename N>
+  EVE_FORCEINLINE wide<T, N> bit_select_(EVE_SUPPORTS(neon128_),
+                                               wide<T, N> const &m,
+                                               wide<T, N> const &v0,
+                                               wide<T, N> const &v1) noexcept
+      requires arm_abi<abi_t<T, N>>
   {
-    constexpr auto cat = categorize<wide<T, N, ABI>>();
+    constexpr auto cat = categorize<wide<T, N>>();
 
          if constexpr(cat == category::float64x1) return vbsl_f64(vreinterpret_u64_f64(m), v0, v1);
     else if constexpr(cat == category::float64x2) return vbslq_f64(vreinterpretq_u64_f64(m), v0, v1);

--- a/include/eve/module/real/core/function/regular/simd/arm/neon/ceil.hpp
+++ b/include/eve/module/real/core/function/regular/simd/arm/neon/ceil.hpp
@@ -13,11 +13,12 @@
 
 namespace eve::detail
 {
-  template<floating_real_scalar_value T, typename N, arm_abi ABI>
-  EVE_FORCEINLINE wide<T, N, ABI> ceil_(EVE_SUPPORTS(neon128_)
-                                       , wide<T, N, ABI> const& v) noexcept
+  template<floating_real_scalar_value T, typename N>
+  EVE_FORCEINLINE wide<T, N> ceil_(EVE_SUPPORTS(neon128_)
+                                       , wide<T, N> const& v) noexcept
+      requires arm_abi<abi_t<T, N>>
   {
-    constexpr auto cat = categorize<wide<T, N, ABI>>();
+    constexpr auto cat = categorize<wide<T, N>>();
 
          if constexpr( cat == category::float32x2) return vrndp_f32(v);
     else if constexpr( cat == category::float32x4) return vrndpq_f32(v);

--- a/include/eve/module/real/core/function/regular/simd/arm/neon/convert.hpp
+++ b/include/eve/module/real/core/function/regular/simd/arm/neon/convert.hpp
@@ -14,12 +14,13 @@
 
 namespace eve::detail
 {
-  template<real_scalar_value T, typename N, real_scalar_value U, arm_abi ABI>
+  template<real_scalar_value T, typename N, real_scalar_value U>
   EVE_FORCEINLINE wide<U, N>  convert_(EVE_SUPPORTS(neon128_)
-                                      , wide<T, N, ABI> const &v0
+                                      , wide<T, N> const &v0
                                       , as_<U> const &tgt) noexcept
+      requires arm_abi<abi_t<T, N>>
   {
-    constexpr auto catin = categorize<wide<T, N, ABI>>();
+    constexpr auto catin = categorize<wide<T, N>>();
     constexpr auto catou = categorize<wide<U, N>>();
 
     // Idempotent call

--- a/include/eve/module/real/core/function/regular/simd/arm/neon/div.hpp
+++ b/include/eve/module/real/core/function/regular/simd/arm/neon/div.hpp
@@ -12,10 +12,11 @@
 
 namespace eve::detail
 {
-  template<real_scalar_value T, typename N, arm_abi ABI>
-  EVE_FORCEINLINE wide<T, N, ABI> div_(EVE_SUPPORTS(neon128_)
-                                      , wide<T, N, ABI> v0
-                                      , wide<T, N, ABI> const &v1) noexcept
+  template<real_scalar_value T, typename N>
+  EVE_FORCEINLINE wide<T, N> div_(EVE_SUPPORTS(neon128_)
+                                      , wide<T, N> v0
+                                      , wide<T, N> const &v1) noexcept
+      requires arm_abi<abi_t<T, N>>
   {
     return v0 /= v1;
   }

--- a/include/eve/module/real/core/function/regular/simd/arm/neon/fma.hpp
+++ b/include/eve/module/real/core/function/regular/simd/arm/neon/fma.hpp
@@ -13,13 +13,14 @@
 
 namespace eve::detail
 {
-  template<real_scalar_value T, typename N, arm_abi ABI>
-  EVE_FORCEINLINE wide<T, N, ABI> fma_(EVE_SUPPORTS(neon128_),
-                                       wide<T, N, ABI> const &v0,
-                                       wide<T, N, ABI> const &v1,
-                                       wide<T, N, ABI> const &v2) noexcept
+  template<real_scalar_value T, typename N>
+  EVE_FORCEINLINE wide<T, N> fma_(EVE_SUPPORTS(neon128_),
+                                       wide<T, N> const &v0,
+                                       wide<T, N> const &v1,
+                                       wide<T, N> const &v2) noexcept
+      requires arm_abi<abi_t<T, N>>
   {
-    constexpr auto cat = categorize<wide<T, N, ABI>>();
+    constexpr auto cat = categorize<wide<T, N>>();
 
          if constexpr(  cat == category::float32x2) return  vfma_f32(v2, v1, v0);
     else if constexpr(  cat == category::float32x4) return vfmaq_f32(v2, v1, v0);

--- a/include/eve/module/real/core/function/regular/simd/arm/neon/fms.hpp
+++ b/include/eve/module/real/core/function/regular/simd/arm/neon/fms.hpp
@@ -14,11 +14,12 @@
 
 namespace eve::detail
 {
-  template<real_scalar_value T, typename N, arm_abi ABI>
-  EVE_FORCEINLINE wide<T, N, ABI> fms_(EVE_SUPPORTS(neon128_),
-                                           wide<T, N, ABI> const &v0,
-                                           wide<T, N, ABI> const &v1,
-                                           wide<T, N, ABI> const &v2) noexcept
+  template<real_scalar_value T, typename N>
+  EVE_FORCEINLINE wide<T, N> fms_(EVE_SUPPORTS(neon128_),
+                                           wide<T, N> const &v0,
+                                           wide<T, N> const &v1,
+                                           wide<T, N> const &v2) noexcept
+      requires arm_abi<abi_t<T, N>>
   {
     return fma(v0, v1, -v2);
   }

--- a/include/eve/module/real/core/function/regular/simd/arm/neon/fnma.hpp
+++ b/include/eve/module/real/core/function/regular/simd/arm/neon/fnma.hpp
@@ -14,13 +14,14 @@
 
 namespace eve::detail
 {
-  template<real_scalar_value T, typename N, arm_abi ABI>
-  EVE_FORCEINLINE wide<T, N, ABI> fnma_(EVE_SUPPORTS(neon128_),
-                                        wide<T, N, ABI> const &v0,
-                                        wide<T, N, ABI> const &v1,
-                                        wide<T, N, ABI> const &v2) noexcept
+  template<real_scalar_value T, typename N>
+  EVE_FORCEINLINE wide<T, N> fnma_(EVE_SUPPORTS(neon128_),
+                                        wide<T, N> const &v0,
+                                        wide<T, N> const &v1,
+                                        wide<T, N> const &v2) noexcept
+      requires arm_abi<abi_t<T, N>>
   {
-    constexpr auto cat = categorize<wide<T, N, ABI>>();
+    constexpr auto cat = categorize<wide<T, N>>();
 
          if constexpr(  cat == category::float32x2) return vfms_f32(v2, v1, v0);
     else if constexpr(  cat == category::float32x4) return vfmsq_f32(v2, v1, v0);

--- a/include/eve/module/real/core/function/regular/simd/arm/neon/fnms.hpp
+++ b/include/eve/module/real/core/function/regular/simd/arm/neon/fnms.hpp
@@ -14,11 +14,12 @@
 
 namespace eve::detail
 {
-  template<real_scalar_value T, typename N, arm_abi ABI>
-  EVE_FORCEINLINE wide<T, N, ABI> fnms_(EVE_SUPPORTS(neon128_),
-                                            wide<T, N, ABI> const &v0,
-                                            wide<T, N, ABI> const &v1,
-                                            wide<T, N, ABI> const &v2) noexcept
+  template<real_scalar_value T, typename N>
+  EVE_FORCEINLINE wide<T, N> fnms_(EVE_SUPPORTS(neon128_),
+                                            wide<T, N> const &v0,
+                                            wide<T, N> const &v1,
+                                            wide<T, N> const &v2) noexcept
+      requires arm_abi<abi_t<T, N>>
   {
     return -fma(v0, v1, v2);
   }

--- a/include/eve/module/real/core/function/regular/simd/arm/neon/if_else.hpp
+++ b/include/eve/module/real/core/function/regular/simd/arm/neon/if_else.hpp
@@ -15,12 +15,13 @@ namespace eve::detail
 {
   //================================================================================================
   // Full logical if_else
-  template<real_scalar_value U, typename N, arm_abi ABI>
+  template<real_scalar_value U, typename N>
   EVE_FORCEINLINE auto if_else_ ( EVE_SUPPORTS(neon128_)
-                                , logical<wide<U, N, ABI>> const &v0
-                                , logical<wide<U, N, ABI>> const &v1
-                                , logical<wide<U, N, ABI>> const &v2
+                                , logical<wide<U, N>> const &v0
+                                , logical<wide<U, N>> const &v1
+                                , logical<wide<U, N>> const &v2
                                 ) noexcept
+      requires arm_abi<abi_t<U, N>>
   {
     return bit_cast(if_else(v0, v1.mask(), v2.mask()), as(v0));
   }

--- a/include/eve/module/real/core/function/regular/simd/arm/neon/max.hpp
+++ b/include/eve/module/real/core/function/regular/simd/arm/neon/max.hpp
@@ -13,12 +13,13 @@
 
 namespace eve::detail
 {
-  template<typename T, typename N, arm_abi ABI>
-  EVE_FORCEINLINE wide<T, N, ABI> max_(EVE_SUPPORTS(neon128_),
-                                       wide<T, N, ABI> const &v0,
-                                       wide<T, N, ABI> const &v1) noexcept
+  template<typename T, typename N>
+  EVE_FORCEINLINE wide<T, N> max_(EVE_SUPPORTS(neon128_),
+                                       wide<T, N> const &v0,
+                                       wide<T, N> const &v1) noexcept
+      requires arm_abi<abi_t<T, N>>
   {
-    constexpr auto cat = categorize<wide<T, N, ABI>>();
+    constexpr auto cat = categorize<wide<T, N>>();
 
           if constexpr( cat == category::int32x4  ) return vmaxq_s32(v0, v1);
     else  if constexpr( cat == category::int16x8  ) return vmaxq_s16(v0, v1);

--- a/include/eve/module/real/core/function/regular/simd/arm/neon/min.hpp
+++ b/include/eve/module/real/core/function/regular/simd/arm/neon/min.hpp
@@ -13,12 +13,13 @@
 
 namespace eve::detail
 {
-  template<typename T, typename N, arm_abi ABI>
-  EVE_FORCEINLINE wide<T, N, ABI> min_(EVE_SUPPORTS(neon128_),
-                                       wide<T, N, ABI> const &v0,
-                                       wide<T, N, ABI> const &v1) noexcept
+  template<typename T, typename N>
+  EVE_FORCEINLINE wide<T, N> min_(EVE_SUPPORTS(neon128_),
+                                       wide<T, N> const &v0,
+                                       wide<T, N> const &v1) noexcept
+      requires arm_abi<abi_t<T, N>>
   {
-    constexpr auto cat = categorize<wide<T, N, ABI>>();
+    constexpr auto cat = categorize<wide<T, N>>();
 
           if constexpr( cat == category::int32x4  ) return vminq_s32(v0, v1);
     else  if constexpr( cat == category::int16x8  ) return vminq_s16(v0, v1);

--- a/include/eve/module/real/core/function/regular/simd/arm/neon/mul.hpp
+++ b/include/eve/module/real/core/function/regular/simd/arm/neon/mul.hpp
@@ -12,26 +12,29 @@
 
 namespace eve::detail
 {
-  template<real_scalar_value T, typename N, arm_abi ABI>
-  EVE_FORCEINLINE wide<T, N, ABI> mul_(EVE_SUPPORTS(neon128_)
-                                      , wide<T, N, ABI> v0
-                                      , wide<T, N, ABI> const &v1) noexcept
+  template<real_scalar_value T, typename N>
+  EVE_FORCEINLINE wide<T, N> mul_(EVE_SUPPORTS(neon128_)
+                                      , wide<T, N> v0
+                                      , wide<T, N> const &v1) noexcept
+      requires arm_abi<abi_t<T, N>>
   {
     return v0 *= v1;
   }
 
-  template<real_scalar_value T, typename N, arm_abi ABI, real_scalar_value U>
-  EVE_FORCEINLINE wide<T, N, ABI> mul_(EVE_SUPPORTS(neon128_)
-                                      , wide<T, N, ABI> v0
+  template<real_scalar_value T, typename N, real_scalar_value U>
+  EVE_FORCEINLINE wide<T, N> mul_(EVE_SUPPORTS(neon128_)
+                                      , wide<T, N> v0
                                       , U const &v1) noexcept
+      requires arm_abi<abi_t<T, N>>
   {
     return v0 *= v1;
   }
 
-  template<real_scalar_value T, typename N, arm_abi ABI, real_scalar_value U>
-  EVE_FORCEINLINE wide<T, N, ABI> mul_(EVE_SUPPORTS(neon128_)
+  template<real_scalar_value T, typename N, real_scalar_value U>
+  EVE_FORCEINLINE wide<T, N> mul_(EVE_SUPPORTS(neon128_)
                                       , U const & v0
-                                      , wide<T, N, ABI> v1) noexcept
+                                      , wide<T, N> v1) noexcept
+      requires arm_abi<abi_t<T, N>>
   {
     return v1 *= v0;
   }

--- a/include/eve/module/real/core/function/regular/simd/arm/neon/nearest.hpp
+++ b/include/eve/module/real/core/function/regular/simd/arm/neon/nearest.hpp
@@ -13,11 +13,12 @@
 
 namespace eve::detail
 {
-  template<floating_real_scalar_value T, typename N, arm_abi ABI>
-  EVE_FORCEINLINE wide<T, N, ABI> nearest_(EVE_SUPPORTS(neon128_)
-                                          , wide<T, N, ABI> const& v) noexcept
+  template<floating_real_scalar_value T, typename N>
+  EVE_FORCEINLINE wide<T, N> nearest_(EVE_SUPPORTS(neon128_)
+                                          , wide<T, N> const& v) noexcept
+      requires arm_abi<abi_t<T, N>>
   {
-    constexpr auto cat = categorize<wide<T, N, ABI>>();
+    constexpr auto cat = categorize<wide<T, N>>();
 
          if constexpr( cat == category::float32x2)  return vrndn_f32(v);
     else if constexpr( cat == category::float32x4)  return vrndnq_f32(v);

--- a/include/eve/module/real/core/function/regular/simd/arm/neon/rec.hpp
+++ b/include/eve/module/real/core/function/regular/simd/arm/neon/rec.hpp
@@ -15,12 +15,13 @@
 
 namespace eve::detail
 {
-  template<floating_real_scalar_value T, typename N, arm_abi ABI>
-  EVE_FORCEINLINE wide<T, N, ABI> rec_(EVE_SUPPORTS(neon128_)
+  template<floating_real_scalar_value T, typename N>
+  EVE_FORCEINLINE wide<T, N> rec_(EVE_SUPPORTS(neon128_)
                                       , raw_type const &
-                                      , wide<T, N, ABI> const& v) noexcept
+                                      , wide<T, N> const& v) noexcept
+      requires arm_abi<abi_t<T, N>>
   {
-    constexpr auto cat = categorize<wide<T, N, ABI>>();
+    constexpr auto cat = categorize<wide<T, N>>();
 
 
          if constexpr( cat == category::float32x2) return vrecpe_f32(v);
@@ -33,9 +34,10 @@ namespace eve::detail
     else                                           return map(rec, v);
   }
 
-  template<floating_real_scalar_value T, typename N, arm_abi ABI>
-  EVE_FORCEINLINE wide<T, N, ABI> rec_(EVE_SUPPORTS(neon128_),
-                                       wide<T, N, ABI> const &v0) noexcept
+  template<floating_real_scalar_value T, typename N>
+  EVE_FORCEINLINE wide<T, N> rec_(EVE_SUPPORTS(neon128_),
+                                       wide<T, N> const &v0) noexcept
+      requires arm_abi<abi_t<T, N>>
   {
       // estimate 1/x with an extra NR step for full precision
       auto a = refine_rec(v0, raw(rec)(v0));

--- a/include/eve/module/real/core/function/regular/simd/arm/neon/refine_rec.hpp
+++ b/include/eve/module/real/core/function/regular/simd/arm/neon/refine_rec.hpp
@@ -13,12 +13,13 @@
 
 namespace eve::detail
 {
-  template<floating_real_scalar_value T, typename N, arm_abi ABI>
-  EVE_FORCEINLINE wide<T, N, ABI> refine_rec_(EVE_SUPPORTS(neon128_)
-                                             , wide<T, N, ABI> const& a0
-                                             , wide<T, N, ABI> const& a1) noexcept
+  template<floating_real_scalar_value T, typename N>
+  EVE_FORCEINLINE wide<T, N> refine_rec_(EVE_SUPPORTS(neon128_)
+                                             , wide<T, N> const& a0
+                                             , wide<T, N> const& a1) noexcept
+      requires arm_abi<abi_t<T, N>>
   {
-    constexpr auto cat = categorize<wide<T, N, ABI>>();
+    constexpr auto cat = categorize<wide<T, N>>();
 
          if constexpr( cat == category::float32x2) return vmul_f32(vrecps_f32(a0, a1), a1);
     else if constexpr( cat == category::float32x4) return vmulq_f32(vrecpsq_f32(a0, a1), a1);

--- a/include/eve/module/real/core/function/regular/simd/arm/neon/rshl.hpp
+++ b/include/eve/module/real/core/function/regular/simd/arm/neon/rshl.hpp
@@ -13,18 +13,20 @@
 
 namespace eve::detail
 {
-  template<integral_real_scalar_value T, typename N, integral_real_scalar_value I, arm_abi ABI>
-  EVE_FORCEINLINE wide<T, N, ABI> rshl_(EVE_SUPPORTS(neon128_),
-                                        wide<T, N, ABI> const &v0,
-                                        wide<I, N, ABI> const &v1) noexcept
+  template<integral_real_scalar_value T, typename N, integral_real_scalar_value I>
+  EVE_FORCEINLINE wide<T, N> rshl_(EVE_SUPPORTS(neon128_),
+                                        wide<T, N> const &v0,
+                                        wide<I, N> const &v1) noexcept
+      requires arm_abi<abi_t<T, N>>
   {
     return neon_shifter(v0, v1);
   }
 
-  template<integral_real_scalar_value T, typename N, integral_real_scalar_value I, arm_abi ABI>
-  EVE_FORCEINLINE wide<T, N, ABI> rshl_(EVE_SUPPORTS(neon128_),
-                                        wide<T, N, ABI> const &v0,
+  template<integral_real_scalar_value T, typename N, integral_real_scalar_value I>
+  EVE_FORCEINLINE wide<T, N> rshl_(EVE_SUPPORTS(neon128_),
+                                        wide<T, N> const &v0,
                                         I const &v1) noexcept
+      requires arm_abi<abi_t<T, N>>
   {
     using i_t = wide<as_integer_t<T, signed>, N>;
     return eve::rshl(v0, i_t(v1));

--- a/include/eve/module/real/core/function/regular/simd/arm/neon/rshr.hpp
+++ b/include/eve/module/real/core/function/regular/simd/arm/neon/rshr.hpp
@@ -13,18 +13,20 @@
 
 namespace eve::detail
 {
-  template<integral_real_scalar_value T, typename N, integral_real_scalar_value I, arm_abi ABI>
-  EVE_FORCEINLINE wide<T, N, ABI> rshr_(EVE_SUPPORTS(neon128_),
-                                        wide<T, N, ABI> const &v0,
-                                        wide<I, N, ABI> const &v1) noexcept
+  template<integral_real_scalar_value T, typename N, integral_real_scalar_value I>
+  EVE_FORCEINLINE wide<T, N> rshr_(EVE_SUPPORTS(neon128_),
+                                        wide<T, N> const &v0,
+                                        wide<I, N> const &v1) noexcept
+      requires arm_abi<abi_t<T, N>>
   {
     return neon_shifter(v0, -v1);
   }
 
-  template<integral_real_scalar_value T, typename N, integral_real_scalar_value I, arm_abi ABI>
-  EVE_FORCEINLINE wide<T, N, ABI> rshr_(EVE_SUPPORTS(neon128_),
-                                        wide<T, N, ABI> const &v0,
+  template<integral_real_scalar_value T, typename N, integral_real_scalar_value I>
+  EVE_FORCEINLINE wide<T, N> rshr_(EVE_SUPPORTS(neon128_),
+                                        wide<T, N> const &v0,
                                         I const &v1) noexcept
+      requires arm_abi<abi_t<T, N>>
   {
     using i_t = wide<as_integer_t<T, signed>, N>;
     return eve::rshr(v0, i_t(v1));

--- a/include/eve/module/real/core/function/regular/simd/arm/neon/rsqrt.hpp
+++ b/include/eve/module/real/core/function/regular/simd/arm/neon/rsqrt.hpp
@@ -16,12 +16,13 @@
 
 namespace eve::detail
 {
-  template<floating_real_scalar_value T, typename N, arm_abi ABI>
-  EVE_FORCEINLINE wide<T, N, ABI> rsqrt_(EVE_SUPPORTS(neon128_)
+  template<floating_real_scalar_value T, typename N>
+  EVE_FORCEINLINE wide<T, N> rsqrt_(EVE_SUPPORTS(neon128_)
                                         , raw_type const &
-                                        , wide<T, N, ABI> const& v) noexcept
+                                        , wide<T, N> const& v) noexcept
+      requires arm_abi<abi_t<T, N>>
   {
-    constexpr auto cat = categorize<wide<T, N, ABI>>();
+    constexpr auto cat = categorize<wide<T, N>>();
 
          if constexpr( cat == category::float32x2) return vrsqrte_f32(v);
     else if constexpr( cat == category::float32x4) return vrsqrteq_f32(v);
@@ -33,12 +34,13 @@ namespace eve::detail
     else                                           return map(rsqrt, v);
   }
 
-  template<floating_real_scalar_value T, typename N, arm_abi ABI>
-  EVE_FORCEINLINE wide<T, N, ABI> rsqrt_(EVE_SUPPORTS(neon128_)
-                                        , wide<T, N, ABI> const& v0) noexcept
+  template<floating_real_scalar_value T, typename N>
+  EVE_FORCEINLINE wide<T, N> rsqrt_(EVE_SUPPORTS(neon128_)
+                                        , wide<T, N> const& v0) noexcept
+      requires arm_abi<abi_t<T, N>>
   {
-    constexpr auto cat = categorize<wide<T, N, ABI>>();
-    using that_t = wide<T, N, ABI>;
+    constexpr auto cat = categorize<wide<T, N>>();
+    using that_t = wide<T, N>;
 
     if constexpr( cat == category::float32x2)
     {

--- a/include/eve/module/real/core/function/regular/simd/arm/neon/sqrt.hpp
+++ b/include/eve/module/real/core/function/regular/simd/arm/neon/sqrt.hpp
@@ -19,12 +19,13 @@ namespace eve::detail
 {
   //------------------------------------------------------------------------------------------------
   // Raw version
-  template<floating_real_scalar_value T, typename N, arm_abi ABI>
-  EVE_FORCEINLINE wide<T, N, ABI>  sqrt_(EVE_SUPPORTS(neon128_)
+  template<floating_real_scalar_value T, typename N>
+  EVE_FORCEINLINE wide<T, N>  sqrt_(EVE_SUPPORTS(neon128_)
                                         , raw_type const &
-                                        , wide<T, N, ABI> const &v0) noexcept
+                                        , wide<T, N> const &v0) noexcept
+      requires arm_abi<abi_t<T, N>>
   {
-    constexpr auto cat = categorize<wide<T, N, ABI>>();
+    constexpr auto cat = categorize<wide<T, N>>();
 
           if constexpr(cat == category::float32x2 )   return vsqrt_f32(v0);
     else  if constexpr(cat == category::float32x4 )   return vsqrtq_f32(v0);
@@ -39,11 +40,12 @@ namespace eve::detail
 
   //------------------------------------------------------------------------------------------------
   // Basic version
-  template<floating_real_scalar_value T, typename N, arm_abi ABI>
-  EVE_FORCEINLINE wide<T, N, ABI>  sqrt_(EVE_SUPPORTS(neon128_)
-                                        , wide<T, N, ABI> const &v0) noexcept
+  template<floating_real_scalar_value T, typename N>
+  EVE_FORCEINLINE wide<T, N>  sqrt_(EVE_SUPPORTS(neon128_)
+                                        , wide<T, N> const &v0) noexcept
+      requires arm_abi<abi_t<T, N>>
   {
-    constexpr auto cat = categorize<wide<T, N, ABI>>();
+    constexpr auto cat = categorize<wide<T, N>>();
 
          if constexpr(cat == category::float32x2 ) return vsqrt_f32(v0);
     else if constexpr(cat == category::float32x4 ) return vsqrtq_f32(v0);

--- a/include/eve/module/real/core/function/regular/simd/arm/neon/store.hpp
+++ b/include/eve/module/real/core/function/regular/simd/arm/neon/store.hpp
@@ -14,10 +14,11 @@
 
 namespace eve::detail
 {
-  template<real_scalar_value T, typename N,  arm_abi ABI>
+  template<real_scalar_value T, typename N>
   EVE_FORCEINLINE void store_(EVE_SUPPORTS(neon128_)
-                             , wide<T, N, ABI> const &value
+                             , wide<T, N> const &value
                              , T *ptr) noexcept
+      requires arm_abi<abi_t<T, N>>
   {
     if constexpr( std::is_same_v<abi_t<T, N>,arm_64_> &&  (N::value * sizeof(T) != arm_64_::bytes ))
     {
@@ -25,7 +26,7 @@ namespace eve::detail
     }
     else
     {
-      constexpr auto cat = categorize<wide<T, N, ABI>>();
+      constexpr auto cat = categorize<wide<T, N>>();
            if constexpr( cat == category::float32x2) vst1_f32(ptr, value);
       else if constexpr( cat == category::float32x4) vst1q_f32(ptr, value);
       else if constexpr( cat == category::int64x1)   vst1_s64(ptr, value);
@@ -91,10 +92,11 @@ namespace eve::detail
     }
   }
 #else
-  template<real_scalar_value T, typename S, std::size_t N, arm_abi ABI>
+  template<real_scalar_value T, typename S, std::size_t N>
   EVE_FORCEINLINE void store_(EVE_SUPPORTS(neon128_)
-                             , wide<T, S, ABI> const &value
+                             , wide<T, S> const &value
                              , aligned_ptr<T, N> ptr) noexcept
+      requires arm_abi<abi_t<T, S>>
   {
     store(value, ptr.get());
   }

--- a/include/eve/module/real/core/function/regular/simd/arm/neon/sub.hpp
+++ b/include/eve/module/real/core/function/regular/simd/arm/neon/sub.hpp
@@ -12,9 +12,10 @@
 
 namespace eve::detail
 {
-  template<real_scalar_value T, typename N, arm_abi ABI>
+  template<real_scalar_value T, typename N>
   EVE_FORCEINLINE auto
-  sub_(EVE_SUPPORTS(neon128_), wide<T, N, ABI> v0, wide<T, N, ABI> const &v1) noexcept
+  sub_(EVE_SUPPORTS(neon128_), wide<T, N> v0, wide<T, N> const &v1) noexcept
+      requires arm_abi<abi_t<T, N>>
   {
     return v0 -= v1;
   }

--- a/include/eve/module/real/core/function/regular/simd/arm/neon/trunc.hpp
+++ b/include/eve/module/real/core/function/regular/simd/arm/neon/trunc.hpp
@@ -13,11 +13,12 @@
 
 namespace eve::detail
 {
-  template<floating_real_scalar_value T, typename N, arm_abi ABI>
-  EVE_FORCEINLINE wide<T, N, ABI> trunc_(EVE_SUPPORTS(neon128_)
-                                       , wide<T, N, ABI> const& v) noexcept
+  template<floating_real_scalar_value T, typename N>
+  EVE_FORCEINLINE wide<T, N> trunc_(EVE_SUPPORTS(neon128_)
+                                       , wide<T, N> const& v) noexcept
+      requires arm_abi<abi_t<T, N>>
   {
-    constexpr auto cat = categorize<wide<T, N, ABI>>();
+    constexpr auto cat = categorize<wide<T, N>>();
 
          if constexpr( cat == category::float32x2) return vrnd_f32(v);
     else if constexpr( cat == category::float32x4) return vrndq_f32(v);

--- a/include/eve/module/real/core/function/regular/simd/x86/bit_andnot.hpp
+++ b/include/eve/module/real/core/function/regular/simd/x86/bit_andnot.hpp
@@ -18,13 +18,14 @@ namespace eve ::detail
 {
   // -----------------------------------------------------------------------------------------------
   // 128 bits implementation
-  template<real_scalar_value T, typename N, x86_abi ABI>
-  EVE_FORCEINLINE wide<T, N, ABI> bit_andnot_ ( EVE_SUPPORTS(sse2_)
-                                              , wide<T, N, ABI> const &v0
-                                              , wide<T, N, ABI> const &v1
+  template<real_scalar_value T, typename N>
+  EVE_FORCEINLINE wide<T, N> bit_andnot_ ( EVE_SUPPORTS(sse2_)
+                                              , wide<T, N> const &v0
+                                              , wide<T, N> const &v1
                                               ) noexcept
+      requires x86_abi<abi_t<T, N>>
   {
-    constexpr auto c = categorize<wide<T, N, ABI>>();
+    constexpr auto c = categorize<wide<T, N>>();
     constexpr bool i = c && category::integer_;
 
           if constexpr( c == category::float64x8 )            return _mm512_andnot_pd(v1, v0);

--- a/include/eve/module/real/core/function/regular/simd/x86/fma.hpp
+++ b/include/eve/module/real/core/function/regular/simd/x86/fma.hpp
@@ -14,12 +14,13 @@
 
 namespace eve::detail
 {
-  template<real_scalar_value T, typename N, x86_abi ABI>
-  EVE_FORCEINLINE wide<T, N, ABI> fma_( EVE_SUPPORTS(avx2_)
-                                      , wide<T, N, ABI> const& a
-                                      , wide<T, N, ABI> const& b
-                                      , wide<T, N, ABI> const& c
+  template<real_scalar_value T, typename N>
+  EVE_FORCEINLINE wide<T, N> fma_( EVE_SUPPORTS(avx2_)
+                                      , wide<T, N> const& a
+                                      , wide<T, N> const& b
+                                      , wide<T, N> const& c
                                       ) noexcept
+      requires x86_abi<abi_t<T, N>>
   {
     if constexpr( std::is_integral_v<T> )
     {
@@ -33,7 +34,7 @@ namespace eve::detail
     }
     else
     {
-      constexpr auto cat = categorize<wide<T, N, ABI>>();
+      constexpr auto cat = categorize<wide<T, N>>();
 
             if constexpr( cat == category::float64x8  )   return _mm512_fmadd_pd(a, b, c);
       else  if constexpr( cat == category::float32x16 )   return _mm512_fmadd_ps(a, b, c);

--- a/include/eve/module/real/core/function/regular/simd/x86/fms.hpp
+++ b/include/eve/module/real/core/function/regular/simd/x86/fms.hpp
@@ -15,12 +15,13 @@
 
 namespace eve::detail
 {
-  template<real_scalar_value T, typename N, x86_abi ABI>
-  EVE_FORCEINLINE wide<T, N, ABI> fms_( EVE_SUPPORTS(avx2_)
-                                      , wide<T, N, ABI> const& a
-                                      , wide<T, N, ABI> const& b
-                                      , wide<T, N, ABI> const& c
+  template<real_scalar_value T, typename N>
+  EVE_FORCEINLINE wide<T, N> fms_( EVE_SUPPORTS(avx2_)
+                                      , wide<T, N> const& a
+                                      , wide<T, N> const& b
+                                      , wide<T, N> const& c
                                       ) noexcept
+      requires x86_abi<abi_t<T, N>>
   {
     if constexpr( std::is_integral_v<T> )
     {
@@ -34,7 +35,7 @@ namespace eve::detail
     }
     else
     {
-      constexpr auto cat = categorize<wide<T, N, ABI>>();
+      constexpr auto cat = categorize<wide<T, N>>();
 
             if constexpr( cat == category::float64x8  )  return _mm512_fmsub_pd(a, b, c);
       else  if constexpr( cat == category::float32x16 )  return _mm512_fmsub_ps(a, b, c);

--- a/include/eve/module/real/core/function/regular/simd/x86/if_else.hpp
+++ b/include/eve/module/real/core/function/regular/simd/x86/if_else.hpp
@@ -18,14 +18,15 @@ namespace eve::detail
 {
   //================================================================================================
   // X86 if_else
-  template<scalar_value T, typename N, x86_abi ABI>
-  EVE_FORCEINLINE wide<T, N, ABI> if_else_( EVE_SUPPORTS(sse4_1_)
-                                          , logical<wide<T, N, ABI>> const &v0
-                                          , wide<T, N, ABI> const &v1
-                                          , wide<T, N, ABI> const &v2
+  template<scalar_value T, typename N>
+  EVE_FORCEINLINE wide<T, N> if_else_( EVE_SUPPORTS(sse4_1_)
+                                          , logical<wide<T, N>> const &v0
+                                          , wide<T, N> const &v1
+                                          , wide<T, N> const &v2
                                           ) noexcept
+      requires x86_abi<abi_t<T, N>>
   {
-    constexpr auto c = categorize<wide<T,N,ABI>>();
+    constexpr auto c = categorize<wide<T,N>>();
 
     if constexpr( !abi_t<T, N>::is_wide_logical )
     {
@@ -95,18 +96,19 @@ namespace eve::detail
 
   //================================================================================================
   // Full logical if_else
-  template<real_scalar_value T, typename N, x86_abi ABI>
+  template<real_scalar_value T, typename N>
   EVE_FORCEINLINE auto if_else_ ( EVE_SUPPORTS(sse2_)
-                                , logical<wide<T, N, ABI>> const &v0
-                                , logical<wide<T, N, ABI>> const &v1
-                                , logical<wide<T, N, ABI>> const &v2
+                                , logical<wide<T, N>> const &v0
+                                , logical<wide<T, N>> const &v1
+                                , logical<wide<T, N>> const &v2
                                 ) noexcept
+      requires x86_abi<abi_t<T, N>>
   {
     if constexpr( !abi_t<T, N>::is_wide_logical )
     {
-      using s_t = typename logical<wide<T,N,ABI>>::storage_type;
+      using s_t = typename logical<wide<T,N>>::storage_type;
       auto    r = bit_select(v0.storage().value,v1.storage().value,v2.storage().value);
-      return logical<wide<T,N,ABI>>( s_t{r} );
+      return logical<wide<T,N>>( s_t{r} );
     }
     else
     {

--- a/include/eve/module/real/core/function/regular/simd/x86/is_lessgreater.hpp
+++ b/include/eve/module/real/core/function/regular/simd/x86/is_lessgreater.hpp
@@ -13,12 +13,13 @@
 
 namespace eve::detail
 {
-  template<floating_real_scalar_value T, typename N, x86_abi ABI>
-  EVE_FORCEINLINE logical<wide<T, N, ABI>>
-  is_lessgreater_( EVE_SUPPORTS(sse2_), wide<T,N,ABI> const& a, wide<T,N,ABI> const& b) noexcept
+  template<floating_real_scalar_value T, typename N>
+  EVE_FORCEINLINE logical<wide<T, N>>
+  is_lessgreater_( EVE_SUPPORTS(sse2_), wide<T,N> const& a, wide<T,N> const& b) noexcept
+      requires x86_abi<abi_t<T, N>>
   {
-    using l_t = logical<wide<T, N, ABI>>;
-    constexpr auto c = categorize<wide<T,N,ABI>>();
+    using l_t = logical<wide<T, N>>;
+    constexpr auto c = categorize<wide<T,N>>();
     constexpr auto m = _CMP_NEQ_OQ;
 
     if constexpr( current_api >= eve::avx512 )

--- a/include/eve/module/real/core/function/regular/simd/x86/is_not_greater_equal.hpp
+++ b/include/eve/module/real/core/function/regular/simd/x86/is_not_greater_equal.hpp
@@ -13,14 +13,15 @@
 
 namespace eve::detail
 {
-  template<floating_real_scalar_value T, typename N, x86_abi ABI>
-  EVE_FORCEINLINE logical<wide<T, N, ABI>>
+  template<floating_real_scalar_value T, typename N>
+  EVE_FORCEINLINE logical<wide<T, N>>
   is_not_greater_equal_ ( EVE_SUPPORTS(sse2_)
-                        , wide<T,N,ABI> const& a, wide<T,N,ABI> const& b
+                        , wide<T,N> const& a, wide<T,N> const& b
                         ) noexcept
+      requires x86_abi<abi_t<T, N>>
   {
-    using s_t = typename logical<wide<T, N, ABI>>::storage_type;
-    constexpr auto c = categorize<wide<T,N,ABI>>();
+    using s_t = typename logical<wide<T, N>>::storage_type;
+    constexpr auto c = categorize<wide<T,N>>();
 
     if constexpr( !x86_128_::is_wide_logical )
     {

--- a/include/eve/module/real/core/function/regular/simd/x86/is_ordered.hpp
+++ b/include/eve/module/real/core/function/regular/simd/x86/is_ordered.hpp
@@ -14,12 +14,13 @@
 
 namespace eve::detail
 {
-  template<floating_real_scalar_value T, typename N, x86_abi ABI>
-  EVE_FORCEINLINE logical<wide<T, N, ABI>>
-  is_ordered_( EVE_SUPPORTS(sse2_), wide<T,N,ABI> const& a, wide<T,N,ABI> const& b) noexcept
+  template<floating_real_scalar_value T, typename N>
+  EVE_FORCEINLINE logical<wide<T, N>>
+  is_ordered_( EVE_SUPPORTS(sse2_), wide<T,N> const& a, wide<T,N> const& b) noexcept
+      requires x86_abi<abi_t<T, N>>
   {
-    using l_t = logical<wide<T, N, ABI>>;
-    constexpr auto c = categorize<wide<T,N,ABI>>();
+    using l_t = logical<wide<T, N>>;
+    constexpr auto c = categorize<wide<T,N>>();
     constexpr auto m = _CMP_ORD_Q;
 
           if constexpr( c && category::integer_    )  return true_(eve::as<l_t>());

--- a/include/eve/module/real/core/function/regular/simd/x86/is_unordered.hpp
+++ b/include/eve/module/real/core/function/regular/simd/x86/is_unordered.hpp
@@ -14,12 +14,13 @@
 
 namespace eve::detail
 {
-  template<floating_real_scalar_value T, typename N, x86_abi ABI>
-  EVE_FORCEINLINE logical<wide<T, N, ABI>>
-  is_unordered_( EVE_SUPPORTS(sse2_), wide<T,N,ABI> const& a, wide<T,N,ABI> const& b) noexcept
+  template<floating_real_scalar_value T, typename N>
+  EVE_FORCEINLINE logical<wide<T, N>>
+  is_unordered_( EVE_SUPPORTS(sse2_), wide<T,N> const& a, wide<T,N> const& b) noexcept
+      requires x86_abi<abi_t<T, N>>
   {
-    using l_t = logical<wide<T, N, ABI>>;
-    constexpr auto c = categorize<wide<T,N,ABI>>();
+    using l_t = logical<wide<T, N>>;
+    constexpr auto c = categorize<wide<T,N>>();
     constexpr auto m = _CMP_UNORD_Q;
 
           if constexpr( c && category::integer_    )  return false_(eve::as<l_t>());

--- a/include/eve/module/real/core/function/regular/simd/x86/store.hpp
+++ b/include/eve/module/real/core/function/regular/simd/x86/store.hpp
@@ -17,10 +17,11 @@
 
 namespace eve::detail
 {
-  template< scalar_value T, typename N, x86_abi ABI
-          , simd_compatible_ptr<wide<T, N, ABI>> Ptr
+  template< scalar_value T, typename N
+          , simd_compatible_ptr<wide<T, N>> Ptr
           >
-  EVE_FORCEINLINE void store_(EVE_SUPPORTS(sse2_), wide<T, N, ABI> const &value, Ptr ptr) noexcept
+  EVE_FORCEINLINE void store_(EVE_SUPPORTS(sse2_), wide<T, N> const &value, Ptr ptr) noexcept
+      requires x86_abi<abi_t<T, N>>
   {
     if constexpr( !std::is_pointer_v<Ptr> )
     {
@@ -71,14 +72,15 @@ namespace eve::detail
     }
   }
 
-  template< scalar_value T, typename N, x86_abi ABI
+  template< scalar_value T, typename N
           , relative_conditional_expr C
-          , simd_compatible_ptr<wide<T, N, ABI>> Ptr
+          , simd_compatible_ptr<wide<T, N>> Ptr
           >
   EVE_FORCEINLINE void store_(EVE_SUPPORTS(sse2_),
                               C const &cond,
-                              wide<T, N, ABI> const &v,
+                              wide<T, N> const &v,
                               Ptr ptr) noexcept
+      requires x86_abi<abi_t<T, N>>
   {
 
          if constexpr ( C::is_complete || C::has_alternative ) store_(EVE_RETARGET(cpu_), cond, v, ptr);
@@ -93,9 +95,9 @@ namespace eve::detail
       }
       else
       {
-        constexpr auto c = categorize<wide<T, N, ABI>>();
+        constexpr auto c = categorize<wide<T, N>>();
 
-        auto m = cond.mask(as_<as_integer_t<wide<T, N, ABI>>>{});
+        auto m = cond.mask(as_<as_integer_t<wide<T, N>>>{});
 
              if constexpr ( c == category::float64x2 )                         _mm_maskstore_pd   (ptr, m, v);
         else if constexpr ( c == category::float64x4 )                         _mm256_maskstore_pd(ptr, m, v);
@@ -112,7 +114,7 @@ namespace eve::detail
       if constexpr ( Ptr::alignment() < 16 || sizeof(T) < 4 ) store[cond](v, ptr.get());
       else
       {
-        constexpr auto c = categorize<wide<T, N, ABI>>();
+        constexpr auto c = categorize<wide<T, N>>();
 
         auto m = cond.mask(as(v)).storage().value;
 
@@ -132,7 +134,7 @@ namespace eve::detail
     }
     else if constexpr ( current_api >= eve::avx512 )
     {
-      constexpr auto c = categorize<wide<T, N, ABI>>();
+      constexpr auto c = categorize<wide<T, N>>();
 
       auto m = cond.mask(as(v)).storage().value;
 


### PR DESCRIPTION
The basic run of the automatic replacer.
Some `wide<T, N, ABI>` didn't get picker up, I suspect there might be some files that actually never included.
Or the clang-tidy running script might be bad.

W/e this does quite a bit.