### PR TITLE
Ordering operators opt-in support for product type UDT

### DIFF
--- a/include/eve/arch/cpu/wide.hpp
+++ b/include/eve/arch/cpu/wide.hpp
@@ -891,7 +891,7 @@ namespace eve
     // Logical operations
     //==============================================================================================
     //! @brief Element-wise equality comparison of two eve::wide
-    friend  EVE_FORCEINLINE auto operator==(wide v, wide w) noexcept
+    friend EVE_FORCEINLINE auto operator==(wide v, wide w) noexcept
     {
       return detail::self_eq(v,w);
     }
@@ -932,6 +932,7 @@ namespace eve
 
     //! @brief Element-wise less-than comparison between eve::wide
     friend EVE_FORCEINLINE auto operator<(wide v, wide w) noexcept
+    requires( !kumi::product_type<Type> )
     {
       return detail::self_less(v,w);
     }
@@ -939,6 +940,7 @@ namespace eve
     //! @brief Element-wise less-than comparison between a eve::wide and a scalar
     template<scalar_value S>
     friend EVE_FORCEINLINE auto operator<(wide v, S w) noexcept
+    requires( !kumi::product_type<Type> )
     {
       return v < wide{w};
     }
@@ -946,12 +948,14 @@ namespace eve
     //! @brief Element-wise less-than comparison between a scalar and a eve::wide
     template<scalar_value S>
     friend EVE_FORCEINLINE auto operator<(S v, wide w) noexcept
+    requires( !kumi::product_type<Type> )
     {
       return wide{v} < w;
     }
 
     //! @brief Element-wise greater-than comparison between eve::wide
     friend EVE_FORCEINLINE auto operator>(wide v, wide w) noexcept
+    requires( !kumi::product_type<Type> )
     {
       return detail::self_greater(v,w);
     }
@@ -959,6 +963,7 @@ namespace eve
     //! @brief Element-wise greater-than comparison between a eve::wide and a scalar
     template<scalar_value S>
     friend EVE_FORCEINLINE auto operator>(wide v, S w) noexcept
+    requires( !kumi::product_type<Type> )
     {
       return v > wide{w};
     }
@@ -966,12 +971,14 @@ namespace eve
     //! @brief Element-wise greater-than comparison between a scalar and a eve::wide
     template<scalar_value S>
     friend EVE_FORCEINLINE auto operator>(S v, wide w) noexcept
+    requires( !kumi::product_type<Type> )
     {
       return wide{v} > w;
     }
 
     //! @brief Element-wise greater-or-equal comparison between eve::wide
     friend EVE_FORCEINLINE auto operator>=(wide v, wide w) noexcept
+    requires( !kumi::product_type<Type> )
     {
       return detail::self_geq(v,w);
     }
@@ -979,6 +986,7 @@ namespace eve
     //! @brief Element-wise greater-or-equal comparison between a eve::wide and a scalar
     template<scalar_value S>
     friend EVE_FORCEINLINE auto operator>=(wide v, S w) noexcept
+    requires( !kumi::product_type<Type> )
     {
       return v >= wide{w};
     }
@@ -986,12 +994,14 @@ namespace eve
     //! @brief Element-wise greater-or-equal comparison between a scalar and a eve::wide
     template<scalar_value S>
     friend EVE_FORCEINLINE auto operator>=(S v, wide w) noexcept
+    requires( !kumi::product_type<Type> )
     {
       return wide{v} >= w;
     }
 
     //! @brief Element-wise less-or-equal comparison between eve::wide
     friend EVE_FORCEINLINE auto operator<=(wide v, wide w) noexcept
+    requires( !kumi::product_type<Type> )
     {
       return detail::self_leq(v,w);
     }
@@ -999,6 +1009,7 @@ namespace eve
     //! @brief Element-wise less-or-equal comparison between a eve::wide and a scalar
     template<scalar_value S>
     friend EVE_FORCEINLINE auto operator<=(wide v, S w) noexcept
+    requires( !kumi::product_type<Type> )
     {
       return v <= wide{w};
     }
@@ -1006,6 +1017,7 @@ namespace eve
     //! @brief Element-wise less-or-equal comparison between a scalar and a eve::wide
     template<scalar_value S>
     friend EVE_FORCEINLINE auto operator<=(S v, wide w) noexcept
+    requires( !kumi::product_type<Type> )
     {
       return wide{v} <= w;
     }

--- a/include/eve/arch/cpu/wide.hpp
+++ b/include/eve/arch/cpu/wide.hpp
@@ -911,7 +911,7 @@ namespace eve
     }
 
     //! @brief Element-wise inequality comparison of two eve::wide
-    friend EVE_FORCEINLINE auto operator!=(wide v, wide w) noexcept
+    friend EVE_FORCEINLINE  auto operator!=(wide v, wide w) noexcept
     {
       return detail::self_neq(v,w);
     }
@@ -931,81 +931,81 @@ namespace eve
     }
 
     //! @brief Element-wise less-than comparison between eve::wide
-    friend EVE_FORCEINLINE logical<wide> operator<(wide v, wide w) noexcept
+    friend EVE_FORCEINLINE auto operator<(wide v, wide w) noexcept
     {
       return detail::self_less(v,w);
     }
 
     //! @brief Element-wise less-than comparison between a eve::wide and a scalar
     template<scalar_value S>
-    friend EVE_FORCEINLINE logical<wide> operator<(wide v, S w) noexcept
+    friend EVE_FORCEINLINE auto operator<(wide v, S w) noexcept
     {
       return v < wide{w};
     }
 
     //! @brief Element-wise less-than comparison between a scalar and a eve::wide
     template<scalar_value S>
-    friend EVE_FORCEINLINE logical<wide> operator<(S v, wide w) noexcept
+    friend EVE_FORCEINLINE auto operator<(S v, wide w) noexcept
     {
       return wide{v} < w;
     }
 
     //! @brief Element-wise greater-than comparison between eve::wide
-    friend EVE_FORCEINLINE logical<wide> operator>(wide v, wide w) noexcept
+    friend EVE_FORCEINLINE auto operator>(wide v, wide w) noexcept
     {
       return detail::self_greater(v,w);
     }
 
     //! @brief Element-wise greater-than comparison between a eve::wide and a scalar
     template<scalar_value S>
-    friend EVE_FORCEINLINE logical<wide> operator>(wide v, S w) noexcept
+    friend EVE_FORCEINLINE auto operator>(wide v, S w) noexcept
     {
       return v > wide{w};
     }
 
     //! @brief Element-wise greater-than comparison between a scalar and a eve::wide
     template<scalar_value S>
-    friend EVE_FORCEINLINE logical<wide> operator>(S v, wide w) noexcept
+    friend EVE_FORCEINLINE auto operator>(S v, wide w) noexcept
     {
       return wide{v} > w;
     }
 
     //! @brief Element-wise greater-or-equal comparison between eve::wide
-    friend EVE_FORCEINLINE logical<wide> operator>=(wide v, wide w) noexcept
+    friend EVE_FORCEINLINE auto operator>=(wide v, wide w) noexcept
     {
       return detail::self_geq(v,w);
     }
 
     //! @brief Element-wise greater-or-equal comparison between a eve::wide and a scalar
     template<scalar_value S>
-    friend EVE_FORCEINLINE logical<wide> operator>=(wide v, S w) noexcept
+    friend EVE_FORCEINLINE auto operator>=(wide v, S w) noexcept
     {
       return v >= wide{w};
     }
 
     //! @brief Element-wise greater-or-equal comparison between a scalar and a eve::wide
     template<scalar_value S>
-    friend EVE_FORCEINLINE logical<wide> operator>=(S v, wide w) noexcept
+    friend EVE_FORCEINLINE auto operator>=(S v, wide w) noexcept
     {
       return wide{v} >= w;
     }
 
     //! @brief Element-wise less-or-equal comparison between eve::wide
-    friend EVE_FORCEINLINE logical<wide> operator<=(wide v, wide w) noexcept
+    friend EVE_FORCEINLINE auto operator<=(wide v, wide w) noexcept
     {
       return detail::self_leq(v,w);
     }
 
     //! @brief Element-wise less-or-equal comparison between a eve::wide and a scalar
     template<scalar_value S>
-    friend EVE_FORCEINLINE logical<wide> operator<=(wide v, S w) noexcept
+    friend EVE_FORCEINLINE auto operator<=(wide v, S w) noexcept
     {
       return v <= wide{w};
     }
 
     //! @brief Element-wise less-or-equal comparison between a scalar and a eve::wide
     template<scalar_value S>
-    friend EVE_FORCEINLINE logical<wide> operator<=(S v, wide w) noexcept
+    friend EVE_FORCEINLINE auto operator<=(S v, wide w) noexcept
     {
       return wide{v} <= w;
     }
@@ -1044,25 +1044,25 @@ namespace eve
         return os << ')';
       }
     }
-
-    //==============================================================================================
-    // Product type Support
-    //==============================================================================================
-    template<std::size_t I> friend EVE_FORCEINLINE auto& get(wide& w) noexcept
-    requires( kumi::product_type<Type> )
-    {
-      return kumi::get<I>(w.storage());
-    }
-
-    template<std::size_t I> friend EVE_FORCEINLINE auto get(wide const& w) noexcept
-    requires( kumi::product_type<Type> )
-    {
-      return kumi::get<I>(w.storage());
-    }
   };
   //================================================================================================
   //! @}
   //================================================================================================
+
+  //==============================================================================================
+  // Product type Support
+  //==============================================================================================
+  template<std::size_t I, typename T, typename N> EVE_FORCEINLINE auto& get(wide<T,N>& w) noexcept
+  requires( kumi::product_type<T> )
+  {
+    return kumi::get<I>(w.storage());
+  }
+
+  template<std::size_t I, typename T, typename N> EVE_FORCEINLINE auto get(wide<T,N> const& w) noexcept
+  requires( kumi::product_type<T> )
+  {
+    return kumi::get<I>(w.storage());
+  }
 #if !defined(EVE_DOXYGEN_INVOKED)
 } }
 #else

--- a/include/eve/arch/cpu/wide.hpp
+++ b/include/eve/arch/cpu/wide.hpp
@@ -26,6 +26,7 @@
 #include <eve/detail/function/slice.hpp>
 #include <eve/detail/function/subscript.hpp>
 #include <eve/detail/function/swizzle.hpp>
+#include <eve/product_type.hpp>
 
 #include <concepts>
 #include <ostream>
@@ -932,7 +933,9 @@ namespace eve
 
     //! @brief Element-wise less-than comparison between eve::wide
     friend EVE_FORCEINLINE auto operator<(wide v, wide w) noexcept
-    requires( !kumi::product_type<Type> )
+#if !defined(EVE_DOXYGEN_INVOKED)
+    requires( supports_ordering_v<Type> )
+#endif
     {
       return detail::self_less(v,w);
     }
@@ -940,7 +943,9 @@ namespace eve
     //! @brief Element-wise less-than comparison between a eve::wide and a scalar
     template<scalar_value S>
     friend EVE_FORCEINLINE auto operator<(wide v, S w) noexcept
-    requires( !kumi::product_type<Type> )
+#if !defined(EVE_DOXYGEN_INVOKED)
+    requires( supports_ordering_v<Type> )
+#endif
     {
       return v < wide{w};
     }
@@ -948,14 +953,18 @@ namespace eve
     //! @brief Element-wise less-than comparison between a scalar and a eve::wide
     template<scalar_value S>
     friend EVE_FORCEINLINE auto operator<(S v, wide w) noexcept
-    requires( !kumi::product_type<Type> )
+#if !defined(EVE_DOXYGEN_INVOKED)
+    requires( supports_ordering_v<Type> )
+#endif
     {
       return wide{v} < w;
     }
 
     //! @brief Element-wise greater-than comparison between eve::wide
     friend EVE_FORCEINLINE auto operator>(wide v, wide w) noexcept
-    requires( !kumi::product_type<Type> )
+#if !defined(EVE_DOXYGEN_INVOKED)
+    requires( supports_ordering_v<Type> )
+#endif
     {
       return detail::self_greater(v,w);
     }
@@ -963,7 +972,9 @@ namespace eve
     //! @brief Element-wise greater-than comparison between a eve::wide and a scalar
     template<scalar_value S>
     friend EVE_FORCEINLINE auto operator>(wide v, S w) noexcept
-    requires( !kumi::product_type<Type> )
+#if !defined(EVE_DOXYGEN_INVOKED)
+    requires( supports_ordering_v<Type> )
+#endif
     {
       return v > wide{w};
     }
@@ -971,14 +982,18 @@ namespace eve
     //! @brief Element-wise greater-than comparison between a scalar and a eve::wide
     template<scalar_value S>
     friend EVE_FORCEINLINE auto operator>(S v, wide w) noexcept
-    requires( !kumi::product_type<Type> )
+#if !defined(EVE_DOXYGEN_INVOKED)
+    requires( supports_ordering_v<Type> )
+#endif
     {
       return wide{v} > w;
     }
 
     //! @brief Element-wise greater-or-equal comparison between eve::wide
     friend EVE_FORCEINLINE auto operator>=(wide v, wide w) noexcept
-    requires( !kumi::product_type<Type> )
+#if !defined(EVE_DOXYGEN_INVOKED)
+    requires( supports_ordering_v<Type> )
+#endif
     {
       return detail::self_geq(v,w);
     }
@@ -986,7 +1001,9 @@ namespace eve
     //! @brief Element-wise greater-or-equal comparison between a eve::wide and a scalar
     template<scalar_value S>
     friend EVE_FORCEINLINE auto operator>=(wide v, S w) noexcept
-    requires( !kumi::product_type<Type> )
+#if !defined(EVE_DOXYGEN_INVOKED)
+    requires( supports_ordering_v<Type> )
+#endif
     {
       return v >= wide{w};
     }
@@ -994,14 +1011,18 @@ namespace eve
     //! @brief Element-wise greater-or-equal comparison between a scalar and a eve::wide
     template<scalar_value S>
     friend EVE_FORCEINLINE auto operator>=(S v, wide w) noexcept
-    requires( !kumi::product_type<Type> )
+#if !defined(EVE_DOXYGEN_INVOKED)
+    requires( supports_ordering_v<Type> )
+#endif
     {
       return wide{v} >= w;
     }
 
     //! @brief Element-wise less-or-equal comparison between eve::wide
     friend EVE_FORCEINLINE auto operator<=(wide v, wide w) noexcept
-    requires( !kumi::product_type<Type> )
+#if !defined(EVE_DOXYGEN_INVOKED)
+    requires( supports_ordering_v<Type> )
+#endif
     {
       return detail::self_leq(v,w);
     }
@@ -1009,7 +1030,9 @@ namespace eve
     //! @brief Element-wise less-or-equal comparison between a eve::wide and a scalar
     template<scalar_value S>
     friend EVE_FORCEINLINE auto operator<=(wide v, S w) noexcept
-    requires( !kumi::product_type<Type> )
+#if !defined(EVE_DOXYGEN_INVOKED)
+    requires( supports_ordering_v<Type> )
+#endif
     {
       return v <= wide{w};
     }
@@ -1017,7 +1040,9 @@ namespace eve
     //! @brief Element-wise less-or-equal comparison between a scalar and a eve::wide
     template<scalar_value S>
     friend EVE_FORCEINLINE auto operator<=(S v, wide w) noexcept
-    requires( !kumi::product_type<Type> )
+#if !defined(EVE_DOXYGEN_INVOKED)
+    requires( supports_ordering_v<Type> )
+#endif
     {
       return wide{v} <= w;
     }

--- a/include/eve/detail/function/simd/common/friends.hpp
+++ b/include/eve/detail/function/simd/common/friends.hpp
@@ -216,28 +216,56 @@ namespace eve::detail
   template<simd_value Wide>
   EVE_FORCEINLINE auto self_less(Wide const& v,Wide const& w) noexcept
   {
-    constexpr auto lt = []<typename E>(E const& e, E const& f) { return as_logical_t<E>(e < f); };
-    return apply_over(lt, v, w);
+    if constexpr( product_type<Wide> )
+    {
+      return kumi::to_tuple(v) < kumi::to_tuple(w);
+    }
+    else
+    {
+      constexpr auto lt = []<typename E>(E const& e, E const& f) { return as_logical_t<E>(e < f); };
+      return apply_over(lt, v, w);
+    }
   }
 
   template<simd_value Wide>
   EVE_FORCEINLINE auto self_leq(Wide const& v,Wide const& w) noexcept
   {
-    constexpr auto ge = []<typename E>(E const& e, E const& f) { return as_logical_t<E>(e <= f); };
-    return apply_over(ge, v, w);
+    if constexpr( product_type<Wide> )
+    {
+      return kumi::to_tuple(v) <= kumi::to_tuple(w);
+    }
+    else
+    {
+      constexpr auto ge = []<typename E>(E const& e, E const& f) { return as_logical_t<E>(e <= f); };
+      return apply_over(ge, v, w);
+    }
   }
 
   template<simd_value Wide>
   EVE_FORCEINLINE auto self_greater(Wide const& v,Wide const& w) noexcept
   {
-    constexpr auto gt = []<typename E>(E const& e, E const& f) { return as_logical_t<E>(e > f); };
-    return apply_over(gt, v, w);
+    if constexpr( product_type<Wide> )
+    {
+      return kumi::to_tuple(v) > kumi::to_tuple(w);
+    }
+    else
+    {
+      constexpr auto gt = []<typename E>(E const& e, E const& f) { return as_logical_t<E>(e > f); };
+      return apply_over(gt, v, w);
+    }
   }
 
   template<simd_value Wide>
   EVE_FORCEINLINE auto self_geq(Wide const& v,Wide const& w) noexcept
   {
-    constexpr auto ge = []<typename E>(E const& e, E const& f) { return as_logical_t<E>(e >= f); };
-    return apply_over(ge, v, w);
+    if constexpr( product_type<Wide> )
+    {
+      return kumi::to_tuple(v) >= kumi::to_tuple(w);
+    }
+    else
+    {
+      constexpr auto ge = []<typename E>(E const& e, E const& f) { return as_logical_t<E>(e >= f); };
+      return apply_over(ge, v, w);
+    }
   }
 }

--- a/include/eve/detail/function/simd/common/friends.hpp
+++ b/include/eve/detail/function/simd/common/friends.hpp
@@ -153,10 +153,7 @@ namespace eve::detail
     }
     else
     {
-      auto zipped = kumi::zip(v.storage(),w.storage());
-      return kumi::fold_right ( [](auto acc , auto e) { return acc && ( get<0>(e) == get<1>(e) ); }
-                              , zipped, true
-                              );
+      return v.storage() == w.storage();
     }
   }
 
@@ -184,7 +181,7 @@ namespace eve::detail
     if constexpr( detail::tag_dispatchable<tag::is_not_equal_,Wide,Wide> )
     {
       static_assert ( detail::tag_dispatchable<tag::is_equal_,Wide,Wide>
-                    , "[EVE] User defined type defines != but not == specialisation."
+                    , "[EVE] User defined type defines != but no == specialization."
                     );
       return tagged_dispatch(tag::is_not_equal_{}, v, w);
     }
@@ -194,10 +191,7 @@ namespace eve::detail
     }
     else
     {
-      auto zipped = kumi::zip(v.storage(),w.storage());
-      return kumi::fold_right ( [](auto acc , auto e) { return acc || ( get<0>(e) != get<1>(e) ); }
-                              , zipped, false
-                              );
+      return v.storage() != w.storage();
     }
   }
 
@@ -224,24 +218,14 @@ namespace eve::detail
   {
     if constexpr( detail::tag_dispatchable<tag::is_less_,Wide,Wide> )
     {
+      static_assert ( detail::tag_dispatchable<tag::is_equal_,Wide,Wide>
+                    , "[EVE] User defined type defines < but no == specialization."
+                    );
       return tagged_dispatch(tag::is_less_{}, v, w);
     }
     else
     {
-      // lexicographical order is defined as
-      // (v0 < w0) || ... andnot(wi < vi, vi+1 < wi+1) ... || andnot(wn-1 < vn-1, vn < wn);
-      auto res = get<0>(v) < get<0>(w);
-      for_<1,1,std::tuple_size<Wide>::value>
-      (
-        [&]<typename Index>(Index)
-        {
-          auto y_less_x_prev = get<Index::value-1>(w) < get<Index::value - 1>(v);
-          auto x_less_y = get<Index::value>(v) < get<Index::value>(w);
-          res = res || (x_less_y && !y_less_x_prev);
-        }
-      );
-
-      return res;
+      return v.storage() < w.storage();
     }
   }
 

--- a/include/eve/detail/function/simd/common/friends.hpp
+++ b/include/eve/detail/function/simd/common/friends.hpp
@@ -14,6 +14,7 @@
 #include <eve/detail/apply_over.hpp>
 #include <eve/detail/function/bit_cast.hpp>
 #include <eve/detail/is_native.hpp>
+#include <eve/product_type.hpp>
 #include <eve/forward.hpp>
 
 // Register tag here so we can use them in tagged_dispatch situation
@@ -21,7 +22,6 @@ namespace eve
 {
   EVE_REGISTER_CALLABLE(is_equal_)
   EVE_REGISTER_CALLABLE(is_not_equal_)
-  EVE_REGISTER_CALLABLE(is_less_)
 }
 
 namespace eve::detail
@@ -212,37 +212,12 @@ namespace eve::detail
   }
 
   //================================================================================================
+  // Ordering operators
   template<simd_value Wide>
   EVE_FORCEINLINE auto self_less(Wide const& v,Wide const& w) noexcept
-  requires( kumi::product_type<element_type_t<Wide>> )
-  {
-    if constexpr( detail::tag_dispatchable<tag::is_less_,Wide,Wide> )
-    {
-      static_assert ( detail::tag_dispatchable<tag::is_equal_,Wide,Wide>
-                    , "[EVE] User defined type defines < but no == specialization."
-                    );
-      return tagged_dispatch(tag::is_less_{}, v, w);
-    }
-    else
-    {
-      return v.storage() < w.storage();
-    }
-  }
-
-  template<simd_value Wide>
-  EVE_FORCEINLINE auto self_less(Wide const& v,Wide const& w) noexcept
-  requires( !kumi::product_type<element_type_t<Wide>> )
   {
     constexpr auto lt = []<typename E>(E const& e, E const& f) { return as_logical_t<E>(e < f); };
     return apply_over(lt, v, w);
-  }
-
-  //================================================================================================
-  template<simd_value Wide>
-  EVE_FORCEINLINE auto self_leq(Wide const& v,Wide const& w) noexcept
-  requires( kumi::product_type<element_type_t<Wide>> )
-  {
-    return (v < w) || (v == w);
   }
 
   template<simd_value Wide>
@@ -252,27 +227,11 @@ namespace eve::detail
     return apply_over(ge, v, w);
   }
 
-  //================================================================================================
-  template<simd_value Wide>
-  EVE_FORCEINLINE auto self_greater(Wide const& v,Wide const& w) noexcept
-  requires( kumi::product_type<element_type_t<Wide>> )
-  {
-    return !(v <= w);
-  }
-
   template<simd_value Wide>
   EVE_FORCEINLINE auto self_greater(Wide const& v,Wide const& w) noexcept
   {
     constexpr auto gt = []<typename E>(E const& e, E const& f) { return as_logical_t<E>(e > f); };
     return apply_over(gt, v, w);
-  }
-
-  //================================================================================================
-  template<simd_value Wide>
-  EVE_FORCEINLINE auto self_geq(Wide const& v,Wide const& w) noexcept
-  requires( kumi::product_type<element_type_t<Wide>> )
-  {
-    return !(v < w);
   }
 
   template<simd_value Wide>

--- a/include/eve/detail/kumi.hpp
+++ b/include/eve/detail/kumi.hpp
@@ -512,13 +512,13 @@ namespace kumi
     template<product_type Other>
     friend constexpr auto operator<=(tuple const &lhs, Other const &rhs) noexcept
     {
-      return (lhs < rhs) || (lhs == rhs);
+      return !(rhs < lhs);
     }
 
     template<product_type Other>
     friend constexpr auto operator>(tuple const &lhs, Other const &rhs) noexcept
     {
-      return !(lhs <= rhs);
+      return rhs < lhs;
     }
 
     template<product_type Other>

--- a/include/eve/detail/kumi.hpp
+++ b/include/eve/detail/kumi.hpp
@@ -8,6 +8,7 @@
 #pragma once
 #include <concepts>
 #include <iosfwd>
+#include <type_traits>
 #include <utility>
 
 #if defined(__clang__)
@@ -465,7 +466,7 @@ namespace kumi
     //==============================================================================================
     // Comparison operators
     //==============================================================================================
-    template<sized_product_type<sizeof...(Ts)> Other>
+    template<product_type Other>
     friend constexpr auto operator==(tuple const &self, Other const &other) noexcept
     {
       return [&]<std::size_t... I>(std::index_sequence<I...>)
@@ -475,7 +476,7 @@ namespace kumi
       (std::make_index_sequence<sizeof...(Ts)>());
     }
 
-    template<sized_product_type<sizeof...(Ts)> Other>
+    template<product_type Other>
     friend constexpr auto operator!=(tuple const &self, Other const &other) noexcept
     {
       return [&]<std::size_t... I>(std::index_sequence<I...>)
@@ -483,6 +484,47 @@ namespace kumi
         return ((get<I>(self) != get<I>(other)) || ...);
       }
       (std::make_index_sequence<sizeof...(Ts)>());
+    }
+
+    template<product_type Other>
+    friend constexpr auto operator<(tuple const &lhs, Other const &rhs) noexcept
+    {
+      // lexicographical order is defined as
+      // (v0 < w0) || ... andnot(wi < vi, vi+1 < wi+1) ... || andnot(wn-1 < vn-1, vn < wn);
+      auto res = get<0>(lhs) < get<0>(rhs);
+
+      auto const order = [&]<typename Index>(Index i)
+      {
+        auto y_less_x_prev  = rhs[i]  < lhs[i];
+        auto x_less_y       = lhs[index_t<Index::value+1>{}] < rhs[index_t<Index::value+1>{}];
+        res                 = res || (x_less_y && !y_less_x_prev);
+      };
+
+      [&]<std::size_t... I>(std::index_sequence<I...>)
+      {
+        (order(index_t<I>{}),...);
+      }
+      (std::make_index_sequence<sizeof...(Ts)-1>());
+
+      return res;
+    }
+
+    template<product_type Other>
+    friend constexpr auto operator<=(tuple const &lhs, Other const &rhs) noexcept
+    {
+      return (lhs < rhs) || (lhs == rhs);
+    }
+
+    template<product_type Other>
+    friend constexpr auto operator>(tuple const &lhs, Other const &rhs) noexcept
+    {
+      return !(lhs <= rhs);
+    }
+
+    template<product_type Other>
+    friend constexpr auto operator>=(tuple const &lhs, Other const &rhs) noexcept
+    {
+      return !(lhs < rhs);
     }
 
     //==============================================================================================
@@ -543,6 +585,15 @@ namespace kumi
   {
     return [&]<std::size_t... I>(std::index_sequence<I...>) { return Type {get<I>(t)...}; }
     (std::make_index_sequence<sizeof...(Ts)>());
+  }
+
+  //==============================================================================================
+  // Conversion to an actual kumi::tuple
+  //==============================================================================================
+  template<product_type Type>
+  [[nodiscard]] inline constexpr auto to_tuple(Type&& that)
+  {
+    return apply([](auto &&...elems) { return tuple{elems...}; }, std::forward<Type>(that));
   }
 
   //================================================================================================

--- a/include/eve/detail/meta.hpp
+++ b/include/eve/detail/meta.hpp
@@ -407,7 +407,7 @@ namespace eve::detail
     using type = decltype(Begin);
     auto body = [&]<typename N>(N)
                 {
-                  return f(std::integral_constant<type, N::value*Step>{} );
+                  return f(std::integral_constant<type, Begin + N::value*Step>{} );
                 };
 
     [&]<auto... Iter>( std::integer_sequence<type,Iter...> )
@@ -423,7 +423,7 @@ namespace eve::detail
 
     return [&]<auto... Iter>( std::integer_sequence<type,Iter...> )
     {
-      return ( f(std::integral_constant<type, Iter * Step>{} ) || ...);
+      return ( f(std::integral_constant<type, Begin + Iter * Step>{} ) || ...);
     }( std::make_integer_sequence<type,End - Begin>{});
   }
 }

--- a/include/eve/function/is_less.hpp
+++ b/include/eve/function/is_less.hpp
@@ -7,6 +7,7 @@
 //==================================================================================================
 #pragma once
 
+#include <eve/detail/function/friends.hpp>
 #include <eve/detail/implementation.hpp>
 #include <eve/traits/as_logical.hpp>
 #include <eve/concept/value.hpp>
@@ -89,8 +90,7 @@ namespace eve
   //!
   //!  @}
   //================================================================================================
-
-  EVE_MAKE_CALLABLE(is_less_, is_less);
+  EVE_IMPLEMENT_CALLABLE(is_less_, is_less);
 
   namespace detail
   {

--- a/include/eve/function/is_less.hpp
+++ b/include/eve/function/is_less.hpp
@@ -7,7 +7,6 @@
 //==================================================================================================
 #pragma once
 
-#include <eve/detail/function/friends.hpp>
 #include <eve/detail/implementation.hpp>
 #include <eve/traits/as_logical.hpp>
 #include <eve/concept/value.hpp>
@@ -90,7 +89,8 @@ namespace eve
   //!
   //!  @}
   //================================================================================================
-  EVE_IMPLEMENT_CALLABLE(is_less_, is_less);
+
+  EVE_MAKE_CALLABLE(is_less_, is_less);
 
   namespace detail
   {

--- a/include/eve/product_type.hpp
+++ b/include/eve/product_type.hpp
@@ -41,11 +41,7 @@ namespace eve
   //!   @tparam Type  Type to register as supporting ordering operators
   //! @}
   //================================================================================================
-  template<typename Type> struct supports_ordering : std::false_type
-  {};
-
-  template<typename... Ts>
-  struct supports_ordering<kumi::tuple<Ts...>> : std::true_type
+  template<typename Type> struct supports_ordering : std::true_type
   {};
 
   //================================================================================================
@@ -71,20 +67,20 @@ namespace eve
   EVE_FORCEINLINE auto operator<= ( LHS const& a, RHS const& b) noexcept
   requires( same_value_type<LHS,RHS> && ordered_structure<LHS> && ordered_structure<RHS> )
   {
-    return (a < b) || (a == b);
+    return kumi::to_tuple(a) <= kumi::to_tuple(b);
   }
 
   template<typename LHS, typename RHS>
   EVE_FORCEINLINE auto operator> ( LHS const& a, RHS const& b) noexcept
   requires( same_value_type<LHS,RHS> && ordered_structure<LHS> && ordered_structure<RHS> )
   {
-    return !(a <= b);
+    return kumi::to_tuple(a) > kumi::to_tuple(b);
   }
 
   template<typename LHS, typename RHS>
   EVE_FORCEINLINE auto operator>= ( LHS const& a, RHS const& b) noexcept
   requires( same_value_type<LHS,RHS> && ordered_structure<LHS> && ordered_structure<RHS> )
   {
-    return !(a < b);
+    return kumi::to_tuple(a) >= kumi::to_tuple(b);
   }
 }

--- a/include/eve/product_type.hpp
+++ b/include/eve/product_type.hpp
@@ -38,49 +38,21 @@ namespace eve
   //! @{
   //!   @struct supports_ordering
   //!   @brief  Register a user-defined type to supports ordering
+  //!
   //!   @tparam Type  Type to register as supporting ordering operators
+  //!
+  //!   ### Helper variable template
+  //!
+  //!   @code
+  //!   template<typename Type>
+  //!   inline constexpr bool supports_ordering_v = eve::supports_ordering<Type>::value;
+  //!   @endcode
+  //!
   //! @}
   //================================================================================================
   template<typename Type> struct supports_ordering : std::true_type
   {};
 
-  //================================================================================================
-  //! @addtogroup concepts
-  //! @{
-  //!   @var generator
-  //!   The concept `ordered_structure<Type>` is satisfied if `Type` satisfies eve::product_type
-  //!   and `supports_ordering<element_type_t<Type>>::value` evaluates to `true`.
-  //! @}
-  //================================================================================================
   template<typename Type>
-  concept ordered_structure =     product_type<element_type_t<Type>>
-                              &&  supports_ordering<element_type_t<Type>>::value;
-
-  template<typename LHS, typename RHS>
-  EVE_FORCEINLINE auto operator<(LHS const& a, RHS const& b) noexcept
-  requires( same_value_type<LHS,RHS> && ordered_structure<LHS> && ordered_structure<RHS> )
-  {
-    return kumi::to_tuple(a) < kumi::to_tuple(b);
-  }
-
-  template<typename LHS, typename RHS>
-  EVE_FORCEINLINE auto operator<= ( LHS const& a, RHS const& b) noexcept
-  requires( same_value_type<LHS,RHS> && ordered_structure<LHS> && ordered_structure<RHS> )
-  {
-    return kumi::to_tuple(a) <= kumi::to_tuple(b);
-  }
-
-  template<typename LHS, typename RHS>
-  EVE_FORCEINLINE auto operator> ( LHS const& a, RHS const& b) noexcept
-  requires( same_value_type<LHS,RHS> && ordered_structure<LHS> && ordered_structure<RHS> )
-  {
-    return kumi::to_tuple(a) > kumi::to_tuple(b);
-  }
-
-  template<typename LHS, typename RHS>
-  EVE_FORCEINLINE auto operator>= ( LHS const& a, RHS const& b) noexcept
-  requires( same_value_type<LHS,RHS> && ordered_structure<LHS> && ordered_structure<RHS> )
-  {
-    return kumi::to_tuple(a) >= kumi::to_tuple(b);
-  }
+  inline constexpr bool supports_ordering_v = supports_ordering<Type>::value;
 }

--- a/include/eve/product_type.hpp
+++ b/include/eve/product_type.hpp
@@ -41,6 +41,14 @@ namespace eve
   //!
   //!   @tparam Type  Type to register as supporting ordering operators
   //!
+  //!   By default, instances of `eve::wide<T>` where `T` is an User-Defined Product Type supports
+  //!   ordering. However, one can specialize `eve::supports_ordering` for a given type to evaluates
+  //!   to `false` in order to disable ordering for this type.
+  //!
+  //!   Alternatively, any type `T` providing an internal `eve_disable_ordering` type will be
+  //!   treated as if `eve::supports_ordering<T>::value` evaluates to `false`, thus disabling
+  //!   ordering operators for `eve::wide<T>`.
+  //!
   //!   ### Helper variable template
   //!
   //!   @code
@@ -51,6 +59,11 @@ namespace eve
   //! @}
   //================================================================================================
   template<typename Type> struct supports_ordering : std::true_type
+  {};
+
+  template<typename Type>
+  requires requires(Type t) { typename Type::eve_disable_ordering; }
+  struct supports_ordering<Type> : std::false_type
   {};
 
   template<typename Type>

--- a/test/unit/api/tuple/comparison.cpp
+++ b/test/unit/api/tuple/comparison.cpp
@@ -20,6 +20,7 @@ EVE_TEST_TYPES( "Check eve::wide<tuple>operator==", eve::test::scalar::all_types
 {
   using s_t = tuple_t<T>;
   using w_t = eve::wide<tuple_t<T>>;
+  using l_t = eve::as_logical_t<w_t>;
 
   w_t lhs = [](auto i, auto)  { return s_t  { static_cast<std::int8_t>(i%3)
                                             , static_cast<T>(i%5)
@@ -33,8 +34,7 @@ EVE_TEST_TYPES( "Check eve::wide<tuple>operator==", eve::test::scalar::all_types
                                             };
                               };
 
-  eve::logical<eve::wide<std::int8_t,eve::cardinal_t<w_t>>>
-  checks = [&](auto i, auto)  { return lhs.get(i) == rhs.get(i); };
+  l_t checks = [&](auto i, auto)  { return lhs.get(i) == rhs.get(i); };
 
   TTS_EQUAL( (lhs == rhs), checks );
 };
@@ -47,6 +47,7 @@ EVE_TEST_TYPES( "Check eve::wide<tuple>operator!=", eve::test::scalar::all_types
 {
   using s_t = tuple_t<T>;
   using w_t = eve::wide<tuple_t<T>>;
+  using l_t = eve::as_logical_t<w_t>;
 
   w_t lhs = [](auto i, auto)  { return s_t  { static_cast<std::int8_t>(i%3)
                                             , static_cast<T>(i%5)
@@ -60,8 +61,49 @@ EVE_TEST_TYPES( "Check eve::wide<tuple>operator!=", eve::test::scalar::all_types
                                             };
                               };
 
-  eve::logical<eve::wide<std::int8_t,eve::cardinal_t<w_t>>>
-  checks = [&](auto i, auto)  { return lhs.get(i) != rhs.get(i); };
+  l_t checks = [&](auto i, auto)  { return lhs.get(i) != rhs.get(i); };
 
   TTS_EQUAL( (lhs != rhs), checks );
 };
+
+//==================================================================================================
+// Ordering
+//==================================================================================================
+EVE_TEST_TYPES( "Check eve::wide<tuple> ordering", eve::test::scalar::all_types)
+<typename T>(eve::as<T>)
+{
+  using s_t = tuple_t<T>;
+  using w_t = eve::wide<tuple_t<T>>;
+
+  w_t lhs = [](auto i, auto)  { return s_t  { static_cast<std::int8_t>('a'+i%3)
+                                            , static_cast<T>(i%5)
+                                            , i%2 ? -1.5 : 1.5
+                                            };
+                              };
+
+  w_t rhs = [](auto i, auto)  { return s_t  { static_cast<std::int8_t>('a'+i%4)
+                                            , static_cast<T>(i%2)
+                                            , i%3 ? -1.5 : 1.5
+                                            };
+                              };
+
+  using l_t = eve::as_logical_t<w_t>;
+
+  l_t clt = [&](auto i, auto) { return lhs.get(i) <  rhs.get(i); };
+  l_t cle = [&](auto i, auto) { return lhs.get(i) <= rhs.get(i); };
+  l_t cgt = [&](auto i, auto) { return lhs.get(i) >  rhs.get(i); };
+  l_t cge = [&](auto i, auto) { return lhs.get(i) >= rhs.get(i); };
+
+  TTS_EQUAL( (lhs <  rhs), clt );
+  TTS_EQUAL( eve::is_less(lhs, rhs), clt );
+
+  TTS_EQUAL( (lhs <= rhs), cle );
+  TTS_EQUAL( eve::is_less_equal(lhs, rhs), cle );
+
+  TTS_EQUAL( (lhs >  rhs), cgt );
+  TTS_EQUAL( eve::is_greater(lhs, rhs), cgt );
+
+  TTS_EQUAL( (lhs >= rhs), cge );
+  TTS_EQUAL( eve::is_greater_equal(lhs, rhs), cge );
+};
+

--- a/test/unit/api/udt/comparison.cpp
+++ b/test/unit/api/udt/comparison.cpp
@@ -41,3 +41,20 @@ TTS_CASE("Check eve::wide<udt> operator!=")
   TTS_EQUAL( udt::grid2d::eq_counter , 0);
   TTS_EQUAL( udt::grid2d::neq_counter, 1);
 };
+
+//==================================================================================================
+// Ordering
+//==================================================================================================
+TTS_CASE("Check eve::wide<udt> ordering")
+{
+  using ug = udt::grid2d;
+
+  udt::grid2d::reset();
+  eve::wide<udt::grid2d,eve::fixed<4>> v00{ug{0,1}, ug{0,1}, ug{1,6 }, ug{2,6}};
+  eve::wide<udt::grid2d,eve::fixed<4>> v01{ug{1,2}, ug{0,4}, ug{0,10}, ug{2,0}};
+
+  std::cout << (v00  < v01) << "\n";
+  std::cout << (v00 <= v01) << "\n";
+  std::cout << (v00  > v01) << "\n";
+  std::cout << (v00 >= v01) << "\n";
+};

--- a/test/unit/api/udt/comparison.cpp
+++ b/test/unit/api/udt/comparison.cpp
@@ -10,17 +10,29 @@
 #include <eve/wide.hpp>
 #include <utility>
 
-using l_t = eve::as_logical_t<eve::wide<udt::grid2d>>;
+using l_t  = eve::as_logical_t<eve::wide<udt::grid2d>>;
+using lp_t = eve::as_logical_t<eve::wide<udt::label_position>>;
 
 //==================================================================================================
 // Operator==
 //==================================================================================================
-TTS_CASE("Check eve::wide<udt> operator==")
+TTS_CASE("Check eve::wide<udt> operator== for external type")
 {
   eve::wide<udt::grid2d> lhs = [](int i, int) { return udt::grid2d{i%2, i%5 ? -1 : 1}; };
   eve::wide<udt::grid2d> rhs = [](int i, int) { return udt::grid2d{i%3, i%3 ? -1 : 1}; };
 
   l_t checks = [&](auto i, auto) { return lhs.get(i) == rhs.get(i); };
+
+  TTS_EQUAL( (lhs == rhs)           , checks );
+  TTS_EQUAL( eve::is_equal(lhs, rhs), checks );
+};
+
+TTS_CASE("Check eve::wide<udt> operator== for kumi::tuple inheritance")
+{
+  eve::wide<udt::label_position> lhs = [](int i, int) { return udt::label_position{i/1.5f, std::uint8_t('A'+i)}; };
+  eve::wide<udt::label_position> rhs = [](int i, int) { return udt::label_position{i/1.5f, std::uint8_t('A'+i)}; };
+
+  lp_t checks = [&](auto i, auto) { return lhs.get(i) == rhs.get(i); };
 
   TTS_EQUAL( (lhs == rhs)           , checks );
   TTS_EQUAL( eve::is_equal(lhs, rhs), checks );
@@ -40,6 +52,17 @@ TTS_CASE("Check eve::wide<udt> operator!=")
   TTS_EQUAL( eve::is_not_equal(lhs, rhs), checks );
 };
 
+TTS_CASE("Check eve::wide<udt> operator!= for kumi::tuple inheritance")
+{
+  eve::wide<udt::label_position> lhs = [](int i, int) { return udt::label_position{i/1.5f, std::uint8_t('A'+i)}; };
+  eve::wide<udt::label_position> rhs = [](int i, int) { return udt::label_position{i/2.3f, std::uint8_t('A'+i)}; };
+
+  lp_t checks = [&](auto i, auto) { return lhs.get(i) != rhs.get(i); };
+
+  TTS_EQUAL( (lhs != rhs)           , checks );
+  TTS_EQUAL( eve::is_not_equal(lhs, rhs), checks );
+};
+
 //==================================================================================================
 // Ordering
 //==================================================================================================
@@ -52,6 +75,36 @@ TTS_CASE("Check eve::wide<udt> ordering")
   l_t cle = [&](auto i, auto) { return lhs.get(i) <= rhs.get(i); };
   l_t cgt = [&](auto i, auto) { return lhs.get(i) >  rhs.get(i); };
   l_t cge = [&](auto i, auto) { return lhs.get(i) >= rhs.get(i); };
+
+  TTS_EQUAL( (lhs <  rhs), clt );
+  TTS_EQUAL( eve::is_less(lhs, rhs), clt );
+
+  TTS_EQUAL( (lhs <= rhs), cle );
+  TTS_EQUAL( eve::is_less_equal(lhs, rhs), cle );
+
+  TTS_EQUAL( (lhs >  rhs), cgt );
+  TTS_EQUAL( eve::is_greater(lhs, rhs), cgt );
+
+  TTS_EQUAL( (lhs >= rhs), cge );
+  TTS_EQUAL( eve::is_greater_equal(lhs, rhs), cge );
+};
+
+TTS_CASE("Check eve::wide<udt> ordering for kumi::tuple inheritance")
+{
+  eve::wide<udt::label_position> lhs = [](int i, int)
+  {
+    return udt::label_position{i%2 ? i : 1.5f, std::uint8_t('A'+i%2)};
+  };
+
+  eve::wide<udt::label_position> rhs = [](int i, int)
+  {
+    return udt::label_position{i%3 ? 2.3f : i, std::uint8_t('A'+i%3)};
+  };
+
+  lp_t clt = [&](auto i, auto) { return lhs.get(i) <  rhs.get(i); };
+  lp_t cle = [&](auto i, auto) { return lhs.get(i) <= rhs.get(i); };
+  lp_t cgt = [&](auto i, auto) { return lhs.get(i) >  rhs.get(i); };
+  lp_t cge = [&](auto i, auto) { return lhs.get(i) >= rhs.get(i); };
 
   TTS_EQUAL( (lhs <  rhs), clt );
   TTS_EQUAL( eve::is_less(lhs, rhs), clt );

--- a/test/unit/api/udt/comparison.cpp
+++ b/test/unit/api/udt/comparison.cpp
@@ -57,4 +57,7 @@ TTS_CASE("Check eve::wide<udt> ordering")
   std::cout << (v00 <= v01) << "\n";
   std::cout << (v00  > v01) << "\n";
   std::cout << (v00 >= v01) << "\n";
+
+  TTS_EQUAL( udt::grid2d::order_counter , 4);
+  TTS_EQUAL( udt::grid2d::eq_counter    , 2);
 };

--- a/test/unit/api/udt/comparison.cpp
+++ b/test/unit/api/udt/comparison.cpp
@@ -10,20 +10,20 @@
 #include <eve/wide.hpp>
 #include <utility>
 
+using l_t = eve::as_logical_t<eve::wide<udt::grid2d>>;
+
 //==================================================================================================
 // Operator==
 //==================================================================================================
 TTS_CASE("Check eve::wide<udt> operator==")
 {
-  udt::grid2d::reset();
   eve::wide<udt::grid2d> lhs = [](int i, int) { return udt::grid2d{i%2, i%5 ? -1 : 1}; };
   eve::wide<udt::grid2d> rhs = [](int i, int) { return udt::grid2d{i%3, i%3 ? -1 : 1}; };
 
-  eve::logical<eve::wide<int>> checks = [&](auto i, auto) { return lhs.get(i) == rhs.get(i); };
+  l_t checks = [&](auto i, auto) { return lhs.get(i) == rhs.get(i); };
 
-  TTS_EQUAL( (lhs == rhs), checks );
-  TTS_EQUAL( udt::grid2d::eq_counter , 1);
-  TTS_EQUAL( udt::grid2d::neq_counter, 0);
+  TTS_EQUAL( (lhs == rhs)           , checks );
+  TTS_EQUAL( eve::is_equal(lhs, rhs), checks );
 };
 
 //==================================================================================================
@@ -31,15 +31,13 @@ TTS_CASE("Check eve::wide<udt> operator==")
 //==================================================================================================
 TTS_CASE("Check eve::wide<udt> operator!=")
 {
-  udt::grid2d::reset();
   eve::wide<udt::grid2d> lhs = [](int i, int) { return udt::grid2d{i%2, i%5 ? -1 : 1}; };
   eve::wide<udt::grid2d> rhs = [](int i, int) { return udt::grid2d{i%3, i%3 ? -1 : 1}; };
 
-  eve::logical<eve::wide<int>> checks = [&](auto i, auto) { return lhs.get(i) != rhs.get(i); };
+  l_t checks = [&](auto i, auto) { return lhs.get(i) != rhs.get(i); };
 
-  TTS_EQUAL( (lhs != rhs), checks );
-  TTS_EQUAL( udt::grid2d::eq_counter , 0);
-  TTS_EQUAL( udt::grid2d::neq_counter, 1);
+  TTS_EQUAL( (lhs != rhs)               , checks );
+  TTS_EQUAL( eve::is_not_equal(lhs, rhs), checks );
 };
 
 //==================================================================================================
@@ -47,17 +45,23 @@ TTS_CASE("Check eve::wide<udt> operator!=")
 //==================================================================================================
 TTS_CASE("Check eve::wide<udt> ordering")
 {
-  using ug = udt::grid2d;
+  eve::wide<udt::grid2d> lhs = [](int i, int) { return udt::grid2d{i%2, i%5 ? -1 : 1}; };
+  eve::wide<udt::grid2d> rhs = [](int i, int) { return udt::grid2d{i%3, i%3 ? -1 : 1}; };
 
-  udt::grid2d::reset();
-  eve::wide<udt::grid2d,eve::fixed<4>> v00{ug{0,1}, ug{0,1}, ug{1,6 }, ug{2,6}};
-  eve::wide<udt::grid2d,eve::fixed<4>> v01{ug{1,2}, ug{0,4}, ug{0,10}, ug{2,0}};
+  l_t clt = [&](auto i, auto) { return lhs.get(i) <  rhs.get(i); };
+  l_t cle = [&](auto i, auto) { return lhs.get(i) <= rhs.get(i); };
+  l_t cgt = [&](auto i, auto) { return lhs.get(i) >  rhs.get(i); };
+  l_t cge = [&](auto i, auto) { return lhs.get(i) >= rhs.get(i); };
 
-  std::cout << (v00  < v01) << "\n";
-  std::cout << (v00 <= v01) << "\n";
-  std::cout << (v00  > v01) << "\n";
-  std::cout << (v00 >= v01) << "\n";
+  TTS_EQUAL( (lhs <  rhs), clt );
+  TTS_EQUAL( eve::is_less(lhs, rhs), clt );
 
-  TTS_EQUAL( udt::grid2d::order_counter , 4);
-  TTS_EQUAL( udt::grid2d::eq_counter    , 2);
+  TTS_EQUAL( (lhs <= rhs), cle );
+  TTS_EQUAL( eve::is_less_equal(lhs, rhs), cle );
+
+  TTS_EQUAL( (lhs >  rhs), cgt );
+  TTS_EQUAL( eve::is_greater(lhs, rhs), cgt );
+
+  TTS_EQUAL( (lhs >= rhs), cge );
+  TTS_EQUAL( eve::is_greater_equal(lhs, rhs), cge );
 };

--- a/test/unit/api/udt/conditional.cpp
+++ b/test/unit/api/udt/conditional.cpp
@@ -17,7 +17,6 @@
 //==================================================================================================
 TTS_CASE("Check eve::wide<udt> if_else")
 {
-  udt::grid2d::reset();
   eve::wide<udt::grid2d> lhs = [](int i, int) { return udt::grid2d{ i%6, i%5 ? -1 :  1}; };
   eve::wide<udt::grid2d> rhs = [](int i, int) { return udt::grid2d{-i%3, i%3 ? +3 : -3}; };
 
@@ -40,7 +39,6 @@ TTS_CASE("Check eve::wide<udt> if_else")
 //==================================================================================================
 TTS_CASE("Check eve::wide<udt> replace_ignored")
 {
-  udt::grid2d::reset();
   eve::wide<udt::grid2d> lhs = [](int i, int) { return udt::grid2d{ i%6, i%5 ? -1 :  1}; };
   eve::wide<udt::grid2d> rhs = [](int i, int) { return udt::grid2d{-i%3, i%3 ? +3 : -3}; };
 

--- a/test/unit/api/udt/udt.hpp
+++ b/test/unit/api/udt/udt.hpp
@@ -47,5 +47,33 @@ template<>              struct eve::is_product_type<udt::grid2d>    : std::true_
 template<>              struct std::tuple_size<udt::grid2d>         : std::integral_constant<std::size_t, 2> {};
 template<std::size_t I> struct std::tuple_element<I,udt::grid2d>    { using type = int; };
 
-// Opt-in for SIMD < > <= >= operators
-template<>  struct eve::supports_ordering<udt::grid2d>  : std::true_type {};
+namespace udt
+{
+  //------------------------------------------------------------------------------------------------
+  // This test UDT is made to be a placeholder for easier case where one just inherits from
+  // kumi::tuple and adapt its interface
+  //------------------------------------------------------------------------------------------------
+  struct label_position : kumi::tuple<float, std::uint8_t>
+  {
+    friend auto&& position(eve::same_value_type<label_position> auto&& self) noexcept
+    {
+      return get<0>(std::forward<decltype(self)>(self));
+    }
+
+    friend auto&& label(eve::same_value_type<label_position> auto&& self) noexcept
+    {
+      return get<1>(std::forward<decltype(self)>(self));
+    }
+  };
+
+  // Stream insertion is also on your behalf
+  std::ostream& operator<<( std::ostream& os, label_position const& p)
+  {
+    return os << "'" << label(p) << "'@( " << position(p) << " )";
+  }
+}
+
+// Opt-in for eve::product_type + adaptation
+template<>  struct std::tuple_size<udt::label_position>       : std::integral_constant<std::size_t, 2> {};
+template<>  struct std::tuple_element<0,udt::label_position>  { using type = float; };
+template<>  struct std::tuple_element<1,udt::label_position>  { using type = std::uint8_t; };

--- a/test/unit/api/udt/udt.hpp
+++ b/test/unit/api/udt/udt.hpp
@@ -6,7 +6,6 @@
 */
 //==================================================================================================
 #include <eve/product_type.hpp>
-#include <eve/function/is_equal.hpp>
 #include <type_traits>
 
 namespace udt
@@ -20,20 +19,12 @@ namespace udt
   struct grid2d
   {
     int x = +1, y = -1;
-    friend constexpr auto operator<=>(grid2d,grid2d) = default;
 
-    static int eq_counter, order_counter, neq_counter;
-    static void reset()
-    {
-      eq_counter = neq_counter = order_counter = 0;
-    }
+    // You're still responsible for your non-SIMD ordering
+    friend constexpr auto operator<=>(grid2d,grid2d) = default;
   };
 
-  int grid2d::eq_counter      = 0;
-  int grid2d::neq_counter     = 0;
-  int grid2d::order_counter   = 0;
-
-  // Adapt as a bindable type for eve::product_type
+  // Adapt as a structured bindings compatible type for eve::product_type
   template<std::size_t I> constexpr int& get( grid2d& p) noexcept
   {
     if constexpr(I==0) return p.x; else if constexpr(I==1) return p.y;
@@ -44,43 +35,17 @@ namespace udt
     if constexpr(I==0) return p.x; else if constexpr(I==1) return p.y;
   }
 
+  // Stream insertion is also on your behalf
   std::ostream& operator<<( std::ostream& os, grid2d const& p)
   {
     return os << "[x: " << p.x << " - y: " << p.y << "]";
   }
-
-  //------------------------------------------------------------------------------------------------
-  // Functions and operators are externally defined using tagged_dispatch
-  //------------------------------------------------------------------------------------------------
-  auto tagged_dispatch( eve::tag::is_equal_
-                      , eve::same_value_type<grid2d> auto a
-                      , eve::same_value_type<grid2d> auto b
-                      )
-  {
-    grid2d::eq_counter++;
-    return (get<0>(a) == get<0>(b)) && (get<1>(a) == get<1>(b));
-  }
-
-  auto tagged_dispatch( eve::tag::is_not_equal_
-                      , eve::same_value_type<grid2d> auto a
-                      , eve::same_value_type<grid2d> auto b
-                      )
-  {
-    grid2d::neq_counter++;
-    return (get<0>(a) != get<0>(b)) || (get<1>(a) != get<1>(b));
-  }
-
-  auto tagged_dispatch( eve::tag::is_less_
-                      , eve::same_value_type<grid2d> auto a
-                      , eve::same_value_type<grid2d> auto b
-                      )
-  {
-    grid2d::order_counter++;
-    return kumi::to_tuple(a) < kumi::to_tuple(b);
-  }
 }
 
 // Opt-in for eve::product_type + adaptation
-template<>              struct eve::is_product_type<udt::grid2d>  : std::true_type {};
-template<>              struct std::tuple_size<udt::grid2d>       : std::integral_constant<std::size_t, 2> {};
-template<std::size_t I> struct std::tuple_element<I,udt::grid2d> { using type = int; };
+template<>              struct eve::is_product_type<udt::grid2d>    : std::true_type {};
+template<>              struct std::tuple_size<udt::grid2d>         : std::integral_constant<std::size_t, 2> {};
+template<std::size_t I> struct std::tuple_element<I,udt::grid2d>    { using type = int; };
+
+// Opt-in for SIMD < > <= >= operators
+template<>  struct eve::supports_ordering<udt::grid2d>  : std::true_type {};

--- a/test/unit/api/udt/udt.hpp
+++ b/test/unit/api/udt/udt.hpp
@@ -22,15 +22,16 @@ namespace udt
     int x = +1, y = -1;
     friend constexpr auto operator<=>(grid2d,grid2d) = default;
 
-    static int eq_counter, neq_counter;
+    static int eq_counter, order_counter, neq_counter;
     static void reset()
     {
-      eq_counter = neq_counter = 0;
+      eq_counter = neq_counter = order_counter = 0;
     }
   };
 
   int grid2d::eq_counter      = 0;
   int grid2d::neq_counter     = 0;
+  int grid2d::order_counter   = 0;
 
   // Adapt as a bindable type for eve::product_type
   template<std::size_t I> constexpr int& get( grid2d& p) noexcept
@@ -57,7 +58,7 @@ namespace udt
                       )
   {
     grid2d::eq_counter++;
-    return (get<0>(a) == get<0>(b)) &&(get<1>(a) == get<1>(b));
+    return (get<0>(a) == get<0>(b)) && (get<1>(a) == get<1>(b));
   }
 
   auto tagged_dispatch( eve::tag::is_not_equal_
@@ -67,6 +68,15 @@ namespace udt
   {
     grid2d::neq_counter++;
     return (get<0>(a) != get<0>(b)) || (get<1>(a) != get<1>(b));
+  }
+
+  auto tagged_dispatch( eve::tag::is_less_
+                      , eve::same_value_type<grid2d> auto a
+                      , eve::same_value_type<grid2d> auto b
+                      )
+  {
+    grid2d::order_counter++;
+    return a.storage() < b.storage();
   }
 }
 

--- a/test/unit/api/udt/udt.hpp
+++ b/test/unit/api/udt/udt.hpp
@@ -76,7 +76,7 @@ namespace udt
                       )
   {
     grid2d::order_counter++;
-    return a.storage() < b.storage();
+    return kumi::to_tuple(a) < kumi::to_tuple(b);
   }
 }
 

--- a/test/unit/api/udt/wide.cpp
+++ b/test/unit/api/udt/wide.cpp
@@ -15,15 +15,22 @@
 //==================================================================================================
 TTS_CASE("Check User Defined Type properties with respect to SIMDification")
 {
-  TTS_CONSTEXPR_EXPECT    ( eve::product_type         <udt::grid2d> );
-  TTS_CONSTEXPR_EXPECT    ( eve::scalar_value         <udt::grid2d> );
-  TTS_CONSTEXPR_EXPECT_NOT( eve::integral_scalar_value<udt::grid2d> );
+  TTS_CONSTEXPR_EXPECT    ( eve::product_type         <udt::grid2d>         );
+  TTS_CONSTEXPR_EXPECT    ( eve::product_type         <udt::label_position> );
+  TTS_CONSTEXPR_EXPECT    ( eve::scalar_value         <udt::grid2d>         );
+  TTS_CONSTEXPR_EXPECT    ( eve::scalar_value         <udt::label_position> );
+  TTS_CONSTEXPR_EXPECT_NOT( eve::integral_scalar_value<udt::grid2d>         );
+  TTS_CONSTEXPR_EXPECT_NOT( eve::integral_scalar_value<udt::label_position> );
 
-  TTS_CONSTEXPR_EXPECT    ( eve::simd_value<eve::wide <udt::grid2d>>);
-  TTS_CONSTEXPR_EXPECT_NOT( eve::integral_simd_value  <udt::grid2d> );
+  TTS_CONSTEXPR_EXPECT    ( eve::simd_value<eve::wide <udt::grid2d>>        );
+  TTS_CONSTEXPR_EXPECT    ( eve::simd_value<eve::wide <udt::label_position>>);
+  TTS_CONSTEXPR_EXPECT_NOT( eve::integral_simd_value  <udt::grid2d>         );
+  TTS_CONSTEXPR_EXPECT_NOT( eve::integral_simd_value  <udt::label_position> );
 
-  TTS_CONSTEXPR_EXPECT( eve::value<udt::grid2d>            );
-  TTS_CONSTEXPR_EXPECT( eve::value<eve::wide <udt::grid2d>>);
+  TTS_CONSTEXPR_EXPECT( eve::value<udt::grid2d>                     );
+  TTS_CONSTEXPR_EXPECT( eve::value<udt::label_position>             );
+  TTS_CONSTEXPR_EXPECT( eve::value<eve::wide <udt::grid2d>>         );
+  TTS_CONSTEXPR_EXPECT( eve::value<eve::wide <udt::label_position>> );
 };
 
 //==================================================================================================
@@ -49,6 +56,14 @@ TTS_CASE( "Check eve::wide<udt> splat constructor")
 
   TTS_EQUAL(get<0>(vp), eve::wide<int>(+6));
   TTS_EQUAL(get<1>(vp), eve::wide<int>(-9));
+
+  eve::wide<udt::label_position> wp{ udt::label_position{42.69f, 'Z'} };
+
+  using pos_t   = std::tuple_element_t<0,eve::wide<udt::label_position>>;
+  using label_t = std::tuple_element_t<1,eve::wide<udt::label_position>>;
+
+  TTS_EQUAL(position(wp), pos_t(42.69f) );
+  TTS_EQUAL(label(wp)   , label_t('Z')  );
 };
 
 //==================================================================================================
@@ -60,6 +75,17 @@ TTS_CASE("Check eve::wide<udt> Lambda construction")
 
   TTS_EQUAL(get<0>(vp), eve::wide<int>([](int i, int  ) { return i;    } ));
   TTS_EQUAL(get<1>(vp), eve::wide<int>([](int i, int c) { return c-i-1;} ));
+
+  eve::wide<udt::label_position> wp = [](int i, int )
+  {
+    return udt::label_position{1.f/(1+i),std::uint8_t('A'+i)};
+  };
+
+  using pos_t   = std::tuple_element_t<0,eve::wide<udt::label_position>>;
+  using label_t = std::tuple_element_t<1,eve::wide<udt::label_position>>;
+
+  TTS_EQUAL(position(wp), pos_t  ([](int i, int  ) { return 1.f/(i+1);            }) );
+  TTS_EQUAL(label(wp)   , label_t([](int i, int  ) { return std::uint8_t('A'+i);  }) );
 };
 
 //==================================================================================================


### PR DESCRIPTION
we provide a cacth-all trait that enables SIMD ordering on a given product_type-like user-defined type. 
This makes error handling simpler and the amount of code to write in the common case lower.