### PR TITLE
FIX-715: zip iterator

### DIFF
--- a/include/eve/algo/README.txt
+++ b/include/eve/algo/README.txt
@@ -123,12 +123,31 @@ For example, using `std::reduce` on a small array to compute a sum will no be ef
 since it will generate instructions that can be executed in parallel.
 `array_reduce` will.
 
+### converting_iterator
+
+* `converting_iterator`
+* `convert`
+
+An iterator on top of a different iterator that applies a convertion to a different type.
+Cardinal stays the same.
+In the future this should use some more efficient platform loads.
+
+convert is a helper function to get a converting iterator.
+
+### zip_iterator
+
+`zip_iterator`
+
+A tuple of iterators with the same cardinal.
+
 ### ptr_iterator
 
 * `aligned_ptr_iterator`
 * `unaligned_ptr_iterator`
 
 A pointer + cardinal with the `iterator` interface.
+
+
 
 ### preprocess_range
 

--- a/include/eve/algo/converting_iterator.hpp
+++ b/include/eve/algo/converting_iterator.hpp
@@ -58,14 +58,13 @@ namespace eve::algo
       return base <=> x.base;
     }
 
-    template <typename I2>
+    converting_iterator&  operator+=(std::ptrdiff_t n) { base += n; return *this; }
+
+    template <sentinel_for<I> I2>
     std::ptrdiff_t operator-(converting_iterator<I2, T> const & x) const
     {
       return base - x.base;
     }
-
-    converting_iterator&  operator+=(std::ptrdiff_t n) { base += n; return *this; }
-    friend std::ptrdiff_t operator-(converting_iterator x, converting_iterator y) { return x.base - y.base; }
 
     template< relative_conditional_expr C, decorator S, typename Pack>
     friend auto tagged_dispatch ( eve::tag::load_, C const& c, S const& s

--- a/include/eve/algo/ptr_iterator.hpp
+++ b/include/eve/algo/ptr_iterator.hpp
@@ -48,7 +48,7 @@ namespace eve::algo
 
     template< relative_conditional_expr C, decorator S, typename Pack>
     friend auto tagged_dispatch ( eve::tag::load_, C const& c, S const& s
-                                , eve::as<Pack> const& , unaligned_ptr_iterator self
+                                , eve::as<Pack> const&, unaligned_ptr_iterator self
                                 )
     {
       return eve::load(c, s, self.ptr, Cardinal{});

--- a/test/unit/algo/iterator_concept_test.hpp
+++ b/test/unit/algo/iterator_concept_test.hpp
@@ -81,6 +81,13 @@ namespace algo_test
     TTS_EQUAL(f, l);
   }
 
+  template <typename I>
+  void cardinal_cast_test(I f)
+  {
+    auto res = f.cardinal_cast(eve::lane<1>);
+    TTS_TYPE_IS(typename decltype(res)::cardinal, eve::fixed<1>);
+  }
+
   template <eve::algo::readable_iterator I, eve::algo::sentinel_for<I> S, typename T, typename ReplaceIgnored>
   void iterator_sentinel_test(I f, S l, T v, ReplaceIgnored replace)
   {

--- a/test/unit/algo/zip_iterator.cpp
+++ b/test/unit/algo/zip_iterator.cpp
@@ -12,6 +12,8 @@
 
 #include <eve/algo/ptr_iterator.hpp>
 
+#include "iterator_concept_test.hpp"
+
 TTS_CASE("zip_iterator, sanity check, types test")
 {
   using unaligned_float = eve::algo::unaligned_ptr_iterator<float, eve::fixed<8>>;
@@ -23,6 +25,11 @@ TTS_CASE("zip_iterator, sanity check, types test")
   using zip_u_a = eve::algo::zip_iterator<unaligned_float, aligned_short>;
   using zip_a_u = eve::algo::zip_iterator<aligned_float,   unaligned_short>;
   using zip_u_u = eve::algo::zip_iterator<unaligned_float, unaligned_short>;
+
+  using aligned_float_4   = eve::algo::aligned_ptr_iterator  <float, eve::fixed<4>>;
+  using unaligned_short_4 = eve::algo::unaligned_ptr_iterator<short, eve::fixed<4>>;
+
+  using zip_a_u_4 = eve::algo::zip_iterator<aligned_float_4, unaligned_short_4>;
 
   using wide_value_type = eve::wide<kumi::tuple<float, short>, eve::fixed<8>>;
 
@@ -42,7 +49,85 @@ TTS_CASE("zip_iterator, sanity check, types test")
   TTS_TYPE_IS(eve::algo::partially_aligned_t<zip_u_a>, zip_u_a);
   TTS_TYPE_IS(eve::algo::partially_aligned_t<zip_u_u>, zip_a_u);
 
+  // Cardinal cast
+  TTS_TYPE_IS(decltype(zip_a_u{}.cardinal_cast(eve::lane<4>)), zip_a_u_4);
+
+  // Equality
+  TTS_TYPE_IS(decltype(zip_a_u{} == zip_a_u{}), bool);
+  TTS_TYPE_IS(decltype(zip_a_u{} == zip_u_u{}), bool);
+  TTS_TYPE_IS(decltype(zip_a_a{} != zip_u_a{}), bool);
+
+  TTS_TYPE_IS(decltype(zip_a_u{} < zip_u_u{}), bool);
+  TTS_TYPE_IS(decltype(zip_a_u{} - zip_u_u{}), std::ptrdiff_t);
+
   // Load
-  //auto loaded = eve::load(zip_a_u{});
   TTS_TYPE_IS(decltype(eve::load(zip_a_u{})), wide_value_type);
+  TTS_TYPE_IS(decltype(eve::load[eve::ignore_first(2)](zip_a_u{})), wide_value_type);
+  TTS_TYPE_IS(decltype(eve::load[eve::ignore_first(2).else_(wide_value_type{})](zip_a_u{})), wide_value_type);
+
+  // Store
+  TTS_TYPE_IS(decltype(eve::store(wide_value_type{}, zip_a_u{})), void);
+  TTS_TYPE_IS(decltype(eve::store[eve::ignore_first(2)](wide_value_type{}, zip_a_u{})), void);
+  TTS_TYPE_IS(decltype(eve::store[eve::ignore_first(2).else_(wide_value_type{})](wide_value_type{}, zip_a_u{})), void);
+
+  // Is readable iterator
+  {
+    eve::algo::readable_iterator auto u_u_test = zip_u_u{};
+    (void) u_u_test;
+    eve::algo::readable_iterator auto a_u_test = zip_a_u{};
+    (void) a_u_test;
+  }
 }
+
+inline constexpr eve::detail::types<
+      eve::wide<std::uint8_t>> some_type;
+
+EVE_TEST_TYPES("Check zip_iterator", some_type)
+<typename T>(eve::as<T>)
+{
+  using t1 = std::int8_t;
+  using t2 = eve::element_type_t<T>;
+  using t3 = std::uint64_t;
+  constexpr std::ptrdiff_t test_cardinal = []{
+    if constexpr ( eve::current_api != eve::avx512           ) return T::size();
+    if constexpr ( T::size() <= eve::expected_cardinal_v<t3> ) return T::size();
+    return eve::expected_cardinal_v<t3>;
+  }();
+  using N  = eve::fixed<test_cardinal>;
+
+  using tuple_t = kumi::tuple<t1, t2, t3>;
+
+  alignas(sizeof(t1) * N{}()) std::array<t1, N{}()> data_1;
+  alignas(sizeof(t2) * N{}()) std::array<t2, N{}()> data_2;
+  alignas(sizeof(t3) * N{}()) std::array<t3, N{}()> data_3;
+
+  std::iota(data_1.begin(), data_1.end(), 0);
+  std::iota(data_2.begin(), data_2.end(), 0);
+  std::iota(data_3.begin(), data_3.end(), 0);
+
+  eve::wide<tuple_t, N> values { [](int i, int) { return tuple_t{(t1)i, (t2)i, (t3)i}; }};
+  eve::wide<tuple_t, N> zeroes { tuple_t{t1{}, t2{}, t3{}} };
+
+  auto replace = [&](auto v, auto ignore) { return eve::replace_ignored(v, ignore, zeroes); };
+
+  auto run_test_one_pair = [&](auto f1, auto f2, auto f3, auto l1) {
+    eve::algo::zip_iterator f {f1, f2, f3};
+    eve::algo::zip_iterator l = f + (l1 - f1);
+    algo_test::iterator_sentinel_test(f, l, values, replace);
+    algo_test::writeable_readable_iterator(f, values, replace);
+  };
+
+  eve::algo::unaligned_ptr_iterator<t1, N> u_f_1{data_1.begin()};
+  eve::algo::unaligned_ptr_iterator<t2, N> u_f_2{data_2.begin()};
+  eve::algo::unaligned_ptr_iterator<t3, N> u_f_3{data_3.begin()};
+
+  auto u_l_1 = u_f_1 + T::size();
+
+  auto a_f_1 = u_f_1.previous_partially_aligned();
+  auto a_f_2 = u_f_2.previous_partially_aligned();
+  auto a_f_3 = u_f_3.previous_partially_aligned();
+
+  run_test_one_pair(u_f_1, u_f_2, u_f_3, u_l_1);
+  run_test_one_pair(a_f_1, a_f_2, a_f_3, u_l_1);
+  run_test_one_pair(u_f_1, a_f_2, u_f_3, u_l_1);
+};


### PR DESCRIPTION
A step to equality.

zip iterator is again our type of iterator, where the interface is designed for convenience of the algorithm writer.
There will be `zip` - a fairly stupid helper and the preprocess range will learn to generate from `zip` `zip_iterator`s