### PR TITLE
Fix #816 - Conditional mask should be cleaned up

### DIFF
--- a/include/eve/arch/arm/tags.hpp
+++ b/include/eve/arch/arm/tags.hpp
@@ -24,6 +24,9 @@ namespace eve
     static constexpr bool        is_wide_logical = Logical;
 
     template<typename Type>
+    static constexpr bool is_full = ((Type::size() * sizeof(typename Type::value_type)) >= 8);
+
+    template<typename Type>
     static constexpr std::size_t expected_cardinal = bytes / sizeof(Type);
   };
 

--- a/include/eve/arch/cpu/tags.hpp
+++ b/include/eve/arch/cpu/tags.hpp
@@ -45,12 +45,14 @@ namespace eve
     {
       using parent = cpu_;
       static constexpr bool is_wide_logical = true;
+      template<typename> static constexpr bool is_full = true;
     };
 
     struct bundle_ : cpu_
     {
       using parent = cpu_;
       static constexpr bool is_wide_logical = true;
+      template<typename> static constexpr bool is_full = true;
     };
   }
 
@@ -60,12 +62,14 @@ namespace eve
     {
       using parent = cpu_;
       static constexpr bool is_wide_logical = false;
+      template<typename> static constexpr bool is_full = true;
     };
 
     struct bundle_ : cpu_
     {
       using parent = cpu_;
       static constexpr bool is_wide_logical = false;
+      template<typename> static constexpr bool is_full = true;
     };
   }
 
@@ -82,6 +86,8 @@ namespace eve
     static constexpr std::size_t bytes                    = 16;
     static constexpr bool        is_wide_logical = true;
 
+    template<typename> static constexpr bool is_full = true;
+
     template<typename Type>
     static constexpr std::size_t expected_cardinal = bytes / sizeof(Type);
   };
@@ -91,6 +97,11 @@ namespace eve
 
   template<typename T>
   concept native_abi = !detail::is_one_of<T>(detail::types<aggregated_, emulated_, bundle_> {});
+
+  //================================================================================================
+  // Checks if a type fills all its storage
+  template<typename Type>
+  inline constexpr bool use_complete_storage = Type::abi_type::template is_full<Type>;
 
   //================================================================================================
   // Checks for logical status in ABI

--- a/include/eve/arch/ppc/tags.hpp
+++ b/include/eve/arch/ppc/tags.hpp
@@ -24,6 +24,9 @@ namespace eve
     static constexpr bool        is_wide_logical = true;
 
     template<typename Type>
+    static constexpr bool is_full = ((Type::size() * sizeof(typename Type::value_type)) >= 16);
+
+    template<typename Type>
     static constexpr std::size_t expected_cardinal = bytes / sizeof(Type);
   };
 

--- a/include/eve/arch/x86/tags.hpp
+++ b/include/eve/arch/x86/tags.hpp
@@ -24,6 +24,9 @@ namespace eve
     static constexpr bool         is_wide_logical  = Logical;
 
     template<typename Type>
+    static constexpr bool is_full = ((Type::size() * sizeof(typename Type::value_type)) >= 16);
+
+    template<typename Type>
     static constexpr std::size_t expected_cardinal = bytes / sizeof(Type);
   };
 

--- a/test/unit/algo/remove.cpp
+++ b/test/unit/algo/remove.cpp
@@ -21,17 +21,11 @@ EVE_TEST_TYPES("Check remove_if basics", algo_test::selected_types)
 {
   using e_t = eve::element_type_t<T>;
 
-  auto alg = [] {
-    // FIX-816
-    if constexpr (T::size() < eve::expected_cardinal_v<e_t>) return eve::algo::remove_if;
-    else return eve::algo::remove_if[eve::algo::force_cardinal<T::size()>];
-  }();
-
   std::vector<e_t> v(100u, e_t{15});
 
   v[3] = v[15] = v[72] = e_t{5};
 
-  v.erase(alg(v, [](auto x) { return x < 10; }), v.end());
+  v.erase(eve::algo::remove_if[eve::algo::force_cardinal<T::size()>](v, [](auto x) { return x < 10; }), v.end());
 
   TTS_EQUAL(v.size(), 97u);
   TTS_EXPECT(std::all_of(v.begin(), v.end(), [](auto x) { return x > 10; }));

--- a/test/unit/memory/compress_store.cpp
+++ b/test/unit/memory/compress_store.cpp
@@ -86,21 +86,18 @@ void precise_tests(T x)
   }
 
   // writing exactly,
-  if constexpr ( T::size() >= eve::expected_cardinal_v<e_t> )  // FIX-816
-  {
-    e_t data[2] = { e_t{0}, e_t{5}} ;
-    L mask{false};
-    mask.set(T::size() - 1, true);
-    eve::safe(eve::compress_store)(x, mask, &data[0]);
-    TTS_EQUAL(data[0], x.back());
-    TTS_EQUAL(data[1], e_t{5});
+  e_t data[2] = { e_t{0}, e_t{5}} ;
+  L mask{false};
+  mask.set(T::size() - 1, true);
+  eve::safe(eve::compress_store)(x, mask, &data[0]);
+  TTS_EQUAL(data[0], x.back());
+  TTS_EQUAL(data[1], e_t{5});
 
-    // unsafe with ignore still acts as safe
-    data[0] = e_t{0};
-    eve::unsafe(eve::compress_store[eve::ignore_first(0)])(x, mask, &data[0]);
-    TTS_EQUAL(data[0], x.back());
-    TTS_EQUAL(data[1], e_t{5});
-  }
+  // unsafe with ignore still acts as safe
+  data[0] = e_t{0};
+  eve::unsafe(eve::compress_store[eve::ignore_first(0)])(x, mask, &data[0]);
+  TTS_EQUAL(data[0], x.back());
+  TTS_EQUAL(data[1], e_t{5});
 }
 
 template <bool all_options, typename T, typename L>


### PR DESCRIPTION
Whenever we generate a mask from a conditional for a wide type less than the native wide size for the current architecture, we need to be sure the 'out of sight' values are equals to `false` so we don't crap on functions like compress_store or remove.

This is done by using the native wide size and generate the mask properly within the requested size.