### PR TITLE
FIX-#768: compress store 4 elements, x86.

### DIFF
--- a/include/eve/memory/pointer.hpp
+++ b/include/eve/memory/pointer.hpp
@@ -22,14 +22,12 @@ namespace eve::detail
 
   template <typename U, typename T, std::size_t size>
   EVE_FORCEINLINE auto ptr_cast(eve::aligned_ptr<T, size> p)
-    requires (sizeof(U) == sizeof(T))
   {
     return aligned_ptr<U, size>{(U*)(p.get())};
   }
 
   template <typename U, typename T>
   EVE_FORCEINLINE auto ptr_cast(T* p)
-    requires (sizeof(U) == sizeof(T))
   {
     return (U*)p;
   }

--- a/include/eve/module/real/core/function/regular/simd/x86/compress_store.hpp
+++ b/include/eve/module/real/core/function/regular/simd/x86/compress_store.hpp
@@ -80,6 +80,7 @@ namespace eve::detail
                      wide<T, N> v,
                      logical<wide<T, N>> mask,
                      Ptr ptr) noexcept
+    requires x86_abi<abi_t<T, N>>
   {
     if constexpr ( N() == 4 && sizeof(T) == 8 && current_api >= avx2 )
     {
@@ -94,6 +95,10 @@ namespace eve::detail
       store(shuffled, ptr);
       int popcount = eve::count_true(mask);
       return as_raw_pointer(ptr) + popcount;
+    }
+    else if constexpr ( std::same_as<abi_t<T, N>, x86_256_> )
+    {
+      return compress_store_aggregated_unsafe(v, mask, ptr);
     }
     else if constexpr ( std::floating_point<T> )
     {

--- a/include/eve/module/real/core/function/regular/simd/x86/convert_128.hpp
+++ b/include/eve/module/real/core/function/regular/simd/x86/convert_128.hpp
@@ -277,4 +277,18 @@ namespace eve::detail
       return convert_(EVE_RETARGET(simd_), v0, tgt);
     }
   }
+
+  template<real_scalar_value In, typename N, real_scalar_value Out>
+  EVE_FORCEINLINE logical<wide<Out, N>>
+  convert_(EVE_SUPPORTS(sse2_), logical<wide<In, N>> const &v0, as_<logical<Out>> const &tgt) noexcept
+    requires std::same_as<abi_t<In, N>, x86_128_>
+  {
+    constexpr auto c  = categorize<wide<In, N>>();
+
+    if constexpr ( match(c, category::int16x8, category::uint16x8) && sizeof(Out) == 1 )
+    {
+      return  _mm_packs_epi16(v0, v0);
+    }
+    else return convert_(EVE_RETARGET(simd_), v0, tgt);
+  }
 }

--- a/include/eve/module/real/core/function/regular/simd/x86/convert_128.hpp
+++ b/include/eve/module/real/core/function/regular/simd/x86/convert_128.hpp
@@ -281,7 +281,7 @@ namespace eve::detail
   template<real_scalar_value In, typename N, real_scalar_value Out>
   EVE_FORCEINLINE logical<wide<Out, N>>
   convert_(EVE_SUPPORTS(sse2_), logical<wide<In, N>> const &v0, as_<logical<Out>> const &tgt) noexcept
-    requires std::same_as<abi_t<In, N>, x86_128_>
+    requires std::same_as<abi_t<In, N>, x86_128_> && (abi_t<In, N>::is_wide_logical)
   {
     constexpr auto c  = categorize<wide<In, N>>();
 


### PR DESCRIPTION
Tagging @aqrit as well.
FYI: we store less than register size in lower bits of _m128i.

Compress store for 4 elements, x86.

For avx2 I decided to stick with calling `popcount` over getting it from shuffle pattern.
I'd have to measure this later.

Also fixed `convert` for logicals just in case.