### PR TITLE
FIX-#725: for each improvements

### DIFF
--- a/include/eve/algo/any_of.hpp
+++ b/include/eve/algo/any_of.hpp
@@ -56,7 +56,7 @@ namespace eve::algo
       delegate d{p};
 
       auto [traits, f, l] = preprocess_range(default_to(_traits, default_traits), _f, _l);
-      for_each_iteration(traits, f, l, d);
+      for_each_iteration(traits, f, l)(d);
       return d.res;
     }
 

--- a/include/eve/algo/for_each_iteration.hpp
+++ b/include/eve/algo/for_each_iteration.hpp
@@ -94,7 +94,15 @@ namespace eve::algo
       S l;
 
       for_each_iteration_precise_f_l(Traits traits, I f, S l) :
-        traits(traits), base(f), f(f), l(l) {}
+        traits(traits), base(f), f(f), l(l)
+      {
+        [[maybe_unused]] static constexpr std::ptrdiff_t step =
+          typename I::cardinal {}();
+        EVE_ASSERT(((l - f) % step == 0),
+          " len of the range is no divisible by cardinal " <<
+          "when `divisible by cardinal is passed`: " <<
+          "l - f: " << (l - f) << " step: " << step);
+      }
 
       template <typename Delegate>
       EVE_FORCEINLINE void operator()(Delegate& delegate)

--- a/include/eve/algo/for_each_iteration.hpp
+++ b/include/eve/algo/for_each_iteration.hpp
@@ -18,111 +18,169 @@
 
 namespace eve::algo
 {
-  struct for_each_iteration_
+  namespace detail
   {
-    template <typename Traits, iterator I, sentinel_for<I> S, typename Delegate>
-    EVE_FORCEINLINE void operator()(Traits traits, I f, S l, Delegate& delegate) const
-      requires (Traits::contains(no_aligning)())
+    struct for_each_iteration_common
     {
-      EVE_ASSERT(f != l, "for_each_iteration requires a non-empty range");
+      template<typename Traits, typename I, typename Delegate>
+      EVE_FORCEINLINE bool main_loop(Traits, I &f, I l, Delegate &delegate) const
+          requires(get_unrolling<Traits>() == 1)
+      {
+        static constexpr std::ptrdiff_t step = typename I::cardinal {}();
 
-      static constexpr std::ptrdiff_t step = typename I::cardinal{}();
-
-      I precise_l = f + ((l - f) / step * step);
-
-      if (main_loop(traits, f, precise_l, delegate)) return;
-
-      if (precise_l == l) return;
-
-      eve::keep_first ignore{l - precise_l};
-      delegate.step(f, ignore);
-    }
-
-    template <typename Traits, unaligned_iterator I, sentinel_for<I> S, typename Delegate>
-    EVE_FORCEINLINE void operator()(Traits traits, I f, S l, Delegate& delegate) const
-      requires (!Traits::contains(no_aligning)())
-    {
-      EVE_ASSERT(f != l, "for_each_iteration requires a non-empty range");
-
-      static constexpr std::ptrdiff_t step = typename I::cardinal{}();
-
-      auto aligned_f = f.previous_partially_aligned();
-      auto aligned_l = (f + (l - f)).previous_partially_aligned();
-
-      eve::ignore_first ignore_first{f - aligned_f};
-
-      if (aligned_f != aligned_l) {
-        // first chunk, maybe partial
-        if (delegate.step(aligned_f, ignore_first)) return;
-        ignore_first = eve::ignore_first{0};
-        aligned_f += step;
-
-        if (main_loop(traits, aligned_f, aligned_l, delegate)) return;
-
-        if (aligned_l == l) return;
-      }
-
-      eve::ignore_last ignore_last { aligned_l + step - l };
-      delegate.step(aligned_l, ignore_first && ignore_last);
-    }
-
-  private:
-
-    template <typename Traits, typename I, typename Delegate>
-    EVE_FORCEINLINE bool main_loop(Traits, I& f, I l, Delegate& delegate) const
-      requires(get_unrolling<Traits>() == 1)
-    {
-      static constexpr std::ptrdiff_t step = typename I::cardinal{}();
-
-      while (f != l) {
-        if (delegate.step(f, eve::ignore_none)) return true;
-        f += step;
-      }
-
-      return false;
-    }
-
-    template <typename Traits, typename I, typename Delegate>
-    EVE_FORCEINLINE bool main_loop(Traits, I& f, I l, Delegate& delegate) const
-      requires(get_unrolling<Traits>() > 1)
-    {
-      static constexpr std::ptrdiff_t step = typename I::cardinal{}();
-      static constexpr std::ptrdiff_t unrolling = get_unrolling<Traits>();
-
-      // In order to optimise for smaller ranges we not only finish but start with
-      // single steps as well.
-      // This does not matter for really big ranges but for when we hit a tiny range,
-      // not doing the full unrolling can be helpful.
-      while (true) {
-        bool reached_end = false;
-        bool should_break = false;
-
-        // single steps
-        if( eve::detail::for_until_<0, 1, unrolling>([&](auto) mutable {
-              reached_end = (f == l);
-              if( reached_end )
-                return true;
-
-              should_break = delegate.step(f, eve::ignore_none);
-              f += step;
-              return should_break;
-            }) )
+        while( f != l )
         {
-          return should_break;
+          if( delegate.step(f, eve::ignore_none) )
+            return true;
+          f += step;
         }
 
-        std::ptrdiff_t big_steps_count = (l - f) / (step * unrolling);
+        return false;
+      }
 
-        while (big_steps_count) {
-          std::array<I, unrolling> arr;
-          eve::detail::for_<0, 1, unrolling>([&](auto idx) mutable {
-            arr[idx()] = f;
-            f += step;
-          });
-          if (delegate.unrolled_step(arr)) return true;
-          --big_steps_count;
+      template<typename Traits, typename I, typename Delegate>
+      EVE_FORCEINLINE bool main_loop(Traits, I &f, I l, Delegate &delegate) const
+          requires(get_unrolling<Traits>() > 1)
+      {
+        static constexpr std::ptrdiff_t step      = typename I::cardinal {}();
+        static constexpr std::ptrdiff_t unrolling = get_unrolling<Traits>();
+
+        // In order to optimise for smaller ranges we not only finish but start with
+        // single steps as well.
+        // This does not matter for really big ranges but for when we hit a tiny range,
+        // not doing the full unrolling can be helpful.
+        while( true )
+        {
+          bool reached_end  = false;
+          bool should_break = false;
+
+          // single steps
+          if( eve::detail::for_until_<0, 1, unrolling>([&](auto) mutable {
+                reached_end = (f == l);
+                if( reached_end )
+                  return true;
+
+                should_break = delegate.step(f, eve::ignore_none);
+                f += step;
+                return should_break;
+              }) )
+          {
+            return should_break;
+          }
+
+          std::ptrdiff_t big_steps_count = (l - f) / (step * unrolling);
+
+          while( big_steps_count )
+          {
+            std::array<I, unrolling> arr;
+            eve::detail::for_<0, 1, unrolling>([&](auto idx) mutable {
+              arr[idx()] = f;
+              f += step;
+            });
+            if( delegate.unrolled_step(arr) )
+              return true;
+            --big_steps_count;
+          }
         }
       }
+    };
+
+    template <typename Traits, iterator I, sentinel_for<I> S>
+    struct for_each_iteration_precise_f_l : for_each_iteration_common
+    {
+      Traits traits;
+      I base;
+      I f;
+      S l;
+
+      for_each_iteration_precise_f_l(Traits traits, I f, S l) :
+        traits(traits), base(f), f(f), l(l) {}
+
+      template <typename Delegate>
+      EVE_FORCEINLINE void operator()(Delegate& delegate)
+      {
+        main_loop(traits, f, l, delegate);
+      }
+    };
+
+    template <typename Traits, iterator I, sentinel_for<I> S>
+    struct for_each_iteration_precise_f : for_each_iteration_common
+    {
+      Traits traits;
+      I base;
+      I f;
+      S l;
+
+      for_each_iteration_precise_f(Traits traits, I f, S l) :
+        traits(traits), base(f), f(f), l(l) {}
+
+      template <typename Delegate>
+      EVE_FORCEINLINE void operator()(Delegate& delegate)
+      {
+        static constexpr std::ptrdiff_t step = typename I::cardinal{}();
+
+        I precise_l = f + ((l - f) / step * step);
+
+        if (main_loop(traits, f, precise_l, delegate)) return;
+
+        if (precise_l == l) return;
+
+        eve::keep_first ignore{l - precise_l};
+        delegate.step(f, ignore);
+      }
+    };
+
+    template <typename Traits, iterator I, sentinel_for<I> S>
+    struct for_each_iteration_aligning : for_each_iteration_common
+    {
+      Traits traits;
+      partially_aligned_t<I> base;
+      I f;
+      S l;
+
+      for_each_iteration_aligning(Traits traits, I f, S l) :
+        traits(traits), base(f.previous_partially_aligned()), f(f), l(l) {}
+
+      template<typename Delegate>
+      EVE_FORCEINLINE void operator()(Delegate &delegate)
+      {
+        static constexpr std::ptrdiff_t step = typename I::cardinal {}();
+
+        auto aligned_f = base;
+        auto aligned_l = (f + (l - f)).previous_partially_aligned();
+
+        eve::ignore_first ignore_first {f - aligned_f};
+
+        if( aligned_f != aligned_l )
+        {
+          // first chunk, maybe partial
+          if( delegate.step(aligned_f, ignore_first) )
+            return;
+          ignore_first = eve::ignore_first {0};
+          aligned_f += step;
+
+          if( main_loop(traits, aligned_f, aligned_l, delegate) )
+            return;
+
+          if( aligned_l == l )
+            return;
+        }
+
+        eve::ignore_last ignore_last {aligned_l + step - l};
+        delegate.step(aligned_l, ignore_first && ignore_last);
+      }
+    };
+  }
+
+  struct
+  {
+    template <typename Traits, iterator I, sentinel_for<I> S>
+    auto operator()(Traits traits, I f, S l) const
+    {
+      EVE_ASSERT(f != l, "for_each_iteration requires a non-empty range");
+           if constexpr (!Traits::contains(no_aligning))          return detail::for_each_iteration_aligning{traits, f, l};
+      else if constexpr (Traits::contains(divisible_by_cardinal)) return detail::for_each_iteration_precise_f_l{traits, f, l};
+      else                                                        return detail::for_each_iteration_precise_f{traits, f, l};
     }
 
   } inline constexpr for_each_iteration;

--- a/include/eve/conditional.hpp
+++ b/include/eve/conditional.hpp
@@ -18,6 +18,7 @@
 #include <eve/traits/as_arithmetic.hpp>
 #include <eve/traits/cardinal.hpp>
 #include <bitset>
+#include <compare>
 #include <ostream>
 
 namespace eve
@@ -99,10 +100,13 @@ namespace eve
       return 0ULL;
     }
 
+    constexpr auto friend operator<=>(ignore_all_ const&, ignore_all_ const&) = default;
+
     friend std::ostream& operator<<(std::ostream& os, ignore_all_ const&)
     {
       return os << "ignore_all";
     }
+
   };
 
   inline constexpr ignore_all_ ignore_all  = {};
@@ -134,6 +138,8 @@ namespace eve
     {
       return cardinal_v<T>;
     }
+
+    constexpr auto friend operator<=>(ignore_none_ const&, ignore_none_ const&) = default;
 
     friend std::ostream& operator<<(std::ostream& os, ignore_none_ const&)
     {
@@ -178,6 +184,8 @@ namespace eve
       }
     }
 
+    constexpr auto friend operator<=>(keep_first const&, keep_first const&) = default;
+
     friend std::ostream& operator<<(std::ostream& os, keep_first const& c)
     {
       return os << "keep_first( " << c.count_ << " )";
@@ -219,6 +227,8 @@ namespace eve
       constexpr auto card = cardinal_v<T>;
       return keep_first{card-count_}.mask(tgt);
     }
+
+    constexpr auto friend operator<=>(ignore_last const&, ignore_last const&) = default;
 
     friend std::ostream& operator<<(std::ostream& os, ignore_last const& c)
     {
@@ -282,6 +292,8 @@ namespace eve
       }
     }
 
+    constexpr auto friend operator<=>(keep_last const&, keep_last const&) = default;
+
     friend std::ostream& operator<<(std::ostream& os, keep_last const& c)
     {
       return os << "keep_last( " << c.count_ << " )";
@@ -338,6 +350,8 @@ namespace eve
     {
       return cardinal_v<T> - count_;
     }
+
+    constexpr auto friend operator<=>(ignore_first const&, ignore_first const&) = default;
 
     friend std::ostream& operator<<(std::ostream& os, ignore_first const& c)
     {
@@ -403,6 +417,8 @@ namespace eve
       return end_ - begin_;
     }
 
+    constexpr auto friend operator<=>(keep_between const&, keep_between const&) = default;
+
     friend std::ostream& operator<<(std::ostream& os, keep_between const& c)
     {
       return os << "keep_between( " << c.begin_ << ", " << c.end_ << " )";
@@ -449,6 +465,8 @@ namespace eve
     {
       return cardinal_v<T> - last_count_ - first_count_;
     }
+
+    constexpr auto friend operator<=>(ignore_extrema const&, ignore_extrema const&) = default;
 
     friend std::ostream& operator<<(std::ostream& os, ignore_extrema const& c)
     {

--- a/include/eve/conditional.hpp
+++ b/include/eve/conditional.hpp
@@ -100,7 +100,7 @@ namespace eve
       return 0ULL;
     }
 
-    constexpr auto friend operator<=>(ignore_all_ const&, ignore_all_ const&) = default;
+    constexpr bool friend operator==(ignore_all_ const&, ignore_all_ const&) = default;
 
     friend std::ostream& operator<<(std::ostream& os, ignore_all_ const&)
     {
@@ -139,7 +139,7 @@ namespace eve
       return cardinal_v<T>;
     }
 
-    constexpr auto friend operator<=>(ignore_none_ const&, ignore_none_ const&) = default;
+    constexpr bool friend operator==(ignore_none_ const&, ignore_none_ const&) = default;
 
     friend std::ostream& operator<<(std::ostream& os, ignore_none_ const&)
     {
@@ -184,7 +184,7 @@ namespace eve
       }
     }
 
-    constexpr auto friend operator<=>(keep_first const&, keep_first const&) = default;
+    constexpr bool friend operator==(keep_first const&, keep_first const&) = default;
 
     friend std::ostream& operator<<(std::ostream& os, keep_first const& c)
     {
@@ -228,7 +228,7 @@ namespace eve
       return keep_first{card-count_}.mask(tgt);
     }
 
-    constexpr auto friend operator<=>(ignore_last const&, ignore_last const&) = default;
+    constexpr bool friend operator==(ignore_last const&, ignore_last const&) = default;
 
     friend std::ostream& operator<<(std::ostream& os, ignore_last const& c)
     {
@@ -292,7 +292,7 @@ namespace eve
       }
     }
 
-    constexpr auto friend operator<=>(keep_last const&, keep_last const&) = default;
+    constexpr bool friend operator==(keep_last const&, keep_last const&) = default;
 
     friend std::ostream& operator<<(std::ostream& os, keep_last const& c)
     {
@@ -351,7 +351,7 @@ namespace eve
       return cardinal_v<T> - count_;
     }
 
-    constexpr auto friend operator<=>(ignore_first const&, ignore_first const&) = default;
+    constexpr bool friend operator==(ignore_first const&, ignore_first const&) = default;
 
     friend std::ostream& operator<<(std::ostream& os, ignore_first const& c)
     {
@@ -417,7 +417,7 @@ namespace eve
       return end_ - begin_;
     }
 
-    constexpr auto friend operator<=>(keep_between const&, keep_between const&) = default;
+    constexpr bool friend operator==(keep_between const&, keep_between const&) = default;
 
     friend std::ostream& operator<<(std::ostream& os, keep_between const& c)
     {
@@ -466,7 +466,7 @@ namespace eve
       return cardinal_v<T> - last_count_ - first_count_;
     }
 
-    constexpr auto friend operator<=>(ignore_extrema const&, ignore_extrema const&) = default;
+    constexpr bool friend operator==(ignore_extrema const&, ignore_extrema const&) = default;
 
     friend std::ostream& operator<<(std::ostream& os, ignore_extrema const& c)
     {

--- a/test/unit/algo/CMakeLists.txt
+++ b/test/unit/algo/CMakeLists.txt
@@ -18,6 +18,7 @@ make_unit("unit.algo" array_utils.cpp)
 make_unit("unit.algo" preprocess_range.cpp)
 make_unit("unit.algo" ptr_iterator.cpp)
 make_unit("unit.algo" traits.cpp)
+make_unit("unit.algo" for_each_iteration.cpp)
 
 # Algorithms
 make_unit("unit.algo" any_of.cpp)

--- a/test/unit/algo/for_each_iteration.cpp
+++ b/test/unit/algo/for_each_iteration.cpp
@@ -297,6 +297,7 @@ TTS_CASE("eve.algo for_each_iteration unrolling, aligning")
       {12, eve::ignore_none},
       {16, eve::ignore_none},
       {20, eve::ignore_none},
+      {24, eve::ignore_extrema(0, 2)},
     }
   );
 
@@ -353,6 +354,97 @@ TTS_CASE("eve.algo for_each_iteration unrolling, aligning")
       {72, eve::ignore_none},
       {76, eve::ignore_none},
       {80, eve::ignore_extrema(0, 1)}
+    }
+  );
+}
+
+TTS_CASE("eve.algo for_each_iteration unrolling, precise")
+{
+  fixture fix;
+  auto f = fix.unaligned_begin();
+
+  auto test = [&](auto traits, auto overall_l, test_res expected) {
+    auto l = f + expected.back().first + expected.back().second.count();
+    run_test(traits, f, l, -1, expected);
+    // stop test
+    run_test(traits, f, overall_l, expected.back().first, expected);
+  };
+
+  auto pattern_test = [&](auto unroll, test_res pattern) {
+    auto overall_l = f + pattern.back().first + pattern.back().second.count();
+
+    for (auto up_to = pattern.begin() + 1; up_to != pattern.end(); ++up_to) {
+      auto traits = eve::algo::traits(unroll, eve::algo::no_aligning);
+      test(traits, overall_l, {pattern.begin(), up_to});
+    }
+
+    pattern.pop_back();
+    for (auto up_to = pattern.begin() + 1; up_to != pattern.end(); ++up_to) {
+      auto traits = eve::algo::traits(unroll, eve::algo::no_aligning, eve::algo::divisible_by_cardinal);
+      test(traits, overall_l, {pattern.begin(), up_to});
+    }
+  };
+
+  // no unrolling
+  pattern_test(
+    eve::algo::unroll<1>,
+    {
+      {0, eve::ignore_none},
+      {4, eve::ignore_none},
+      {8, eve::ignore_none},
+      {12, eve::ignore_none},
+      {16, eve::ignore_none},
+      {20, eve::ignore_none},
+      {24, eve::keep_first(2)},
+    }
+  );
+
+  // unroll 2
+  pattern_test(
+    eve::algo::unroll<2>,
+    {
+      {0, eve::ignore_none},
+      {4, eve::ignore_none},
+      // unrolling starts
+      {8, eve::ignore_none},
+      {16, eve::ignore_none},
+      {24, eve::ignore_none},
+      // unrolling ends
+      {32, eve::keep_first(2)},
+    }
+  );
+
+  // unroll 3
+  pattern_test(
+    eve::algo::unroll<3>,
+    {
+      {0, eve::ignore_none},
+      {4, eve::ignore_none},
+      {8, eve::ignore_none},
+      // unrolling starts
+      {12, eve::ignore_none},
+      {24, eve::ignore_none},
+      {36, eve::ignore_none},
+      // unrolling ends
+      {40, eve::ignore_none},
+      {44, eve::keep_first(3)},
+    }
+  );
+
+  // unroll 4
+  pattern_test(
+    eve::algo::unroll<4>,
+    {
+      {0, eve::ignore_none},
+      {4, eve::ignore_none},
+      {8, eve::ignore_none},
+      {12, eve::ignore_none},
+      // unrolling starts
+      {16, eve::ignore_none},
+      {32, eve::ignore_none},
+      {48, eve::ignore_none},
+      // unrolling ends
+      {64, eve::keep_first(1)},
     }
   );
 }

--- a/test/unit/algo/for_each_iteration.cpp
+++ b/test/unit/algo/for_each_iteration.cpp
@@ -1,0 +1,251 @@
+//==================================================================================================
+/**
+  EVE - Expressive Vector Engine
+  Copyright : EVE Contributors & Maintainers
+  SPDX-License-Identifier: MIT
+**/
+//==================================================================================================
+
+#include "algo_test.hpp"
+
+#include <eve/algo/for_each_iteration.hpp>
+#include <eve/algo/ptr_iterator.hpp>
+#include <eve/algo/traits.hpp>
+
+#include <utility>
+#include <numeric>
+#include <variant>
+
+namespace
+{
+  struct fixture
+  {
+    fixture()
+    {
+      std::iota(data.begin(), data.end(), 0);
+    }
+
+    auto aligned_begin() const
+    {
+      return eve::algo::aligned_ptr_iterator<const int, eve::fixed<4>> {
+        eve::aligned_ptr<const int, 4 * sizeof(int)>(data.begin())
+      };
+    }
+
+    auto aligned_end() const { return aligned_begin() + data.size(); }
+
+    auto unaligned_begin() const { return aligned_begin().unaligned(); }
+    auto unaligned_end()   const { return aligned_end().unaligned(); }
+
+    alignas(sizeof(int) * 4) std::array<int, 100> data;
+  };
+}
+
+TTS_CASE("eve.algo for_each_iteration, selection")
+  {
+    fixture fix;
+
+    auto f = fix.unaligned_begin() + 3;
+    auto l = f + 40;
+
+    using u_it = decltype(f);
+    using a_it = decltype(fix.aligned_begin());
+
+    // aligning
+    {
+      auto tr  = eve::algo::traits();
+      auto sel = eve::algo::for_each_iteration(tr, f, l);
+      TTS_TYPE_IS(decltype(sel),
+                  (eve::algo::detail::for_each_iteration_aligning<decltype(tr), u_it, u_it>));
+
+      TTS_EQUAL(sel.base, fix.aligned_begin());
+      TTS_TYPE_IS(decltype(sel.base), a_it);
+    }
+
+    // precise f, l
+    {
+      auto tr  = eve::algo::traits(eve::algo::no_aligning, eve::algo::divisible_by_cardinal);
+      auto sel = eve::algo::for_each_iteration(tr, f, l);
+
+      TTS_TYPE_IS(decltype(sel),
+                  (eve::algo::detail::for_each_iteration_precise_f_l<decltype(tr), u_it, u_it>));
+
+      TTS_EQUAL(sel.base, f);
+      TTS_TYPE_IS(decltype(sel.base), u_it);
+    }
+
+    // precise f
+    {
+      auto tr  = eve::algo::traits(eve::algo::no_aligning);
+      auto sel = eve::algo::for_each_iteration(tr, f, l);
+
+      TTS_TYPE_IS(decltype(sel),
+                  (eve::algo::detail::for_each_iteration_precise_f<decltype(tr), u_it, u_it>));
+
+      TTS_EQUAL(sel.base, f);
+      TTS_TYPE_IS(decltype(sel.base), u_it);
+    }
+}
+
+namespace
+{
+
+  struct ignore
+  {
+    std::variant<eve::ignore_none_, eve::ignore_first,
+                 eve::ignore_last, eve::ignore_extrema,
+                 eve::keep_first> body;
+
+    ignore(eve::relative_conditional_expr auto expr) : body(expr) {}
+
+    friend bool operator==(ignore const& x, ignore const& y) = default;
+
+    friend std::ostream& operator<<(std::ostream& out, ignore const& x) {
+      return std::visit([&](auto elem) -> decltype(auto) { return out << elem; }, x.body);
+    }
+
+  };
+
+  using test_res = std::vector<std::pair<std::ptrdiff_t, ignore>>;
+
+  template <typename I>
+  struct test_delegate
+  {
+    test_delegate(I base, std::ptrdiff_t stop_at) :
+      base{base},
+      stop_at(stop_at) {}
+
+    I base;
+    std::ptrdiff_t stop_at;
+    test_res res;
+
+    bool step(auto it, eve::relative_conditional_expr auto ignore)
+    {
+      res.emplace_back(it - base, ignore);
+      return stop_at == (it - base);
+    }
+
+    template <std::size_t size>
+    bool unrolled_step(std::array<I, size> arr)
+    {
+      res.emplace_back(arr[0] - base, eve::ignore_none);
+      return stop_at == (arr[0] - base);
+    }
+  };
+
+  template <typename Traits, typename I, typename S>
+  void run_test(Traits traits, I f, S l, std::ptrdiff_t stop_at, test_res expected)
+  {
+    auto iteration = eve::algo::for_each_iteration(traits, f, l);
+    test_delegate del{iteration.base, stop_at};
+    iteration(del);
+    TTS_EQUAL(expected.size(), del.res.size());
+    if (expected.size() != del.res.size()) return;
+
+    for (std::size_t i = 0; i != del.res.size(); ++i) {
+      TTS_EQUAL(del.res[i].first,  expected[i].first);
+      TTS_EQUAL(del.res[i].second, expected[i].second);
+    }
+  }
+
+}
+
+TTS_CASE("eve.algo for_each_iteration border cases, aligning")
+{
+  fixture fix;
+
+  auto test = [](auto f, auto l, test_res expected){
+    run_test(eve::algo::traits(eve::algo::unroll<4>), f, l, -1, expected);
+  };
+
+  // <= wide
+  {
+    auto f = fix.unaligned_begin();
+    auto l = f + 4;
+
+    for (int i = 0; i != 4; ++i)
+    {
+      test(f + i, l, {{0, eve::ignore_first(i)}});
+    }
+
+    for (int i = 3; i != 0; --i)
+    {
+      test(f, l - i, {{0, eve::ignore_extrema(0, i)}});
+    }
+
+    test(f + 1, l - 1, {{0, eve::ignore_extrema(1, 1)}});
+    test(f + 2, l - 1, {{0, eve::ignore_extrema(2, 1)}});
+    test(f + 1, l - 2, {{0, eve::ignore_extrema(1, 2)}});
+  }
+
+  //  <= two wides
+  {
+    auto f = fix.unaligned_begin();
+    auto l = f + 8;
+
+    test(f, l, {{0, eve::ignore_first(0)}, {4, eve::ignore_none}});
+
+    for (int i = 1; i != 4; ++i)
+    {
+      test(f + i, l    , {{0, eve::ignore_first(i)}, {4, eve::ignore_none}});
+      test(f    , l - i, {{0, eve::ignore_first(0)}, {4, eve::ignore_extrema(0, i)}});
+      test(f + i, l - i, {{0, eve::ignore_first(i)}, {4, eve::ignore_extrema(0, i)}});
+    }
+  }
+}
+
+TTS_CASE("eve.algo for_each_iteration border cases, precise")
+{
+  fixture fix;
+
+  auto test = [](auto f, auto l, test_res expected){
+    auto traits = eve::algo::traits(eve::algo::no_aligning, eve::algo::unroll<4>);
+    run_test(traits, f, l, -1, expected);
+
+    if ((f - l) % 4 == 0) {
+      run_test(eve::algo::default_to(
+        traits, eve::algo::traits(eve::algo::divisible_by_cardinal)),
+        f, l, -1, expected);
+    }
+  };
+
+  // <= wide
+  {
+    auto f = fix.unaligned_begin();
+    auto l = f + 4;
+
+    test(f, l, {{0, eve::ignore_none}});
+
+    for (int i = 1; i != 4; ++i)
+    {
+      test(f + i, l, {{0, eve::keep_first(4 - i)}});
+    }
+
+    for (int i = 3; i != 0; --i)
+    {
+      test(f, l - i, {{0, eve::keep_first(4 - i)}});
+    }
+
+    test(f + 1, l - 1, {{0, eve::keep_first(2)}});
+    test(f + 2, l - 1, {{0, eve::keep_first(1)}});
+    test(f + 1, l - 2, {{0, eve::keep_first(1)}});
+  }
+
+  //  <= two wides
+  {
+    auto f = fix.unaligned_begin();
+    auto l = f + 8;
+
+    test(f, l, {{0, eve::ignore_none}, {4, eve::ignore_none}});
+
+    for (int i = 1; i != 4; ++i)
+    {
+      test(f + i, l    , {{0, eve::ignore_none}, {4, eve::keep_first(4 - i)}});
+      test(f    , l - i, {{0, eve::ignore_none}, {4, eve::keep_first(4 - i)}});
+    }
+
+    test(f + 1, l - 1, {{0, eve::ignore_none}, {4, eve::keep_first(2)}});
+    test(f + 1, l - 2, {{0, eve::ignore_none}, {4, eve::keep_first(1)}});
+    test(f + 2, l - 1, {{0, eve::ignore_none}, {4, eve::keep_first(1)}});
+  }
+}

--- a/test/unit/algo/for_each_iteration.cpp
+++ b/test/unit/algo/for_each_iteration.cpp
@@ -386,6 +386,7 @@ TTS_CASE("eve.algo for_each_iteration unrolling, precise")
     }
 
     pattern.pop_back();
+    overall_l = f + pattern.back().first + 4;
     for (auto up_to = pattern.begin() + 1; up_to != pattern.end(); ++up_to) {
       auto traits = eve::algo::traits(unroll, eve::algo::no_aligning, eve::algo::divisible_by_cardinal);
       test(traits, overall_l, {pattern.begin(), up_to});

--- a/test/unit/algo/for_each_iteration.cpp
+++ b/test/unit/algo/for_each_iteration.cpp
@@ -271,15 +271,19 @@ TTS_CASE("eve.algo for_each_iteration unrolling, aligning")
   fixture fix;
   auto f = fix.unaligned_begin();
 
-  auto test = [&](auto unroll, test_res expected) {
+  auto test = [&](auto traits, auto overall_l, test_res expected) {
     auto l = f + expected.back().first + expected.back().second.count();
-    auto traits = eve::algo::traits(unroll);
     run_test(traits, f, l, -1, expected);
+    // stop test
+    run_test(traits, f, overall_l, expected.back().first, expected);
   };
 
   auto pattern_test = [&](auto unroll, test_res pattern) {
+    auto overall_l = f + pattern.back().first + pattern.back().second.count();
+
     for (auto up_to = pattern.begin() + 1; up_to != pattern.end(); ++up_to) {
-      test(unroll, {pattern.begin(), up_to});
+      auto traits = eve::algo::traits(unroll);
+      test(traits, overall_l, {pattern.begin(), up_to});
     }
   };
 

--- a/test/unit/algo/for_each_iteration.cpp
+++ b/test/unit/algo/for_each_iteration.cpp
@@ -172,6 +172,9 @@ TTS_CASE("eve.algo for_each_iteration border cases, aligning")
 
   auto test = [](auto f, auto l, test_res expected){
     run_test(eve::algo::traits(), f, l, -1, expected);
+
+    if (expected.size() > 1) expected.pop_back();
+    run_test(eve::algo::traits(), f, l, 0, expected);
   };
 
   // <= wide
@@ -214,14 +217,18 @@ TTS_CASE("eve.algo for_each_iteration border cases, precise")
 {
   fixture fix;
 
-  auto test = [](auto f, auto l, test_res expected){
-    auto traits = eve::algo::traits(eve::algo::no_aligning, eve::algo::unroll<4>);
-    run_test(traits, f, l, -1, expected);
+  auto one_test = [](auto traits, auto f, auto l, test_res expected) {
+     run_test(traits, f, l, -1, expected);
+     if (expected.size() > 1) expected.pop_back();
+     run_test(traits, f, l, 0, expected);
+  };
+
+  auto test = [&](auto f, auto l, test_res expected){
+    one_test(eve::algo::traits(eve::algo::no_aligning), f, l, expected);
 
     if ((f - l) % 4 == 0) {
-      run_test(eve::algo::default_to(
-        traits, eve::algo::traits(eve::algo::divisible_by_cardinal)),
-        f, l, -1, expected);
+      auto traits = eve::algo::traits(eve::algo::no_aligning, eve::algo::divisible_by_cardinal);
+      one_test(traits, f, l, expected);
     }
   };
 

--- a/test/unit/algo/for_each_iteration.cpp
+++ b/test/unit/algo/for_each_iteration.cpp
@@ -146,6 +146,11 @@ namespace
     iteration(del);
     TTS_EQUAL(expected.size(), del.res.size());
     if (expected.size() != del.res.size()) {
+      std::cout << "expected : {" << std::endl;
+      for (auto const& e : expected) {
+         std::cout << e.first << ' ' << e.second << std::endl;
+      }
+      std::cout << "}" << std::endl;
       std::cout << "actual : {" << std::endl;
       for (auto const& e : del.res) {
          std::cout << e.first << ' ' << e.second << std::endl;
@@ -298,11 +303,52 @@ TTS_CASE("eve.algo for_each_iteration unrolling, aligning")
       {0, eve::ignore_first(0)},
       {4, eve::ignore_none},
       {8, eve::ignore_none},
+      // unrolling starts
       {12, eve::ignore_none},
       {20, eve::ignore_none},
       {28, eve::ignore_none},
       {36, eve::ignore_none},
+      // unrolling ends
       {44, eve::ignore_extrema(0, 2)},
+    }
+  );
+
+  // unroll 3
+  pattern_test(
+    eve::algo::unroll<3>,
+    {
+      {0, eve::ignore_first(0)},
+      {4, eve::ignore_none},
+      {8, eve::ignore_none},
+      {12, eve::ignore_none},
+      // unrolling starts
+      {16, eve::ignore_none},
+      {28, eve::ignore_none},
+      // unrolling ends
+      {40, eve::ignore_none},
+      {44, eve::ignore_none},
+      {48, eve::ignore_extrema(0, 3)}
+    }
+  );
+
+  // unroll 4
+  pattern_test(
+    eve::algo::unroll<4>,
+    {
+      {0, eve::ignore_first(0)},
+      {4, eve::ignore_none},
+      {8, eve::ignore_none},
+      {12, eve::ignore_none},
+      {16, eve::ignore_none},
+      // unrolling starts
+      {20, eve::ignore_none},
+      {36, eve::ignore_none},
+      {52, eve::ignore_none},
+      // unrolling ends
+      {68, eve::ignore_none},
+      {72, eve::ignore_none},
+      {76, eve::ignore_none},
+      {80, eve::ignore_extrema(0, 1)}
     }
   );
 }


### PR DESCRIPTION
Changes:
* Split `for_each` into the `selection` part and the `execution` part. This is needed because many algorithms actually need to know the `base` of iteration before the actual algorithm starts (for example in-place transform).
* Added support for `divisible_by_cardinal`
* Added proper testing to `for_each`. This should help to reduce the need for testing all cases in all algorithms, though I'm not entirely sure how that'd look.

