### PR TITLE
FIX-670: manual fixes for specifically mentioned ABI

### DIFF
--- a/include/eve/detail/function/simd/common/combine.hpp
+++ b/include/eve/detail/function/simd/common/combine.hpp
@@ -25,7 +25,7 @@ namespace eve::detail
     {
       return apply<N::value>([&](auto... I) { return that_t {l.get(I)..., h.get(I)...}; });
     }
-    else if constexpr( is_aggregated_v<abi_t<T, N>> )
+    else if constexpr( has_aggregated_abi_v<that_t> )
     {
       that_t that;
 
@@ -46,7 +46,7 @@ namespace eve::detail
     {
       return apply<N::value>([&](auto... I) { return that_t {l.get(I)..., h.get(I)...}; });
     }
-    else if constexpr( is_aggregated_v<abi_t<T, N>> )
+    else if constexpr( has_aggregated_abi_v<that_t> )
     {
       that_t that;
 

--- a/include/eve/detail/function/simd/x86/combine.hpp
+++ b/include/eve/detail/function/simd/x86/combine.hpp
@@ -92,7 +92,7 @@ namespace eve::detail
   combine ( avx512_ const & , logical<wide<T, N>> const &l
                             , logical<wide<T, N>> const &h
           ) noexcept
-      requires x86_abi<abi_t<T, N>>
+    requires x86_abi<abi_t<T, N>>
   {
     using s_t = typename logical<wide<T, typename N::combined_type>>::storage_type;
     using i_t  = typename s_t::type;

--- a/include/eve/detail/function/simd/x86/combine.hpp
+++ b/include/eve/detail/function/simd/x86/combine.hpp
@@ -92,7 +92,7 @@ namespace eve::detail
   combine ( avx512_ const & , logical<wide<T, N>> const &l
                             , logical<wide<T, N>> const &h
           ) noexcept
-    requires x86_abi<abi_t<T, N>>
+      requires x86_abi<abi_t<T, typename N::combined_type>>
   {
     using s_t = typename logical<wide<T, typename N::combined_type>>::storage_type;
     using i_t  = typename s_t::type;

--- a/include/eve/detail/function/simd/x86/combine.hpp
+++ b/include/eve/detail/function/simd/x86/combine.hpp
@@ -7,8 +7,10 @@
 //==================================================================================================
 #pragma once
 
+#include <eve/concept/abi.hpp>
 #include <eve/detail/function/simd/x86/make.hpp>
 #include <eve/detail/implementation.hpp>
+
 
 namespace eve::detail
 {
@@ -17,34 +19,45 @@ namespace eve::detail
   //================================================================================================
   template<typename T, typename N>
   EVE_FORCEINLINE auto
-  combine(sse2_ const &, wide<T, N, x86_128_> const &l, wide<T, N, x86_128_> const &h) noexcept
+  combine(sse2_ const &, wide<T, N> const &l, wide<T, N> const &h) noexcept
+    requires x86_abi<abi_t<T, N>>
   {
     using t_t = wide<T, typename N::combined_type>;
     using s_t = typename t_t::storage_type;
 
-    //==============================================================================================
-    // If we aggregate two fully sized wide, just coalesce inside new storage
-    if constexpr( N::value * sizeof(T) == eve::x86_128_::bytes )
+         if constexpr ( has_aggregated_abi_v<t_t>                 )  return s_t {l , h};
+    else if constexpr ( native_simd_for_abi<wide<T, N>, x86_256_> )  // 256 -> 512 on avx512
     {
-      return s_t {l, h};
+      if constexpr( std::same_as<T, double> )
+      {
+        auto il = _mm512_castpd_si512(_mm512_castpd256_pd512(l));
+        return _mm512_castsi512_pd(_mm512_inserti64x4(il, _mm256_castpd_si256(h), 1));
+      }
+      else if constexpr( std::same_as<T, float> )
+      {
+        auto il = _mm512_castps_si512(_mm512_castps256_ps512(l));
+        return _mm512_castsi512_ps(_mm512_inserti32x8(il, _mm256_castps_si256(h), 1));
+      }
+      else
+      {
+        return _mm512_inserti64x4(_mm512_castsi256_si512(l), h, 1);
+      }
     }
-    //==============================================================================================
-    // Handle half-storage
-    //==============================================================================================
-    else if constexpr( 2 * N::value * sizeof(T) == eve::x86_128_::bytes )
+    else if constexpr ( native_simd_for_abi<wide<T, N>, x86_128_> )  // 128 -> 256 on avx2
+    {
+            if constexpr( std::same_as<T, double>) return _mm256_insertf128_pd   (_mm256_castpd128_pd256(l), h, 1);
+      else  if constexpr( std::same_as<T, float> ) return _mm256_insertf128_ps   (_mm256_castps128_ps256(l), h, 1);
+      else                                         return _mm256_insertf128_si256(_mm256_castsi128_si256(l), h, 1);
+    }
+    else if constexpr( N() * sizeof(T) == 8 )
     {
             if constexpr( std::same_as<T, double> ) return _mm_shuffle_pd(l, h, 0);
       else  if constexpr( std::same_as<T, float > ) return _mm_shuffle_ps(l, h, 0x44);
-      else  if constexpr( std::integral<T> )
-      {
-        return _mm_castps_si128(
-            _mm_shuffle_ps(_mm_castsi128_ps(l.storage()), _mm_castsi128_ps(h.storage()), 0x44));
-      }
+      else                                          return _mm_castps_si128(_mm_shuffle_ps(_mm_castsi128_ps(l),
+                                                                            _mm_castsi128_ps(h),
+                                                                            0x44));
     }
-    //==============================================================================================
-    // Handle quarter-storage
-    //==============================================================================================
-    else if constexpr( 4 * N::value * sizeof(T) == eve::x86_128_::bytes )
+    else if constexpr( N() * sizeof(T) == 4 )
     {
       if constexpr( std::same_as<T, float> )
       {
@@ -52,103 +65,27 @@ namespace eve::detail
         that.set(1,h.get(0));
         return that.storage();
       }
-      else if constexpr( std::integral<T> )
+      else
       {
-        return _mm_shuffle_epi32(
-            _mm_castps_si128(
-                _mm_shuffle_ps(_mm_castsi128_ps(l.storage()), _mm_castsi128_ps(h.storage()), 0x44)),
-            0x88);
+        auto shuffle_ps = _mm_shuffle_ps(_mm_castsi128_ps(l), _mm_castsi128_ps(h), 0x44);
+        return _mm_shuffle_epi32(_mm_castps_si128(shuffle_ps), 0x88);
       }
     }
     //==============================================================================================
     // Handle 1/8th and 1/16th -storage - Those cases are obviously integrals
     //==============================================================================================
-    else if constexpr( std::integral<T> && ((sizeof(T) != 8) && (N::value == 2)) )
+    else if constexpr( N()== 2 )
     {
       return make(eve::as_<t_t> {}, l.get(0), l.get(1), h.get(0), h.get(1));
     }
-    else if constexpr( std::integral<T> && (sizeof(T) != 8) && (N::value == 1) )
+    else if constexpr( N() == 1 )
     {
       return make(eve::as_<t_t> {}, l.get(0), h.get(0));
     }
   }
 
   //================================================================================================
-  // 256-bits combine
-  //================================================================================================
-  template<typename T, typename N>
-  EVE_FORCEINLINE auto
-  combine(avx_ const &, wide<T, N, x86_256_> const &l, wide<T, N, x86_256_> const &h) noexcept
-  {
-    using that_t = typename wide<T, typename N::combined_type>::storage_type;
-    return that_t {l, h};
-  }
-
-  //================================================================================================
-  // 512-bits combine
-  //================================================================================================
-  template<typename T, typename N>
-  EVE_FORCEINLINE auto
-  combine(avx512_ const &, wide<T, N, x86_512_> const &l, wide<T, N, x86_512_> const &h) noexcept
-  {
-    using that_t = typename wide<T, typename N::combined_type>::storage_type;
-    return that_t {l, h};
-  }
-
-  template<typename T, typename N>
-  EVE_FORCEINLINE auto
-  combine ( avx512_ const & , logical<wide<T, N, x86_512_>> const &l
-                            , logical<wide<T, N, x86_512_>> const &h
-          ) noexcept
-  {
-    using that_t = typename logical<wide<T, typename N::combined_type>>::storage_type;
-    return that_t{l, h};
-  }
-
-  //================================================================================================
-  // 2*128-bits to 256-bits combine
-  //================================================================================================
-  template<typename T, typename N>
-  EVE_FORCEINLINE auto
-  combine(avx_ const &, wide<T, N, x86_128_> const &l, wide<T, N, x86_128_> const &h) noexcept
-  {
-    if constexpr( N::value * sizeof(T) == eve::x86_128_::bytes )
-    {
-            if constexpr( std::same_as<T, double>) return _mm256_insertf128_pd(_mm256_castpd128_pd256(l), h, 1);
-      else  if constexpr( std::same_as<T, float> ) return _mm256_insertf128_ps(_mm256_castps128_ps256(l), h, 1);
-      else  if constexpr( std::integral<T>       ) return _mm256_insertf128_si256(_mm256_castsi128_si256(l), h, 1);
-    }
-    else
-    {
-      return combine(sse2_ {}, l, h);
-    }
-  }
-
-  //================================================================================================
-  // 2*256-bits to 512-bits combine
-  //================================================================================================
-  template<typename T, typename N>
-  EVE_FORCEINLINE auto
-  combine(avx512_ const &, wide<T, N, x86_256_> const &l, wide<T, N, x86_256_> const &h) noexcept
-  {
-    if constexpr( std::same_as<T, double> )
-    {
-      auto il = _mm512_castpd_si512(_mm512_castpd256_pd512(l));
-      return _mm512_castsi512_pd(_mm512_inserti64x4(il, _mm256_castpd_si256(h), 1));
-    }
-    else if constexpr( std::same_as<T, float> )
-    {
-      auto il = _mm512_castps_si512(_mm512_castps256_ps512(l));
-      return _mm512_castsi512_ps(_mm512_inserti32x8(il, _mm256_castps_si256(h), 1));
-    }
-    else if constexpr( std::integral<T> )
-    {
-      return _mm512_inserti64x4(_mm512_castsi256_si512(l), h, 1);
-    }
-  }
-
-  //================================================================================================
-  // 2*256-bits to 512-bits combine
+  // Non aggregated, skinny logicals
   //================================================================================================
   template<typename T, typename N>
   EVE_FORCEINLINE auto

--- a/include/eve/detail/function/simd/x86/lookup.hpp
+++ b/include/eve/detail/function/simd/x86/lookup.hpp
@@ -14,8 +14,9 @@
 namespace eve::detail
 {
   template<typename T, typename I, typename N>
-  EVE_FORCEINLINE wide<T, N, x86_128_>
-                  lookup_(EVE_SUPPORTS(ssse3_), wide<T, N, x86_128_> a, wide<I, N, x86_128_> idx) noexcept
+  EVE_FORCEINLINE wide<T, N>
+  lookup_(EVE_SUPPORTS(ssse3_), wide<T, N> a, wide<I, N> idx) noexcept
+    requires std::same_as<abi_t<T, N>, x86_128_>
   {
     // TODO: We use sizeof as a discriminant but we could actually use shuffle
     // to extract the one byte for the lookup form bigger integer and put them inside
@@ -27,10 +28,10 @@ namespace eve::detail
     }
     else
     {
-      using t8_t = typename wide<T, N, x86_128_>::template rebind<std::uint8_t, fixed<16>>;
+      using t8_t = typename wide<T, N>::template rebind<std::uint8_t, fixed<16>>;
 
       t8_t i1 = _mm_shuffle_epi8(  idx << shift<I>, t8_t {repeater<I>});
-      i1      = bit_cast(bit_cast(i1, as<wide<I, N, x86_128_>>()) + offset<I>, as<t8_t>());
+      i1      = bit_cast(bit_cast(i1, as<wide<I, N>>()) + offset<I>, as<t8_t>());
 
       t8_t const blocks = _mm_shuffle_epi8(bit_cast(a, as<t8_t>()), i1);
       return bit_cast(blocks, as(a));

--- a/include/eve/function/add.hpp
+++ b/include/eve/function/add.hpp
@@ -91,7 +91,3 @@ namespace eve
 }
 
 #include <eve/module/real/core/function/regular/generic/add.hpp>
-
-#if defined(EVE_INCLUDE_X86_HEADER)
-#  include <eve/module/real/core/function/regular/simd/x86/floor.hpp>
-#endif

--- a/include/eve/function/add.hpp
+++ b/include/eve/function/add.hpp
@@ -91,3 +91,7 @@ namespace eve
 }
 
 #include <eve/module/real/core/function/regular/generic/add.hpp>
+
+#if defined(EVE_INCLUDE_X86_HEADER)
+#  include <eve/module/real/core/function/regular/simd/x86/floor.hpp>
+#endif

--- a/include/eve/function/floor.hpp
+++ b/include/eve/function/floor.hpp
@@ -16,3 +16,6 @@ namespace eve
 
 #include <eve/module/real/core/function/regular/generic/floor.hpp>
 
+#if defined(EVE_INCLUDE_X86_HEADER)
+#  include <eve/module/real/core/function/regular/simd/x86/floor.hpp>
+#endif

--- a/include/eve/module/real/core/function/pedantic/simd/x86/rsqrt.hpp
+++ b/include/eve/module/real/core/function/pedantic/simd/x86/rsqrt.hpp
@@ -19,7 +19,8 @@ namespace eve::detail
   template<floating_real_scalar_value T, typename N>
   EVE_FORCEINLINE auto rsqrt_(EVE_SUPPORTS(sse2_)
                              , pedantic_type const &
-                             , wide<T, N, x86_128_> const &a0) noexcept
+                             , wide<T, N>    const &a0) noexcept
+    requires std::same_as<abi_t<T, N>, x86_128_>
   {
      return rsqrt_x86_pedantic(a0);
   }

--- a/include/eve/module/real/core/function/regular/simd/x86/average.hpp
+++ b/include/eve/module/real/core/function/regular/simd/x86/average.hpp
@@ -16,32 +16,24 @@
 
 namespace eve::detail
 {
-  // -----------------------------------------------------------------------------------------------
-  // 128 bits implementation
   template<unsigned_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, x86_128_> average_(EVE_SUPPORTS(sse2_)
-                                           , wide<T, N, x86_128_> const &a
-                                           , wide<T, N, x86_128_> const &b) noexcept
+  EVE_FORCEINLINE wide<T, N> average_(EVE_SUPPORTS(sse2_), wide<T, N> a, wide<T, N> b) noexcept
+    requires x86_abi<abi_t<T, N>>
   {
-         if constexpr(sizeof(T) == 1) return _mm_avg_epu8(a, b);
-    else if constexpr(sizeof(T) == 2) return _mm_avg_epu16(a, b);
-    else                              return (a & b) + ((a ^ b) >> 1);
-  }
-
-  // -----------------------------------------------------------------------------------------------
-  // 256 bits implementation
-  template<unsigned_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, x86_256_> average_(EVE_SUPPORTS(avx_)
-                                           , wide<T, N, x86_256_> const &a
-                                           , wide<T, N, x86_256_> const &b) noexcept
-  {
-    if constexpr(current_api >= avx2)
+    if constexpr ( sizeof(T) == 2 )
     {
-             if constexpr(sizeof(T) == 1) return _mm256_avg_epu8(a, b);
-        else if constexpr(sizeof(T) == 2) return _mm256_avg_epu16(a, b);
-        else                              return (a & b) + ((a ^ b) >> 1);
+           if constexpr (                        std::same_as<abi_t<T, N>, x86_512_> ) return _mm512_avg_epu16(a, b);
+      else if constexpr ( current_api >= avx2 && std::same_as<abi_t<T, N>, x86_256_> ) return _mm256_avg_epu16(a, b);
+      else if constexpr (                        std::same_as<abi_t<T, N>, x86_128_> ) return _mm_avg_epu16   (a, b);
+      else                                                                             return average_        (EVE_RETARGET(cpu_), a, b);
     }
-    else                                   return average_(EVE_RETARGET(cpu_), a, b);
-
+    if constexpr ( sizeof(T) == 1 )
+    {
+           if constexpr (                        std::same_as<abi_t<T, N>, x86_512_> ) return _mm512_avg_epu8 (a, b);
+      else if constexpr ( current_api >= avx2 && std::same_as<abi_t<T, N>, x86_256_> ) return _mm256_avg_epu8 (a, b);
+      else if constexpr (                        std::same_as<abi_t<T, N>, x86_128_> ) return _mm_avg_epu8    (a, b);
+      else                                                                             return average_        (EVE_RETARGET(cpu_), a, b);
+    }
+    else return average_(EVE_RETARGET(cpu_), a, b);
   }
 }

--- a/include/eve/module/real/core/function/regular/simd/x86/bit_notand.hpp
+++ b/include/eve/module/real/core/function/regular/simd/x86/bit_notand.hpp
@@ -18,9 +18,8 @@ namespace eve ::detail
   // -----------------------------------------------------------------------------------------------
   // 128 bits implementation
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, x86_128_> bit_notand_(EVE_SUPPORTS(sse2_),
-                                                   wide<T, N, x86_128_> const &v0,
-                                                   wide<T, N, x86_128_> const &v1) noexcept
+  EVE_FORCEINLINE wide<T, N> bit_notand_(EVE_SUPPORTS(sse2_), wide<T, N> const &v0, wide<T, N> const &v1) noexcept
+    requires std::same_as<abi_t<T, N>, x86_128_>
   {
     if constexpr(std::is_same_v<T, float>)       return _mm_andnot_ps(v0, v1);
     else if constexpr(std::is_same_v<T, double>) return _mm_andnot_pd(v0, v1);
@@ -30,9 +29,8 @@ namespace eve ::detail
   // -----------------------------------------------------------------------------------------------
   // 256 bits implementation
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, x86_256_> bit_notand_(EVE_SUPPORTS(avx_),
-                                                   wide<T, N, x86_256_> const &v0,
-                                                   wide<T, N, x86_256_> const &v1) noexcept
+  EVE_FORCEINLINE wide<T, N> bit_notand_(EVE_SUPPORTS(avx_), wide<T, N> const &v0, wide<T, N> const &v1) noexcept
+    requires std::same_as<abi_t<T, N>, x86_256_>
   {
     if constexpr(std::is_same_v<T, float>)       return _mm256_andnot_ps(v0, v1);
     else if constexpr(std::is_same_v<T, double>) return _mm256_andnot_pd(v0, v1);
@@ -46,9 +44,8 @@ namespace eve ::detail
   // -----------------------------------------------------------------------------------------------
   // 512 bits implementation
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, x86_512_> bit_notand_(EVE_SUPPORTS(avx512_),
-                                                   wide<T, N, x86_512_> const &v0,
-                                                   wide<T, N, x86_512_> const &v1) noexcept
+  EVE_FORCEINLINE wide<T, N> bit_notand_(EVE_SUPPORTS(avx512_), wide<T, N> const &v0, wide<T, N> const &v1) noexcept
+    requires std::same_as<abi_t<T, N>, x86_512_>
   {
          if constexpr ( std::is_same_v<T, double> ) return _mm512_andnot_pd(v0, v1);
     else if constexpr ( std::is_same_v<T, float>  ) return _mm512_andnot_ps(v0, v1);

--- a/include/eve/module/real/core/function/regular/simd/x86/bit_select.hpp
+++ b/include/eve/module/real/core/function/regular/simd/x86/bit_select.hpp
@@ -16,17 +16,18 @@
 namespace eve::detail
 {
   template<typename U, typename T, typename N>
-  EVE_FORCEINLINE wide<T, N, x86_128_> bit_select_(EVE_SUPPORTS(avx_),
-                                                   wide<U, N, x86_128_> const &v0,
-                                                   wide<T, N, x86_128_> const &v1,
-                                                   wide<T, N, x86_128_> const &v2) noexcept
+  EVE_FORCEINLINE wide<T, N> bit_select_(EVE_SUPPORTS(avx_),
+                                         wide<U, N> const &v0,
+                                         wide<T, N> const &v1,
+                                         wide<T, N> const &v2) noexcept
+    requires std::same_as<abi_t<T, N>, x86_128_>
   {
     if constexpr(supports_xop)
     {
       if constexpr(std::is_floating_point_v<T>)
       {
-        using itype = wide<as_integer_t<T, unsigned>, N, x86_128_>;
-        using utype = wide<as_integer_t<U, unsigned>, N, x86_128_>;
+        using itype = wide<as_integer_t<T, unsigned>, N>;
+        using utype = wide<as_integer_t<U, unsigned>, N>;
         itype tmp   = _mm_cmov_si128( bit_cast(v1,as_<itype>()),
                                       bit_cast(v2,as_<itype>()),
                                       bit_cast(v0,as_<utype>())
@@ -47,17 +48,18 @@ namespace eve::detail
 
 #if defined(SPY_COMPILER_IS_MSVC)
   template<typename U, typename T, typename N>
-  EVE_FORCEINLINE wide<T, N, x86_256_> bit_select_(EVE_SUPPORTS(avx_),
-                                                   wide<U, N, x86_256_> const &v0,
-                                                   wide<T, N, x86_256_> const &v1,
-                                                   wide<T, N, x86_256_> const &v2) noexcept
+  EVE_FORCEINLINE wide<T, N> bit_select_(EVE_SUPPORTS(avx_),
+                                         wide<U, N> const &v0,
+                                         wide<T, N> const &v1,
+                                         wide<T, N> const &v2) noexcept
+    requires std::same_as<abi_t<T, N>, x86_256_>
   {
     if constexpr(supports_xop)
     {
       if constexpr(std::is_floating_point_v<T>)
       {
-        using itype = wide<as_integer_t<T, unsigned>, N, x86_256_>;
-        using utype = wide<as_integer_t<U, unsigned>, N, x86_256_>;
+        using itype = wide<as_integer_t<T, unsigned>, N>;
+        using utype = wide<as_integer_t<U, unsigned>, N>;
         itype tmp   =  _mm256_cmov_si256( bit_cast(v1,as_<itype>()),
                                           bit_cast(v2,as_<itype>()),
                                           bit_cast(v0,as_<utype>())

--- a/include/eve/module/real/core/function/regular/simd/x86/ceil.hpp
+++ b/include/eve/module/real/core/function/regular/simd/x86/ceil.hpp
@@ -20,21 +20,20 @@ namespace eve::detail
   //-----------------------------------------------------------------------------------------------
   // 128 bits implementation
   template<floating_real_scalar_value T, typename N, typename ABI>
-  EVE_FORCEINLINE wide<T, N, x86_128_> ceil_(EVE_SUPPORTS(sse4_1_)
-                                        , wide<T, N, x86_128_> const &a0) noexcept
+  EVE_FORCEINLINE wide<T, N> ceil_(EVE_SUPPORTS(sse4_1_), wide<T, N> const &a0) noexcept
+    requires std::same_as<abi_t<T, N>, x86_128_>
   {
-    if constexpr(std::is_same_v<T, double>)     return _mm_ceil_pd(a0);
-    else if constexpr(std::is_same_v<T, float>) return _mm_ceil_ps(a0);
+         if constexpr (std::is_same_v<T, double>) return _mm_ceil_pd(a0);
+    else if constexpr (std::is_same_v<T, float> ) return _mm_ceil_ps(a0);
   }
 
   //-----------------------------------------------------------------------------------------------
   // 256 bits implementation
   template<floating_real_scalar_value T, typename N, typename ABI>
-  EVE_FORCEINLINE wide<T, N, x86_256_> ceil_(EVE_SUPPORTS(avx_)
-                                        , wide<T, N, x86_256_> const &a0) noexcept
+  EVE_FORCEINLINE wide<T, N> ceil_(EVE_SUPPORTS(avx_), wide<T, N> const &a0) noexcept
+    requires std::same_as<abi_t<T, N>, x86_256_>
   {
-    if constexpr(std::is_same_v<T, double>)     return _mm256_round_pd(a0, _MM_FROUND_CEIL);
-    else if constexpr(std::is_same_v<T, float>) return _mm256_round_ps(a0, _MM_FROUND_CEIL);
+         if constexpr (std::is_same_v<T, double>)  return _mm256_round_pd(a0, _MM_FROUND_CEIL);
+    else if constexpr (std::is_same_v<T, float> )  return _mm256_round_ps(a0, _MM_FROUND_CEIL);
   }
 }
-

--- a/include/eve/module/real/core/function/regular/simd/x86/ceil.hpp
+++ b/include/eve/module/real/core/function/regular/simd/x86/ceil.hpp
@@ -17,23 +17,21 @@
 
 namespace eve::detail
 {
-  //-----------------------------------------------------------------------------------------------
-  // 128 bits implementation
   template<floating_real_scalar_value T, typename N, typename ABI>
   EVE_FORCEINLINE wide<T, N> ceil_(EVE_SUPPORTS(sse4_1_), wide<T, N> const &a0) noexcept
-    requires std::same_as<abi_t<T, N>, x86_128_>
+    requires x86_abi<abi_t<T, N>>
   {
-         if constexpr (std::is_same_v<T, double>) return _mm_ceil_pd(a0);
-    else if constexpr (std::is_same_v<T, float> ) return _mm_ceil_ps(a0);
-  }
-
-  //-----------------------------------------------------------------------------------------------
-  // 256 bits implementation
-  template<floating_real_scalar_value T, typename N, typename ABI>
-  EVE_FORCEINLINE wide<T, N> ceil_(EVE_SUPPORTS(avx_), wide<T, N> const &a0) noexcept
-    requires std::same_as<abi_t<T, N>, x86_256_>
-  {
-         if constexpr (std::is_same_v<T, double>)  return _mm256_round_pd(a0, _MM_FROUND_CEIL);
-    else if constexpr (std::is_same_v<T, float> )  return _mm256_round_ps(a0, _MM_FROUND_CEIL);
+    if constexpr (std::same_as<T, double> )
+    {
+           if constexpr (std::same_as<abi_t<T, N>, x86_512_>) return _mm512_roundscale_pd(a0, _MM_FROUND_CEIL);
+      else if constexpr (std::same_as<abi_t<T, N>, x86_256_>) return _mm256_round_pd     (a0, _MM_FROUND_CEIL);
+      else                                                    return _mm_ceil_pd         (a0);
+    }
+    else
+    {
+           if constexpr (std::same_as<abi_t<T, N>, x86_512_>) return _mm512_roundscale_ps(a0, _MM_FROUND_CEIL);
+      else if constexpr (std::same_as<abi_t<T, N>, x86_256_>) return _mm256_round_ps     (a0, _MM_FROUND_CEIL);
+      else                                                    return _mm_ceil_ps         (a0);
+    }
   }
 }

--- a/include/eve/module/real/core/function/regular/simd/x86/convert_128.hpp
+++ b/include/eve/module/real/core/function/regular/simd/x86/convert_128.hpp
@@ -32,7 +32,8 @@ namespace eve::detail
   //================================================================================================
   template<real_scalar_value In, typename N, real_scalar_value Out>
   EVE_FORCEINLINE wide<Out, N>
-  convert_(EVE_SUPPORTS(sse2_), wide<In, N, x86_128_> const &v0, as_<Out> const &tgt) noexcept
+  convert_(EVE_SUPPORTS(sse2_), wide<In, N> const &v0, as_<Out> const &tgt) noexcept
+    requires std::same_as<abi_t<In, N>, x86_128_>
   {
     //==============================================================================================
     // Idempotent call

--- a/include/eve/module/real/core/function/regular/simd/x86/convert_256.hpp
+++ b/include/eve/module/real/core/function/regular/simd/x86/convert_256.hpp
@@ -23,7 +23,8 @@ namespace eve::detail
   //================================================================================================
   template<real_scalar_value In, typename N, real_scalar_value Out>
   EVE_FORCEINLINE wide<Out, N>
-  convert_(EVE_SUPPORTS(avx_), wide<In, N, x86_256_> const &v0, as_<Out> const &tgt) noexcept
+  convert_(EVE_SUPPORTS(avx_), wide<In, N> const &v0, as_<Out> const &tgt) noexcept
+    requires std::same_as<abi_t<In, N>, x86_256_>
   {
     if constexpr( std::is_same_v<In, Out> )
     {
@@ -48,7 +49,8 @@ namespace eve::detail
   //================================================================================================
   template<real_scalar_value In, typename N, real_scalar_value Out>
   EVE_FORCEINLINE wide<Out, N>
-  convert_(EVE_SUPPORTS(avx_), wide<In, N, x86_128_> const &v0, as_<Out> const &tgt) noexcept
+  convert_(EVE_SUPPORTS(avx_), wide<In, N> const &v0, as_<Out> const &tgt) noexcept
+    requires std::same_as<abi_t<In, N>, x86_128_>
   {
     //==============================================================================================
     // Idempotent call

--- a/include/eve/module/real/core/function/regular/simd/x86/div.hpp
+++ b/include/eve/module/real/core/function/regular/simd/x86/div.hpp
@@ -12,22 +12,10 @@
 
 namespace eve::detail
 {
-  // -----------------------------------------------------------------------------------------------
-  // 128 bits implementation
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, x86_128_>
-                  div_(EVE_SUPPORTS(sse2_), wide<T, N, x86_128_> v0, wide<T, N, x86_128_> const &v1) noexcept
-  {
-    return v0 /= v1;
-  }
-
-  // -----------------------------------------------------------------------------------------------
-  // 256 bits implementation
-  template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, x86_256_>
-                  div_(EVE_SUPPORTS(avx_), wide<T, N, x86_256_> v0, wide<T, N, x86_256_> const &v1) noexcept
+  EVE_FORCEINLINE wide<T, N> div_(EVE_SUPPORTS(sse2_), wide<T, N> v0, wide<T, N> const &v1) noexcept
+    requires x86_abi<abi_t<T, N>>
   {
     return v0 /= v1;
   }
 }
-

--- a/include/eve/module/real/core/function/regular/simd/x86/floor.hpp
+++ b/include/eve/module/real/core/function/regular/simd/x86/floor.hpp
@@ -18,20 +18,20 @@
 namespace eve::detail
 {
   template<floating_scalar_value T, typename N, typename ABI>
-  EVE_FORCEINLINE wide<T, N, x86_128_> floor_(EVE_SUPPORTS(sse4_1_),
-                                          wide<T, N, x86_128_> const &a0) noexcept
+  EVE_FORCEINLINE wide<T, N> floor_(EVE_SUPPORTS(sse4_1_), wide<T, N> a0) noexcept
+    requires x86_abi<abi_t<T, N>>
   {
-         if constexpr(std::is_same_v<T, double>) return _mm_floor_pd(a0);
-    else if constexpr(std::is_same_v<T, float>)  return _mm_floor_ps(a0);
-  }
-
-  //-----------------------------------------------------------------------------------------------
-  // 256 bits implementation
-  template<floating_scalar_value T, typename N, typename ABI>
-  EVE_FORCEINLINE wide<T, N, x86_256_> floor_(EVE_SUPPORTS(avx_), wide<T, N, x86_256_> const &a0) noexcept
-  {
-         if constexpr(std::is_same_v<T, double>) return _mm256_round_pd(a0, _MM_FROUND_FLOOR);
-    else if constexpr(std::is_same_v<T, float>)  return _mm256_round_ps(a0, _MM_FROUND_FLOOR);
+    if constexpr (std::same_as<T, double> )
+    {
+           if constexpr (std::same_as<abi_t<T, N>, x86_512_>) return _mm512_roundscale_pd(a0, _MM_FROUND_TO_ZERO);
+      else if constexpr (std::same_as<abi_t<T, N>, x86_256_>) return _mm256_round_pd     (a0, _MM_FROUND_TO_ZERO);
+      else                                                    return _mm_floor_pd        (a0);
+    }
+    else
+    {
+           if constexpr (std::same_as<abi_t<T, N>, x86_512_>) return _mm512_roundscale_ps(a0, _MM_FROUND_TO_ZERO);
+      else if constexpr (std::same_as<abi_t<T, N>, x86_256_>) return _mm256_round_ps     (a0, _MM_FROUND_TO_ZERO);
+      else                                                    return _mm_floor_ps        (a0);
+    }
   }
 }
-

--- a/include/eve/module/real/core/function/regular/simd/x86/fnma.hpp
+++ b/include/eve/module/real/core/function/regular/simd/x86/fnma.hpp
@@ -18,47 +18,26 @@
 
 namespace eve::detail
 {
-  template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, x86_128_> fnma_(EVE_SUPPORTS(avx2_),
-                                         wide<T, N, x86_128_> const &a,
-                                         wide<T, N, x86_128_> const &b,
-                                         wide<T, N, x86_128_> const &c) noexcept
+  template<floating_scalar_value T, typename N>
+  EVE_FORCEINLINE wide<T, N> fnma_(EVE_SUPPORTS(avx2_),
+                                         wide<T, N> const &a,
+                                         wide<T, N> const &b,
+                                         wide<T, N> const &c) noexcept
+    requires x86_abi<abi_t<T, N>>
   {
-    if constexpr( std::is_floating_point_v<T> )
+    if constexpr ( std::is_same_v<T, double> )
     {
-      if constexpr( supports_fma3 )
-      {
-        if constexpr( std::is_same_v<T, double> )
-          return _mm_fnmadd_pd(a, b, c);
-        else if constexpr( std::is_same_v<T, float> )
-          return _mm_fnmadd_ps(a, b, c);
-      }
-      else
-        return fma(-a, b, c);
+           if constexpr ( std::same_as<abi_t<T, N>, x86_512_>                  ) return _mm512_fnmadd_pd(a, b, c);
+      else if constexpr ( std::same_as<abi_t<T, N>, x86_256_> && supports_fma4 ) return _mm256_fnmadd_pd(a, b, c);
+      else if constexpr ( std::same_as<abi_t<T, N>, x86_128_> && supports_fma3 ) return _mm_fnmadd_pd   (a, b, c);
+      else                                                                       return fnma_           (EVE_RETARGET(cpu_), a, b, c);
     }
     else
-      return fma(-a, b, c);
-  }
-
-  template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, x86_256_> fnma_(EVE_SUPPORTS(avx2_),
-                                         wide<T, N, x86_256_> const &a,
-                                         wide<T, N, x86_256_> const &b,
-                                         wide<T, N, x86_256_> const &c) noexcept
-  {
-    if constexpr( std::is_floating_point_v<T> )
     {
-      if constexpr( supports_fma4 )
-      {
-        if constexpr( std::is_same_v<T, double> )
-          return _mm256_fnmadd_pd(a, b, c);
-        else if constexpr( std::is_same_v<T, float> )
-          return _mm256_fnmadd_ps(a, b, c);
-      }
-      else
-        return fma(-a, b, c);
+           if constexpr ( std::same_as<abi_t<T, N>, x86_512_>                  ) return _mm512_fnmadd_ps(a, b, c);
+      else if constexpr ( std::same_as<abi_t<T, N>, x86_256_> && supports_fma4 ) return _mm256_fnmadd_ps(a, b, c);
+      else if constexpr ( std::same_as<abi_t<T, N>, x86_128_> && supports_fma3 ) return _mm_fnmadd_ps   (a, b, c);
+      else                                                                       return fnma_           (EVE_RETARGET(cpu_), a, b, c);
     }
-    else
-      return fma(-a, b, c);
   }
 }

--- a/include/eve/module/real/core/function/regular/simd/x86/fnms.hpp
+++ b/include/eve/module/real/core/function/regular/simd/x86/fnms.hpp
@@ -19,10 +19,11 @@
 namespace eve::detail
 {
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, x86_128_> fnms_(EVE_SUPPORTS(avx2_),
-                                         wide<T, N, x86_128_> const &a,
-                                         wide<T, N, x86_128_> const &b,
-                                         wide<T, N, x86_128_> const &c) noexcept
+  EVE_FORCEINLINE wide<T, N> fnms_(EVE_SUPPORTS(avx2_),
+                                   wide<T, N> const &a,
+                                   wide<T, N> const &b,
+                                   wide<T, N> const &c) noexcept
+    requires std::same_as<abi_t<T, N>, x86_128_>
   {
     if constexpr( std::is_floating_point_v<T> )
     {
@@ -53,10 +54,11 @@ namespace eve::detail
   }
 
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, x86_256_> fnms_(EVE_SUPPORTS(avx2_),
-                                         wide<T, N, x86_256_> const &a,
-                                         wide<T, N, x86_256_> const &b,
-                                         wide<T, N, x86_256_> const &c) noexcept
+  EVE_FORCEINLINE wide<T, N> fnms_(EVE_SUPPORTS(avx2_),
+                                   wide<T, N> const &a,
+                                   wide<T, N> const &b,
+                                   wide<T, N> const &c) noexcept
+    requires std::same_as<abi_t<T, N>, x86_256_>
   {
     if constexpr( std::is_floating_point_v<T> )
     {

--- a/include/eve/module/real/core/function/regular/simd/x86/frac.hpp
+++ b/include/eve/module/real/core/function/regular/simd/x86/frac.hpp
@@ -21,8 +21,8 @@ namespace eve::detail
   // -----------------------------------------------------------------------------------------------
   // 128 bits implementation for xop
   template<floating_real_scalar_value T, typename N>
-  EVE_FORCEINLINE auto frac_(EVE_SUPPORTS(avx_),
-                             wide<T, N, x86_128_> const &a0) noexcept
+  EVE_FORCEINLINE wide<T, N> frac_(EVE_SUPPORTS(avx_), wide<T, N> const &a0) noexcept
+    requires std::same_as<abi_t<T, N>, x86_128_>
   {
     if constexpr(supports_xop)
     {
@@ -35,12 +35,12 @@ namespace eve::detail
   // -----------------------------------------------------------------------------------------------
   // 256 bits implementation for xop
   template<floating_real_scalar_value T, typename N>
-  EVE_FORCEINLINE auto frac_(EVE_SUPPORTS(avx_),
-                             wide<T, N, x86_256_> const &a0) noexcept
+  EVE_FORCEINLINE wide<T, N> frac_(EVE_SUPPORTS(avx_), wide<T, N> const &a0) noexcept
+    requires std::same_as<abi_t<T, N>, x86_256_>
   {
     if constexpr(supports_xop)
     {
-      if constexpr(std::is_same_v<T, float>)       return _mm256_frcz_ps(a0);
+      if constexpr(std::is_same_v<T, float>      ) return _mm256_frcz_ps(a0);
       else if constexpr(std::is_same_v<T, double>) return _mm256_frcz_pd(a0);
     }
     else  return frac_(EVE_RETARGET(cpu_), a0);

--- a/include/eve/module/real/core/function/regular/simd/x86/if_else.hpp
+++ b/include/eve/module/real/core/function/regular/simd/x86/if_else.hpp
@@ -75,7 +75,7 @@ namespace eve::detail
       else  if constexpr( c == category::float32x4   ) return _mm_blendv_ps   (v2, v1, msk);
       else
       {
-        if constexpr( std::same_as<abi_t<T, N>,x86_128_> ) return _mm_blendv_epi8(v2, v1, msk);
+        if constexpr( std::same_as<abi_t<T, N>, x86_128_> ) return _mm_blendv_epi8(v2, v1, msk);
         else if constexpr(current_api >= avx2)
         {
           using a_t = wide<as_integer_t<T>, N>;
@@ -86,7 +86,7 @@ namespace eve::detail
                 if constexpr(sizeof(T) <= 2)      return aggregate(if_else, v0, v1, v2);
           else  if constexpr(sizeof(T) >= 4)
           {
-            using f_t = wide<as_floating_point_t<T>, N, x86_256_>;
+            using f_t = wide<as_floating_point_t<T>, N>;
             return bit_cast( if_else( v0, bit_cast(v1,as_<f_t>()), bit_cast(v2,as_<f_t>())), as(v2));
           }
         }

--- a/include/eve/module/real/core/function/regular/simd/x86/is_not_greater.hpp
+++ b/include/eve/module/real/core/function/regular/simd/x86/is_not_greater.hpp
@@ -21,10 +21,11 @@ namespace eve::detail
   // 128 bits implementation
   template<floating_real_scalar_value T, typename N>
   EVE_FORCEINLINE auto is_not_greater_(EVE_SUPPORTS(sse2_),
-                                       wide<T, N, x86_128_> const &v0,
-                                       wide<T, N, x86_128_> const &v1) noexcept
+                                       wide<T, N> const &v0,
+                                       wide<T, N> const &v1) noexcept
+    requires std::same_as<abi_t<T, N>, x86_128_>
   {
-    using t_t = wide<T, N, x86_128_>;
+    using t_t = wide<T, N>;
     using l_t = as_logical_t<t_t>;
 
          if constexpr( !x86_128_::is_wide_logical ) return is_not_greater_(EVE_RETARGET(cpu_), v0, v1);
@@ -36,10 +37,11 @@ namespace eve::detail
   // 256 bits implementation
   template<floating_real_scalar_value T, typename N>
   EVE_FORCEINLINE auto is_not_greater_(EVE_SUPPORTS(avx_),
-                                       wide<T, N, x86_256_> const &v0,
-                                       wide<T, N, x86_256_> const &v1) noexcept
+                                       wide<T, N> const &v0,
+                                       wide<T, N> const &v1) noexcept
+    requires std::same_as<abi_t<T, N>, x86_256_>
   {
-    using t_t = wide<T, N, x86_256_>;
+    using t_t = wide<T, N>;
     using l_t = as_logical_t<t_t>;
 
          if constexpr( !x86_256_::is_wide_logical ) return is_not_greater_(EVE_RETARGET(cpu_), v0, v1);

--- a/include/eve/module/real/core/function/regular/simd/x86/is_not_less.hpp
+++ b/include/eve/module/real/core/function/regular/simd/x86/is_not_less.hpp
@@ -22,10 +22,11 @@ namespace eve::detail
   // 128 bits implementation
   template<floating_real_scalar_value T, typename N>
   EVE_FORCEINLINE auto is_not_less_(EVE_SUPPORTS(sse2_)
-                                   , wide<T, N, x86_128_> const &v0
-                                   , wide<T, N, x86_128_> const &v1) noexcept
+                                   , wide<T, N> const &v0
+                                   , wide<T, N> const &v1) noexcept
+    requires std::same_as<abi_t<T, N>, x86_128_>
   {
-    using t_t = wide<T, N, x86_128_>;
+    using t_t = wide<T, N>;
     using l_t = as_logical_t<t_t>;
 
          if constexpr( !x86_128_::is_wide_logical ) return is_not_less_(EVE_RETARGET(cpu_), v0, v1);
@@ -37,10 +38,11 @@ namespace eve::detail
   // 256 bits implementation
   template<floating_real_scalar_value T, typename N>
   EVE_FORCEINLINE auto is_not_less_(EVE_SUPPORTS(avx_)
-                                   , wide<T, N, x86_256_> const &v0
-                                   , wide<T, N, x86_256_> const &v1) noexcept
+                                   , wide<T, N> const &v0
+                                   , wide<T, N> const &v1) noexcept
+    requires std::same_as<abi_t<T, N>, x86_256_>
   {
-    using t_t = wide<T, N, x86_256_>;
+    using t_t = wide<T, N>;
     using l_t = as_logical_t<t_t>;
 
          if constexpr( !x86_256_::is_wide_logical ) return is_not_less_(EVE_RETARGET(cpu_), v0, v1);

--- a/include/eve/module/real/core/function/regular/simd/x86/is_not_less_equal.hpp
+++ b/include/eve/module/real/core/function/regular/simd/x86/is_not_less_equal.hpp
@@ -17,10 +17,11 @@ namespace eve::detail
 {
   template<floating_real_scalar_value T, typename N>
   EVE_FORCEINLINE auto is_not_less_equal_(EVE_SUPPORTS(sse2_),
-                                          wide<T, N, x86_128_> const &v0,
-                                          wide<T, N, x86_128_> const &v1) noexcept
+                                          wide<T, N> const &v0,
+                                          wide<T, N> const &v1) noexcept
+    requires std::same_as<abi_t<T, N>, x86_128_>
   {
-    using t_t = wide<T, N, x86_128_>;
+    using t_t = wide<T, N>;
     using l_t = as_logical_t<t_t>;
          if constexpr(std::is_same_v<T, float>)  return l_t(_mm_cmpnle_ps(v0, v1));
     else if constexpr(std::is_same_v<T, double>) return l_t(_mm_cmpnle_pd(v0, v1));
@@ -28,12 +29,12 @@ namespace eve::detail
 
   template<floating_real_scalar_value T, typename N>
   EVE_FORCEINLINE auto is_not_less_equal_(EVE_SUPPORTS(avx_),
-                                          wide<T, N, x86_256_> const &v0,
-                                          wide<T, N, x86_256_> const &v1) noexcept
+                                          wide<T, N> const &v0,
+                                          wide<T, N> const &v1) noexcept
+    requires std::same_as<abi_t<T, N>, x86_256_>
   {
-    using l_t = as_logical_t<wide<T, N, x86_256_>>;
+    using l_t = as_logical_t<wide<T, N>>;
          if constexpr(std::is_same_v<T, float>)  return l_t(_mm256_cmp_ps(v0, v1, _CMP_NLE_UQ));
     else if constexpr(std::is_same_v<T, double>) return l_t(_mm256_cmp_pd(v0, v1, _CMP_NLE_UQ));
   }
 }
-

--- a/include/eve/module/real/core/function/regular/simd/x86/max.hpp
+++ b/include/eve/module/real/core/function/regular/simd/x86/max.hpp
@@ -46,7 +46,7 @@ namespace eve::detail
     // 256 - 64 bit ints
     else if constexpr ( current_api >= avx512 && c == category::int64x4  ) return _mm256_max_epi64(v0, v1);
     else if constexpr ( current_api >= avx512 && c == category::uint64x4 ) return _mm256_max_epu64(v0, v1);
-    else if constexpr ( match(c, category::int64x8, category::uint64x8)  ) return detail::if_else_max(v0, v1);
+    else if constexpr ( match(c, category::int64x4, category::uint64x4)  ) { return detail::if_else_max(v0, v1); }
     // 256 - 32 bit ints
     else if constexpr ( current_api >= avx2 && c == category::int32x8    ) return _mm256_max_epi32(v0, v1);
     else if constexpr ( current_api >= avx2 && c == category::uint32x8   ) return _mm256_max_epu32(v0, v1);

--- a/include/eve/module/real/core/function/regular/simd/x86/min.hpp
+++ b/include/eve/module/real/core/function/regular/simd/x86/min.hpp
@@ -46,7 +46,7 @@ namespace eve::detail
     // 256 - 64 bit ints
     else if constexpr ( current_api >= avx512 && c == category::int64x4  ) return _mm256_min_epi64(v0, v1);
     else if constexpr ( current_api >= avx512 && c == category::uint64x4 ) return _mm256_min_epu64(v0, v1);
-    else if constexpr ( match(c, category::int64x8, category::uint64x8)  ) return detail::if_else_min(v0, v1);
+    else if constexpr ( match(c, category::int64x4, category::uint64x4)  ) return detail::if_else_min(v0, v1);
     // 256 - 32 bit ints
     else if constexpr ( current_api >= avx2 && c == category::int32x8    ) return _mm256_min_epi32(v0, v1);
     else if constexpr ( current_api >= avx2 && c == category::uint32x8   ) return _mm256_min_epu32(v0, v1);
@@ -79,7 +79,7 @@ namespace eve::detail
     else if constexpr ( c == category::uint16x8                          ) return detail::if_else_min(v0, v1);
     // 128 - 8 bit ints
     else if constexpr ( current_api >= sse4_1 && c == category::int8x16 ) return _mm_min_epi8(v0, v1);
-    else if constexpr ( c == category::int8x16                          ) return detail::if_else_max(v0, v1);
+    else if constexpr ( c == category::int8x16                          ) return detail::if_else_min(v0, v1);
     else if constexpr ( c == category::uint8x16                         ) return _mm_min_epu8(v0, v1);
   }
 }

--- a/include/eve/module/real/core/function/regular/simd/x86/min.hpp
+++ b/include/eve/module/real/core/function/regular/simd/x86/min.hpp
@@ -22,74 +22,13 @@ namespace eve::detail
     return eve::if_else(x > y, y, x);
   }
 
-  // -----------------------------------------------------------------------------------------------
-  // 128 bits implementation
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, x86_128_> min_(EVE_SUPPORTS(sse2_)
-                                       , wide<T, N, x86_128_> const &v0
-                                       , wide<T, N, x86_128_> const &v1) noexcept
+  EVE_FORCEINLINE wide<T, N> min_(EVE_SUPPORTS(sse2_), wide<T, N> v0, wide<T, N> v1)
+    requires x86_abi<abi_t<T, N>>
   {
-         if constexpr(std::is_same_v<T, double>) return _mm_min_pd(v0, v1);
-    else if constexpr(std::is_same_v<T, float>)  return _mm_min_ps(v0, v1);
-    else if constexpr(sizeof(T) == 1)
-    {
-           if constexpr(!std::is_signed_v<T>)    return _mm_min_epu8(v0, v1);
-      else if constexpr(current_api >= sse4_1)   return _mm_min_epi8(v0, v1);
-      else                                       return detail::if_else_min(v0, v1);
-    }
-    else if constexpr(sizeof(T) == 2)
-    {
-           if constexpr(std::is_signed_v<T>)    return _mm_min_epi16(v0, v1);
-      else if constexpr(current_api >= sse4_1)  return _mm_min_epu16(v0, v1);
-      else                                      return detail::if_else_min(v0, v1);
-    }
-    else if constexpr(sizeof(T) == 4)
-    {
-           if constexpr(current_api < sse4_1)   return detail::if_else_min(v0, v1);
-      else if constexpr(std::is_signed_v<T>)    return _mm_min_epi32(v0, v1);
-      else                                      return _mm_min_epu32(v0, v1);
-    }
-    else
-    {
-           if constexpr(current_api >= sse4_2)  return detail::if_else_min(v0, v1);
-      else                                      return map(min, v0, v1);
-    }
-  }
+    constexpr auto c = categorize<wide<T, N>>();
 
-  // -----------------------------------------------------------------------------------------------
-  // 256 bits implementation
-  template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, x86_256_> min_(EVE_SUPPORTS(avx_)
-                                       , wide<T, N, x86_256_> const &v0
-                                       , wide<T, N, x86_256_> const &v1) noexcept
-  {
-         if constexpr(std::is_same_v<T, float>)            return _mm256_min_ps(v0, v1);
-    else if constexpr(std::is_same_v<T, double>)           return _mm256_min_pd(v0, v1);
-    else if constexpr(current_api == avx && sizeof(T) < 8) return aggregate(min, v0, v1);
-    else if constexpr(sizeof(T) == 8)                      return detail::if_else_min(v0, v1);
-    else if constexpr(std::is_signed_v<T>)
-      {
-             if constexpr(sizeof(T) == 1)                  return _mm256_min_epi8(v0, v1);
-        else if constexpr(sizeof(T) == 2)                  return _mm256_min_epi16(v0, v1);
-        else if constexpr(sizeof(T) == 4)                  return _mm256_min_epi32(v0, v1);
-      }
-    else
-      {
-             if constexpr(sizeof(T) == 1)                  return _mm256_min_epu8(v0, v1);
-        else if constexpr(sizeof(T) == 2)                  return _mm256_min_epu16(v0, v1);
-        else if constexpr(sizeof(T) == 4)                  return _mm256_min_epu32(v0, v1);
-      }
-  }
-
-  // -----------------------------------------------------------------------------------------------
-  // 512 bits implementation
-  template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, x86_512_> min_(EVE_SUPPORTS(avx512_)
-                                       , wide<T, N, x86_512_> const &v0
-                                       , wide<T, N, x86_512_> const &v1) noexcept
-  {
-    constexpr auto c = categorize<wide<T, N, x86_512_>>();
-
+    // 512
          if constexpr ( c == category::float64x8  ) return _mm512_min_pd(v0, v1);
     else if constexpr ( c == category::float32x16 ) return _mm512_min_ps(v0, v1);
     else if constexpr ( c == category::int64x8    ) return _mm512_min_epi64(v0, v1);
@@ -100,5 +39,47 @@ namespace eve::detail
     else if constexpr ( c == category::uint16x32  ) return _mm512_min_epu16(v0, v1);
     else if constexpr ( c == category::int8x64    ) return _mm512_min_epi8(v0, v1);
     else if constexpr ( c == category::uint8x64   ) return _mm512_min_epu8(v0, v1);
+
+    // 256
+    else if constexpr ( c == category::float64x4  ) return _mm256_min_pd(v0, v1);
+    else if constexpr ( c == category::float32x8  ) return _mm256_min_ps(v0, v1);
+    // 256 - 64 bit ints
+    else if constexpr ( current_api >= avx512 && c == category::int64x4  ) return _mm256_min_epi64(v0, v1);
+    else if constexpr ( current_api >= avx512 && c == category::uint64x4 ) return _mm256_min_epu64(v0, v1);
+    else if constexpr ( match(c, category::int64x8, category::uint64x8)  ) return detail::if_else_min(v0, v1);
+    // 256 - 32 bit ints
+    else if constexpr ( current_api >= avx2 && c == category::int32x8    ) return _mm256_min_epi32(v0, v1);
+    else if constexpr ( current_api >= avx2 && c == category::uint32x8   ) return _mm256_min_epu32(v0, v1);
+    else if constexpr ( match(c, category::int32x8, category::uint32x8)  ) return detail::if_else_min(v0, v1);
+    // 256 - 16 bit ints
+    else if constexpr ( current_api >= avx2 && c == category::int16x16   ) return _mm256_min_epi16(v0, v1);
+    else if constexpr ( current_api >= avx2 && c == category::uint16x16  ) return _mm256_min_epu16(v0, v1);
+    else if constexpr ( match(c, category::int16x16, category::uint16x16)) return aggregate(min, v0, v1);
+    // 256 - 8 bit ints
+    else if constexpr ( current_api >= avx2 && c == category::int8x32    ) return _mm256_min_epi8(v0, v1);
+    else if constexpr ( current_api >= avx2 && c == category::uint8x32   ) return _mm256_min_epu8(v0, v1);
+    else if constexpr ( match(c, category::int8x32, category::uint8x32  )) return aggregate(min, v0, v1);
+
+    // 128
+    else if constexpr ( c == category::float64x2 ) return _mm_min_pd(v0, v1);
+    else if constexpr ( c == category::float32x4 ) return _mm_min_ps(v0, v1);
+    // 128 - 64 bit ints
+    else if constexpr ( current_api >= avx512 && c == category::int64x2  ) return _mm_min_epi64(v0, v1);
+    else if constexpr ( current_api >= avx512 && c == category::uint64x2 ) return _mm_min_epu64(v0, v1);
+    else if constexpr ( current_api >= sse4_2 && c == category::int64x2  ) return detail::if_else_min(v0, v1);
+    else if constexpr ( current_api >= sse4_2 && c == category::uint64x2 ) return detail::if_else_min(v0, v1);
+    else if constexpr ( match(c, category::int64x2, category::uint64x2 ) ) return map(min, v0, v1);
+    // 128 - 32 bit ints
+    else if constexpr ( current_api >= sse4_1 && c == category::int32x4  ) return _mm_min_epi32(v0, v1);
+    else if constexpr ( current_api >= sse4_1 && c == category::uint32x4 ) return _mm_min_epu32(v0, v1);
+    else if constexpr ( match(c, category::int32x4, category::uint32x4  )) return detail::if_else_min(v0, v1);
+    // 128 - 16 bit ints
+    else if constexpr ( c == category::int16x8                           ) return _mm_min_epi16(v0, v1);
+    else if constexpr ( current_api >= sse4_1 && c == category::uint16x8 ) return _mm_min_epu16(v0, v1);
+    else if constexpr ( c == category::uint16x8                          ) return detail::if_else_min(v0, v1);
+    // 128 - 8 bit ints
+    else if constexpr ( current_api >= sse4_1 && c == category::int8x16 ) return _mm_min_epi8(v0, v1);
+    else if constexpr ( c == category::int8x16                          ) return detail::if_else_max(v0, v1);
+    else if constexpr ( c == category::uint8x16                         ) return _mm_min_epu8(v0, v1);
   }
 }

--- a/include/eve/module/real/core/function/regular/simd/x86/mul.hpp
+++ b/include/eve/module/real/core/function/regular/simd/x86/mul.hpp
@@ -13,23 +13,10 @@
 
 namespace eve::detail
 {
-  // -----------------------------------------------------------------------------------------------
-  // 128 bits implementation
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, x86_128_>
-                  mul_(EVE_SUPPORTS(sse2_), wide<T, N, x86_128_> v0, wide<T, N, x86_128_> const &v1) noexcept
+  EVE_FORCEINLINE wide<T, N> mul_(EVE_SUPPORTS(sse2_), wide<T, N> v0, wide<T, N> v1) noexcept
+    requires x86_abi<abi_t<T, N>>
   {
     return v0 *= v1;
   }
-
-  // -----------------------------------------------------------------------------------------------
-  // 256 bits implementation
-  template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, x86_256_>
-                  mul_(EVE_SUPPORTS(avx_), wide<T, N, x86_256_> v0, wide<T, N, x86_256_> const &v1) noexcept
-  {
-    return v0 *= v1;
-  }
-
-
 }

--- a/include/eve/module/real/core/function/regular/simd/x86/nearest.hpp
+++ b/include/eve/module/real/core/function/regular/simd/x86/nearest.hpp
@@ -16,24 +16,20 @@ namespace eve::detail
   // -----------------------------------------------------------------------------------------------
   // 128 bits implementation
   template<floating_real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, x86_128_> nearest_(EVE_SUPPORTS(sse4_1_),
-                                            wide<T, N, x86_128_> const &a0) noexcept
+  EVE_FORCEINLINE wide<T, N> nearest_(EVE_SUPPORTS(sse4_1_), wide<T, N> a0) noexcept
+    requires x86_abi<abi_t<T, N>>
   {
     if constexpr(std::is_same_v<T, double>)
-      return _mm_round_pd(a0, _MM_FROUND_TO_NEAREST_INT);
-    else if constexpr(std::is_same_v<T, float>)
-      return _mm_round_ps(a0, _MM_FROUND_TO_NEAREST_INT);
-  }
-
-  // -----------------------------------------------------------------------------------------------
-  // 256 bits implementation
-  template<floating_real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, x86_256_> nearest_(EVE_SUPPORTS(avx_), wide<T, N, x86_256_> const &a0) noexcept
-  {
-    if constexpr(std::is_same_v<T, double>)
-      return _mm256_round_pd(a0, _MM_FROUND_TO_NEAREST_INT);
-    else if constexpr(std::is_same_v<T, float>)
-      return _mm256_round_ps(a0, _MM_FROUND_TO_NEAREST_INT);
+    {
+           if constexpr (std::same_as<abi_t<T, N>, x86_512_>) return _mm512_roundscale_pd(a0, _MM_FROUND_TO_NEAREST_INT);
+      else if constexpr (std::same_as<abi_t<T, N>, x86_256_>) return _mm256_round_pd     (a0, _MM_FROUND_TO_NEAREST_INT);
+      else                                                    return _mm_round_pd        (a0, _MM_FROUND_TO_NEAREST_INT);
+    }
+    else
+    {
+           if constexpr (std::same_as<abi_t<T, N>, x86_512_>) return _mm512_roundscale_ps(a0, _MM_FROUND_TO_NEAREST_INT);
+      else if constexpr (std::same_as<abi_t<T, N>, x86_256_>) return _mm256_round_ps     (a0, _MM_FROUND_TO_NEAREST_INT);
+      else                                                    return _mm_round_ps        (a0, _MM_FROUND_TO_NEAREST_INT);
+    }
   }
 }
-

--- a/include/eve/module/real/core/function/saturated/simd/x86/add.hpp
+++ b/include/eve/module/real/core/function/saturated/simd/x86/add.hpp
@@ -14,103 +14,37 @@
 
 namespace eve::detail
 {
-  //================================================================================================
-  // 128 bits saturated implementation
-  //================================================================================================
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, x86_128_> add_(EVE_SUPPORTS(sse2_),
-                                        saturated_type const &  st,
-                                        wide<T, N, x86_128_> const &v0,
-                                        wide<T, N, x86_128_> const &v1) noexcept
+  EVE_FORCEINLINE wide<T, N> add_(EVE_SUPPORTS(sse2_),
+    saturated_type const &  st, wide<T, N> v0, wide<T, N> v1) noexcept
+    requires x86_abi<abi_t<T, N>>
   {
-    if constexpr( std::floating_point<T> )
+         if constexpr ( std::floating_point<T>                                    ) return add(v0, v1);
+    else if constexpr ( sizeof(T) > 2                                             ) return add_(EVE_RETARGET(cpu_), st, v0, v1);
+    else if constexpr ( std::same_as<abi_t<T, N>, x86_256_> && current_api == avx ) return add_(EVE_RETARGET(cpu_), st, v0, v1);
+    else if constexpr ( std::signed_integral<T> && sizeof(T) == 1 )
     {
-      return add(v0, v1);
+           if constexpr ( std::same_as<abi_t<T, N>, x86_512_> ) return _mm512_adds_epi8(v0, v1);
+      else if constexpr ( std::same_as<abi_t<T, N>, x86_256_> ) return _mm256_adds_epi8(v0, v1);
+      else if constexpr ( std::same_as<abi_t<T, N>, x86_128_> ) return _mm_adds_epi8   (v0, v1);
     }
-    else
+    else if constexpr ( std::signed_integral<T> && sizeof(T) == 2 )
     {
-      if constexpr( std::signed_integral<T> )
-      {
-        if constexpr( sizeof(T) == 1 )
-        {
-          return _mm_adds_epi8(v0, v1);
-        }
-        else if constexpr( sizeof(T) == 2 )
-        {
-          return _mm_adds_epi16(v0, v1);
-        }
-        else
-        {
-          return add_(EVE_RETARGET(cpu_), st, v0, v1);
-        }
-      }
-      else if constexpr( std::unsigned_integral<T> )
-      {
-        if constexpr( sizeof(T) == 1 )
-        {
-          return _mm_adds_epu8(v0, v1);
-        }
-        else if constexpr( sizeof(T) == 2 )
-        {
-          return _mm_adds_epu16(v0, v1);
-        }
-        else
-        {
-          return add_(EVE_RETARGET(cpu_), st, v0, v1);
-        }
-      }
+           if constexpr ( std::same_as<abi_t<T, N>, x86_512_> ) return _mm512_adds_epi16(v0, v1);
+      else if constexpr ( std::same_as<abi_t<T, N>, x86_256_> ) return _mm256_adds_epi16(v0, v1);
+      else if constexpr ( std::same_as<abi_t<T, N>, x86_128_> ) return _mm_adds_epi16   (v0, v1);
     }
-  }
-
-  //================================================================================================
-  // 256 bits saturated implementation
-  //================================================================================================
-  template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, x86_256_> add_(EVE_SUPPORTS(avx2_),
-                                        saturated_type const &  st,
-                                        wide<T, N, x86_256_> const &v0,
-                                        wide<T, N, x86_256_> const &v1) noexcept
-  {
-    if constexpr( std::floating_point<T> )
+    else if constexpr ( std::unsigned_integral<T> && sizeof(T) == 1 )
     {
-      return add(v0, v1);
+           if constexpr ( std::same_as<abi_t<T, N>, x86_512_> ) return _mm512_adds_epu8(v0, v1);
+      else if constexpr ( std::same_as<abi_t<T, N>, x86_256_> ) return _mm256_adds_epu8(v0, v1);
+      else if constexpr ( std::same_as<abi_t<T, N>, x86_128_> ) return _mm_adds_epu8   (v0, v1);
     }
-    else if constexpr( current_api >= avx2 )
+    else if constexpr ( std::unsigned_integral<T> && sizeof(T) == 2 )
     {
-      if constexpr( std::signed_integral<T> )
-      {
-        if constexpr( sizeof(T) == 1 )
-        {
-          return _mm256_adds_epi8(v0, v1);
-        }
-        else if constexpr( sizeof(T) == 2 )
-        {
-          return _mm256_adds_epi16(v0, v1);
-        }
-        else
-        {
-          return add_(EVE_RETARGET(cpu_), st, v0, v1);
-        }
-      }
-      else if constexpr( std::unsigned_integral<T> )
-      {
-        if constexpr( sizeof(T) == 1 )
-        {
-          return _mm256_adds_epu8(v0, v1);
-        }
-        else if constexpr( sizeof(T) == 2 )
-        {
-          return _mm256_adds_epu16(v0, v1);
-        }
-        else
-        {
-          return add_(EVE_RETARGET(cpu_), st, v0, v1);
-        }
-      }
-    }
-    else
-    {
-      return add_(EVE_RETARGET(cpu_), st, v0, v1);
+           if constexpr ( std::same_as<abi_t<T, N>, x86_512_> ) return _mm512_adds_epu16(v0, v1);
+      else if constexpr ( std::same_as<abi_t<T, N>, x86_256_> ) return _mm256_adds_epu16(v0, v1);
+      else if constexpr ( std::same_as<abi_t<T, N>, x86_128_> ) return _mm_adds_epu16   (v0, v1);
     }
   }
 }

--- a/include/eve/module/real/core/function/saturated/simd/x86/mul.hpp
+++ b/include/eve/module/real/core/function/saturated/simd/x86/mul.hpp
@@ -17,8 +17,9 @@ namespace eve::detail
   // -----------------------------------------------------------------------------------------------
   // 128 bits implementation only
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, x86_128_>
-                  mul_(EVE_SUPPORTS(avx_), saturated_type const &, wide<T, N, x86_128_> v0, wide<T, N, x86_128_> const &v1) noexcept
+  EVE_FORCEINLINE wide<T, N>
+  mul_(EVE_SUPPORTS(avx_), saturated_type const &, wide<T, N> v0, wide<T, N> const &v1) noexcept
+    requires std::same_as<abi_t<T, N>, x86_128_>
   {
     if constexpr(supports_xop)
     {

--- a/include/eve/module/real/math/function/regular/simd/x86/log.hpp
+++ b/include/eve/module/real/math/function/regular/simd/x86/log.hpp
@@ -151,7 +151,8 @@ namespace eve::detail
   // -----------------------------------------------------------------------------------------------
   // 256 bits implementation for avx
   template<floating_real_scalar_value T, typename N>
-  EVE_FORCEINLINE auto log_(EVE_SUPPORTS(avx_), wide<T, N, x86_256_> const &v) noexcept
+  EVE_FORCEINLINE auto log_(EVE_SUPPORTS(avx_), wide<T, N> const &v) noexcept
+    requires std::same_as<abi_t<T, N>, x86_256_>
   {
     if constexpr( current_api < avx2 )
       return plain(log)(v);

--- a/include/eve/module/real/math/function/regular/simd/x86/log10.hpp
+++ b/include/eve/module/real/math/function/regular/simd/x86/log10.hpp
@@ -186,7 +186,8 @@ namespace eve::detail
   // -----------------------------------------------------------------------------------------------
   // 256 bits implementation for avx
   template<floating_real_scalar_value T, typename N>
-  EVE_FORCEINLINE auto log10_(EVE_SUPPORTS(avx_), wide<T, N, x86_256_> const &v) noexcept
+  EVE_FORCEINLINE auto log10_(EVE_SUPPORTS(avx_), wide<T, N> const &v) noexcept
+    requires std::same_as<abi_t<T, N>, x86_256_>
   {
     if constexpr( current_api < avx2 )
       return plain(log10)(v);

--- a/include/eve/module/real/math/function/regular/simd/x86/log1p.hpp
+++ b/include/eve/module/real/math/function/regular/simd/x86/log1p.hpp
@@ -107,7 +107,8 @@ namespace eve::detail
   // -----------------------------------------------------------------------------------------------
   // 256 bits implementation for avx
   template<floating_real_scalar_value T, typename N>
-  EVE_FORCEINLINE auto log1p_(EVE_SUPPORTS(avx_), wide<T, N, x86_256_> const &v) noexcept
+  EVE_FORCEINLINE auto log1p_(EVE_SUPPORTS(avx_), wide<T, N> const &v) noexcept
+    requires std::same_as<abi_t<T, N>, x86_256_>
   {
     if constexpr( current_api < avx2 )
       return plain(log1p)(v);
@@ -115,4 +116,3 @@ namespace eve::detail
       return musl_(log1p)(v);
   }
 }
-

--- a/include/eve/module/real/math/function/regular/simd/x86/log2.hpp
+++ b/include/eve/module/real/math/function/regular/simd/x86/log2.hpp
@@ -205,7 +205,8 @@ namespace eve::detail
   // -----------------------------------------------------------------------------------------------
   // 256 bits implementation for avx
   template<floating_real_scalar_value T, typename N>
-  EVE_FORCEINLINE auto log2_(EVE_SUPPORTS(avx_), wide<T, N, x86_256_> const &v) noexcept
+  EVE_FORCEINLINE auto log2_(EVE_SUPPORTS(avx_), wide<T, N> const &v) noexcept
+    requires std::same_as<abi_t<T, N>, x86_256_>
   {
     if constexpr( current_api < avx2 )
       return plain(log2)(v);


### PR DESCRIPTION
These fixes are not as dumb, but I refactor a bit and also add support for avx512 where it's easy.

in max/ min for avx went to if_else for 4 byte integers since there is a blend.