### PR TITLE
adding to floor and ceil tests

### DIFF
--- a/include/eve/function/floor.hpp
+++ b/include/eve/function/floor.hpp
@@ -19,3 +19,11 @@ namespace eve
 #if defined(EVE_INCLUDE_X86_HEADER)
 #  include <eve/module/real/core/function/regular/simd/x86/floor.hpp>
 #endif
+
+#if defined(EVE_INCLUDE_POWERPC_HEADER)
+#  include <eve/module/real/core/function/regular/simd/ppc/floor.hpp>
+#endif
+
+#if defined(EVE_INCLUDE_ARM_HEADER)
+#  include <eve/module/real/core/function/regular/simd/arm/neon/floor.hpp>
+#endif

--- a/include/eve/module/real/core/function/regular/simd/ppc/floor.hpp
+++ b/include/eve/module/real/core/function/regular/simd/ppc/floor.hpp
@@ -13,8 +13,8 @@
 namespace eve::detail
 {
   template<floating_real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N> floor_(EVE_SUPPORTS(vmx_)
-                                         , wide<T, N> const &v0) noexcept
+  EVE_FORCEINLINE wide<T, N> floor_(EVE_SUPPORTS(vmx_), wide<T, N> const &v0) noexcept
+  requires( ppc_abi<wide<T,N>> )
   {
     return vec_floor(v0.storage());
   }

--- a/include/eve/module/real/core/function/regular/simd/ppc/floor.hpp
+++ b/include/eve/module/real/core/function/regular/simd/ppc/floor.hpp
@@ -12,10 +12,9 @@
 
 namespace eve::detail
 {
-  template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N>
-  floor_(EVE_SUPPORTS(vmx_), wide<T, N> const &v0) noexcept
-    requires ppc_abi<abi_t<T, N>>
+  template<floating_real_scalar_value T, typename N>
+  EVE_FORCEINLINE wide<T, N> floor_(EVE_SUPPORTS(vmx_)
+                                         , wide<T, N> const &v0) noexcept
   {
     return vec_floor(v0.storage());
   }

--- a/include/eve/module/real/core/function/regular/simd/x86/ceil.hpp
+++ b/include/eve/module/real/core/function/regular/simd/x86/ceil.hpp
@@ -17,21 +17,17 @@
 
 namespace eve::detail
 {
-  template<floating_real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N> ceil_(EVE_SUPPORTS(sse4_1_), wide<T, N> const &a0) noexcept
-    requires x86_abi<abi_t<T, N>>
+template<floating_scalar_value T, typename N>
+  EVE_FORCEINLINE wide<T, N> ceil_(EVE_SUPPORTS(sse4_1_), wide<T, N> a0) noexcept
+      requires x86_abi<abi_t<T, N>>
   {
-    if constexpr (std::same_as<T, double> )
-    {
-           if constexpr (std::same_as<abi_t<T, N>, x86_512_>) return _mm512_roundscale_pd(a0, _MM_FROUND_CEIL);
-      else if constexpr (std::same_as<abi_t<T, N>, x86_256_>) return _mm256_round_pd     (a0, _MM_FROUND_CEIL);
-      else                                                    return _mm_ceil_pd         (a0);
-    }
-    else
-    {
-           if constexpr (std::same_as<abi_t<T, N>, x86_512_>) return _mm512_roundscale_ps(a0, _MM_FROUND_CEIL);
-      else if constexpr (std::same_as<abi_t<T, N>, x86_256_>) return _mm256_round_ps     (a0, _MM_FROUND_CEIL);
-      else                                                    return _mm_ceil_ps         (a0);
-    }
+    constexpr auto c = categorize<wide<T, N>>();
+
+         if constexpr ( c == category::float64x8  ) return _mm512_roundscale_pd(a0, _MM_FROUND_CEIL);
+    else if constexpr ( c == category::float32x16 ) return _mm512_roundscale_ps(a0, _MM_FROUND_CEIL);
+    else if constexpr ( c == category::float64x4  ) return _mm256_round_pd     (a0, _MM_FROUND_CEIL);
+    else if constexpr ( c == category::float32x8  ) return _mm256_round_ps     (a0, _MM_FROUND_CEIL);
+    else if constexpr ( c == category::float64x2  ) return _mm_round_pd        (a0, _MM_FROUND_CEIL);
+    else if constexpr ( c == category::float32x4  ) return _mm_round_ps        (a0, _MM_FROUND_CEIL);
   }
 }

--- a/include/eve/module/real/core/function/regular/simd/x86/floor.hpp
+++ b/include/eve/module/real/core/function/regular/simd/x86/floor.hpp
@@ -17,21 +17,17 @@
 
 namespace eve::detail
 {
-  template<floating_scalar_value T, typename N, typename ABI>
+template<floating_scalar_value T, typename N>
   EVE_FORCEINLINE wide<T, N> floor_(EVE_SUPPORTS(sse4_1_), wide<T, N> a0) noexcept
-    requires x86_abi<abi_t<T, N>>
+      requires x86_abi<abi_t<T, N>>
   {
-    if constexpr (std::same_as<T, double> )
-    {
-           if constexpr (std::same_as<abi_t<T, N>, x86_512_>) return _mm512_roundscale_pd(a0, _MM_FROUND_TO_NEG_INF);
-      else if constexpr (std::same_as<abi_t<T, N>, x86_256_>) return _mm256_round_pd     (a0, _MM_FROUND_TO_NEG_INF);
-      else                                                    return _mm_floor_pd        (a0);
-    }
-    else
-    {
-           if constexpr (std::same_as<abi_t<T, N>, x86_512_>) return _mm512_roundscale_ps(a0, _MM_FROUND_TO_NEG_INF);
-      else if constexpr (std::same_as<abi_t<T, N>, x86_256_>) return _mm256_round_ps     (a0, _MM_FROUND_TO_NEG_INF);
-      else                                                    return _mm_floor_ps        (a0);
-    }
+    constexpr auto c = categorize<wide<T, N>>();
+
+         if constexpr ( c == category::float64x8  ) return _mm512_roundscale_pd(a0, _MM_FROUND_FLOOR);
+    else if constexpr ( c == category::float32x16 ) return _mm512_roundscale_ps(a0, _MM_FROUND_FLOOR);
+    else if constexpr ( c == category::float64x4  ) return _mm256_round_pd     (a0, _MM_FROUND_FLOOR);
+    else if constexpr ( c == category::float32x8  ) return _mm256_round_ps     (a0, _MM_FROUND_FLOOR);
+    else if constexpr ( c == category::float64x2  ) return _mm_round_pd        (a0, _MM_FROUND_FLOOR);
+    else if constexpr ( c == category::float32x4  ) return _mm_round_ps        (a0, _MM_FROUND_FLOOR);
   }
 }

--- a/include/eve/module/real/core/function/regular/simd/x86/floor.hpp
+++ b/include/eve/module/real/core/function/regular/simd/x86/floor.hpp
@@ -23,14 +23,14 @@ namespace eve::detail
   {
     if constexpr (std::same_as<T, double> )
     {
-           if constexpr (std::same_as<abi_t<T, N>, x86_512_>) return _mm512_roundscale_pd(a0, _MM_FROUND_TO_ZERO);
-      else if constexpr (std::same_as<abi_t<T, N>, x86_256_>) return _mm256_round_pd     (a0, _MM_FROUND_TO_ZERO);
+           if constexpr (std::same_as<abi_t<T, N>, x86_512_>) return _mm512_roundscale_pd(a0, _MM_FROUND_TO_NEG_INF);
+      else if constexpr (std::same_as<abi_t<T, N>, x86_256_>) return _mm256_round_pd     (a0, _MM_FROUND_TO_NEG_INF);
       else                                                    return _mm_floor_pd        (a0);
     }
     else
     {
-           if constexpr (std::same_as<abi_t<T, N>, x86_512_>) return _mm512_roundscale_ps(a0, _MM_FROUND_TO_ZERO);
-      else if constexpr (std::same_as<abi_t<T, N>, x86_256_>) return _mm256_round_ps     (a0, _MM_FROUND_TO_ZERO);
+           if constexpr (std::same_as<abi_t<T, N>, x86_512_>) return _mm512_roundscale_ps(a0, _MM_FROUND_TO_NEG_INF);
+      else if constexpr (std::same_as<abi_t<T, N>, x86_256_>) return _mm256_round_ps     (a0, _MM_FROUND_TO_NEG_INF);
       else                                                    return _mm_floor_ps        (a0);
     }
   }

--- a/test/unit/module/real/core/ceil.cpp
+++ b/test/unit/module/real/core/ceil.cpp
@@ -49,6 +49,19 @@ EVE_TEST_TYPES( "Check  with specific values"
               )
 <typename T>(eve::as_<T>)
 {
+  TTS_EQUAL(eve::ceil(T(-1)), T(-1));
+  TTS_EQUAL(eve::ceil(T(-2)), T(-2));
+  TTS_EQUAL(eve::ceil(T(0)), T(0));
+  TTS_EQUAL(eve::ceil(T(1)), T(1));
+  TTS_EQUAL(eve::ceil(T(2)), T(2));
+
+  TTS_EQUAL(eve::ceil(T(-1.3)), T(-1));
+  TTS_EQUAL(eve::ceil(T(-1.5)), T(-1));
+  TTS_EQUAL(eve::ceil(T(-1.6)), T(-1));
+  TTS_EQUAL(eve::ceil(T(1.3)) , T(2));
+  TTS_EQUAL(eve::ceil(T(1.5)) , T(2));
+  TTS_EQUAL(eve::ceil(T(1.6)) , T(2));
+
   TTS_EQUAL(eve::tolerant(eve::ceil)(T(-1)), T(-1));
   TTS_EQUAL(eve::tolerant(eve::ceil)(T(-2)), T(-2));
   TTS_EQUAL(eve::tolerant(eve::ceil)(T(0)), T(0));
@@ -61,7 +74,6 @@ EVE_TEST_TYPES( "Check  with specific values"
   TTS_EQUAL(eve::tolerant(eve::ceil)(T(1.3)) , T(2));
   TTS_EQUAL(eve::tolerant(eve::ceil)(T(1.5)) , T(2));
   TTS_EQUAL(eve::tolerant(eve::ceil)(T(1.6)) , T(2));
-  TTS_EQUAL(eve::tolerant(eve::ceil)(T(0)), T(0));
   TTS_EQUAL(eve::tolerant(eve::ceil)(eve::eps(eve::as<T>())), T(0));
   TTS_EQUAL(eve::tolerant(eve::ceil)(2*eve::eps(eve::as<T>())), T(0));
   TTS_EQUAL(eve::tolerant(eve::ceil)(3*eve::eps(eve::as<T>())), T(0));

--- a/test/unit/module/real/core/floor.cpp
+++ b/test/unit/module/real/core/floor.cpp
@@ -51,6 +51,13 @@ EVE_TEST_TYPES( "Check  with particular values"
               )
 <typename T>(eve::as_<T>)
 {
+  TTS_EQUAL(eve::floor(static_cast<T>(-1.3)), T(-2));
+  TTS_EQUAL(eve::floor(static_cast<T>(-1.5)), T(-2));
+  TTS_EQUAL(eve::floor(static_cast<T>(-1.6)), T(-2));
+  TTS_EQUAL(eve::floor(static_cast<T>(1.3)) , T( 1));
+  TTS_EQUAL(eve::floor(static_cast<T>(1.5)) , T( 1));
+  TTS_EQUAL(eve::floor(static_cast<T>(1.6)) , T( 1));
+
   TTS_EQUAL(eve::tolerant(eve::floor)(static_cast<T>(-1.3)), T(-2));
   TTS_EQUAL(eve::tolerant(eve::floor)(static_cast<T>(-1.5)), T(-2));
   TTS_EQUAL(eve::tolerant(eve::floor)(static_cast<T>(-1.6)), T(-2));


### PR DESCRIPTION
fix-#745 in fact the definition file for floor didn't contain any intrinsics include and tolerant(floor) was tested and not floor
ceill also was in the later case