### PR TITLE
Fix get() on wide<tuple> to not require default constructor

### DIFF
--- a/include/eve/detail/function/simd/common/subscript.hpp
+++ b/include/eve/detail/function/simd/common/subscript.hpp
@@ -66,10 +66,12 @@ namespace eve::detail
   {
     if constexpr( has_bundle_abi_v<Wide> )
     {
-      // Constructs piecewise so we don't have to ask for special ctor
-      typename Wide::value_type that;
-      kumi::for_each( [i](auto m, auto& d) { d = m.get(i); }, p, that);
-      return that;
+      return kumi::apply( [=](auto const&... m)
+                          {
+                            return typename Wide::value_type{ at_begin(m)[i]... };
+                          }
+                          , p.storage()
+                        );
     }
     else
     {


### PR DESCRIPTION
More than being a bad constraint, it leads to bad codegen by g++ in -O3 when at least one member of the tuple was a 32 bits int.
This is certainly a g++ bug that we'll reproduce and fill later on.