### PR TITLE
FIX-768: compress_store: ignore support

### DIFF
--- a/docs/developer/build_and_test.html
+++ b/docs/developer/build_and_test.html
@@ -122,12 +122,12 @@ CMAKE configurations
 |emulated                | cmake .. -G Ninja -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchain/clang.x86.cmake -DEVE_OPTIONS='-DEVE_NO_SIMD' |
 |x86_sse2                | cmake .. -G Ninja -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchain/clang.x86.cmake -DEVE_OPTIONS='-msse2' |
 |x86_sse2-asan           | cmake .. -G Ninja -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchain/clang.x86.asan.cmake -DEVE_OPTIONS='-msse2' |
-|x86_sse4                | cmake .. -G Ninja -DCMAKE_TOOLCHAIN_FILE=./cmake/toolchain/clang.x86.cmake  -DEVE_OPTIONS='-msse4' |
-|x86_avx                 | cmake .. -G Ninja -DCMAKE_TOOLCHAIN_FILE=./cmake/toolchain/clang.x86.cmake  -DEVE_OPTIONS='-mavx' |
-|x86_avx2                | cmake .. -G Ninja -DCMAKE_TOOLCHAIN_FILE=./cmake/toolchain/clang.x86.cmake  -DEVE_OPTIONS='-mavx2' |
-|x86_fma                 | cmake .. -G Ninja -DCMAKE_TOOLCHAIN_FILE=./cmake/toolchain/clang.x86.cmake  -DEVE_OPTIONS='-mavx2 -mfma' |
-|x86_avx512              | cmake .. -G Ninja -DCMAKE_TOOLCHAIN_FILE=./cmake/toolchain/clang.x86.cmake  -DEVE_OPTIONS='-march=skylake-avx512' |
-|x86_avx512_no_native    | cmake .. -G Ninja -DCMAKE_TOOLCHAIN_FILE=./cmake/toolchain/clang.x86.sde.cmake  -DEVE_OPTIONS='-march=skylake-avx512' |
+|x86_sse4                | cmake .. -G Ninja -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchain/clang.x86.cmake  -DEVE_OPTIONS='-msse4' |
+|x86_avx                 | cmake .. -G Ninja -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchain/clang.x86.cmake  -DEVE_OPTIONS='-mavx' |
+|x86_avx2                | cmake .. -G Ninja -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchain/clang.x86.cmake  -DEVE_OPTIONS='-mavx2' |
+|x86_fma                 | cmake .. -G Ninja -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchain/clang.x86.cmake  -DEVE_OPTIONS='-mavx2 -mfma' |
+|x86_avx512              | cmake .. -G Ninja -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchain/clang.x86.cmake  -DEVE_OPTIONS='-march=skylake-avx512' |
+|x86_avx512_no_native    | cmake .. -G Ninja -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchain/clang.x86.sde.cmake  -DEVE_OPTIONS='-march=skylake-avx512' |
 |tiny (sse2)             | cmake .. -G Ninja -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchain/clang.x86.cmake -DEVE_TEST_TYPE=tiny_wide |
 |small (sse2)            | cmake .. -G Ninja -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchain/clang.x86.cmake -DEVE_TEST_TYPE=small_wide |
 |extra (sse2)            | cmake .. -G Ninja -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchain/clang.x86.cmake -DEVE_TEST_TYPE=extra_wide |

--- a/include/eve/detail/function/compress_store_impl.hpp
+++ b/include/eve/detail/function/compress_store_impl.hpp
@@ -10,6 +10,15 @@
 #include <eve/arch.hpp>
 #include <eve/detail/implementation.hpp>
 
+// compress_store_impl
+// Writes all compressed values to the provided pointer
+// Unlike a real compress store, offset of ignore won't move values.
+//
+// Example:
+//   [a b c d], [true, true, true, true], ignore_first(1)
+//  compress_store     : [ _ b c d]
+//  compress_store_impl: [b c d _ ]
+
 namespace eve
 {
   EVE_REGISTER_CALLABLE(compress_store_impl_)

--- a/include/eve/detail/function/compress_store_impl.hpp
+++ b/include/eve/detail/function/compress_store_impl.hpp
@@ -1,0 +1,30 @@
+//==================================================================================================
+/**
+  EVE - Expressive Vector Engine
+  Copyright : EVE Contributors & Maintainers
+  SPDX-License-Identifier: MIT
+**/
+//==================================================================================================
+#pragma once
+
+#include <eve/arch.hpp>
+#include <eve/detail/implementation.hpp>
+
+namespace eve
+{
+  EVE_REGISTER_CALLABLE(compress_store_impl_)
+  EVE_DECLARE_CALLABLE(compress_store_impl_, compress_store_impl)
+
+  namespace detail
+  {
+    EVE_ALIAS_CALLABLE(compress_store_impl_, compress_store_impl);
+  }
+
+  EVE_CALLABLE_API(compress_store_impl_, compress_store_impl)
+}
+
+#include <eve/detail/function/simd/common/compress_store_impl.hpp>
+
+#if defined(EVE_INCLUDE_X86_HEADER)
+#  include <eve/detail/function/simd/x86/compress_store_impl.hpp>
+#endif

--- a/include/eve/detail/function/simd/common/compress_store_impl.hpp
+++ b/include/eve/detail/function/simd/common/compress_store_impl.hpp
@@ -18,22 +18,24 @@
 
 namespace eve::detail
 {
-  template<real_scalar_value T, typename N, simd_compatible_ptr<wide<T, N>> Ptr>
+  template<relative_conditional_expr Cond, real_scalar_value T, typename N, simd_compatible_ptr<wide<T, N>> Ptr>
   EVE_FORCEINLINE
-  T* compress_store_impl_aggregated(wide<T, N> v,
+  T* compress_store_impl_aggregated(Cond c,
+                                    wide<T, N> v,
                                     logical<wide<T, N>> mask,
                                     Ptr ptr)
   {
     auto [l, h] = v.slice();
     auto [ml, mh] = mask.slice();
 
-    T* ptr1 = compress_store_impl(l, ml, ptr);
-    return compress_store_impl(h, mh, ptr1);
+    T* ptr1 = compress_store_impl(c, l, ml, ptr);
+    return compress_store_impl(c, h, mh, ptr1);
   }
 
-  template<real_scalar_value T, typename N, simd_compatible_ptr<wide<T, N>> Ptr>
+  template<relative_conditional_expr Cond, real_scalar_value T, typename N, simd_compatible_ptr<wide<T, N>> Ptr>
   EVE_FORCEINLINE
   T* compress_store_impl_(EVE_SUPPORTS(cpu_),
+                          Cond c,
                           wide<T, N> v,
                           logical<wide<T, N>> mask,
                           Ptr ptr) noexcept
@@ -47,7 +49,7 @@ namespace eve::detail
     }
     else if constexpr ( !has_emulated_abi_v<wide<T, N>> && N() > 2 )
     {
-      return compress_store_impl_aggregated(v, mask, ptr);
+      return compress_store_impl_aggregated(c, v, mask, ptr);
     }
     else
     {

--- a/include/eve/detail/function/simd/common/compress_store_impl.hpp
+++ b/include/eve/detail/function/simd/common/compress_store_impl.hpp
@@ -1,0 +1,63 @@
+//==================================================================================================
+/**
+  EVE - Expressive Vector Engine
+  Copyright : EVE Contributors & Maintainers
+  SPDX-License-Identifier: MIT
+**/
+//==================================================================================================
+#pragma once
+
+#include <eve/concept/value.hpp>
+#include <eve/detail/implementation.hpp>
+#include <eve/detail/meta.hpp>
+#include <eve/function/count_true.hpp>
+#include <eve/function/slide_left.hpp>
+#include <eve/function/store.hpp>
+#include <eve/function/unsafe.hpp>
+#include <eve/memory/pointer.hpp>
+
+namespace eve::detail
+{
+  template<real_scalar_value T, typename N, simd_compatible_ptr<wide<T, N>> Ptr>
+  EVE_FORCEINLINE
+  T* compress_store_impl_aggregated(wide<T, N> v,
+                                    logical<wide<T, N>> mask,
+                                    Ptr ptr)
+  {
+    auto [l, h] = v.slice();
+    auto [ml, mh] = mask.slice();
+
+    T* ptr1 = compress_store_impl(l, ml, ptr);
+    return compress_store_impl(h, mh, ptr1);
+  }
+
+  template<real_scalar_value T, typename N, simd_compatible_ptr<wide<T, N>> Ptr>
+  EVE_FORCEINLINE
+  T* compress_store_impl_(EVE_SUPPORTS(cpu_),
+                          wide<T, N> v,
+                          logical<wide<T, N>> mask,
+                          Ptr ptr) noexcept
+  {
+    if constexpr ( !has_emulated_abi_v<wide<T, N>> && N() == 2 )
+    {
+      auto to_left     = eve::slide_left( v, eve::index<1> );
+      auto compressed  = eve::if_else[mask]( v, to_left );
+      eve::store(compressed, ptr);
+      return as_raw_pointer(ptr) + eve::count_true(mask);
+    }
+    else if constexpr ( !has_emulated_abi_v<wide<T, N>> && N() > 2 )
+    {
+      return compress_store_impl_aggregated(v, mask, ptr);
+    }
+    else
+    {
+      auto* ptr_ = as_raw_pointer(ptr);
+      detail::for_<0,1, N{}()>([&](auto idx) mutable
+      {
+        *ptr_ = v.get(idx());
+        ptr_ += mask.get(idx());
+      });
+      return ptr_;
+    }
+  }
+}

--- a/include/eve/detail/function/simd/x86/compress_store_impl.hpp
+++ b/include/eve/detail/function/simd/x86/compress_store_impl.hpp
@@ -7,12 +7,22 @@
 //==================================================================================================
 #pragma once
 
+#include <eve/function/convert.hpp>
+
 #include <array>
 #include <bit>
 
+/*
+  NOTE:
+    We have 3 implementations: 4 elements, 8 elements and 16 elements.
+    For 4 elements we can process ignore better, utilizing top_bits.
+    For every other case since we do a shift + & we have to use the mask => we use the base case.
+
+    At the moment we don't have avx-512 implementation, since the logical is different.
+*/
+
 namespace eve::detail
 {
-
   EVE_FORCEINLINE constexpr std::uint32_t add_popcount(std::uint32_t idx, std::uint32_t count)
   {
     return count << 4 | idx;
@@ -111,31 +121,32 @@ namespace eve::detail
   // The idea from: https://gist.github.com/aqrit/6e73ca6ff52f72a2b121d584745f89f3#file-despace-cpp-L141
   // Was shown to me by: @aqrit
   // Stack Overflow discussion: https://chat.stackoverflow.com/rooms/212510/discussion-between-denis-yaroshevskiy-and-peter-cordes
-  template<relative_conditional_expr Cond, real_scalar_value T, typename N, simd_compatible_ptr<wide<T, N>> Ptr>
+  template<relative_conditional_expr C, real_scalar_value T, typename N, simd_compatible_ptr<wide<T, N>> Ptr>
   EVE_FORCEINLINE
   T* compress_store_impl_(EVE_SUPPORTS(ssse3_),
-                          Cond c,
+                          C c,
                           wide<T, N> v,
                           logical<wide<T, N>> mask,
                           Ptr ptr) noexcept
     requires x86_abi<abi_t<T, N>> && ( N() == 4 )
   {
-    if constexpr ( N() == 4 && sizeof(T) == 8 && current_api == avx  )
+         if ( C::is_complete && !C::is_inverted ) return as_raw_pointer(ptr);
+    else if constexpr ( N() == 4 && sizeof(T) == 8 && current_api == avx  )
     {
-      return compress_store_impl_aggregated(c, v, mask, ptr);
+      return compress_store_impl_(EVE_RETARGET(cpu_), v, mask, ptr);
     }
     else if constexpr ( N() == 4 && sizeof(T) == 8 )
     {
       alignas(sizeof(T) * N()) auto patterns = pattern_4_elements(idx_dwords<std::uint64_t>);
 
-      top_bits mmask{mask};
+      top_bits mmask{mask, c};
       aligned_ptr<std::uint64_t, eve::fixed<4>> pattern_ptr{patterns[mmask.as_int() & 7].data()};
       wide<std::uint32_t, eve::fixed<8>> pattern{ptr_cast<std::uint32_t>(pattern_ptr)};
 
       wide<T, N> shuffled = permvar8(v, pattern);
 
       store(shuffled, ptr);
-      int popcount = eve::count_true(mask);
+      int popcount = count_true(mmask);
       return as_raw_pointer(ptr) + popcount;
     }
     else if constexpr ( std::floating_point<T> )
@@ -159,11 +170,12 @@ namespace eve::detail
       auto mmask = [&] {
         if constexpr ( sizeof(T) == 2 && abi_t<T, N>::is_wide_logical )
         {
-          return _mm_movemask_epi8(_mm_packs_epi16(mask, mask));
+          auto shrink_bytes = eve::convert(mask, eve::as<eve::logical<std::uint8_t>>{});
+          return top_bits{shrink_bytes, c}.as_int();
         }
         else
         {
-          return top_bits{mask}.as_int();
+          return top_bits{mask, c}.as_int();
         }
       }();
 
@@ -176,6 +188,21 @@ namespace eve::detail
       int popcount = get_popcount(pattern.get(0)) + (bool)(mmask & 8);
       return as_raw_pointer(ptr) + popcount;
     }
+  }
+
+  template<real_scalar_value T, typename N, simd_compatible_ptr<wide<T, N>> Ptr>
+  EVE_FORCEINLINE
+  T* compress_store_impl_(EVE_SUPPORTS(ssse3_),
+                          wide<T, N> v,
+                          logical<wide<T, N>> mask,
+                          Ptr ptr) noexcept
+    requires x86_abi<abi_t<T, N>> && ( N() == 4 )
+  {
+    if constexpr ( N() == 4 && sizeof(T) == 8 && current_api == avx  )
+    {
+      return compress_store_impl_aggregated(v, mask, ptr);
+    }
+    else return compress_store_impl[eve::ignore_none](v, mask, ptr);
   }
 
   /*
@@ -302,10 +329,9 @@ namespace eve::detail
     return res;
   }
 
-  template<relative_conditional_expr Cond, real_scalar_value T, typename N, simd_compatible_ptr<wide<T, N>> Ptr>
+  template<real_scalar_value T, typename N, simd_compatible_ptr<wide<T, N>> Ptr>
   EVE_FORCEINLINE
   T* compress_store_impl_(EVE_SUPPORTS(ssse3_),
-                          Cond,
                           wide<T, N> v,
                           logical<wide<T, N>> mask,
                           Ptr ptr) noexcept
@@ -351,10 +377,9 @@ namespace eve::detail
     }
   }
 
-  template<relative_conditional_expr Cond, real_scalar_value T, typename N, simd_compatible_ptr<wide<T, N>> Ptr>
+  template<real_scalar_value T, typename N, simd_compatible_ptr<wide<T, N>> Ptr>
   EVE_FORCEINLINE
   T* compress_store_impl_(EVE_SUPPORTS(ssse3_),
-                          Cond,
                           wide<T, N> v,
                           logical<wide<T, N>> mask,
                           Ptr ptr) noexcept

--- a/include/eve/detail/function/simd/x86/compress_store_impl.hpp
+++ b/include/eve/detail/function/simd/x86/compress_store_impl.hpp
@@ -113,16 +113,15 @@ namespace eve::detail
   // Stack Overflow discussion: https://chat.stackoverflow.com/rooms/212510/discussion-between-denis-yaroshevskiy-and-peter-cordes
   template<real_scalar_value T, typename N, simd_compatible_ptr<wide<T, N>> Ptr>
   EVE_FORCEINLINE
-  T* compress_store_(EVE_SUPPORTS(ssse3_),
-                     unsafe_type,
-                     wide<T, N> v,
-                     logical<wide<T, N>> mask,
-                     Ptr ptr) noexcept
+  T* compress_store_impl_(EVE_SUPPORTS(ssse3_),
+                          wide<T, N> v,
+                          logical<wide<T, N>> mask,
+                          Ptr ptr) noexcept
     requires x86_abi<abi_t<T, N>> && ( N() == 4 )
   {
     if constexpr ( N() == 4 && sizeof(T) == 8 && current_api == avx  )
     {
-      return compress_store_aggregated_unsafe(v, mask, ptr);
+      return compress_store_impl_aggregated(v, mask, ptr);
     }
     else if constexpr ( N() == 4 && sizeof(T) == 8 )
     {
@@ -145,7 +144,7 @@ namespace eve::detail
       auto  i_v = eve::bit_cast(v, eve::as<wide<i_t, N>>{});
       auto  i_m = eve::bit_cast(mask, eve::as<eve::logical<wide<i_t, N>>>{});
 
-      i_t* stored = unsafe(compress_store)(i_v, i_m, i_p);
+      i_t* stored = compress_store_impl(i_v, i_m, i_p);
       return (T*) stored;
     }
     else
@@ -304,14 +303,13 @@ namespace eve::detail
 
   template<real_scalar_value T, typename N, simd_compatible_ptr<wide<T, N>> Ptr>
   EVE_FORCEINLINE
-  T* compress_store_(EVE_SUPPORTS(ssse3_),
-                     unsafe_type,
-                     wide<T, N> v,
-                     logical<wide<T, N>> mask,
-                     Ptr ptr) noexcept
+  T* compress_store_impl_(EVE_SUPPORTS(ssse3_),
+                          wide<T, N> v,
+                          logical<wide<T, N>> mask,
+                          Ptr ptr) noexcept
     requires x86_abi<abi_t<T, N>> && (current_api <= avx2) && ( N() == 8 )
   {
-    if constexpr ( sizeof(T) == 4 && current_api == avx ) return compress_store_aggregated_unsafe(v, mask, ptr);
+    if constexpr ( sizeof(T) == 4 && current_api == avx ) return compress_store_impl_aggregated(v, mask, ptr);
     else
     {
       // First let's reduce the variability in each pair
@@ -353,11 +351,10 @@ namespace eve::detail
 
   template<real_scalar_value T, typename N, simd_compatible_ptr<wide<T, N>> Ptr>
   EVE_FORCEINLINE
-  T* compress_store_(EVE_SUPPORTS(ssse3_),
-                     unsafe_type,
-                     wide<T, N> v,
-                     logical<wide<T, N>> mask,
-                     Ptr ptr) noexcept
+  T* compress_store_impl_(EVE_SUPPORTS(ssse3_),
+                          wide<T, N> v,
+                          logical<wide<T, N>> mask,
+                          Ptr ptr) noexcept
     requires x86_abi<abi_t<T, N>> && (current_api <= avx2) && ( N() == 16 )
   {
     using half_wide = wide<T, eve::fixed<8>>;

--- a/include/eve/detail/function/simd/x86/compress_store_impl.hpp
+++ b/include/eve/detail/function/simd/x86/compress_store_impl.hpp
@@ -18,7 +18,7 @@
     For 4 elements we can process ignore better, utilizing top_bits.
     For every other case since we do a shift + & we have to use the mask => we use the base case.
 
-    At the moment we don't have avx-512 implementation, since the logical is different.
+    At the moment we don't have an avx-512 implementation, since the logical is different.
 */
 
 namespace eve::detail
@@ -133,7 +133,7 @@ namespace eve::detail
          if ( C::is_complete && !C::is_inverted ) return as_raw_pointer(ptr);
     else if constexpr ( N() == 4 && sizeof(T) == 8 && current_api == avx  )
     {
-      return compress_store_impl_(EVE_RETARGET(cpu_), v, mask, ptr);
+      return compress_store_impl_(EVE_RETARGET(cpu_), c, v, mask, ptr);
     }
     else if constexpr ( N() == 4 && sizeof(T) == 8 )
     {

--- a/include/eve/detail/function/simd/x86/compress_store_impl.hpp
+++ b/include/eve/detail/function/simd/x86/compress_store_impl.hpp
@@ -111,9 +111,10 @@ namespace eve::detail
   // The idea from: https://gist.github.com/aqrit/6e73ca6ff52f72a2b121d584745f89f3#file-despace-cpp-L141
   // Was shown to me by: @aqrit
   // Stack Overflow discussion: https://chat.stackoverflow.com/rooms/212510/discussion-between-denis-yaroshevskiy-and-peter-cordes
-  template<real_scalar_value T, typename N, simd_compatible_ptr<wide<T, N>> Ptr>
+  template<relative_conditional_expr Cond, real_scalar_value T, typename N, simd_compatible_ptr<wide<T, N>> Ptr>
   EVE_FORCEINLINE
   T* compress_store_impl_(EVE_SUPPORTS(ssse3_),
+                          Cond c,
                           wide<T, N> v,
                           logical<wide<T, N>> mask,
                           Ptr ptr) noexcept
@@ -121,7 +122,7 @@ namespace eve::detail
   {
     if constexpr ( N() == 4 && sizeof(T) == 8 && current_api == avx  )
     {
-      return compress_store_impl_aggregated(v, mask, ptr);
+      return compress_store_impl_aggregated(c, v, mask, ptr);
     }
     else if constexpr ( N() == 4 && sizeof(T) == 8 )
     {
@@ -144,7 +145,7 @@ namespace eve::detail
       auto  i_v = eve::bit_cast(v, eve::as<wide<i_t, N>>{});
       auto  i_m = eve::bit_cast(mask, eve::as<eve::logical<wide<i_t, N>>>{});
 
-      i_t* stored = compress_store_impl(i_v, i_m, i_p);
+      i_t* stored = compress_store_impl(c, i_v, i_m, i_p);
       return (T*) stored;
     }
     else
@@ -301,9 +302,10 @@ namespace eve::detail
     return res;
   }
 
-  template<real_scalar_value T, typename N, simd_compatible_ptr<wide<T, N>> Ptr>
+  template<relative_conditional_expr Cond, real_scalar_value T, typename N, simd_compatible_ptr<wide<T, N>> Ptr>
   EVE_FORCEINLINE
   T* compress_store_impl_(EVE_SUPPORTS(ssse3_),
+                          Cond,
                           wide<T, N> v,
                           logical<wide<T, N>> mask,
                           Ptr ptr) noexcept
@@ -349,9 +351,10 @@ namespace eve::detail
     }
   }
 
-  template<real_scalar_value T, typename N, simd_compatible_ptr<wide<T, N>> Ptr>
+  template<relative_conditional_expr Cond, real_scalar_value T, typename N, simd_compatible_ptr<wide<T, N>> Ptr>
   EVE_FORCEINLINE
   T* compress_store_impl_(EVE_SUPPORTS(ssse3_),
+                          Cond,
                           wide<T, N> v,
                           logical<wide<T, N>> mask,
                           Ptr ptr) noexcept

--- a/include/eve/function/compress_store.hpp
+++ b/include/eve/function/compress_store.hpp
@@ -16,7 +16,3 @@ namespace eve
 }
 
 #include <eve/module/real/core/function/regular/generic/compress_store.hpp>
-
-#if defined(EVE_INCLUDE_X86_HEADER)
-#  include <eve/module/real/core/function/regular/simd/x86/compress_store.hpp>
-#endif

--- a/include/eve/module/real/core/function/regular/generic/compress_store.hpp
+++ b/include/eve/module/real/core/function/regular/generic/compress_store.hpp
@@ -20,13 +20,15 @@ namespace eve::detail
                     logical<wide<T, N>> mask,
                     Ptr ptr) noexcept
   {
-    wide<T, N> buffer;
+    alignas(sizeof(v)) std::array<element_type_t<T>, N{}()> buffer;
     T* up_to = compress_store_impl(c, v, mask, buffer.begin());
     std::ptrdiff_t n = up_to - buffer.begin();
 
-    // TODO: we can do this slightly better.
     auto* out = as_raw_pointer(ptr) + c.offset(as(mask));
-    store[eve::keep_first(n)](buffer, out);
+
+    wide<T, N> compressed{aligned_ptr<T, N>{buffer.begin()}};
+
+    store[keep_first(n)](compressed, out);
     return out + n;
   }
 

--- a/include/eve/module/real/core/function/regular/generic/compress_store.hpp
+++ b/include/eve/module/real/core/function/regular/generic/compress_store.hpp
@@ -11,27 +11,50 @@
 
 namespace eve::detail
 {
-  template<real_scalar_value T, typename N, simd_compatible_ptr<wide<T, N>> Ptr>
+  template<relative_conditional_expr C, real_scalar_value T, typename N, simd_compatible_ptr<wide<T, N>> Ptr>
   EVE_FORCEINLINE
   T* compress_store_(EVE_SUPPORTS(cpu_),
+                    C c,
                     unsafe_type,
                     wide<T, N> v,
                     logical<wide<T, N>> mask,
                     Ptr ptr) noexcept
   {
-    return compress_store_impl(v, mask, ptr);
+    return compress_store_impl(c, v, mask, ptr);
   }
 
-  template<real_scalar_value T, typename N, simd_compatible_ptr<logical<wide<T, N>>> Ptr>
+  template<relative_conditional_expr C, decorator Decorator, real_scalar_value T, typename N, simd_compatible_ptr<logical<wide<T, N>>> Ptr>
   EVE_FORCEINLINE
   logical<T>*  compress_store_(EVE_SUPPORTS(cpu_),
-                               unsafe_type,
+                               C c,
+                               Decorator d,
                                logical<wide<T, N>> v,
                                logical<wide<T, N>> mask,
                                Ptr ptr) noexcept
   {
-    auto* raw_ptr =
-      unsafe(compress_store)(v.mask(), mask, ptr_cast<typename logical<T>::mask_type>(ptr));
+    auto* raw_ptr = compress_store(c, d, v.mask(), mask, ptr_cast<typename logical<T>::mask_type>(ptr));
     return (logical<T> *)raw_ptr;
+  }
+
+  template <decorator Decorator, simd_value T, simd_compatible_ptr<T> Ptr>
+  EVE_FORCEINLINE
+  auto compress_store_(EVE_SUPPORTS(cpu_),
+                       Decorator d,
+                       T v,
+                       logical<T> mask,
+                       Ptr ptr) noexcept
+  {
+    return compress_store(ignore_none, d, v, mask, ptr);
+  }
+
+  template <decorator Decorator, simd_value T, simd_compatible_ptr<T> Ptr>
+  EVE_FORCEINLINE
+  auto compress_store_(EVE_SUPPORTS(cpu_),
+                       Decorator d,
+                       logical<T> v,
+                       logical<T> mask,
+                       Ptr ptr) noexcept
+  {
+    return compress_store(ignore_none, d, v, mask, ptr);
   }
 }

--- a/include/eve/module/real/core/function/regular/generic/compress_store.hpp
+++ b/include/eve/module/real/core/function/regular/generic/compress_store.hpp
@@ -7,30 +7,10 @@
 //==================================================================================================
 #pragma once
 
-#include <eve/concept/value.hpp>
-#include <eve/detail/implementation.hpp>
-#include <eve/detail/meta.hpp>
-#include <eve/function/count_true.hpp>
-#include <eve/function/slide_left.hpp>
-#include <eve/function/store.hpp>
-#include <eve/function/unsafe.hpp>
-#include <eve/memory/pointer.hpp>
+#include <eve/detail/function/compress_store_impl.hpp>
 
 namespace eve::detail
 {
-  template<real_scalar_value T, typename N, simd_compatible_ptr<wide<T, N>> Ptr>
-  EVE_FORCEINLINE
-  T* compress_store_aggregated_unsafe(wide<T, N> v,
-                                      logical<wide<T, N>> mask,
-                                      Ptr ptr)
-  {
-    auto [l, h] = v.slice();
-    auto [ml, mh] = mask.slice();
-
-    T* ptr1 = eve::unsafe(eve::compress_store)(l, ml, ptr);
-    return eve::unsafe(eve::compress_store)(h, mh, ptr1);
-  }
-
   template<real_scalar_value T, typename N, simd_compatible_ptr<wide<T, N>> Ptr>
   EVE_FORCEINLINE
   T* compress_store_(EVE_SUPPORTS(cpu_),
@@ -39,27 +19,7 @@ namespace eve::detail
                     logical<wide<T, N>> mask,
                     Ptr ptr) noexcept
   {
-    if constexpr ( !has_emulated_abi_v<wide<T, N>> && N() == 2 )
-    {
-      auto to_left     = eve::slide_left( v, eve::index<1> );
-      auto compressed  = eve::if_else[mask]( v, to_left );
-      eve::store(compressed, ptr);
-      return as_raw_pointer(ptr) + eve::count_true(mask);
-    }
-    else if constexpr ( !has_emulated_abi_v<wide<T, N>> && N() > 2 )
-    {
-      return compress_store_aggregated_unsafe(v, mask, ptr);
-    }
-    else
-    {
-      auto* ptr_ = as_raw_pointer(ptr);
-      detail::for_<0,1, N{}()>([&](auto idx) mutable
-      {
-        *ptr_ = v.get(idx());
-        ptr_ += mask.get(idx());
-      });
-      return ptr_;
-    }
+    return compress_store_impl(v, mask, ptr);
   }
 
   template<real_scalar_value T, typename N, simd_compatible_ptr<logical<wide<T, N>>> Ptr>

--- a/test/unit/memory/compress_store.cpp
+++ b/test/unit/memory/compress_store.cpp
@@ -22,6 +22,10 @@ void ignore_test(T x, L m, C c)
   using e_t = eve::element_type_t<T>;
   using arr = std::array<e_t, T::size()>;
 
+  // gcc bug workaround
+  arr x_arr;
+  eve::store(x, x_arr.data());
+
   arr expected;
   expected.fill(e_t{0});
 
@@ -31,7 +35,7 @@ void ignore_test(T x, L m, C c)
 
   for (std::int8_t i = f_i; i != l_i; ++i) {
     if (!m.get(i)) continue;
-    expected[o++] = x.get(i);
+    expected[o++] = x_arr[i];
   }
 
   alignas(sizeof(arr)) arr actual;


### PR DESCRIPTION
The last patch before we should be able to have an implementation of `remove`.
Well - we also need https://github.com/jfalcou/eve/issues/816 to fix a bug.

Tagging @aqrit, though I doubt there is something here for him to review really.

### Whats' `relative_conditional_expr` / `ignore`:
(For @aqrit's sake)

In `eve` we decided not to do loop pealing, it makes the interfaces awkward, since the user needs to be able to accept both: scalar and vector parameters.
Instead what we do is `ignore` some elements from the beginning and some elements from the end.
When we do a read, often we know that we are still on the allocated page, so we are good. Or we can do a masked load.
When we do a write, we can do a masked store. (if masked operations are not available, we can just `memcpy`).
The performance difference with pealing is not significant.
More details on writes here: https://stackoverflow.com/questions/62183557/how-to-most-efficiently-store-a-part-of-m128i-m256i-while-ignoring-some-num/62492369#62492369

### How should `ignore` behave in `compress_store`.

We have 2 versions of `compress_store`: `safe(compress_store)` and `unsafe(compress_store)`.
Safe writes only the elements that should be written and no more.
So, if 3 elements are selected in the `mask` - 3 elements are written.
With respect to `ignore`: all the elements that are ignored are not written: 
`[a b c d]` `[true, true, true, false]`, `ignore_first(2)` -> will write only `c` and only the size of `c`.
+ Same as for `store` ignore_first implies moving of the pointer forward, so the previous example it will do `*(out + 2) = c;`.

Now `unsafe(compress_store[ignore_first(2)])`. It turns out from my previous experiments, that it should just do `safe(compress_store[ignore_first(2)])`. In some respects: `ignore` should apply to the `store` part too.

**NOTE: I have no idea what `ignore_first(1).else(some_value)` should do in compress store.**

### Code changes

1. Moved current implementation of `unsafe(compress_store)` into `compress_store_impl`.
Added ignore support there.

This is needed because `unsafe(compress_store)` won't have the correct semantics on `ignore`.
`impl` just treats `ignores` as `false` in the mask.

Basically, the only case where we can process ignore here faster is with 4 elements. There we can just achieve the `ignore` effect with shifts (this is what `top_bits` are doing). In all other cases -> ignore has to be converted to a `logical` mask.

2. Introduced `safe(compress_store)`.
3. Fixed a typo in the `build` docs.

I did very limited `precise` testing, the `ignore` should cover it functionally.
