### PR TITLE
FIX-#726: one range algorithm common interface + find_if

### DIFF
--- a/include/eve/algo/README.txt
+++ b/include/eve/algo/README.txt
@@ -7,6 +7,7 @@ Main eve supports it's callables for scalars. We don't do that for algorithms. T
 # Algorithms
 
 * any_of
+* find_if
 
 # Helpers
 

--- a/include/eve/algo/README.txt
+++ b/include/eve/algo/README.txt
@@ -65,7 +65,9 @@ Main model: iota_iterator.
 These are not phisical iterators but rather some mechanisms that pretend to be iterators.
 alignment does not matter to them, every position is just as efficient as any other.
 
-### iteration pattern (concept)
+### iteration patterns
+
+*`for_each_iteration`
 
 A reusable component to do `while(f != l) ++f;`.
 Given traits, f, l, delegate calls the delegate for each piece with (f, ignore).
@@ -73,6 +75,14 @@ The specific api of the delegate varies by iteration pattern.
 
 Main one is `for_each_iteration`.
 However for some algorithms, like `reverse` and maybe `partition` it's not a good.
+
+### range algorithm adaters
+
+* `one_range_algorithm_adapter`
+
+These are helpers to deal with all of the boilerplate of algorithm interfaces.
+Get's from the ranges,std::contigious iterators, various eve iterators, default traits, provided traits etc
+to something uniform that specific algorithms can actually use.
 
 ### traits
 
@@ -123,6 +133,8 @@ A pointer + cardinal with the `iterator` interface.
 
 Given a more general notion of a range + traits returns enhanced traits +
 iterator/sentinel pair that is understood by eve.
+This is one hand a helper for `range algorithm adapters` and on the other (*TODO*)
+a customization point for different ranges that need some non-default handling.
 
 ### for_each_iteration
 

--- a/include/eve/algo/any_of.hpp
+++ b/include/eve/algo/any_of.hpp
@@ -51,11 +51,10 @@ namespace eve::algo
     template <typename Traits, typename I, typename S, typename P>
     EVE_FORCEINLINE bool operator()(Traits _traits, I _f, S _l, P p) const
     {
-      if (_f == _l) return false;
-
       delegate d{p};
 
       auto [traits, f, l] = preprocess_range(default_to(_traits, default_traits), _f, _l);
+      if (f == l) return false;
       for_each_iteration(traits, f, l)(d);
       return d.res;
     }

--- a/include/eve/algo/any_of.hpp
+++ b/include/eve/algo/any_of.hpp
@@ -23,7 +23,7 @@ namespace eve::algo
   {
     static constexpr auto default_traits()
     {
-      return algo::traits(algo::unroll<4>);
+      return default_simple_algo_traits;
     };
 
     template <typename P>

--- a/include/eve/algo/any_of.hpp
+++ b/include/eve/algo/any_of.hpp
@@ -51,13 +51,13 @@ namespace eve::algo
       bool res = false;
     };
 
-    template <instance_of<algo::traits> Traits, iterator I, sentinel_for<I> S, typename P>
-    EVE_FORCEINLINE bool impl(Traits traits, I f, S l, P p) const
+    template <typename P>
+    EVE_FORCEINLINE bool impl(auto processed, P p) const
     {
-      if (f == l) return false;
+      if (processed.begin() == processed.end()) return false;
 
       delegate d{p};
-      algo::for_each_iteration(traits, f, l)(d);
+      algo::for_each_iteration(processed.traits(), processed.begin(), processed.end())(d);
       return d.res;
     }
   } inline constexpr any_of;

--- a/include/eve/algo/array_utils.hpp
+++ b/include/eve/algo/array_utils.hpp
@@ -46,10 +46,14 @@ namespace eve::algo
   }
 
   template <typename T, std::size_t N, typename Op>
-  EVE_FORCEINLINE constexpr void array_reverse_it(std::array<T, N> x, Op op)
-  {
-    [&]<std::size_t ...i>(std::index_sequence<i...>){
-      (op(x[N - i - 1]), ...);
+  EVE_FORCEINLINE constexpr std::size_t find_branchless(std::array<T, N> x, Op op) {
+    return [&]<std::size_t ...i> ( std::index_sequence<i...> ) {
+      std::size_t res = N;
+      auto update_res_if = [&](std::size_t j) mutable {
+        if (op(x[j])) res = j;  // should generate cmov
+      };
+      (update_res_if(N - i - 1), ...);
+      return res;
     }(std::make_index_sequence<N>{});
   }
 

--- a/include/eve/algo/array_utils.hpp
+++ b/include/eve/algo/array_utils.hpp
@@ -44,4 +44,13 @@ namespace eve::algo
   {
     return detail::array_reduce_impl<0, N>(x, op);
   }
+
+  template <typename T, std::size_t N, typename Op>
+  EVE_FORCEINLINE constexpr void array_reverse_it(std::array<T, N> x, Op op)
+  {
+    [&]<std::size_t ...i>(std::index_sequence<i...>){
+      (op(x[N - i - 1]), ...);
+    }(std::make_index_sequence<N>{});
+  }
+
 }

--- a/include/eve/algo/concepts.hpp
+++ b/include/eve/algo/concepts.hpp
@@ -95,4 +95,16 @@ namespace eve::algo
 
   template <typename T, typename U>
   concept same_unaligned_iterator = std::same_as<unaligned_t<T>, unaligned_t<U>>;
+
+  namespace detail
+  {
+    template <template <typename ...> class Templ, typename T>
+    struct instance_of_impl : std::false_type {};
+
+    template <template <typename ...> class Templ, typename ...Args>
+    struct instance_of_impl<Templ, Templ<Args...>> : std::true_type {};
+  }
+
+  template <template <typename ...> class Templ, typename T>
+  concept instance_of = detail::instance_of_impl<Templ, T>::value;
 }

--- a/include/eve/algo/concepts.hpp
+++ b/include/eve/algo/concepts.hpp
@@ -98,13 +98,13 @@ namespace eve::algo
 
   namespace detail
   {
-    template <template <typename ...> class Templ, typename T>
+    template <typename T, template <typename ...> class Templ>
     struct instance_of_impl : std::false_type {};
 
-    template <template <typename ...> class Templ, typename ...Args>
-    struct instance_of_impl<Templ, Templ<Args...>> : std::true_type {};
+    template <typename ...Args, template <typename ...> class Templ>
+    struct instance_of_impl<Templ<Args...>, Templ> : std::true_type {};
   }
 
-  template <template <typename ...> class Templ, typename T>
-  concept instance_of = detail::instance_of_impl<Templ, T>::value;
+  template <typename T, template <typename ...> class Templ>
+  concept instance_of = detail::instance_of_impl<T, Templ>::value;
 }

--- a/include/eve/algo/concepts.hpp
+++ b/include/eve/algo/concepts.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <concepts>
+#include <iterator>
 #include <type_traits>
 #include <eve/function/load.hpp>
 
@@ -107,4 +108,11 @@ namespace eve::algo
 
   template <typename T, template <typename ...> class Templ>
   concept instance_of = detail::instance_of_impl<T, Templ>::value;
+
+  // While standard ranges are not properly supported
+  namespace detail
+  {
+    template<typename R>
+    concept contiguous_range = std::contiguous_iterator<decltype(std::declval<R>().begin())>;
+  }
 }

--- a/include/eve/algo/find.hpp
+++ b/include/eve/algo/find.hpp
@@ -1,0 +1,94 @@
+//==================================================================================================
+/**
+  EVE - Expressive Vector Engine
+  Copyright : EVE Contributors & Maintainers
+  SPDX-License-Identifier: MIT
+**/
+//==================================================================================================
+#pragma once
+
+#include <eve/algo/array_utils.hpp>
+#include <eve/algo/for_each_iteration.hpp>
+#include <eve/algo/one_range_algorithm_adapter.hpp>
+#include <eve/algo/traits.hpp>
+
+#include <eve/function/any.hpp>
+#include <eve/function/first_true.hpp>
+#include <eve/function/logical_or.hpp>
+
+#include <array>
+
+namespace eve::algo
+{
+  struct find_if_ : one_range_algorithm_adapter<find_if_>
+  {
+    static constexpr auto default_traits()
+    {
+      return default_simple_algo_traits;
+    };
+
+    template <typename UnalignedI, typename P>
+    struct delegate
+    {
+      explicit delegate(UnalignedI found, P p) : found(found), p(p) {}
+
+      EVE_FORCEINLINE bool step(auto it, eve::relative_conditional_expr auto ignore)
+      {
+        eve::logical test = p(eve::load[ignore](it));
+        std::optional match = eve::first_true[ignore](test);
+        if (!match) return false;
+
+        found = it.unaligned() + *match;
+        return true;
+      }
+
+      template <typename I, std::size_t size>
+      EVE_FORCEINLINE bool unrolled_step(std::array<I, size> arr)
+      {
+        auto tests = array_map(arr, [&](I it) { return p(eve::load(it)); });
+
+        // TODO: this is not the best solution, see: #764
+        auto overall = array_reduce(tests, eve::logical_or);
+        if (!eve::any(overall)) return false;
+
+        std::size_t i = size - 1;
+        std::optional<std::ptrdiff_t> match;
+        std::size_t pos = i;
+
+        array_reverse_it(tests, [&](auto test) mutable {
+          auto local_match = eve::first_true(test);
+          // should generate cmovs
+          if (local_match)
+          {
+            pos = i;
+            match = local_match;
+          }
+          --i;
+        });
+
+        const std::ptrdiff_t lanes = typename I::cardinal{}();
+        found = arr[0].unaligned() + (pos * lanes) + *match;
+
+        return true;
+      }
+
+      UnalignedI found;
+      P p;
+    };
+
+    template <typename P>
+    EVE_FORCEINLINE auto impl(auto processed, P p) const
+    {
+      if (processed.begin() == processed.end())
+      {
+        return processed.to_output_iterator(processed.begin());
+      }
+
+      auto l = processed.begin().unaligned() + (processed.end() - processed.begin());
+
+      delegate d{l, p};
+      algo::for_each_iteration(processed.traits(), processed.begin(), processed.end())(d);
+      return processed.to_output_iterator(d.found);
+    }
+  } inline constexpr find_if;
+}

--- a/include/eve/algo/one_range_algorithm_adapter.hpp
+++ b/include/eve/algo/one_range_algorithm_adapter.hpp
@@ -1,0 +1,56 @@
+//==================================================================================================
+/**
+  EVE - Expressive Vector Engine
+  Copyright : EVE Contributors & Maintainers
+  SPDX-License-Identifier: MIT
+**/
+//==================================================================================================
+#pragma once
+
+#include <eve/algo/concepts.hpp>
+#include <eve/algo/preprocess_range.hpp>
+#include <eve/algo/traits.hpp>
+
+namespace eve::algo
+{
+  template <typename Adaptee>
+  struct one_range_algorithm_adapter
+  {
+   private:
+    Adaptee const& self() const { return static_cast<Adaptee const&>(*this); }
+
+    template <instance_of<algo::traits> Traits, typename I, typename S, typename ... Args>
+      requires std::invocable<preprocess_range_, Traits, I, S>
+    EVE_FORCEINLINE decltype(auto) after_dealing_with_traits(Traits tr_, I f_, S l_, Args&& ... args) const
+    {
+      auto [tr, f, l] = preprocess_range(tr_, f_, l_);
+      return self().impl(tr, f, l, std::forward<Args>(args)...);
+    }
+
+
+    template <instance_of<algo::traits> Traits, typename Rng, typename ... Args>
+      requires std::invocable<preprocess_range_, Traits, Rng>
+    EVE_FORCEINLINE decltype(auto) after_dealing_with_traits(Traits tr_, Rng&& rng, Args&& ... args) const
+    {
+      auto [tr, f, l] = preprocess_range(tr_, std::forward<Rng>(rng));
+      return self().impl(tr, f, l, std::forward<Args>(args)...);
+    }
+
+   public:
+
+    template <typename Arg, typename ... Args>
+    EVE_FORCEINLINE decltype(auto) operator()(Arg&& arg, Args&& ... args) const
+    {
+      if constexpr( instance_of<Arg, algo::traits> )
+      {
+        auto tr_ = eve::algo::default_to(arg, self().default_traits());
+        return after_dealing_with_traits(tr_, std::forward<Args>(args)...);
+      }
+      else
+      {
+        return after_dealing_with_traits(
+            self().default_traits(), std::forward<Arg>(arg), std::forward<Args>(args)...);
+      }
+    }
+  };
+}

--- a/include/eve/algo/one_range_algorithm_adapter.hpp
+++ b/include/eve/algo/one_range_algorithm_adapter.hpp
@@ -23,8 +23,8 @@ namespace eve::algo
       requires std::invocable<preprocess_range_, Traits, I, S>
     EVE_FORCEINLINE decltype(auto) after_dealing_with_traits(Traits tr_, I f_, S l_, Args&& ... args) const
     {
-      auto [tr, f, l] = preprocess_range(tr_, f_, l_);
-      return self().impl(tr, f, l, std::forward<Args>(args)...);
+      auto processed = preprocess_range(tr_, f_, l_);
+      return self().impl(processed, std::forward<Args>(args)...);
     }
 
 
@@ -32,8 +32,8 @@ namespace eve::algo
       requires std::invocable<preprocess_range_, Traits, Rng>
     EVE_FORCEINLINE decltype(auto) after_dealing_with_traits(Traits tr_, Rng&& rng, Args&& ... args) const
     {
-      auto [tr, f, l] = preprocess_range(tr_, std::forward<Rng>(rng));
-      return self().impl(tr, f, l, std::forward<Args>(args)...);
+      auto processed = preprocess_range(tr_, std::forward<Rng>(rng));
+      return self().impl(processed, std::forward<Args>(args)...);
     }
 
    public:

--- a/include/eve/algo/preprocess_range.hpp
+++ b/include/eve/algo/preprocess_range.hpp
@@ -54,9 +54,7 @@ namespace eve::algo
     template <typename Traits, typename Rng>
       requires std::ranges::contiguous_range<std::remove_reference_t<Rng>>
     auto operator()(Traits traits_, Rng&& rng) const {
-      return operator()(traits_,
-                        std::ranges::begin(std::forward<Rng>(rng)),
-                        std::ranges::end(std::forward<Rng>(rng)));
+      return operator()(traits_, std::ranges::begin(rng), std::ranges::end(rng));
     }
 
     template <typename Traits, typename T>
@@ -67,6 +65,15 @@ namespace eve::algo
       using unaligned_it = unaligned_ptr_iterator<T, N>;
 
       return operator()(traits_, aligned_it(f), unaligned_it(l));
+    }
+
+    template <typename Traits, typename T>
+    auto operator()(Traits traits_, eve::aligned_ptr<T> f, eve::aligned_ptr<T> l) const
+    {
+      using N            = eve::fixed<eve::expected_cardinal_v<T>>;
+      using aligned_it   = aligned_ptr_iterator<T, N>;
+
+      return operator()(traits_, aligned_it(f), aligned_it(l));
     }
 
     // Base case. Should validate that I, S are a valid iterator pair

--- a/include/eve/algo/preprocess_range.hpp
+++ b/include/eve/algo/preprocess_range.hpp
@@ -7,11 +7,11 @@
 //==================================================================================================
 #pragma once
 
+#include <eve/algo/concepts.hpp>
 #include <eve/algo/ptr_iterator.hpp>
 #include <eve/algo/traits.hpp>
 
 #include <iterator>
-#include <ranges>
 #include <type_traits>
 #include <utility>
 
@@ -52,9 +52,9 @@ namespace eve::algo
     }
 
     template <typename Traits, typename Rng>
-      requires std::ranges::contiguous_range<std::remove_reference_t<Rng>>
+      requires detail::contiguous_range<std::remove_reference_t<Rng>>
     auto operator()(Traits traits_, Rng&& rng) const {
-      return operator()(traits_, std::ranges::begin(rng), std::ranges::end(rng));
+      return operator()(traits_, rng.begin(), rng.end());
     }
 
     template <typename Traits, typename T>

--- a/include/eve/algo/traits.hpp
+++ b/include/eve/algo/traits.hpp
@@ -80,4 +80,6 @@ namespace eve::algo
 
     return no_aligning_();
   }
+
+  inline constexpr algo::traits default_simple_algo_traits{algo::unroll<4>};
 }

--- a/include/eve/memory/aligned_ptr.hpp
+++ b/include/eve/memory/aligned_ptr.hpp
@@ -393,6 +393,27 @@ namespace eve
     return that -= o;
   }
 
+  template <typename Type, std::size_t Alignment>
+  std::ptrdiff_t operator-(aligned_ptr<Type, Alignment> const& lhs, aligned_ptr<Type, Alignment> const& rhs) noexcept
+    requires (!std::same_as<Type, void>)
+  {
+    return lhs.get() - rhs.get();
+  }
+
+  template <typename Type, std::size_t Alignment>
+  std::ptrdiff_t operator-(aligned_ptr<Type, Alignment> const& lhs, Type* rhs) noexcept
+    requires (!std::same_as<Type, void>)
+  {
+    return lhs.get() - rhs;
+  }
+
+  template <typename Type, std::size_t Alignment>
+  std::ptrdiff_t operator-(Type* lhs, aligned_ptr<Type, Alignment> const& rhs) noexcept
+    requires (!std::same_as<Type, void>)
+  {
+    return lhs - rhs.get();
+  }
+
   template<typename Type, std::size_t Alignment>
   aligned_ptr<Type, Alignment> operator+(aligned_ptr<Type, Alignment> const &p,
                                          std::ptrdiff_t                      o) noexcept

--- a/test/unit/algo/CMakeLists.txt
+++ b/test/unit/algo/CMakeLists.txt
@@ -23,3 +23,4 @@ make_unit("unit.algo" for_each_iteration.cpp)
 
 # Algorithms
 make_unit("unit.algo" any_of.cpp)
+make_unit("unit.algo" find.cpp)

--- a/test/unit/algo/CMakeLists.txt
+++ b/test/unit/algo/CMakeLists.txt
@@ -15,6 +15,7 @@ add_custom_target(unit.algo.simd.exe  )
 
 # Components
 make_unit("unit.algo" array_utils.cpp)
+make_unit("unit.algo" one_range_algorithm_adapter.cpp)
 make_unit("unit.algo" preprocess_range.cpp)
 make_unit("unit.algo" ptr_iterator.cpp)
 make_unit("unit.algo" traits.cpp)

--- a/test/unit/algo/array_utils.cpp
+++ b/test/unit/algo/array_utils.cpp
@@ -41,16 +41,12 @@ TTS_CASE("eve.algo.array_utils array_map")
   }
 }
 
-TTS_CASE("eve.algo.array_utils reverse it")
+TTS_CASE("eve.algo.array_utils find_branchless")
 {
-  constexpr auto res = [] {
-    std::array in = {3, 2, 1};
-    std::array out = in;
-    eve::algo::array_reverse_it(in, [&, i = 0u] (int x) mutable{
-      out[i++] = x;
-    });
-    return out;
-  }();
+  constexpr std::array in = {1, -2, 5};
 
-  TTS_CONSTEXPR_EQUAL(res, (std::array{1, 2, 3}));
+  constexpr std::size_t find_neg_2   = eve::algo::find_branchless(in, [](int x) { return x == -2; });
+  constexpr std::size_t find_more_10 = eve::algo::find_branchless(in, [](int x) { return x > 10; });
+  TTS_CONSTEXPR_EQUAL(find_neg_2, 1u);
+  TTS_CONSTEXPR_EQUAL(find_more_10, 3u);
 }

--- a/test/unit/algo/array_utils.cpp
+++ b/test/unit/algo/array_utils.cpp
@@ -40,3 +40,17 @@ TTS_CASE("eve.algo.array_utils array_map")
     TTS_CONSTEXPR_EXPECT( actual == 1 );
   }
 }
+
+TTS_CASE("eve.algo.array_utils reverse it")
+{
+  constexpr auto res = [] {
+    std::array in = {3, 2, 1};
+    std::array out = in;
+    eve::algo::array_reverse_it(in, [&, i = 0u] (int x) mutable{
+      out[i++] = x;
+    });
+    return out;
+  }();
+
+  TTS_CONSTEXPR_EQUAL(res, (std::array{1, 2, 3}));
+}

--- a/test/unit/algo/find.cpp
+++ b/test/unit/algo/find.cpp
@@ -1,0 +1,22 @@
+//==================================================================================================
+/**
+  EVE - Expressive Vector Engine
+  Copyright : EVE Contributors & Maintainers
+  SPDX-License-Identifier: MIT
+**/
+//==================================================================================================
+
+#include "algo_test.hpp"
+
+#include <eve/algo/find.hpp>
+
+#include "find_generic_test.hpp"
+
+EVE_TEST_TYPES("Check find_if", algo_test::selected_types)
+<typename T>(eve::as_<T> as_t)
+{
+  algo_test::find_generic_test(as_t, eve::algo::find_if,
+  [](auto, auto, auto expected, auto actual) {
+    TTS_EQUAL(actual, expected);
+  });
+};

--- a/test/unit/algo/one_range_algorithm_adapter.cpp
+++ b/test/unit/algo/one_range_algorithm_adapter.cpp
@@ -1,0 +1,92 @@
+//==================================================================================================
+/**
+  EVE - Expressive Vector Engine
+  Copyright : EVE Contributors & Maintainers
+  SPDX-License-Identifier: MIT
+**/
+//==================================================================================================
+
+#include "algo_test.hpp"
+
+#include <eve/algo/one_range_algorithm_adapter.hpp>
+
+#include <utility>
+
+namespace
+{
+
+template <typename Traits, typename Impl>
+struct fake_algorithm :
+  eve::algo::one_range_algorithm_adapter<fake_algorithm<Traits, Impl>>
+{
+  Traits traits_;
+  Impl   impl_;
+
+  fake_algorithm(Traits traits, Impl impl) :
+    traits_(traits), impl_(impl) {}
+
+  Traits default_traits() const
+  {
+    return traits_;
+  }
+
+  template <typename ...Args>
+  auto impl(Args&&... args) const
+  {
+    return impl_(std::forward<Args>(args)...);
+  }
+};
+
+}
+
+EVE_TEST_TYPES("Vector/const vector", algo_test::selected_types)
+<typename T>(eve::as_<T>)
+{
+  using e_t = eve::element_type_t<T>;
+  using N = eve::fixed<eve::expected_cardinal_v<e_t>>;
+
+  std::vector<e_t> v(3, 0);
+
+  auto const non_const_aglorithm =
+      fake_algorithm(eve::algo::traits(eve::algo::unroll<4>), [&](auto traits, auto f, auto l) {
+        TTS_CONSTEXPR_EQUAL(eve::algo::get_unrolling<decltype(traits)>(), 4);
+        TTS_TYPE_IS(decltype(f), (eve::algo::unaligned_ptr_iterator<e_t, N>));
+        TTS_TYPE_IS(decltype(l), (eve::algo::unaligned_ptr_iterator<e_t, N>));
+        TTS_EQUAL(f.ptr, v.data());
+        TTS_EQUAL(l.ptr, v.data() + v.size());
+      });
+
+  non_const_aglorithm(v);
+  non_const_aglorithm(v.begin(), v.end());
+  non_const_aglorithm(v.data(), v.data() + v.size());
+
+  auto const const_algorithm =
+      fake_algorithm(eve::algo::traits(eve::algo::unroll<4>), [&](auto traits, auto f, auto l) {
+        TTS_CONSTEXPR_EQUAL(eve::algo::get_unrolling<decltype(traits)>(), 2);
+        TTS_TYPE_IS(decltype(f), (eve::algo::unaligned_ptr_iterator<e_t const, N>));
+        TTS_TYPE_IS(decltype(l), (eve::algo::unaligned_ptr_iterator<e_t const, N>));
+        TTS_EQUAL(f.ptr, v.data());
+        TTS_EQUAL(l.ptr, v.data() + v.size());
+      });
+
+  const_algorithm(eve::algo::traits(eve::algo::unroll<2>), std::as_const(v));
+  const_algorithm(eve::algo::traits(eve::algo::unroll<2>), v.cbegin(), v.cend());
+
+  e_t const* const_data = v.data();
+  const_algorithm(eve::algo::traits(eve::algo::unroll<2>), const_data, const_data + v.size());
+};
+
+EVE_TEST_TYPES("aligned_ptr, empty range", algo_test::selected_types)
+<typename T>(eve::as_<T>)
+{
+  using e_t = eve::element_type_t<T>;
+  using N = eve::fixed<eve::expected_cardinal_v<e_t>>;
+
+  fake_algorithm(eve::algo::traits(), [](auto traits, auto f, auto l) {
+    auto expected_traits = eve::algo::traits(eve::algo::divisible_by_cardinal, eve::algo::no_aligning);
+    TTS_TYPE_IS(decltype(traits),decltype(expected_traits));
+    TTS_TYPE_IS(decltype(f), (eve::algo::aligned_ptr_iterator<e_t, N>));
+    TTS_TYPE_IS(decltype(l), (eve::algo::aligned_ptr_iterator<e_t, N>));
+    TTS_EQUAL(f, l);
+  })(eve::aligned_ptr<e_t>(), eve::aligned_ptr<e_t>());
+};

--- a/test/unit/algo/one_range_algorithm_adapter.cpp
+++ b/test/unit/algo/one_range_algorithm_adapter.cpp
@@ -31,9 +31,9 @@ struct fake_algorithm :
   }
 
   template <typename ...Args>
-  auto impl(Args&&... args) const
+  auto impl(auto processed, Args&&... args) const
   {
-    return impl_(std::forward<Args>(args)...);
+    return impl_(processed.traits(), processed.begin(), processed.end(), std::forward<Args>(args)...);
   }
 };
 

--- a/test/unit/algo/preprocess_range.cpp
+++ b/test/unit/algo/preprocess_range.cpp
@@ -26,111 +26,91 @@ EVE_TEST_TYPES("Check preprocess_range for contiguous iterators", algo_test::sel
 
   std::vector<e_t> vec(100u, 0);
 
+  auto common_test = [](auto f, auto l, auto expected_f_type, auto expected_l_type) {
+    auto processed = eve::algo::preprocess_range(eve::algo::traits(eve::algo::unroll<2>), f, l);
+    TTS_CONSTEXPR_EXPECT(eve::algo::get_unrolling<decltype(processed.traits())>() == 2);
+    TTS_TYPE_IS(decltype(processed.begin()), decltype(expected_f_type));
+    TTS_TYPE_IS(decltype(processed.end()), decltype(expected_l_type));
+
+    TTS_EQUAL((processed.end() - processed.begin()), (l - f));
+
+    auto back_to_f = processed.to_output_iterator(processed.begin().unaligned());
+    TTS_EQUAL(back_to_f, f);
+
+    auto processed_empty = eve::algo::preprocess_range(eve::algo::traits(eve::algo::unroll<2>), f, f);
+    TTS_EQUAL(processed_empty.begin(), processed_empty.end());
+    back_to_f = processed_empty.to_output_iterator(processed_empty.begin().unaligned());
+    TTS_EQUAL(back_to_f, f);
+
+    return processed;
+  };
+
   // pointers
-  {
-
-    auto [traits, f, l] = eve::algo::preprocess_range(eve::algo::traits(eve::algo::unroll<2>), arr.begin(), arr.end());
-    TTS_CONSTEXPR_EXPECT(eve::algo::get_unrolling<decltype(traits)>() == 2);
-    TTS_TYPE_IS(decltype(f), (eve::algo::unaligned_ptr_iterator<e_t, N>));
-    TTS_TYPE_IS(decltype(l), (eve::algo::unaligned_ptr_iterator<e_t, N>));
-    TTS_EQUAL((void*)f.ptr, (void*)arr.begin());
-    TTS_EQUAL((void*)l.ptr, (void*)arr.end());
-
-    auto [traits1, f1, l1] = eve::algo::preprocess_range(eve::algo::traits(eve::algo::unroll<2>), arr.begin(), arr.begin());
-    TTS_EQUAL(f1, l1);
-  }
+  common_test(
+    arr.begin(), arr.end(),
+    eve::algo::unaligned_ptr_iterator<e_t, N>{}, eve::algo::unaligned_ptr_iterator<e_t, N>{});
 
   // const pointers
-  {
-    auto [traits, f, l] = eve::algo::preprocess_range(eve::algo::traits(eve::algo::unroll<2>), arr.cbegin(), arr.cend());
-    TTS_CONSTEXPR_EXPECT(eve::algo::get_unrolling<decltype(traits)>() == 2);
-    TTS_TYPE_IS(decltype(f), (eve::algo::unaligned_ptr_iterator<const e_t, N>));
-    TTS_TYPE_IS(decltype(l), (eve::algo::unaligned_ptr_iterator<const e_t, N>));
-    TTS_EQUAL((void*)f.ptr, (void*)arr.cbegin());
-    TTS_EQUAL((void*)l.ptr, (void*)arr.cend());
-
-    auto [traits1, f1, l1] = eve::algo::preprocess_range(eve::algo::traits(eve::algo::unroll<2>), arr.cbegin(), arr.cbegin());
-    TTS_EQUAL(f1, l1);
-  }
+  common_test(
+    arr.cbegin(), arr.cend(),
+    eve::algo::unaligned_ptr_iterator<e_t const, N>{},
+    eve::algo::unaligned_ptr_iterator<e_t const, N>{}
+  );
 
   // aligned_pointer
   {
-    auto [traits, f, l] = eve::algo::preprocess_range(eve::algo::traits(eve::algo::unroll<2>), eve::aligned_ptr<e_t>{arr.begin()}, arr.end());
-    TTS_TYPE_IS(decltype(traits), decltype(eve::algo::traits(eve::algo::unroll<2>, eve::algo::no_aligning)));
-    TTS_TYPE_IS(decltype(f), (eve::algo::aligned_ptr_iterator<e_t, N>));
-    TTS_TYPE_IS(decltype(l), (eve::algo::unaligned_ptr_iterator<e_t, N>));
-    TTS_EQUAL((void*)f.ptr.get(), (void*)arr.begin());
-    TTS_EQUAL((void*)l.ptr, (void*)arr.end());
-
-    auto [traits1, f1, l1] = eve::algo::preprocess_range(eve::algo::traits(eve::algo::unroll<2>), eve::aligned_ptr<e_t>{arr.begin()}, arr.begin());
-    TTS_EQUAL(f1, l1);
+    auto processed = common_test(
+      eve::aligned_ptr<e_t>{arr.begin()}, arr.end(),
+      eve::algo::aligned_ptr_iterator<e_t, N>{},
+      eve::algo::unaligned_ptr_iterator<e_t, N>{}
+    );
+    TTS_CONSTEXPR_EXPECT(decltype(processed.traits())::contains(eve::algo::no_aligning));
   }
+
 
   // const aligned_pointer
   {
-    auto [traits, f, l] = eve::algo::preprocess_range(eve::algo::traits(eve::algo::unroll<2>), eve::aligned_ptr<const e_t>{arr.cbegin()}, arr.cend());
-    TTS_TYPE_IS(decltype(traits), decltype(eve::algo::traits(eve::algo::unroll<2>, eve::algo::no_aligning)));
-    TTS_TYPE_IS(decltype(f), (eve::algo::aligned_ptr_iterator<const e_t, N>));
-    TTS_TYPE_IS(decltype(l), (eve::algo::unaligned_ptr_iterator<const e_t, N>));
-    TTS_EQUAL((void*)f.ptr.get(), (void*)arr.begin());
-    TTS_EQUAL((void*)l.ptr, (void*)arr.end());
-
-    auto [traits1, f1, l1] = eve::algo::preprocess_range(eve::algo::traits(eve::algo::unroll<2>), eve::aligned_ptr<const e_t>{arr.cbegin()}, arr.cbegin());
-    TTS_EQUAL(f1, l1);
+    auto processed = common_test(
+      eve::aligned_ptr<e_t const>{arr.cbegin()}, arr.cend(),
+      eve::algo::aligned_ptr_iterator<e_t const, N>{},
+      eve::algo::unaligned_ptr_iterator<e_t const, N>{}
+    );
+    TTS_CONSTEXPR_EXPECT(decltype(processed.traits())::contains(eve::algo::no_aligning));
   }
 
   // two aligned_pointers
   {
-    auto [traits, f, l] = eve::algo::preprocess_range(eve::algo::traits(eve::algo::unroll<2>), eve::aligned_ptr<e_t>{arr.begin()}, eve::aligned_ptr<e_t>{arr.end()});
-    TTS_TYPE_IS(decltype(traits), decltype(eve::algo::traits(eve::algo::unroll<2>, eve::algo::divisible_by_cardinal, eve::algo::no_aligning)));
-    TTS_TYPE_IS(decltype(f), (eve::algo::aligned_ptr_iterator<e_t, N>));
-    TTS_TYPE_IS(decltype(l), (eve::algo::aligned_ptr_iterator<e_t, N>));
-    TTS_EQUAL((void*)f.ptr.get(), (void*)arr.begin());
-    TTS_EQUAL((void*)l.ptr.get(), (void*)arr.end());
-
-    auto [traits1, f1, l1] = eve::algo::preprocess_range(eve::algo::traits(eve::algo::unroll<2>), eve::aligned_ptr<e_t>{arr.begin()}, eve::aligned_ptr<e_t>{arr.begin()});
-    TTS_EQUAL(f1, l1);
+    auto processed = common_test(
+      eve::aligned_ptr<e_t>{arr.begin()}, eve::aligned_ptr<e_t>{arr.end()},
+      eve::algo::aligned_ptr_iterator<e_t, N>{},
+      eve::algo::aligned_ptr_iterator<e_t, N>{}
+    );
+    TTS_CONSTEXPR_EXPECT(decltype(processed.traits())::contains(eve::algo::no_aligning));
+    TTS_CONSTEXPR_EXPECT(decltype(processed.traits())::contains(eve::algo::divisible_by_cardinal));
   }
 
-  // two const aligned_pointer
+  // two const aligned_pointers
   {
-    auto [traits, f, l] = eve::algo::preprocess_range(eve::algo::traits(eve::algo::unroll<2>), eve::aligned_ptr<const e_t>{arr.cbegin()}, eve::aligned_ptr<const e_t>{arr.cend()});
-    TTS_TYPE_IS(decltype(traits), decltype(eve::algo::traits(eve::algo::unroll<2>, eve::algo::divisible_by_cardinal, eve::algo::no_aligning)));
-    TTS_TYPE_IS(decltype(f), (eve::algo::aligned_ptr_iterator<const e_t, N>));
-    TTS_TYPE_IS(decltype(l), (eve::algo::aligned_ptr_iterator<const e_t, N>));
-    TTS_EQUAL((void*)f.ptr.get(), (void*)arr.begin());
-    TTS_EQUAL((void*)l.ptr.get(), (void*)arr.end());
-
-    auto [traits1, f1, l1] = eve::algo::preprocess_range(eve::algo::traits(eve::algo::unroll<2>), eve::aligned_ptr<const e_t>{arr.cbegin()}, eve::aligned_ptr<const e_t>{arr.cbegin()});
-    TTS_EQUAL(f1, l1);
+    auto processed = common_test(
+      eve::aligned_ptr<e_t const>{arr.cbegin()}, eve::aligned_ptr<e_t const>{arr.cend()},
+      eve::algo::aligned_ptr_iterator<e_t const, N>{},
+      eve::algo::aligned_ptr_iterator<e_t const, N>{}
+    );
+    TTS_CONSTEXPR_EXPECT(decltype(processed.traits())::contains(eve::algo::no_aligning));
+    TTS_CONSTEXPR_EXPECT(decltype(processed.traits())::contains(eve::algo::divisible_by_cardinal));
   }
 
   // vector::iterator
-  {
-    auto [traits, f, l] = eve::algo::preprocess_range(eve::algo::traits(eve::algo::unroll<2>), vec.begin(), vec.end());
-    TTS_CONSTEXPR_EXPECT(eve::algo::get_unrolling<decltype(traits)>() == 2);
-    TTS_TYPE_IS(decltype(f), (eve::algo::unaligned_ptr_iterator<e_t, N>));
-    TTS_TYPE_IS(decltype(l), (eve::algo::unaligned_ptr_iterator<e_t, N>));
-    TTS_EQUAL((void*)f.ptr, (void*)vec.data());
-    TTS_EQUAL((void*)l.ptr, (void*)(vec.data() + static_cast<std::ptrdiff_t>(vec.size())));
-
-    auto [traits1, f1, l1] = eve::algo::preprocess_range(eve::algo::traits(eve::algo::unroll<2>), vec.begin(), vec.begin());
-    TTS_EQUAL(f1, l1);
-  }
+  common_test(
+    vec.begin(), vec.end(),
+    eve::algo::unaligned_ptr_iterator<e_t, N>{}, eve::algo::unaligned_ptr_iterator<e_t, N>{});
 
   // vector::const_iterator
-  {
-    auto [traits, f, l] = eve::algo::preprocess_range(eve::algo::traits(eve::algo::unroll<2>), vec.cbegin(), vec.cend());
-    TTS_CONSTEXPR_EXPECT(eve::algo::get_unrolling<decltype(traits)>() == 2);
-    TTS_TYPE_IS(decltype(f), (eve::algo::unaligned_ptr_iterator<const e_t, N>));
-    TTS_TYPE_IS(decltype(l), (eve::algo::unaligned_ptr_iterator<const e_t, N>));
-    TTS_EQUAL((void*)f.ptr, (void*)vec.data());
-    TTS_EQUAL((void*)l.ptr, (void*)(vec.data() + static_cast<std::ptrdiff_t>(vec.size())));
-
-    auto [traits1, f1, l1] = eve::algo::preprocess_range(eve::algo::traits(eve::algo::unroll<2>), vec.cbegin(), vec.cbegin());
-    TTS_EQUAL(f1, l1);
-  }
+  common_test(
+    vec.cbegin(), vec.cend(),
+    eve::algo::unaligned_ptr_iterator<e_t const, N>{}, eve::algo::unaligned_ptr_iterator<e_t const, N>{});
 };
+
 
 EVE_TEST_TYPES("Check preprocess_range for eve ptr iterators", algo_test::selected_types)
 <typename T>(eve::as_<T>)
@@ -140,17 +120,23 @@ EVE_TEST_TYPES("Check preprocess_range for eve ptr iterators", algo_test::select
 
   alignas(sizeof(T)) std::array<e_t, T::size()> arr;
 
-  auto run_one_test = [&]<typename I, typename S, typename ExpectedTraits>(I _f, S _l, ExpectedTraits)
+  auto run_one_test = [&]<typename I, typename S, typename ExpectedTraits>(I f, S l, ExpectedTraits)
   {
-    auto [traits, f, l] = eve::algo::preprocess_range(eve::algo::traits(eve::algo::unroll<2>), _f, _l);
-    TTS_TYPE_IS(decltype(traits), ExpectedTraits);
-    TTS_TYPE_IS(decltype(f), I);
-    TTS_TYPE_IS(decltype(l), S);
-    TTS_EQUAL(f, _f);
-    TTS_EQUAL(l, _l);
+    auto processed = eve::algo::preprocess_range(eve::algo::traits(eve::algo::unroll<2>), f, l);
+    TTS_TYPE_IS(decltype(processed.traits()), ExpectedTraits);
+    TTS_TYPE_IS(decltype(processed.begin()), I);
+    TTS_TYPE_IS(decltype(processed.end()), S);
+    TTS_EQUAL(processed.begin(), f);
+    TTS_EQUAL(processed.end(), l);
 
-    auto [traits1, f1, l1] = eve::algo::preprocess_range(eve::algo::traits(eve::algo::unroll<2>), _f, _f);
-    TTS_EQUAL(f1, l1);
+    auto back_to_f = processed.to_output_iterator(processed.begin().unaligned());
+    TTS_TYPE_IS(decltype(back_to_f), eve::algo::unaligned_t<I>);
+    TTS_EQUAL(back_to_f, f);
+
+    auto processed_empty = eve::algo::preprocess_range(eve::algo::traits(eve::algo::unroll<2>), f, f);
+    TTS_EQUAL(processed_empty.begin(), processed_empty.end());
+    back_to_f = processed_empty.to_output_iterator(processed_empty.begin().unaligned());
+    TTS_EQUAL(back_to_f, f);
   };
 
   auto run_test = [&] <typename U>(U* f, U* l) {
@@ -183,29 +169,30 @@ EVE_TEST_TYPES("contigious ranges", algo_test::selected_types)
     std::vector<e_t> v;
     using u_it = eve::algo::unaligned_ptr_iterator<e_t, N>;
 
-    auto [tr, f, l] = eve::algo::preprocess_range(eve::algo::traits(), v);
-    TTS_TYPE_IS(decltype(tr), decltype(eve::algo::traits()));
-    TTS_TYPE_IS(decltype(f), u_it);
-    TTS_TYPE_IS(decltype(l), u_it);
-    TTS_EQUAL(f, l);
+    auto processed = eve::algo::preprocess_range(eve::algo::traits(), v);
+    TTS_TYPE_IS(decltype(processed.traits()), decltype(eve::algo::traits()));
+    TTS_TYPE_IS(decltype(processed.begin()), u_it);
+    TTS_TYPE_IS(decltype(processed.end()), u_it);
+    TTS_EQUAL(processed.begin(), processed.end());
+
+    auto back_to_f = processed.to_output_iterator(processed.begin().unaligned());
+    TTS_TYPE_IS(decltype(back_to_f), typename std::vector<e_t>::iterator);
+    TTS_EQUAL(back_to_f, v.begin());
   }
 
   auto non_empty_range_test = [](auto&& rng) {
-    auto [tr, f, l] = eve::algo::preprocess_range(eve::algo::traits(), rng);
+    auto processed = eve::algo::preprocess_range(eve::algo::traits(), rng);
 
     using u_it = eve::algo::unaligned_ptr_iterator<
       std::remove_reference_t<decltype(*std::begin(rng))>, N>;
 
-    TTS_TYPE_IS(decltype(tr), decltype(eve::algo::traits()));
-    TTS_TYPE_IS(decltype(f), u_it);
-    TTS_TYPE_IS(decltype(l), u_it);
+    TTS_TYPE_IS(decltype(processed.traits()), decltype(eve::algo::traits()));
+    TTS_TYPE_IS(decltype(processed.begin()), u_it);
+    TTS_TYPE_IS(decltype(processed.end()), u_it);
 
-    auto* f_ = &*std::begin(rng);
-    auto* l_ = f_ + (std::end(rng) - std::begin(rng));
-
-    TTS_EQUAL((l - f), (l_ - f_));
-    TTS_EQUAL(f.ptr, f_);
-    TTS_EQUAL(l.ptr, l_);
+    auto back_to_f = processed.to_output_iterator(processed.begin().unaligned());
+    TTS_TYPE_IS(decltype(back_to_f), decltype(std::begin(rng)));
+    TTS_EQUAL(back_to_f, std::begin(rng));
   };
 
   {

--- a/test/unit/algo/preprocess_range.cpp
+++ b/test/unit/algo/preprocess_range.cpp
@@ -22,7 +22,7 @@ EVE_TEST_TYPES("Check preprocess_range for contiguous iterators", algo_test::sel
   using e_t = eve::element_type_t<T>;
   using N = eve::fixed<eve::expected_cardinal_v<e_t>>;
 
-  alignas(sizeof(eve::wide<e_t, N>)) std::array<e_t, T::size()> arr{};
+  alignas(sizeof(eve::wide<e_t, N>)) std::array<e_t, N{}()> arr{};
 
   std::vector<e_t> vec(100u, 0);
 
@@ -76,6 +76,32 @@ EVE_TEST_TYPES("Check preprocess_range for contiguous iterators", algo_test::sel
     TTS_EQUAL((void*)l.ptr, (void*)arr.end());
 
     auto [traits1, f1, l1] = eve::algo::preprocess_range(eve::algo::traits(eve::algo::unroll<2>), eve::aligned_ptr<const e_t>{arr.cbegin()}, arr.cbegin());
+    TTS_EQUAL(f1, l1);
+  }
+
+  // two aligned_pointers
+  {
+    auto [traits, f, l] = eve::algo::preprocess_range(eve::algo::traits(eve::algo::unroll<2>), eve::aligned_ptr<e_t>{arr.begin()}, eve::aligned_ptr<e_t>{arr.end()});
+    TTS_TYPE_IS(decltype(traits), decltype(eve::algo::traits(eve::algo::unroll<2>, eve::algo::divisible_by_cardinal, eve::algo::no_aligning)));
+    TTS_TYPE_IS(decltype(f), (eve::algo::aligned_ptr_iterator<e_t, N>));
+    TTS_TYPE_IS(decltype(l), (eve::algo::aligned_ptr_iterator<e_t, N>));
+    TTS_EQUAL((void*)f.ptr.get(), (void*)arr.begin());
+    TTS_EQUAL((void*)l.ptr.get(), (void*)arr.end());
+
+    auto [traits1, f1, l1] = eve::algo::preprocess_range(eve::algo::traits(eve::algo::unroll<2>), eve::aligned_ptr<e_t>{arr.begin()}, eve::aligned_ptr<e_t>{arr.begin()});
+    TTS_EQUAL(f1, l1);
+  }
+
+  // two const aligned_pointer
+  {
+    auto [traits, f, l] = eve::algo::preprocess_range(eve::algo::traits(eve::algo::unroll<2>), eve::aligned_ptr<const e_t>{arr.cbegin()}, eve::aligned_ptr<const e_t>{arr.cend()});
+    TTS_TYPE_IS(decltype(traits), decltype(eve::algo::traits(eve::algo::unroll<2>, eve::algo::divisible_by_cardinal, eve::algo::no_aligning)));
+    TTS_TYPE_IS(decltype(f), (eve::algo::aligned_ptr_iterator<const e_t, N>));
+    TTS_TYPE_IS(decltype(l), (eve::algo::aligned_ptr_iterator<const e_t, N>));
+    TTS_EQUAL((void*)f.ptr.get(), (void*)arr.begin());
+    TTS_EQUAL((void*)l.ptr.get(), (void*)arr.end());
+
+    auto [traits1, f1, l1] = eve::algo::preprocess_range(eve::algo::traits(eve::algo::unroll<2>), eve::aligned_ptr<const e_t>{arr.cbegin()}, eve::aligned_ptr<const e_t>{arr.cbegin()});
     TTS_EQUAL(f1, l1);
   }
 

--- a/test/unit/algo/preprocess_range.cpp
+++ b/test/unit/algo/preprocess_range.cpp
@@ -218,6 +218,8 @@ EVE_TEST_TYPES("contigious ranges", algo_test::selected_types)
     non_empty_range_test(v);
   }
 
+// We need better ranges support for it.
+#if 0
   {
     e_t v[10] = {};
     non_empty_range_test(v);
@@ -227,6 +229,7 @@ EVE_TEST_TYPES("contigious ranges", algo_test::selected_types)
     e_t const v[10] = {};
     non_empty_range_test(v);
   }
+#endif
 
   {
     std::array<e_t, 10> v = {};

--- a/test/unit/memory/aligned_ptr.cpp
+++ b/test/unit/memory/aligned_ptr.cpp
@@ -165,6 +165,16 @@ TTS_CASE("aligned_ptr provides pointer-like interface")
       TTS_EQUAL(ptr->member, 42);
       TTS_EQUAL(other_ptr->member, 17);
     }
+
+    TTS_AND_THEN("we check interation with raw ptr")
+    {
+      TTS_EQUAL(ptr, ptr.get());
+      TTS_EQUAL(ptr.get(), ptr);
+      TTS_NOT_EQUAL(ptr, other_ptr.get());
+      TTS_NOT_EQUAL(ptr.get(), other_ptr);
+      TTS_EQUAL((other_ptr.get() - ptr), 1);
+      TTS_EQUAL((other_ptr - ptr.get()), 1);
+    }
   }
 }
 


### PR DESCRIPTION
Introducing a common interface adapter for all our algorithms over one range.
The goal is to get to a canonicalised `traits, iterator, sentinel` interface from all of the possible variations on the subject.

Added `find_if` since it utilises more features of the API.
So far - not sure how to go about `first_true(array<wide>)` - created a story to think about it: https://github.com/jfalcou/eve/issues/764
We'll see what makes sense.

Had to add a few apis to aligned_ptr.

UPD: ranges support is busted in clang, even libstdcxx is not working.
So for now - no built in arrays.