### PR TITLE
Don't detect AVX512 if we don't have proper setup

### DIFF
--- a/include/eve/arch/spec.hpp
+++ b/include/eve/arch/spec.hpp
@@ -25,7 +25,11 @@ namespace eve
   inline constexpr auto current_api     = spy::undefined_simd_;
   inline constexpr bool supports_simd   = false;
 # else
+#   if !defined(EVE_INCOMPLETE_AVX512_SUPPORT)
   inline constexpr auto current_api   = spy::simd_instruction_set;
+#   else
+  inline constexpr auto current_api   = spy::avx2_;
+#   endif
   inline constexpr bool supports_simd = true;
 # endif
 }

--- a/include/eve/arch/x86/predef.hpp
+++ b/include/eve/arch/x86/predef.hpp
@@ -45,4 +45,18 @@
 #  define EVE_SUPPORTS_NATIVE_SIMD
 #  define EVE_HW_X86
 #  define EVE_INCLUDE_X86_HEADER
+
+// Don't trigger AVX512 if we don't have at least Skylake support
+#  if defined(SPY_SIMD_IS_X86_AVX512)
+#   if !(   defined(__AVX512BW__) && defined(__AVX512CD__)  \
+        &&  defined(__AVX512DQ__) && defined(__AVX512VL__)  \
+        &&  defined(__AVX512DQ__) && defined(__AVX512VL__)  )
+#    undef SPY_SIMD_IS_X86_AVX512
+#    undef SPY_SIMD_DETECTED ::spy::detail::simd_version::avx512_
+#    define EVE_INCOMPLETE_AVX512_SUPPORT
+#    define SPY_SIMD_IS_X86_AVX2
+#    define SPY_SIMD_DETECTED ::spy::detail::simd_version::avx2_
+#   endif
+#  endif
+
 #endif


### PR DESCRIPTION
Manually unselect AVX512 related settings if we don't have at least Skylake like architecture