### PR TITLE
FIX-670: no more ABI parameter in wide

### DIFF
--- a/include/eve/arch/cpu/logical_wide.hpp
+++ b/include/eve/arch/cpu/logical_wide.hpp
@@ -322,8 +322,8 @@ namespace eve
     // Logical operations
     //==============================================================================================
     //! Perform a logical and operation between two eve::logical
-    template<typename U, typename A2>
-    friend EVE_FORCEINLINE auto operator&&(logical const& v, logical<wide<U,Cardinal,A2>> const& w) noexcept
+    template<typename U>
+    friend EVE_FORCEINLINE auto operator&&(logical const& v, logical<wide<U, Cardinal>> const& w) noexcept
     {
       return detail::self_logand(EVE_CURRENT_API{},v,w);
     }
@@ -343,8 +343,8 @@ namespace eve
     }
 
     //! Perform a logical or operation between two eve::logical
-    template<typename U, typename A2>
-    friend EVE_FORCEINLINE auto operator||(logical const& v, logical<wide<U,Cardinal,A2>> const& w) noexcept
+    template<typename U>
+    friend EVE_FORCEINLINE auto operator||(logical const& v, logical<wide<U, Cardinal>> const& w) noexcept
     {
       return detail::self_logor(EVE_CURRENT_API{},v,w);
     }

--- a/include/eve/arch/cpu/wide.hpp
+++ b/include/eve/arch/cpu/wide.hpp
@@ -47,13 +47,13 @@ namespace eve
   //! @tparam Cardinal  Cardinal of the register. By default, the best cardinal for current
   //!                    architecture is selected.
   //================================================================================================
-  template<typename Type, typename Cardinal, typename ABI>
+  template<typename Type, typename Cardinal>
   struct  EVE_MAY_ALIAS  wide
         : detail::wide_cardinal<Cardinal>
-        , detail::wide_storage<as_register_t<Type, Cardinal, ABI>>
+        , detail::wide_storage<as_register_t<Type, Cardinal, abi_t<Type, Cardinal>>>
   {
     using card_base     = detail::wide_cardinal<Cardinal>;
-    using storage_base  = detail::wide_storage<as_register_t<Type, Cardinal, ABI>>;
+    using storage_base  = detail::wide_storage<as_register_t<Type, Cardinal, abi_t<Type, Cardinal>>>;
 
     public:
 
@@ -61,7 +61,7 @@ namespace eve
     using value_type    = Type;
 
     //! The ABI tag for this register.
-    using abi_type      = ABI;
+    using abi_type      = abi_t<Type, Cardinal>;
 
     //! The type used for this register storage
     using storage_type  = typename storage_base::storage_type;

--- a/include/eve/detail/function/simd/arm/neon/combine.hpp
+++ b/include/eve/detail/function/simd/arm/neon/combine.hpp
@@ -13,15 +13,8 @@ namespace eve::detail
 {
   template<typename T, typename N>
   EVE_FORCEINLINE auto
-  combine(neon128_ const &, wide<T, N, arm_128_> const &l, wide<T, N, arm_128_> const &h) noexcept
-  {
-    using that_t = wide<T, typename N::combined_type>;
-    return that_t(typename that_t::storage_type {l, h});
-  }
-
-  template<typename T, typename N>
-  EVE_FORCEINLINE auto
-  combine(neon128_ const &, wide<T, N, arm_64_> const &l, wide<T, N, arm_64_> const &h) noexcept
+  combine(neon128_ const &, wide<T, N> const &l, wide<T, N> const &h) noexcept
+    requires std::same_as<abi_t<T, N>, arm_64_>
   {
     using that_t = wide<T, typename N::combined_type>;
 

--- a/include/eve/detail/function/simd/arm/neon/lookup.hpp
+++ b/include/eve/detail/function/simd/arm/neon/lookup.hpp
@@ -15,7 +15,8 @@ namespace eve::detail
 {
   template<typename T, typename I, typename N>
   EVE_FORCEINLINE auto
-  lookup_(EVE_SUPPORTS(neon128_), wide<T, N, arm_64_> a, wide<I, N, arm_64_> idx) noexcept
+  lookup_(EVE_SUPPORTS(neon128_), wide<T, N> a, wide<I, N> idx) noexcept
+    requires std::same_as<abi_t<T, N>, arm_64_>
   {
     if constexpr( std::is_signed_v<I> )
     {
@@ -24,7 +25,7 @@ namespace eve::detail
     }
     else
     {
-      using t8_t = typename wide<T, N, arm_64_>::template rebind<std::uint8_t, fixed<8>>;
+      using t8_t = typename wide<T, N>::template rebind<std::uint8_t, fixed<8>>;
 
       if constexpr( sizeof(I) == 1 )
       {
@@ -33,7 +34,7 @@ namespace eve::detail
       else
       {
         t8_t i1 = lookup(bit_cast( idx << shift<I>, as(i1)), t8_t {repeater<I>});
-        i1      = bit_cast(bit_cast(i1, as<wide<I, N, arm_64_>>()) + offset<I>, as<t8_t>());
+        i1      = bit_cast(bit_cast(i1, as<wide<I, N>>()) + offset<I>, as<t8_t>());
         return bit_cast(lookup(bit_cast(a, as<t8_t>()), i1), as(a));
       }
     }
@@ -41,7 +42,8 @@ namespace eve::detail
 
   template<typename T, typename I, typename N>
   EVE_FORCEINLINE auto
-  lookup_(EVE_SUPPORTS(neon128_), wide<T, N, arm_128_> a, wide<I, N, arm_128_> idx) noexcept
+  lookup_(EVE_SUPPORTS(neon128_), wide<T, N> a, wide<I, N> idx) noexcept
+    requires std::same_as<abi_t<T, N>, arm_128_>
   {
     if constexpr( std::is_signed_v<I> )
     {
@@ -50,11 +52,11 @@ namespace eve::detail
     }
     else
     {
-      using t8_t = typename wide<T, N, arm_128_>::template rebind<std::uint8_t, fixed<16>>;
+      using t8_t = typename wide<T, N>::template rebind<std::uint8_t, fixed<16>>;
 
       if constexpr( sizeof(I) == 1 )
       {
-        using t8h_t = typename wide<T, N, arm_128_>::template rebind<std::uint8_t, fixed<8>>;
+        using t8h_t = typename wide<T, N>::template rebind<std::uint8_t, fixed<8>>;
 
         auto        pieces = bit_cast(a, as<t8_t>());
         uint8x8x2_t tbl    = {{pieces.slice(lower_), pieces.slice(upper_)}};
@@ -65,7 +67,7 @@ namespace eve::detail
       else
       {
         t8_t i1 = lookup(bit_cast( idx << shift<I>, as(i1)), t8_t {repeater<I>});
-        i1      = bit_cast(bit_cast(i1, as<wide<I, N, arm_128_>>()) + offset<I>, as<t8_t>());
+        i1      = bit_cast(bit_cast(i1, as<wide<I, N>>()) + offset<I>, as<t8_t>());
         return bit_cast(lookup(bit_cast(a, as<t8_t>()), i1), as(a));
       }
     }

--- a/include/eve/detail/function/simd/arm/neon/movemask.hpp
+++ b/include/eve/detail/function/simd/arm/neon/movemask.hpp
@@ -45,9 +45,10 @@ namespace eve::detail
   }
 
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE auto movemask (logical<wide<T, N, arm_64_>> const &v) noexcept
+  EVE_FORCEINLINE auto movemask (logical<wide<T, N>> const &v) noexcept
+    requires std::same_as<abi_t<T, N>, arm_64_>
   {
-    using w_t = wide<T, N, arm_64_>;
+    using w_t = wide<T, N>;
     using u16_4 = typename w_t::template rebind<std::uint16_t, eve::fixed<4>>;
     using u32_2 = typename w_t::template rebind<std::uint32_t, eve::fixed<2>>;
     using u64_1 = typename w_t::template rebind<std::uint64_t, eve::fixed<1>>;
@@ -82,9 +83,10 @@ namespace eve::detail
   }
 
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE auto movemask (logical<wide<T, N, arm_128_>> const &v) noexcept
+  EVE_FORCEINLINE auto movemask (logical<wide<T, N>> const &v) noexcept
+    requires std::same_as<abi_t<T, N>, arm_128_>
   {
-    using w_t = wide<T, N, arm_128_>;
+    using w_t = wide<T, N>;
     using u8_8  = typename w_t::template rebind <std::uint8_t,  eve::fixed<8>>;
     using u16_8 = typename w_t::template rebind <std::uint16_t, eve::fixed<8>>;
     using u32_4 = typename w_t::template rebind <std::uint32_t, eve::fixed<4>>;

--- a/include/eve/detail/function/simd/common/load.hpp
+++ b/include/eve/detail/function/simd/common/load.hpp
@@ -57,7 +57,8 @@ namespace eve::detail
   // Emulation
   //================================================================================================
   template<typename T, typename N, typename Pointer>
-  EVE_FORCEINLINE auto load(eve::as_<wide<T,N,emulated_>> const& tgt, Pointer i) noexcept
+  EVE_FORCEINLINE auto load(eve::as_<wide<T, N>> const& tgt, Pointer i) noexcept
+    requires std::same_as<abi_t<T, N>, emulated_>
   {
     auto const get = [](auto p)
     {
@@ -72,7 +73,8 @@ namespace eve::detail
   // Aggregation
   //================================================================================================
   template<typename T, typename N, typename Pointer>
-  EVE_FORCEINLINE auto load(eve::as_<wide<T,N,aggregated_>> const & tgt, Pointer ptr) noexcept
+  EVE_FORCEINLINE auto load(eve::as_<wide<T,N>> const & tgt, Pointer ptr) noexcept
+    requires std::same_as<abi_t<T, N>, aggregated_>
   {
     return aggregate_load(tgt,ptr);
   }

--- a/include/eve/detail/function/simd/common/load.hpp
+++ b/include/eve/detail/function/simd/common/load.hpp
@@ -100,7 +100,9 @@ namespace eve::detail
   auto load(eve::as_<logical<wide<T, N>>> const & tgt, Ptr p)
   requires( dereference_as<logical<T>, Ptr>::value && !x86_abi<abi_t<T, N>>)
   {
-    return  bit_cast
+    if constexpr ( std::same_as<abi_t<T, N>, aggregated_> ) return aggregate_load(tgt,p);
+    else return
+      bit_cast
             ( [&]() -> wide<T, N>
               {
                 using wtg = eve::as_<wide<T, N>>;
@@ -116,13 +118,5 @@ namespace eve::detail
               }()
             , tgt
             );
-  }
-
-  template<typename T, typename N, typename Ptr>
-  EVE_FORCEINLINE
-  auto load(eve::as_<logical<wide<T, N, aggregated_>>> const & tgt, Ptr p)
-  requires( dereference_as<logical<T>, Ptr>::value )
-  {
-    return aggregate_load(tgt,p);
   }
 }

--- a/include/eve/detail/function/simd/common/lookup.hpp
+++ b/include/eve/detail/function/simd/common/lookup.hpp
@@ -14,9 +14,9 @@
 
 namespace eve::detail
 {
-  template<scalar_value T, integral_scalar_value I, typename N, typename X, typename Y>
+  template<scalar_value T, integral_scalar_value I, typename N>
   EVE_FORCEINLINE auto
-  lookup_(EVE_SUPPORTS(cpu_), wide<T, N, X> const &a, wide<I, N, Y> const &ind) noexcept
+  lookup_(EVE_SUPPORTS(cpu_), wide<T, N> const &a, wide<I, N> const &ind) noexcept
   {
     auto const cond = [&]()
     {
@@ -30,7 +30,7 @@ namespace eve::detail
     auto  msk  = cond.mask();
 
     // Rebuild as scalar
-    wide<T, N, X> data;
+    wide<T, N> data;
     apply<N::value>([&](auto... v) { (data.set(v,a.get(idx.get(v))),...); });
 
     // Apply mask as SIMD
@@ -38,16 +38,17 @@ namespace eve::detail
     return data;
   }
 
-  template<scalar_value T, integral_scalar_value I, typename N, typename X, typename Y>
+  template<scalar_value T, integral_scalar_value I, typename N>
   EVE_FORCEINLINE auto
-  lookup_(EVE_SUPPORTS(cpu_), logical<wide<T, N, X>> const &a, wide<I, N, Y> const &ind) noexcept
+  lookup_(EVE_SUPPORTS(cpu_), logical<wide<T, N>> const &a, wide<I, N> const &ind) noexcept
   {
     return bit_cast(lookup(a.bits(),ind), as(a));
   }
 
-  template<scalar_value T, integral_scalar_value I, typename N, typename X>
+  template<scalar_value T, integral_scalar_value I, typename N>
   EVE_FORCEINLINE auto
-  lookup_(EVE_SUPPORTS(cpu_), wide<T, N, X> const &a, wide<I, N, aggregated_> const &ind) noexcept
+  lookup_(EVE_SUPPORTS(cpu_), wide<T, N> const &a, wide<I, N> const &ind) noexcept
+    requires std::same_as<abi_t<I, N>, aggregated_>
   {
     auto const cond = [&]()
     {
@@ -61,7 +62,7 @@ namespace eve::detail
     auto  msk  = cond.mask();
 
     // Rebuild as scalar
-    wide<T, N, X> data;
+    wide<T, N> data;
 
     constexpr auto const half = N::value / 2;
     apply<half>([&, lx = idx.slice(lower_)](auto... v) { (data.set(v     , a.get(lx.get(v))),...); } );

--- a/include/eve/detail/function/simd/common/make.hpp
+++ b/include/eve/detail/function/simd/common/make.hpp
@@ -37,15 +37,17 @@ namespace eve::detail
   }
 
   template<typename T, typename N, typename... Vs>
-  EVE_FORCEINLINE auto make(eve::as_<wide<T,N,emulated_>> const &, Vs... vs) noexcept
+  EVE_FORCEINLINE auto make(eve::as_<wide<T, N>> const &, Vs... vs) noexcept
+    requires std::same_as<abi_t<T, N>, emulated_>
   {
-    return make_emulated<wide<T,N,emulated_>>(vs...);
+    return make_emulated<wide<T, N>>(vs...);
   }
 
   template<typename T, typename N, typename... Vs>
-  EVE_FORCEINLINE auto make(eve::as_<logical<wide<T,N,emulated_>>> const &, Vs... vs) noexcept
+  EVE_FORCEINLINE auto make(eve::as_<logical<wide<T, N>>> const &, Vs... vs) noexcept
+    requires std::same_as<abi_t<T, N>, emulated_>
   {
-    return make_emulated<logical<wide<T,N,emulated_>>>(vs...);
+    return make_emulated<logical<wide<T, N>>>(vs...);
   }
 
   //================================================================================================
@@ -77,14 +79,16 @@ namespace eve::detail
   }
 
   template<typename T, typename N, typename... Vs>
-  EVE_FORCEINLINE auto make(eve::as_<wide<T,N,aggregated_>> const &, Vs... vs) noexcept
+  EVE_FORCEINLINE auto make(eve::as_<wide<T,N>> const &, Vs... vs) noexcept
+    requires std::same_as<abi_t<T, N>, aggregated_>
   {
-    return make_aggregated<wide<T,N,aggregated_>>(vs...);
+    return make_aggregated<wide<T, N>>(vs...);
   }
 
   template<typename T, typename N, typename... Vs>
-  EVE_FORCEINLINE auto make(eve::as_<logical<wide<T,N,aggregated_>>> const &, Vs... vs) noexcept
+  EVE_FORCEINLINE auto make(eve::as_<logical<wide<T,N>>> const &, Vs... vs) noexcept
+    requires std::same_as<abi_t<T, N>, aggregated_>
   {
-    return make_aggregated<logical<wide<T,N,aggregated_>>>(vs...);
+    return make_aggregated<logical<wide<T, N>>>(vs...);
   }
 }

--- a/include/eve/detail/function/simd/ppc/arithmetic_compounds.hpp
+++ b/include/eve/detail/function/simd/ppc/arithmetic_compounds.hpp
@@ -19,10 +19,10 @@ namespace eve::detail
   // +=
   //================================================================================================
   template<scalar_value T, value U, typename N>
-  EVE_FORCEINLINE decltype(auto) self_add( wide<T,N,ppc_>& self, U const& other )
-  requires( scalar_value<U> || std::same_as<wide<T,N,ppc_>,U> )
+  EVE_FORCEINLINE decltype(auto) self_add( wide<T, N>& self, U const& other )
+  requires( scalar_value<U> || std::same_as<wide<T, N>, U> ) && ppc_abi<abi_t<T, N>>
   {
-    using type = wide<T, N, ppc_>;
+    using type = wide<T, N>;
 
     if constexpr( scalar_value<U> )
     {
@@ -40,10 +40,10 @@ namespace eve::detail
   // -=
   //================================================================================================
   template<scalar_value T, value U, typename N>
-  EVE_FORCEINLINE decltype(auto) self_sub( wide<T,N,ppc_>& self, U const& other )
-  requires( scalar_value<U> || std::same_as<wide<T,N,ppc_>,U> )
+  EVE_FORCEINLINE decltype(auto) self_sub( wide<T,N>& self, U const& other )
+  requires( scalar_value<U> || std::same_as<wide<T, N>,U> ) && ppc_abi<abi_t<T, N>>
   {
-    using type = wide<T, N, ppc_>;
+    using type = wide<T, N>;
 
     if constexpr( scalar_value<U> )
     {
@@ -61,10 +61,10 @@ namespace eve::detail
   // *=
   //================================================================================================
   template<scalar_value T, value U, typename N>
-  EVE_FORCEINLINE decltype(auto) self_mul( wide<T,N,ppc_>& self, U const& other )
-  requires( scalar_value<U> || std::same_as<wide<T,N,ppc_>,U> )
+  EVE_FORCEINLINE decltype(auto) self_mul( wide<T,N>& self, U const& other )
+  requires( scalar_value<U> || std::same_as<wide<T, N>,U> ) && ppc_abi<abi_t<T, N>>
   {
-    using type = wide<T, N, ppc_>;
+    using type = wide<T, N>;
 
     if constexpr( scalar_value<U> )
     {
@@ -82,10 +82,10 @@ namespace eve::detail
   // /=
   //================================================================================================
   template<scalar_value T, value U, typename N>
-  EVE_FORCEINLINE decltype(auto) self_div( wide<T,N,ppc_>& self, U const& other )
-  requires( scalar_value<U> || std::same_as<wide<T,N,ppc_>,U> )
+  EVE_FORCEINLINE decltype(auto) self_div( wide<T, N>& self, U const& other )
+  requires( scalar_value<U> || std::same_as<wide<T, N>,U> ) && ppc_abi<abi_t<T, N>>
   {
-    using type = wide<T, N, ppc_>;
+    using type = wide<T, N>;
 
     if constexpr( scalar_value<U> )
     {
@@ -99,4 +99,3 @@ namespace eve::detail
     return self;
   }
 }
-

--- a/include/eve/detail/function/simd/ppc/broadcast.hpp
+++ b/include/eve/detail/function/simd/ppc/broadcast.hpp
@@ -12,14 +12,14 @@
 
 namespace eve::detail
 {
-  template<typename T, typename N, ppc_abi ABI, typename Index>
+  template<typename T, typename N, typename Index>
   EVE_FORCEINLINE auto broadcast_(EVE_SUPPORTS(vmx_), logical<wide<T,N>> v, Index) noexcept
     requires ppc_abi<abi_t<T, N>>
   {
     return logical<wide<T,N>>{ vec_splat(v.storage(), Index::value ) };
   }
 
-  template<typename T, typename N, ppc_abi ABI, typename Index, std::ptrdiff_t C>
+  template<typename T, typename N, typename Index, std::ptrdiff_t C>
   EVE_FORCEINLINE auto broadcast_(EVE_SUPPORTS(vmx_), logical<wide<T,N>> v, Index, fixed<C>) noexcept
     requires ppc_abi<abi_t<T, N>>
   {
@@ -27,14 +27,14 @@ namespace eve::detail
     return that_t{ vec_splat(v.storage(), Index::value ) };
   }
 
-  template<typename T, typename N, ppc_abi ABI, typename Index>
+  template<typename T, typename N, typename Index>
   EVE_FORCEINLINE auto broadcast_(EVE_SUPPORTS(vmx_), wide<T,N> v, Index) noexcept
     requires ppc_abi<abi_t<T, N>>
   {
     return wide<T,N>{ vec_splat(v.storage(), Index::value ) };
   }
 
-  template<typename T, typename N, ppc_abi ABI, typename Index, std::ptrdiff_t C>
+  template<typename T, typename N, typename Index, std::ptrdiff_t C>
   EVE_FORCEINLINE auto broadcast_(EVE_SUPPORTS(vmx_), wide<T,N> v, Index, fixed<C>) noexcept
     requires ppc_abi<abi_t<T, N>>
   {

--- a/include/eve/detail/function/simd/ppc/combine.hpp
+++ b/include/eve/detail/function/simd/ppc/combine.hpp
@@ -13,7 +13,8 @@ namespace eve::detail
 {
   template<typename T, typename N>
   EVE_FORCEINLINE auto
-  combine(vmx_ const &, wide<T, N, ppc_> const &l, wide<T, N, ppc_> const &h) noexcept
+  combine(vmx_ const &, wide<T, N> const &l, wide<T, N> const &h) noexcept
+    requires ppc_abi<abi_t<T, N>>
   {
     using that_t = wide<T, typename N::combined_type>;
 

--- a/include/eve/detail/function/simd/ppc/lookup.hpp
+++ b/include/eve/detail/function/simd/ppc/lookup.hpp
@@ -15,9 +15,10 @@ namespace eve::detail
 {
   template<typename T, typename I, typename N>
   EVE_FORCEINLINE auto
-  lookup_(EVE_SUPPORTS(vmx_), wide<T, N, ppc_> a, wide<I, N, ppc_> idx) noexcept
+  lookup_(EVE_SUPPORTS(vmx_), wide<T, N> a, wide<I, N> idx) noexcept
+    requires ppc_abi<abi_t<T, N>>
   {
-    using type = wide<T, N, ppc_>;
+    using type = wide<T, N>;
     using t8_t = typename type::template rebind<std::uint8_t, fixed<16>>;
 
     if constexpr( sizeof(I) == 1 )
@@ -31,10 +32,9 @@ namespace eve::detail
       t8_t i1 = lookup(bit_cast(vec_sl(idx.storage(), shf.storage()), as<t8_t>()),
                        t8_t {repeater<I, false>});
 
-      i1 = bit_cast(bit_cast(i1, as<wide<I, N, ppc_>>()) + offset<I, false>, as<t8_t>());
+      i1 = bit_cast(bit_cast(i1, as<wide<I, N>>()) + offset<I, false>, as<t8_t>());
 
       return bit_cast(lookup(bit_cast(a, as<t8_t>()), i1), as(a));
     }
   }
 }
-

--- a/include/eve/detail/function/simd/ppc/make.hpp
+++ b/include/eve/detail/function/simd/ppc/make.hpp
@@ -18,7 +18,8 @@ namespace eve::detail
   // arithmetic cases
   //================================================================================================
   template<real_scalar_value T, typename N, typename... Vs>
-  EVE_FORCEINLINE auto make(eve::as_<wide<T,N,ppc_>> const &, Vs... vs) noexcept
+  EVE_FORCEINLINE auto make(eve::as_<wide<T, N>> const &, Vs... vs) noexcept
+    requires ppc_abi<abi_t<T, N>>
   {
     using type = as_register_t<T, N, ppc_>;
     type that  = {static_cast<T>(vs)...};
@@ -26,7 +27,8 @@ namespace eve::detail
   }
 
   template<real_scalar_value T, typename N, typename V>
-  EVE_FORCEINLINE auto make(eve::as_<wide<T,N,ppc_>> const &, V v) noexcept
+  EVE_FORCEINLINE auto make(eve::as_<wide<T, N>> const &, V v) noexcept
+    requires ppc_abi<abi_t<T, N>>
   {
     auto impl = [&](auto... I)
     {
@@ -45,7 +47,8 @@ namespace eve::detail
   // logical cases
   //================================================================================================
   template<real_scalar_value T, typename N, typename... Vs>
-  EVE_FORCEINLINE auto make(eve::as_<logical<wide<T,N,ppc_>>> const &, Vs... vs) noexcept
+  EVE_FORCEINLINE auto make(eve::as_<logical<wide<T, N>>> const &, Vs... vs) noexcept
+    requires ppc_abi<abi_t<T, N>>
   {
     using type = as_logical_register_t<T, N, ppc_>;
     type that  = {logical<T>(vs).bits()...};
@@ -53,7 +56,8 @@ namespace eve::detail
   }
 
   template<real_scalar_value T, typename N, typename V>
-  EVE_FORCEINLINE auto make(eve::as_<logical<wide<T,N,ppc_>>> const &, V v) noexcept
+  EVE_FORCEINLINE auto make(eve::as_<logical<wide<T, N>>> const &, V v) noexcept
+    requires ppc_abi<abi_t<T, N>>
   {
     auto impl   = [&](auto... I)
     {

--- a/include/eve/detail/function/simd/ppc/slice.hpp
+++ b/include/eve/detail/function/simd/ppc/slice.hpp
@@ -12,7 +12,8 @@
 namespace eve::detail
 {
   template<typename T, typename N, typename Slice>
-  EVE_FORCEINLINE auto slice(wide<T, N, ppc_> const &a, Slice const &) noexcept
+  EVE_FORCEINLINE auto slice(wide<T, N> const &a, Slice const &) noexcept
+    requires ppc_abi<abi_t<T, N>>
   {
     if constexpr( Slice::value )
     {
@@ -35,7 +36,8 @@ namespace eve::detail
   }
 
   template<typename T, typename N>
-  EVE_FORCEINLINE auto slice(wide<T, N, ppc_> const &a) noexcept
+  EVE_FORCEINLINE auto slice(wide<T, N> const &a) noexcept
+    requires ppc_abi<abi_t<T, N>>
   {
     std::array<wide<T, typename N::split_type>, 2> that{slice(a, lower_), slice(a, upper_)};
     return that;

--- a/include/eve/detail/function/simd/x86/make.hpp
+++ b/include/eve/detail/function/simd/x86/make.hpp
@@ -24,13 +24,14 @@ namespace eve::detail
   // enumerated make - 128bits
   //================================================================================================
   template<real_scalar_value T, typename S, typename... Vs>
-  EVE_FORCEINLINE auto make(eve::as_<wide<T,S,x86_128_>> const &, Vs... vs) noexcept
+  EVE_FORCEINLINE auto make(eve::as_<wide<T,S>> const &, Vs... vs) noexcept
+    requires std::same_as<abi_t<T, S>, x86_128_>
   {
     static_assert ( sizeof...(Vs) <= S::value
                   , "[eve::make] - Invalid number of arguments"
                   );
 
-    constexpr auto c = categorize<wide<T,S,x86_128_>>();
+    constexpr auto c = categorize<wide<T,S>>();
 
           if constexpr( c == category::float64x2) return _mm_setr_pd(static_cast<T>(vs)...);
     else  if constexpr( c == category::float32x4)
@@ -79,13 +80,14 @@ namespace eve::detail
   // enumerated make - 256bits
   //================================================================================================
   template<real_scalar_value T, typename S, typename... Vs>
-  EVE_FORCEINLINE auto make(eve::as_<wide<T,S,x86_256_>> const &, Vs... vs) noexcept
+  EVE_FORCEINLINE auto make(eve::as_<wide<T, S>> const &, Vs... vs) noexcept
+    requires std::same_as<abi_t<T, S>, x86_256_>
   {
     static_assert ( sizeof...(Vs) <= S::value
                   , "[eve::make] - Invalid number of arguments"
                   );
 
-    constexpr auto c = categorize<wide<T,S,x86_256_>>();
+    constexpr auto c = categorize<wide<T, S>>();
 
           if constexpr( c == category::float64x4) return _mm256_setr_pd(vs...);
     else  if constexpr( c == category::float32x8) return _mm256_setr_ps(vs...);
@@ -99,13 +101,14 @@ namespace eve::detail
   // enumerated make - 512bits
   //================================================================================================
   template<real_scalar_value T, typename S, typename... Vs>
-  EVE_FORCEINLINE auto make(eve::as_<wide<T,S,x86_512_>> const &, Vs... vs) noexcept
+  EVE_FORCEINLINE auto make(eve::as_<wide<T,S>> const &, Vs... vs) noexcept
+    requires std::same_as<abi_t<T, S>, x86_512_>
   {
     static_assert ( sizeof...(Vs) <= S::value
                   , "[eve::make] - Invalid number of arguments"
                   );
 
-    constexpr auto c = categorize<wide<T,S,x86_512_>>();
+    constexpr auto c = categorize<wide<T,S>>();
 
     /*
       Please take a minute to acknowledge the effect of deciding _mm512_setr should be

--- a/include/eve/detail/function/simd/x86/slice.hpp
+++ b/include/eve/detail/function/simd/x86/slice.hpp
@@ -65,7 +65,7 @@ namespace eve::detail
       else
       {
         // Slice bits via uint64 then go back
-        using retarget_t = typename wide<T, N, avx512_>::template rebind<std::uint64_t>;
+        using retarget_t = typename wide<T, N>::template rebind<std::uint64_t>;
         return bit_cast ( slice( bit_cast(a, as<retarget_t>()),Slice{})
                         , as<wide<T, typename N::split_type>>()
                         );

--- a/include/eve/detail/function/simd/x86/swizzle.hpp
+++ b/include/eve/detail/function/simd/x86/swizzle.hpp
@@ -56,10 +56,11 @@ namespace eve::detail
   // SSE2-SSSE3 variant
   //================================================================================================
   template<typename T, typename N, shuffle_pattern Pattern>
-  EVE_FORCEINLINE auto basic_swizzle_( EVE_SUPPORTS(sse2_), wide<T,N,x86_128_> const& v, Pattern const&)
+  EVE_FORCEINLINE auto basic_swizzle_( EVE_SUPPORTS(sse2_), wide<T, N> const& v, Pattern const&)
+    requires std::same_as<abi_t<T, N>, x86_128_>
   {
     constexpr auto sz = Pattern::size();
-    using that_t      = as_wide_t<wide<T,N,x86_128_>,fixed<sz>>;
+    using that_t      = as_wide_t<wide<T, N>, fixed<sz>>;
 
     constexpr Pattern q = {};
 
@@ -79,7 +80,7 @@ namespace eve::detail
     {
       using st_t    = typename that_t::storage_type;
       using bytes_t = typename that_t::template rebind<std::uint8_t,fixed<16>>;
-      using i_t     = as_integer_t<wide<T,N,x86_128_>>;
+      using i_t     = as_integer_t<wide<T, N>>;
 
       return that_t ( (st_t)_mm_shuffle_epi8( bit_cast(v,as_<i_t>{}).storage()
                                             , as_bytes<that_t>(q,as_<bytes_t>())

--- a/include/eve/forward.hpp
+++ b/include/eve/forward.hpp
@@ -17,7 +17,6 @@ namespace eve
 
   // Wrapper for SIMD registers holding arithmetic types with compile-time size
   template<typename Type,
-           typename Size = expected_cardinal_t<Type>,
-           typename ABI  = abi_t<Type, Size>>
+           typename Size = expected_cardinal_t<Type>>
   struct wide;
 }

--- a/include/eve/module/real/algorithm/function/regular/simd/arm/neon/all.hpp
+++ b/include/eve/module/real/algorithm/function/regular/simd/arm/neon/all.hpp
@@ -17,9 +17,10 @@ namespace eve::detail
 {
 
   template<real_scalar_value T, typename N, relative_conditional_expr C>
-  EVE_FORCEINLINE bool all_(EVE_SUPPORTS(neon128_), C const &cond, logical<wide<T, N, arm_64_>> const &v0) noexcept
+  EVE_FORCEINLINE bool all_(EVE_SUPPORTS(neon128_), C const &cond, logical<wide<T, N>> v0) noexcept
+      requires std::same_as<abi_t<T, N>, arm_64_>
   {
-    using u32_2 = typename wide<T, N, arm_64_>::template rebind<std::uint32_t, eve::fixed<2>>;
+    using u32_2 = typename wide<T, N>::template rebind<std::uint32_t, eve::fixed<2>>;
 
          if constexpr ( C::is_complete && !C::is_inverted ) return true;
     else if constexpr ( !C::is_complete )                   return all_(EVE_RETARGET(cpu_), cond, v0);
@@ -39,9 +40,10 @@ namespace eve::detail
   }
 
   template<real_scalar_value T, typename N, relative_conditional_expr C>
-  EVE_FORCEINLINE bool all_(EVE_SUPPORTS(neon128_), C const &cond, logical<wide<T, N, arm_128_>> const &v0) noexcept
+  EVE_FORCEINLINE bool all_(EVE_SUPPORTS(neon128_), C const &cond, logical<wide<T, N>> v0) noexcept
+    requires std::same_as<abi_t<T, N>, arm_128_>
   {
-    using u32_4 = typename wide<T, N, arm_128_>::template rebind<std::uint32_t, eve::fixed<4>>;
+    using u32_4 = typename wide<T, N>::template rebind<std::uint32_t, eve::fixed<4>>;
 
          if constexpr ( C::is_complete && !C::is_inverted ) return true;
     // we still have to convert down here, so we can do it before ignore.
@@ -65,7 +67,7 @@ namespace eve::detail
     }
     else  // chars, no asimd
     {
-      using u32_4 = typename wide<T, N, arm_128_>::template rebind<std::uint32_t, eve::fixed<4>>;
+      using u32_4 = typename wide<T, N>::template rebind<std::uint32_t, eve::fixed<4>>;
       auto dwords = eve::bit_cast(v0, eve::as<u32_4>());
 
       // not the same logic as for uint_32 plain so duplicated.

--- a/include/eve/module/real/algorithm/function/regular/simd/arm/neon/any.hpp
+++ b/include/eve/module/real/algorithm/function/regular/simd/arm/neon/any.hpp
@@ -16,9 +16,10 @@
 namespace eve::detail
 {
   template<real_scalar_value T, typename N, relative_conditional_expr C>
-  EVE_FORCEINLINE bool any_(EVE_SUPPORTS(neon128_), C const &cond, logical<wide<T, N, arm_64_>> const &v0) noexcept
+  EVE_FORCEINLINE bool any_(EVE_SUPPORTS(neon128_), C const &cond, logical<wide<T, N>> v0) noexcept
+    requires std::same_as<abi_t<T, N>, arm_64_>
   {
-    using u32_2 = typename wide<T, N, arm_64_>::template rebind<std::uint32_t, eve::fixed<2>>;
+    using u32_2 = typename wide<T, N>::template rebind<std::uint32_t, eve::fixed<2>>;
 
          if constexpr ( C::is_complete && !C::is_inverted ) return false;
     else if constexpr ( !C::is_complete )                   return any_(EVE_RETARGET(cpu_), cond, v0);
@@ -34,9 +35,10 @@ namespace eve::detail
   }
 
   template<real_scalar_value T, typename N, relative_conditional_expr C>
-  EVE_FORCEINLINE bool any_(EVE_SUPPORTS(neon128_), C const &cond, logical<wide<T, N, arm_128_>> const &v0) noexcept
+  EVE_FORCEINLINE bool any_(EVE_SUPPORTS(neon128_), C const &cond, logical<wide<T, N>> v0) noexcept
+    requires std::same_as<abi_t<T, N>, arm_128_>
   {
-    using u32_4 = typename wide<T, N, arm_128_>::template rebind<std::uint32_t, eve::fixed<4>>;
+    using u32_4 = typename wide<T, N>::template rebind<std::uint32_t, eve::fixed<4>>;
 
          if constexpr ( C::is_complete && !C::is_inverted ) return false;
     // we still have to convert down here, so we can do it before ignore.

--- a/include/eve/module/real/algorithm/function/regular/simd/arm/neon/first_true.hpp
+++ b/include/eve/module/real/algorithm/function/regular/simd/arm/neon/first_true.hpp
@@ -16,7 +16,8 @@ namespace eve::detail
 
   template<real_scalar_value T, typename N, relative_conditional_expr C>
   EVE_FORCEINLINE std::optional<std::ptrdiff_t> first_true_(
-    EVE_SUPPORTS(neon128_), C const &cond, logical<wide<T, N, arm_128_>> const &v0) noexcept
+    EVE_SUPPORTS(neon128_), C const &cond, logical<wide<T, N>> const &v0) noexcept
+    requires std::same_as<abi_t<T, N>, arm_128_>
   {
          if constexpr ( C::is_complete && !C::is_inverted ) return std::nullopt;
     // we still have to convert down here, so we can do it before ignore.

--- a/include/eve/module/real/algorithm/function/regular/simd/ppc/all.hpp
+++ b/include/eve/module/real/algorithm/function/regular/simd/ppc/all.hpp
@@ -14,7 +14,8 @@
 namespace eve::detail
 {
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE bool all_(EVE_SUPPORTS(vmx_), logical<wide<T, N, ppc_>> const &v0) noexcept
+  EVE_FORCEINLINE bool all_(EVE_SUPPORTS(vmx_), logical<wide<T, N>> const &v0) noexcept
+    requires ppc_abi<abi_t<T, N>>
   {
     auto m = v0.bits();
 
@@ -28,7 +29,7 @@ namespace eve::detail
     }
     else
     {
-      using type = logical<wide<T, N, ppc_>>;
+      using type = logical<wide<T, N>>;
 
       auto mm = apply<N::value>([](auto... I) { return type {(I < N::value)...}; });
       m &= mm.bits();

--- a/include/eve/module/real/algorithm/function/regular/simd/ppc/any.hpp
+++ b/include/eve/module/real/algorithm/function/regular/simd/ppc/any.hpp
@@ -14,7 +14,8 @@
 namespace eve::detail
 {
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE bool any_(EVE_SUPPORTS(vmx_), logical<wide<T, N, ppc_>> const &v0) noexcept
+  EVE_FORCEINLINE bool any_(EVE_SUPPORTS(vmx_), logical<wide<T, N>> const &v0) noexcept
+    requires ppc_abi<abi_t<T, N>>
   {
     auto m = v0.bits();
 
@@ -28,7 +29,7 @@ namespace eve::detail
     }
     else
     {
-      using type = logical<wide<T, N, ppc_>>;
+      using type = logical<wide<T, N>>;
 
       auto mm = apply<N::value>([](auto... I) { return type {(I < N::value)...}; });
       m &= mm.bits();

--- a/include/eve/module/real/core/function/numeric/simd/ppc/fma.hpp
+++ b/include/eve/module/real/core/function/numeric/simd/ppc/fma.hpp
@@ -18,11 +18,12 @@
 namespace eve::detail
 {
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, ppc_> fma_(EVE_SUPPORTS(vmx_),
-                                        numeric const &,
-                                        wide<T, N, ppc_> const &v0,
-                                        wide<T, N, ppc_> const &v1,
-                                        wide<T, N, ppc_> const &v2) noexcept
+  EVE_FORCEINLINE wide<T, N> fma_(EVE_SUPPORTS(vmx_),
+                                  numeric const &,
+                                  wide<T, N> const &v0,
+                                  wide<T, N> const &v1,
+                                  wide<T, N> const &v2) noexcept
+    requires ppc_abi<abi_t<T, N>>
   {
     if constexpr( std::is_floating_point_v<T> )
       return vec_madd(v0.storage(), v1.storage(), v2.storage());

--- a/include/eve/module/real/core/function/pedantic/simd/ppc/fma.hpp
+++ b/include/eve/module/real/core/function/pedantic/simd/ppc/fma.hpp
@@ -18,11 +18,12 @@
 namespace eve::detail
 {
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, ppc_> fma_(EVE_SUPPORTS(vmx_),
-                                        pedantic const &,
-                                        wide<T, N, ppc_> const &v0,
-                                        wide<T, N, ppc_> const &v1,
-                                        wide<T, N, ppc_> const &v2) noexcept
+  EVE_FORCEINLINE wide<T, N> fma_(EVE_SUPPORTS(vmx_),
+                                  pedantic const &,
+                                  wide<T, N> const &v0,
+                                  wide<T, N> const &v1,
+                                  wide<T, N> const &v2) noexcept
+    requires ppc_abi<abi_t<T, N>>
   {
     if constexpr( std::is_floating_point_v<T> )
       return vec_madd(v0.storage(), v1.storage(), v2.storage());

--- a/include/eve/module/real/core/function/regular/generic/store.hpp
+++ b/include/eve/module/real/core/function/regular/generic/store.hpp
@@ -35,14 +35,16 @@ namespace eve::detail
   // simd Regular case
   template<real_scalar_value T, typename N>
   EVE_FORCEINLINE void
-  store_(EVE_SUPPORTS(cpu_), wide<T, N, emulated_> const &value, T *ptr) noexcept
+  store_(EVE_SUPPORTS(cpu_), wide<T, N> const &value, T *ptr) noexcept
+    requires std::same_as<abi_t<T, N>, emulated_>
   {
     apply<N::value>([&](auto... I) { ((*ptr++ = value.get(I)), ...); });
   }
 
   template<real_scalar_value T, typename N>
   EVE_FORCEINLINE void
-  store_(EVE_SUPPORTS(cpu_), wide<T, N, aggregated_> const &value, T *ptr) noexcept
+  store_(EVE_SUPPORTS(cpu_), wide<T, N> const &value, T *ptr) noexcept
+    requires std::same_as<abi_t<T, N>, aggregated_>
   {
     value.storage().apply
     ( [&]<typename... Sub>(Sub&... v)

--- a/include/eve/module/real/core/function/regular/generic/store.hpp
+++ b/include/eve/module/real/core/function/regular/generic/store.hpp
@@ -59,16 +59,16 @@ namespace eve::detail
   // simd Aligned case
   template<real_scalar_value T, typename S, std::size_t N>
   EVE_FORCEINLINE void
-  store_(EVE_SUPPORTS(cpu_), wide<T, S, emulated_> const &value, aligned_ptr<T, N> ptr) noexcept
-      requires(wide<T, S, emulated_>::alignment() <= N)
+  store_(EVE_SUPPORTS(cpu_), wide<T, S> const &value, aligned_ptr<T, N> ptr) noexcept
+      requires(wide<T, S>::alignment() <= N) && std::same_as<abi_t<T, S>, emulated_>
   {
     store(value, ptr.get());
   }
 
   template<real_scalar_value T, typename S, std::size_t N>
   EVE_FORCEINLINE void
-  store_(EVE_SUPPORTS(cpu_), wide<T, S, aggregated_> const &value, aligned_ptr<T, N> ptr) noexcept
-      requires(wide<T, S, aggregated_>::alignment() <= N)
+  store_(EVE_SUPPORTS(cpu_), wide<T, S> const &value, aligned_ptr<T, N> ptr) noexcept
+      requires(wide<T, S>::alignment() <= N) && std::same_as<abi_t<T, S>, aggregated_>
   {
     auto cast = []<typename Ptr, typename Sub>(Ptr ptr, as_<Sub>)
     {

--- a/include/eve/module/real/core/function/regular/simd/arm/neon/detail/shift.hpp
+++ b/include/eve/module/real/core/function/regular/simd/arm/neon/detail/shift.hpp
@@ -15,46 +15,32 @@
 
 namespace eve::detail
 {
-  template<typename T, typename N, typename I>
-  EVE_FORCEINLINE auto neon_shifter(wide<T, N, arm_64_> const &v0,
-                                    wide<I, N, arm_64_> const &v1) noexcept
+  template<integral_real_scalar_value T, typename N, typename I>
+  EVE_FORCEINLINE wide<T, N> neon_shifter(wide<T, N> v0, wide<I, N> v1) noexcept
+    requires arm_abi<abi_t<T, N>>
   {
-    using t_t                      = wide<T, N, arm_64_>;
-    constexpr bool is_signed_int   = std::is_integral_v<T> && std::is_signed_v<T>;
-    constexpr bool is_unsigned_int = std::is_integral_v<T> && std::is_unsigned_v<T>;
-
     using i_t = wide<as_integer_t<T, signed>, N>;
-    auto s1   = bit_cast(v1,as_<i_t>()).storage();
+    auto s1 = bit_cast(v1, as_<i_t>());
 
-    if constexpr(is_signed_int && sizeof(T) == 8) return t_t(vshl_s64(v0, s1));
-    if constexpr(is_signed_int && sizeof(T) == 4) return t_t(vshl_s32(v0, s1));
-    if constexpr(is_signed_int && sizeof(T) == 2) return t_t(vshl_s16(v0, s1));
-    if constexpr(is_signed_int && sizeof(T) == 1) return t_t(vshl_s8(v0, s1));
-    if constexpr(is_unsigned_int && sizeof(T) == 8) return t_t(vshl_u64(v0, s1));
-    if constexpr(is_unsigned_int && sizeof(T) == 4) return t_t(vshl_u32(v0, s1));
-    if constexpr(is_unsigned_int && sizeof(T) == 2) return t_t(vshl_u16(v0, s1));
-    if constexpr(is_unsigned_int && sizeof(T) == 1) return t_t(vshl_u8(v0, s1));
-  }
+    constexpr auto c = categorize<wide<T, N>>();
 
-  template<typename T, typename N, typename I>
-  EVE_FORCEINLINE auto neon_shifter(wide<T, N, arm_128_> const &v0,
-                                    wide<I, N, arm_128_> const &v1) noexcept
-  {
-    using t_t                      = wide<T, N, arm_128_>;
-    constexpr bool is_signed_int   = std::is_integral_v<T> && std::is_signed_v<T>;
-    constexpr bool is_unsigned_int = std::is_integral_v<T> && std::is_unsigned_v<T>;
-
-    using i_t = wide<as_integer_t<T, signed>, N>;
-    auto s1   = bit_cast(v1,as_<i_t>()).storage();
-
-    if constexpr(is_signed_int && sizeof(T) == 8) return t_t(vshlq_s64(v0, s1));
-    if constexpr(is_signed_int && sizeof(T) == 4) return t_t(vshlq_s32(v0, s1));
-    if constexpr(is_signed_int && sizeof(T) == 2) return t_t(vshlq_s16(v0, s1));
-    if constexpr(is_signed_int && sizeof(T) == 1) return t_t(vshlq_s8(v0, s1));
-    if constexpr(is_unsigned_int && sizeof(T) == 8) return t_t(vshlq_u64(v0, s1));
-    if constexpr(is_unsigned_int && sizeof(T) == 4) return t_t(vshlq_u32(v0, s1));
-    if constexpr(is_unsigned_int && sizeof(T) == 2) return t_t(vshlq_u16(v0, s1));
-    if constexpr(is_unsigned_int && sizeof(T) == 1) return t_t(vshlq_u8(v0, s1));
+    // arm_128
+         if constexpr ( c == category::int64x2  ) return vshlq_s64(v0, s1);
+    else if constexpr ( c == category::uint64x2 ) return vshlq_u64(v0, s1);
+    else if constexpr ( c == category::int32x4  ) return vshlq_s32(v0, s1);
+    else if constexpr ( c == category::uint32x4 ) return vshlq_u32(v0, s1);
+    else if constexpr ( c == category::int16x8  ) return vshlq_s16(v0, s1);
+    else if constexpr ( c == category::uint16x8 ) return vshlq_u16(v0, s1);
+    else if constexpr ( c == category::int8x16  ) return vshlq_s8 (v0, s1);
+    else if constexpr ( c == category::uint8x16 ) return vshlq_u8 (v0, s1);
+    // arm_64
+    else if constexpr ( c == category::int64x1  ) return vshl_s64 (v0, s1);
+    else if constexpr ( c == category::uint64x1 ) return vshl_s32 (v0, s1);
+    else if constexpr ( c == category::int32x2  ) return vshl_s32 (v0, s1);
+    else if constexpr ( c == category::uint32x2 ) return vshl_u32 (v0, s1);
+    else if constexpr ( c == category::int16x4  ) return vshl_s16 (v0, s1);
+    else if constexpr ( c == category::uint16x4 ) return vshl_u16 (v0, s1);
+    else if constexpr ( c == category::int8x8   ) return vshl_s8  (v0, s1);
+    else if constexpr ( c == category::uint8x8  ) return vshl_u8  (v0, s1);
   }
 }
-

--- a/include/eve/module/real/core/function/regular/simd/arm/neon/store.hpp
+++ b/include/eve/module/real/core/function/regular/simd/arm/neon/store.hpp
@@ -60,7 +60,7 @@ namespace eve::detail
                              , aligned_ptr<T, N> ptr) noexcept
     requires arm_abi<abi_t<T, N>>
   {
-    if constexpr( std::is_same<ABI,arm_64_> &&  (ABI N::value * sizeof(T) != arm_64_::bytes ))
+    if constexpr( std::is_same<abi_t<T, N>,arm_64_> &&  ( N::value * sizeof(T) != arm_64_::bytes ))
     {
       memcpy(ptr, (T const*)(&value), N::value * sizeof(T));
     }

--- a/include/eve/module/real/core/function/regular/simd/ppc/abs.hpp
+++ b/include/eve/module/real/core/function/regular/simd/ppc/abs.hpp
@@ -16,13 +16,13 @@
 namespace eve::detail
 {
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, ppc_> abs_(EVE_SUPPORTS(vmx_), wide<T, N, ppc_> const& v) noexcept
+  EVE_FORCEINLINE wide<T, N> abs_(EVE_SUPPORTS(vmx_), wide<T, N> const& v) noexcept
+    requires ppc_abi<abi_t<T, N>>
   {
-    constexpr auto cat = categorize<wide<T, N, ppc_>>();
+    constexpr auto cat = categorize<wide<T, N>>();
 
           if constexpr( cat && category::unsigned_) return v;
     else  if constexpr( cat && category::size64_  ) return map(eve::abs, v);
     else                                            return vec_abs(v.storage());
   }
 }
-

--- a/include/eve/module/real/core/function/regular/simd/ppc/average.hpp
+++ b/include/eve/module/real/core/function/regular/simd/ppc/average.hpp
@@ -18,13 +18,13 @@
 namespace eve::detail
 {
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, ppc_> average_(EVE_SUPPORTS(vmx_)
-                                           , wide<T, N, ppc_> const &v0
-                                           , wide<T, N, ppc_> const &v1) noexcept
+  EVE_FORCEINLINE wide<T, N> average_(EVE_SUPPORTS(vmx_)
+                                      , wide<T, N> const &v0
+                                      , wide<T, N> const &v1) noexcept
+    requires ppc_abi<abi_t<T, N>>
   {
-    if constexpr(integral_value<T> && sizeof(T) < 8) return vec_avg(v0.storage(), v1.storage());
-    else if constexpr(floating_value<T>)             return fma(v0,  half(eve::as(v0)), v1 *  half(eve::as(v0)));
-    else                                             return map(average, v0, v1);
+         if constexpr(integral_value<T> && sizeof(T) < 8) return vec_avg(v0.storage(), v1.storage());
+    else if constexpr(floating_value<T>)                  return fma(v0,  half(eve::as(v0)), v1 *  half(eve::as(v0)));
+    else                                                  return map(average, v0, v1);
   }
 }
-

--- a/include/eve/module/real/core/function/regular/simd/ppc/bit_andnot.hpp
+++ b/include/eve/module/real/core/function/regular/simd/ppc/bit_andnot.hpp
@@ -15,11 +15,11 @@
 namespace eve::detail
 {
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, ppc_> bit_andnot_(EVE_SUPPORTS(vmx_),
-                                                   wide<T, N, ppc_> const &v0,
-                                                   wide<T, N, ppc_> const &v1) noexcept
+  EVE_FORCEINLINE wide<T, N> bit_andnot_(EVE_SUPPORTS(vmx_),
+                                         wide<T, N> const &v0,
+                                         wide<T, N> const &v1) noexcept
+    requires ppc_abi<abi_t<T, N>>
   {
     return vec_andc(v0.storage(), v1.storage());
   }
 }
-

--- a/include/eve/module/real/core/function/regular/simd/ppc/bit_notand.hpp
+++ b/include/eve/module/real/core/function/regular/simd/ppc/bit_notand.hpp
@@ -15,11 +15,11 @@
 namespace eve::detail
 {
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, ppc_> bit_notand_(EVE_SUPPORTS(vmx_),
-                                                   wide<T, N, ppc_> const &v0,
-                                                   wide<T, N, ppc_> const &v1) noexcept
+  EVE_FORCEINLINE wide<T, N> bit_notand_(EVE_SUPPORTS(vmx_),
+                                         wide<T, N> const &v0,
+                                         wide<T, N> const &v1) noexcept
+    requires ppc_abi<abi_t<T, N>>
   {
     return vec_andc(v1.storage(), v0.storage());
   }
 }
-

--- a/include/eve/module/real/core/function/regular/simd/ppc/bit_select.hpp
+++ b/include/eve/module/real/core/function/regular/simd/ppc/bit_select.hpp
@@ -15,14 +15,14 @@
 namespace eve::detail
 {
   template<typename T, typename U, typename N>
-  EVE_FORCEINLINE wide<T, N, ppc_> bit_select_(EVE_SUPPORTS(vmx_),
-                                                   wide<U, N, ppc_> const &m,
-                                                   wide<T, N, ppc_> const &v0,
-                                                   wide<T, N, ppc_> const &v1) noexcept
+  EVE_FORCEINLINE wide<T, N> bit_select_(EVE_SUPPORTS(vmx_),
+                                        wide<U, N> const &m,
+                                        wide<T, N> const &v0,
+                                        wide<T, N> const &v1) noexcept
+    requires ppc_abi<abi_t<T, N>>
   {
     using i_t = wide<as_integer_t<T, unsigned>, N>;
 
     return vec_sel(v1.storage(), v0.storage(), bit_cast(m,as_<i_t>()).storage());
   }
 }
-

--- a/include/eve/module/real/core/function/regular/simd/ppc/bit_shr.hpp
+++ b/include/eve/module/real/core/function/regular/simd/ppc/bit_shr.hpp
@@ -19,21 +19,22 @@ namespace eve::detail
 {
   template<integral_scalar_value T, typename N, integral_scalar_value I>
   EVE_FORCEINLINE auto bit_shr_ ( EVE_SUPPORTS(vmx_),
-                                  wide<T, N, ppc_> const &v0,
-                                  wide<I, N, ppc_> const &v1
+                                  wide<T, N> const &v0,
+                                  wide<I, N> const &v1
                                 ) noexcept
+    requires ppc_abi<abi_t<T, N>>
   {
     using i_t = wide<as_integer_t<T, unsigned>, N>;
-    return wide<T, N, ppc_>(vec_sr(v0.storage(), bit_cast(v1,as_<i_t>()).storage()));
+    return wide<T, N>(vec_sr(v0.storage(), bit_cast(v1,as_<i_t>()).storage()));
   }
 
   template<integral_scalar_value T, typename N, integral_scalar_value I>
   EVE_FORCEINLINE auto bit_shr_(EVE_SUPPORTS(vmx_)
-                               , wide<T, N, ppc_> const &v0
+                               , wide<T, N> const &v0
                                , I v1) noexcept
+    requires ppc_abi<abi_t<T, N>>
   {
     using i_t = wide<as_integer_t<T, unsigned>, N>;
     return bit_shr(v0, i_t(v1));
   }
 }
-

--- a/include/eve/module/real/core/function/regular/simd/ppc/ceil.hpp
+++ b/include/eve/module/real/core/function/regular/simd/ppc/ceil.hpp
@@ -13,10 +13,10 @@
 namespace eve::detail
 {
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, ppc_> ceil_(EVE_SUPPORTS(vmx_), wide<T, N, ppc_> const &v0) noexcept
+  EVE_FORCEINLINE wide<T, N> ceil_(EVE_SUPPORTS(vmx_), wide<T, N> const &v0) noexcept
+    requires ppc_abi<abi_t<T, N>>
   {
     if constexpr(floating_value<T>) return vec_ceil(v0.storage());
     else                            return v0;
   }
 }
-

--- a/include/eve/module/real/core/function/regular/simd/ppc/convert.hpp
+++ b/include/eve/module/real/core/function/regular/simd/ppc/convert.hpp
@@ -17,7 +17,8 @@ namespace eve::detail
 {
   template<real_scalar_value T, typename N, real_scalar_value U>
   EVE_FORCEINLINE wide<U, N>
-                  convert_(EVE_SUPPORTS(vmx_), wide<T, N, ppc_> const &v0, as_<U> const &tgt) noexcept
+  convert_(EVE_SUPPORTS(vmx_), wide<T, N> const &v0, as_<U> const &tgt) noexcept
+    requires ppc_abi<abi_t<T, N>>
   {
     // Idempotent call
     if constexpr( std::is_same_v<T, U> )
@@ -52,4 +53,3 @@ namespace eve::detail
     }
   }
 }
-

--- a/include/eve/module/real/core/function/regular/simd/ppc/div.hpp
+++ b/include/eve/module/real/core/function/regular/simd/ppc/div.hpp
@@ -13,10 +13,10 @@
 namespace eve::detail
 {
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, ppc_>
-                  div_(EVE_SUPPORTS(vsx_), wide<T, N, ppc_> v0, wide<T, N, ppc_> const &v1) noexcept
+  EVE_FORCEINLINE wide<T, N>
+  div_(EVE_SUPPORTS(vsx_), wide<T, N> v0, wide<T, N> const &v1) noexcept
+    requires ppc_abi<abi_t<T, N>>
   {
     return v0 /= v1;
   }
 }
-

--- a/include/eve/module/real/core/function/regular/simd/ppc/floor.hpp
+++ b/include/eve/module/real/core/function/regular/simd/ppc/floor.hpp
@@ -13,10 +13,10 @@
 namespace eve::detail
 {
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, ppc_> floor_(EVE_SUPPORTS(vmx_)
-                                         , wide<T, N, ppc_> const &v0) noexcept
+  EVE_FORCEINLINE wide<T, N>
+  floor_(EVE_SUPPORTS(vmx_), wide<T, N> const &v0) noexcept
+    requires ppc_abi<abi_t<T, N>>
   {
     return vec_floor(v0.storage());
   }
 }
-

--- a/include/eve/module/real/core/function/regular/simd/ppc/fma.hpp
+++ b/include/eve/module/real/core/function/regular/simd/ppc/fma.hpp
@@ -17,10 +17,11 @@
 namespace eve::detail
 {
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, ppc_> fma_(EVE_SUPPORTS(vmx_),
-                                        wide<T, N, ppc_> const &v0,
-                                        wide<T, N, ppc_> const &v1,
-                                        wide<T, N, ppc_> const &v2) noexcept
+  EVE_FORCEINLINE wide<T, N> fma_(EVE_SUPPORTS(vmx_),
+                                  wide<T, N> const &v0,
+                                  wide<T, N> const &v1,
+                                  wide<T, N> const &v2) noexcept
+    requires ppc_abi<abi_t<T, N>>
   {
     if constexpr( std::is_floating_point_v<T> )
       return vec_madd(v0.storage(), v1.storage(), v2.storage());

--- a/include/eve/module/real/core/function/regular/simd/ppc/if_else.hpp
+++ b/include/eve/module/real/core/function/regular/simd/ppc/if_else.hpp
@@ -13,21 +13,23 @@
 namespace eve::detail
 {
   template<real_scalar_value U, typename N>
-  EVE_FORCEINLINE wide<U, N, ppc_> if_else_ ( EVE_SUPPORTS(vmx_)
-                                            , logical<wide<U, N, ppc_>> const &m
-                                            , wide<U, N, ppc_> const &  v0
-                                            , wide<U, N, ppc_> const &  v1
-                                            ) noexcept
+  EVE_FORCEINLINE wide<U, N> if_else_ ( EVE_SUPPORTS(vmx_)
+                                        , logical<wide<U, N>> const &m
+                                        , wide<U, N> const &  v0
+                                        , wide<U, N> const &  v1
+                                        ) noexcept
+    requires ppc_abi<abi_t<U, N>>
   {
     return vec_sel(v1.storage(), v0.storage(), bit_cast(m, as_<logical<wide<U,N>>>()).storage());
   }
 
   template<real_scalar_value U, typename N>
-  EVE_FORCEINLINE logical<wide<U, N, ppc_>> if_else_( EVE_SUPPORTS(vmx_)
-                                                    , logical<wide<U, N, ppc_>> const & m
-                                                    , logical<wide<U, N, ppc_>> const & v0
-                                                    , logical<wide<U, N, ppc_>> const & v1
-                                                    ) noexcept
+  EVE_FORCEINLINE logical<wide<U, N>> if_else_( EVE_SUPPORTS(vmx_)
+                                              , logical<wide<U, N>> const & m
+                                              , logical<wide<U, N>> const & v0
+                                              , logical<wide<U, N>> const & v1
+                                              ) noexcept
+    requires ppc_abi<abi_t<U, N>>
   {
     return bit_cast ( vec_sel ( v1.storage(), v0.storage()
                               , bit_cast(m, as_<logical<wide<U,N>>>()).storage()

--- a/include/eve/module/real/core/function/regular/simd/ppc/max.hpp
+++ b/include/eve/module/real/core/function/regular/simd/ppc/max.hpp
@@ -15,11 +15,10 @@
 namespace eve::detail
 {
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, ppc_> max_(EVE_SUPPORTS(vmx_)
-                                       , wide<T, N, ppc_> const &v0
-                                       , wide<T, N, ppc_> const &v1) noexcept
+  EVE_FORCEINLINE wide<T, N>
+  max_(EVE_SUPPORTS(vmx_), wide<T, N> const &v0, wide<T, N> const &v1) noexcept
+    requires ppc_abi<abi_t<T, N>>
   {
     return vec_max(v0.storage(), v1.storage());
   }
 }
-

--- a/include/eve/module/real/core/function/regular/simd/ppc/min.hpp
+++ b/include/eve/module/real/core/function/regular/simd/ppc/min.hpp
@@ -15,12 +15,10 @@
 namespace eve::detail
 {
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, ppc_>
-                  min_(EVE_SUPPORTS(vmx_)
-                      , wide<T, N, ppc_> const &v0
-                      , wide<T, N, ppc_> const &v1) noexcept
+  EVE_FORCEINLINE wide<T, N>
+  min_(EVE_SUPPORTS(vmx_), wide<T, N> const &v0, wide<T, N> const &v1) noexcept
+    requires ppc_abi<abi_t<T, N>>
   {
     return vec_min(v0.storage(), v1.storage());
   }
 }
-

--- a/include/eve/module/real/core/function/regular/simd/ppc/mul.hpp
+++ b/include/eve/module/real/core/function/regular/simd/ppc/mul.hpp
@@ -13,10 +13,10 @@
 namespace eve::detail
 {
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, ppc_>
-                  mul_(EVE_SUPPORTS(vmx_), wide<T, N, ppc_> v0, wide<T, N, ppc_> const &v1) noexcept
+  EVE_FORCEINLINE wide<T, N>
+  mul_(EVE_SUPPORTS(vmx_), wide<T, N> v0, wide<T, N> const &v1) noexcept
+    requires ppc_abi<abi_t<T, N>>
   {
     return v0 *= v1;
   }
 }
-

--- a/include/eve/module/real/core/function/regular/simd/ppc/nearest.hpp
+++ b/include/eve/module/real/core/function/regular/simd/ppc/nearest.hpp
@@ -12,7 +12,8 @@
 namespace eve::detail
 {
   template<floating_real_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, ppc_> nearest_(EVE_SUPPORTS(vmx_), wide<T, N, ppc_> const &v0) noexcept
+  EVE_FORCEINLINE wide<T, N> nearest_(EVE_SUPPORTS(vmx_), wide<T, N> const &v0) noexcept
+      requires ppc_abi<abi_t<T, N>>
   {
     if constexpr(std::is_same_v<T, float>) { return vec_round(v0.storage()); }
     else if constexpr(std::is_same_v<T, double>)
@@ -22,4 +23,3 @@ namespace eve::detail
     }
   }
 }
-

--- a/include/eve/module/real/core/function/regular/simd/ppc/rec.hpp
+++ b/include/eve/module/real/core/function/regular/simd/ppc/rec.hpp
@@ -21,14 +21,16 @@
 namespace eve::detail
 {
   template<floating_real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, ppc_>
-                  rec_(EVE_SUPPORTS(vmx_), raw_type const&, wide<T, N, ppc_> const &v0) noexcept
+  EVE_FORCEINLINE wide<T, N>
+  rec_(EVE_SUPPORTS(vmx_), raw_type const&, wide<T, N> const &v0) noexcept
+    requires ppc_abi<abi_t<T, N>>
   {
     return vec_re(v0.storage());
   }
 
   template<floating_real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, ppc_> rec_(EVE_SUPPORTS(vmx_), wide<T, N, ppc_> const &v0) noexcept
+  EVE_FORCEINLINE wide<T, N> rec_(EVE_SUPPORTS(vmx_), wide<T, N> const &v0) noexcept
+    requires ppc_abi<abi_t<T, N>>
   {
     auto constexpr fix_inf = [](auto v, auto e)
     {

--- a/include/eve/module/real/core/function/regular/simd/ppc/rsqrt.hpp
+++ b/include/eve/module/real/core/function/regular/simd/ppc/rsqrt.hpp
@@ -18,7 +18,8 @@
 namespace eve::detail
 {
   template<floating_real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, ppc_> rsqrt_(EVE_SUPPORTS(vmx_), wide<T, N, ppc_> const &v0) noexcept
+  EVE_FORCEINLINE wide<T, N> rsqrt_(EVE_SUPPORTS(vmx_), wide<T, N> const &v0) noexcept
+    requires ppc_abi<abi_t<T, N>>
   {
     if constexpr(std::same_as<T, float>)
     {
@@ -42,8 +43,8 @@ namespace eve::detail
     {
       auto refine = [](auto sw0, auto w0)
       {
-        wide<T, N, ppc_> hest = sw0 * half(eve::as(w0));
-        wide<T, N, ppc_> tmp  = vec_nmsub(w0.storage(), sqr(sw0).storage(), one(eve::as(w0)).storage());
+        wide<T, N> hest = sw0 * half(eve::as(w0));
+        wide<T, N> tmp  = vec_nmsub(w0.storage(), sqr(sw0).storage(), one(eve::as(w0)).storage());
         return fma(tmp, hest, sw0);
       };
 
@@ -62,8 +63,9 @@ namespace eve::detail
   }
 
   template<floating_real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, ppc_>
-                  rsqrt_(EVE_SUPPORTS(vmx_), raw_type const &, wide<T, N, ppc_> const &v0) noexcept
+  EVE_FORCEINLINE wide<T, N>
+  rsqrt_(EVE_SUPPORTS(vmx_), raw_type const &, wide<T, N> const &v0) noexcept
+    requires ppc_abi<abi_t<T, N>>
   {
     if constexpr(std::is_floating_point_v<T>) { return vec_rsqrte(v0.storage()); }
     else
@@ -72,4 +74,3 @@ namespace eve::detail
     }
   }
 }
-

--- a/include/eve/module/real/core/function/regular/simd/ppc/sqrt.hpp
+++ b/include/eve/module/real/core/function/regular/simd/ppc/sqrt.hpp
@@ -17,7 +17,8 @@
 namespace eve::detail
 {
   template<floating_real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, ppc_> sqrt_(EVE_SUPPORTS(vmx_), wide<T, N, ppc_> const &v0) noexcept
+  EVE_FORCEINLINE wide<T, N> sqrt_(EVE_SUPPORTS(vmx_), wide<T, N> const &v0) noexcept
+      requires ppc_abi<abi_t<T, N>>
   {
     if constexpr(std::is_floating_point_v<T>)
     {
@@ -38,8 +39,9 @@ namespace eve::detail
   }
 
   template<floating_real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, ppc_>
-                  sqrt_(EVE_SUPPORTS(vmx_), raw_type const &, wide<T, N, ppc_> const &v0) noexcept
+  EVE_FORCEINLINE wide<T, N>
+  sqrt_(EVE_SUPPORTS(vmx_), raw_type const &, wide<T, N> const &v0) noexcept
+    requires ppc_abi<abi_t<T, N>>
   {
     if constexpr(std::is_floating_point_v<T>)
     {
@@ -51,4 +53,3 @@ namespace eve::detail
     }
   }
 }
-

--- a/include/eve/module/real/core/function/regular/simd/ppc/store.hpp
+++ b/include/eve/module/real/core/function/regular/simd/ppc/store.hpp
@@ -14,9 +14,10 @@
 namespace eve::detail
 {
   template< scalar_value T, typename N
-          , simd_compatible_ptr<wide<T, N, ppc_>> Ptr
+          , simd_compatible_ptr<wide<T, N>> Ptr
           >
-  EVE_FORCEINLINE void store_(EVE_SUPPORTS(vmx_), wide<T, N, ppc_> const &value, Ptr ptr) noexcept
+  EVE_FORCEINLINE void store_(EVE_SUPPORTS(vmx_), wide<T, N> const &value, Ptr ptr) noexcept
+    requires ppc_abi<abi_t<T, N>>
   {
     if constexpr( !std::is_pointer_v<Ptr> )
     {
@@ -27,7 +28,7 @@ namespace eve::detail
     {
       if constexpr( current_api == eve::vmx )
       {
-        *((typename wide<T, N, ppc_>::storage_type *)(ptr)) = value;
+        *((typename wide<T, N>::storage_type *)(ptr)) = value;
       }
       else if constexpr( current_api == eve::vsx )
       {
@@ -48,4 +49,3 @@ namespace eve::detail
     }
   }
 }
-

--- a/include/eve/module/real/core/function/regular/simd/ppc/sub.hpp
+++ b/include/eve/module/real/core/function/regular/simd/ppc/sub.hpp
@@ -12,10 +12,10 @@
 namespace eve::detail
 {
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, ppc_>
-                  sub_(EVE_SUPPORTS(vmx_), wide<T, N, ppc_> v0, wide<T, N, ppc_> const &v1) noexcept
+  EVE_FORCEINLINE wide<T, N>
+  sub_(EVE_SUPPORTS(vmx_), wide<T, N> v0, wide<T, N> const &v1) noexcept
+    requires ppc_abi<abi_t<T, N>>
   {
     return v0 -= v1;
   }
 }
-

--- a/include/eve/module/real/core/function/regular/simd/ppc/trunc.hpp
+++ b/include/eve/module/real/core/function/regular/simd/ppc/trunc.hpp
@@ -14,17 +14,16 @@
 namespace eve::detail
 {
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, ppc_> trunc_(EVE_SUPPORTS(vmx_)
-                                         , wide<T, N, ppc_> const &v0) noexcept
+  EVE_FORCEINLINE wide<T, N> trunc_(EVE_SUPPORTS(vmx_), wide<T, N> const &v0) noexcept
+    requires ppc_abi<abi_t<T, N>>
   {
     if constexpr(integral_value<T>)      return v0;
     else if constexpr(floating_value<T>) return vec_trunc(v0.storage());
   }
 
   template<real_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N, ppc_> trunc_(EVE_SUPPORTS(vmx_)
-                                         , raw_type const &
-                                         , wide<T, N, ppc_> const &v0) noexcept
+  EVE_FORCEINLINE wide<T, N> trunc_(EVE_SUPPORTS(vmx_), raw_type, wide<T, N> const &v0) noexcept
+    requires ppc_abi<abi_t<T, N>>
   {
     return trunc(v0);
   }

--- a/include/eve/module/real/core/function/regular/simd/x86/ceil.hpp
+++ b/include/eve/module/real/core/function/regular/simd/x86/ceil.hpp
@@ -17,7 +17,7 @@
 
 namespace eve::detail
 {
-  template<floating_real_scalar_value T, typename N, typename ABI>
+  template<floating_real_scalar_value T, typename N>
   EVE_FORCEINLINE wide<T, N> ceil_(EVE_SUPPORTS(sse4_1_), wide<T, N> const &a0) noexcept
     requires x86_abi<abi_t<T, N>>
   {

--- a/include/eve/traits/element_type.hpp
+++ b/include/eve/traits/element_type.hpp
@@ -17,7 +17,6 @@ namespace eve
   //================================================================================================
   template<typename T> struct element_type { using type = T; };
 
-  template<typename T, typename N, typename A> struct element_type<wide<T,N,A>> { using type = T; };
   template<typename T, typename N>             struct element_type<wide<T,N>>   { using type = T; };
   template<typename T>                         struct element_type<wide<T>>     { using type = T; };
 

--- a/test/unit/meta/native_simd_for_abi.cpp
+++ b/test/unit/meta/native_simd_for_abi.cpp
@@ -15,7 +15,7 @@ template<typename T> using tiny_wide  = eve::wide<T,eve::fixed<1>>;
 
 #if !defined(EVE_NO_SIMD)
 #if defined(SPY_SIMD_IS_X86)
-TTS_CASE_TPL( "Check that wide<T,N,x86*> satisfies native_simd_for_abi with any X86 ABI"
+TTS_CASE_TPL( "Check that wide<T,N> satisfies native_simd_for_abi with any X86 ABI"
             , TTS_NUMERIC_TYPES
             )
 {
@@ -26,7 +26,7 @@ TTS_CASE_TPL( "Check that wide<T,N,x86*> satisfies native_simd_for_abi with any 
   TTS_EXPECT((eve::native_simd_for_abi<logical<wide<T>> , eve::x86_128_ , eve::x86_256_, eve::x86_512_> ));
 }
 
-TTS_CASE_TPL( "Check that wide<T,N,x86*> does not satisfy native_simd_for_abi with other ABI"
+TTS_CASE_TPL( "Check that wide<T,N> does not satisfy native_simd_for_abi with other ABI"
             , TTS_NUMERIC_TYPES
             )
 {
@@ -63,7 +63,7 @@ TTS_CASE_TPL( "Check that wide<T,N,ppc*> does not satisfy native_simd_for_abi wi
   TTS_EXPECT_NOT((eve::native_simd_for_abi<logical<wide<T>> , eve::x86_128_ , eve::x86_256_, eve::x86_512_ > ));
 }
 #elif defined(SPY_SIMD_IS_ARM)
-TTS_CASE_TPL( "Check that wide<T,N,arm*> satisfies native_simd_for_abi with any ARM ABI"
+TTS_CASE_TPL( "Check that wide<T,N> satisfies native_simd_for_abi with any ARM ABI"
             , TTS_NUMERIC_TYPES
             )
 {
@@ -90,7 +90,7 @@ TTS_CASE_TPL( "Check that wide<T,N,arm*> satisfies native_simd_for_abi with any 
   }
 }
 
-TTS_CASE_TPL( "Check that wide<T,N,arm*> does not satisfy native_simd_for_abi with other ABI"
+TTS_CASE_TPL( "Check that wide<T,N> does not satisfy native_simd_for_abi with other ABI"
             , TTS_NUMERIC_TYPES
             )
 {


### PR DESCRIPTION
removes the last usages of the ABI parameter in wide and removes it from the wide itself.