### PR TITLE
FIX-#719: zip, end-to-end

### DIFF
--- a/include/eve/algo/detail/preprocess_zip_range.hpp
+++ b/include/eve/algo/detail/preprocess_zip_range.hpp
@@ -1,0 +1,56 @@
+//==================================================================================================
+/*
+  EVE - Expressive Vector Engine
+  Copyright : EVE Contributors & Maintainers
+  SPDX-License-Identifier: MIT
+*/
+//==================================================================================================
+#pragma once
+
+#include <eve/detail/kumi.hpp>
+
+namespace eve::algo
+{
+  template <typename ...Is>
+  struct zip_iterator;
+
+  namespace detail
+  {
+    template<typename Ranges>
+    struct preprocessed_zip_result
+    {
+      Ranges ranges;
+
+      auto traits() const { return get<0>(ranges).traits(); }
+
+      auto begin() const
+      {
+        return zip_iterator(kumi::map([](auto r) { return r.begin(); }, ranges));
+      }
+
+      auto end() const
+      {
+        return zip_iterator(kumi::map([](auto r) { return r.end(); }, ranges));
+      }
+
+      template<typename I> auto to_output_iterator(I i) const
+      {
+        return zip_iterator(
+            kumi::map([](auto r_i, auto i_i) { return r_i.to_output_iterator(i_i); }, ranges, i));
+      }
+    };
+
+    template <typename Ranges>
+    preprocessed_zip_result(Ranges) -> preprocessed_zip_result<Ranges>;
+
+    template <typename Traits, typename ...Rngs>
+    auto preprocess_zip_range(Traits traits, kumi::tuple<Rngs...> rngs) {
+      return preprocessed_zip_result{
+        kumi::map([traits](auto rng) { return preprocess_range(traits, rng); }, rngs)
+      };
+    }
+
+
+  }
+
+}

--- a/include/eve/algo/detail/preprocess_zip_range.hpp
+++ b/include/eve/algo/detail/preprocess_zip_range.hpp
@@ -49,8 +49,5 @@ namespace eve::algo
         kumi::map([traits](auto rng) { return preprocess_range(traits, rng); }, rngs)
       };
     }
-
-
   }
-
 }

--- a/include/eve/algo/zip.hpp
+++ b/include/eve/algo/zip.hpp
@@ -1,0 +1,126 @@
+//==================================================================================================
+/*
+  EVE - Expressive Vector Engine
+  Copyright : EVE Contributors & Maintainers
+  SPDX-License-Identifier: MIT
+*/
+//==================================================================================================
+#pragma once
+
+#include <eve/algo/as_range.hpp>
+#include <eve/algo/preprocess_range.hpp>
+#include <eve/algo/traits.hpp>
+#include <eve/algo/zip_iterator.hpp>
+
+#include <eve/algo/detail/preprocess_zip_range.hpp>
+
+#include <eve/detail/kumi.hpp>
+
+namespace eve::algo
+{
+  template <typename ...Rngs>
+  struct zip_range
+  {
+    kumi::tuple<Rngs...> ranges;
+
+    auto begin() const
+    {
+      return zip_iterator(kumi::map([](auto r) { return r.begin(); }, ranges));
+    }
+
+    auto end() const
+    {
+      return zip_iterator(kumi::map([](auto r) { return r.end(); }, ranges));
+    }
+
+    template <typename Traits>
+    friend auto tagged_dispatch(preprocess_range_, Traits traits, zip_range self)
+    {
+      return preprocess_zip_range(traits, self.ranges);
+    }
+  };
+
+  template <typename ...Rngs>
+  zip_range(kumi::tuple<Rngs...>) -> zip_range<Rngs...>;
+
+  namespace detail
+  {
+    // FIX-874: we should do this proper
+    template <typename Rng>
+    concept light_range = requires (Rng& rng) {
+      { rng.begin() };
+      { rng.end() };
+    };
+
+    template <light_range Rng>
+    struct rng_ref
+    {
+      Rng* rng;
+
+      // FIX-874: non member ones should be used
+      auto begin() const { return rng->begin(); }
+      auto end()   const { return rng->end(); }
+
+      template <typename Traits>
+      friend auto tagged_dispatch(preprocess_range_, Traits traits, rng_ref self)
+      {
+        return preprocess_range(traits, *self.rng);
+      }
+    };
+  }
+
+  template <typename TraitsSupport>
+  // this is zip traits, not algo traits.
+  struct zip_ : TraitsSupport
+  {
+   private:
+     template <typename ...Components>
+     std::ptrdiff_t compute_distance(Components&& ... components) const
+     {
+       std::ptrdiff_t res = -1;
+       auto process_one = [&]<typename C>(C const& c) mutable {
+         if constexpr (detail::light_range<C>)
+         {
+           std::ptrdiff_t cur = c.end() - c.begin();
+           if (res == -1) res = cur;
+           // We'd need to support zipping to min size at some point
+           EVE_ASSERT(res == cur, "Can't zip ranges of different sizes");
+         }
+       };
+       (process_one(components), ...);
+       return res;
+     }
+
+     template <typename ...Components>
+     auto perform_replacements(std::ptrdiff_t distance, Components&& ... components) const
+     {
+       return kumi::tuple{
+         [&]<typename C>(C&& c)
+         {
+           using no_ref = std::remove_reference_t<C>;
+                if constexpr (instance_of<no_ref, detail::rng_ref>) return c;
+           else if constexpr (detail::light_range<no_ref>         ) return detail::rng_ref<no_ref>{&c};
+           else                                                     return as_range(c, unalign(c) + distance);
+         }(components)...
+       };
+     }
+
+   public:
+
+    template <typename ...Components>
+    auto operator()(Components&& ... components) const
+    {
+      if constexpr ((!detail::light_range<Components> && ... ))
+      {
+        return zip_iterator{components...};
+      }
+      else
+      {
+        std::ptrdiff_t distance = compute_distance(components...);
+        return zip_range{perform_replacements(distance, components...)};
+      }
+    }
+  };
+
+  inline constexpr auto zip = function_with_traits<zip_>;
+}

--- a/test/unit/algo/CMakeLists.txt
+++ b/test/unit/algo/CMakeLists.txt
@@ -23,6 +23,7 @@ make_unit("unit.algo" ptr_iterator.cpp)
 make_unit("unit.algo" traits.cpp)
 make_unit("unit.algo" unalign.cpp)
 make_unit("unit.algo" zip_iterator.cpp)
+make_unit("unit.algo" zip.cpp)
 
 # Algorithms
 make_unit("unit.algo" any_of.cpp)

--- a/test/unit/algo/preprocess_zip_range.cpp
+++ b/test/unit/algo/preprocess_zip_range.cpp
@@ -9,6 +9,7 @@
 #include "algo_test.hpp"
 
 #include <eve/algo/zip_iterator.hpp>
+#include <eve/algo/zip.hpp>
 
 #include <eve/algo/as_range.hpp>
 #include <eve/algo/traits.hpp>
@@ -106,14 +107,16 @@ TTS_CASE("missmatch prototype")
   std::vector<int> v1{1, 2, 3, 4};
   std::vector<int> v2{1, 2, 4, 5};
 
-  eve::algo::zip_iterator zf {v1.begin(), v2.begin()};
-
-  auto found = eve::algo::find_if(eve::algo::as_range(zf, v1.end()), [](auto x1_x2) {
+  auto found = eve::algo::find_if(eve::algo::zip(v1, v2), [](auto x1_x2) {
     auto [x1, x2] = x1_x2;
     return x1 != x2;
   });
 
-  TTS_EQUAL((found - zf), 2);
-  TTS_EQUAL(get<0>(*found), 3);
-  TTS_EQUAL(get<1>(*found), 4);
+  auto [r1, r2] = found;
+
+  TTS_EQUAL((r1 - v1.begin()), 2);
+  TTS_EQUAL((r2 - v2.begin()), 2);
+
+  TTS_EQUAL(*r1, 3);
+  TTS_EQUAL(*r2, 4);
 }

--- a/test/unit/algo/preprocess_zip_range.cpp
+++ b/test/unit/algo/preprocess_zip_range.cpp
@@ -18,25 +18,87 @@
 
 #include <vector>
 
-TTS_CASE("zip_iterator, preprocess range")
+TTS_CASE("zip_iterator, preprocess range, scalar end")
 {
   std::vector<int> v1{1, 2, 3};
   std::vector<int> v2{1, 2, 4};
-  eve::algo::zip_iterator zf{v1.begin(), v2.begin()};
+
+  using v_i = std::vector<int>::iterator;
+  using zip_vi = eve::algo::zip_iterator<v_i, v_i>;
+
+  using N = eve::fixed<eve::expected_cardinal_v<int>>;
+  using ui_it = eve::algo::unaligned_ptr_iterator<int, N>;
+  using zip_ui = eve::algo::zip_iterator<ui_it, ui_it>;
+
+  zip_vi zf{v1.begin(), v2.begin()};
 
   auto processed = eve::algo::preprocess_range(eve::algo::traits{}, eve::algo::as_range(zf, v1.end()));
 
-  using ui_it = eve::algo::unaligned_ptr_iterator<int, eve::fixed<eve::expected_cardinal_v<int>>>;
-  using zip_ui = eve::algo::zip_iterator<ui_it, ui_it>;
   zip_ui processed_f = processed.begin();
   zip_ui processed_l = processed.end();
 
   TTS_EQUAL((processed_l - processed_f), 3);
 
-  using v_i = std::vector<int>::iterator;
-  using zip_vi = eve::algo::zip_iterator<v_i, v_i>;
   zip_vi back_zf = processed.to_output_iterator(processed_f);
   TTS_EQUAL(back_zf, zf);
+}
+
+TTS_CASE("zip_iterator, preprocess range, zip end")
+{
+  using u      = int const*;
+  using a      = eve::aligned_ptr<int const>;
+  using zip_au = eve::algo::zip_iterator<a, u>;
+  using zip_uu = eve::algo::zip_iterator<u, u>;
+
+  using N = eve::fixed<eve::expected_cardinal_v<int>>;
+  using a_it = eve::algo::aligned_ptr_iterator  <int const, N>;
+  using u_it = eve::algo::unaligned_ptr_iterator<int const, N>;
+  using zip_au_it = eve::algo::zip_iterator<a_it, u_it>;
+  using zip_uu_it = eve::algo::zip_iterator<u_it, u_it>;
+
+  // au_uu
+  {
+    using zip_au_uu_rng = decltype(eve::algo::as_range(zip_au{}, zip_uu{}));
+
+    using processed =
+      decltype(eve::algo::preprocess_range(eve::algo::traits{}, zip_au_uu_rng{}));
+
+    TTS_TYPE_IS(decltype(std::declval<processed>().begin()), zip_au_it);
+    TTS_TYPE_IS(decltype(std::declval<processed>().end()),   zip_uu_it);
+  }
+
+  // au_au
+  {
+    using zip_au_au_rng = decltype(eve::algo::as_range(zip_au{}, zip_au{}));
+
+    using processed =
+      decltype(eve::algo::preprocess_range(eve::algo::traits{}, zip_au_au_rng{}));
+
+    TTS_TYPE_IS(decltype(std::declval<processed>().begin()), zip_au_it);
+    TTS_TYPE_IS(decltype(std::declval<processed>().end()),   zip_au_it);
+  }
+
+  // au_u
+  {
+    using zip_au_u_rng = decltype(eve::algo::as_range(zip_au{}, u{}));
+
+    using processed =
+      decltype(eve::algo::preprocess_range(eve::algo::traits{}, zip_au_u_rng{}));
+
+    TTS_TYPE_IS(decltype(std::declval<processed>().begin()), zip_au_it);
+    TTS_TYPE_IS(decltype(std::declval<processed>().end()),   zip_uu_it);
+  }
+
+  // au_a
+  {
+    using zip_au_a_rng = decltype(eve::algo::as_range(zip_au{}, a{}));
+
+    using processed =
+      decltype(eve::algo::preprocess_range(eve::algo::traits{}, zip_au_a_rng{}));
+
+    TTS_TYPE_IS(decltype(std::declval<processed>().begin()), zip_au_it);
+    TTS_TYPE_IS(decltype(std::declval<processed>().end()),   zip_au_it);
+  }
 }
 
 TTS_CASE("missmatch prototype")

--- a/test/unit/algo/zip.cpp
+++ b/test/unit/algo/zip.cpp
@@ -1,0 +1,38 @@
+//==================================================================================================
+/**
+  EVE - Expressive Vector Engine
+  Copyright : EVE Contributors & Maintainers
+  SPDX-License-Identifier: MIT
+**/
+//==================================================================================================
+
+#include "algo_test.hpp"
+
+#include <eve/algo/zip.hpp>
+
+#include <vector>
+
+TTS_CASE("zip iterators")
+{
+  std::vector<int>         v{1, 2, 3, 4};
+  std::vector<std::int8_t> c{'a', 'b', 'c', 'd'};
+
+  eve::algo::zip_iterator f = eve::algo::zip(v.begin(), c.begin());
+  TTS_EQUAL(v.begin(), get<0>(f));
+  TTS_EQUAL(c.begin(), get<1>(f));
+
+  eve::algo::zip_iterator l = eve::algo::zip(v.end(), c.end());
+  TTS_EQUAL(v.end(), get<0>(l));
+  TTS_EQUAL(c.end(), get<1>(l));
+
+  auto rng_test = [&](auto rng) {
+    TTS_EQUAL(rng.begin(), f);
+    TTS_TYPE_IS(decltype(rng.begin()), decltype(f));
+    TTS_EQUAL(rng.end(), l);
+    TTS_TYPE_IS(decltype(rng.end()), decltype(l));
+  };
+
+  rng_test(eve::algo::zip(v, c));
+  rng_test(eve::algo::zip(v, c.begin()));
+  rng_test(eve::algo::zip(v.begin(), c));
+}

--- a/test/unit/algo/zip_iterator.cpp
+++ b/test/unit/algo/zip_iterator.cpp
@@ -58,6 +58,17 @@ TTS_CASE("zip_iterator for not eve iterators")
   }
 }
 
+TTS_CASE("zip_iterator for not eve iterators, unaligned")
+{
+  using a_p = eve::aligned_ptr<int>;
+  using u_p = int*;
+
+  using expected = eve::algo::zip_iterator<u_p, u_p>;
+  using actual   = eve::algo::unaligned_t<eve::algo::zip_iterator<a_p, u_p>>;
+  TTS_TYPE_IS(expected, actual);
+}
+
+
 TTS_CASE("zip_iterator, sanity check, types test")
 {
   using unaligned_float = eve::algo::unaligned_ptr_iterator<float, eve::fixed<8>>;


### PR DESCRIPTION
Got to a point where `missmatch` looks sort of right:

```
  auto found = eve::algo::find_if(eve::algo::zip(v1, v2), [](auto x1_x2) {
    auto [x1, x2] = x1_x2;
    return x1 != x2;
  });
```

Specific fixes are:
* `zip_iterator` can now form a range with both match for the first iterator and a complete zip_iterator. Not sure if it's the correct behaviour, but I thought it was at some point.
* cleaned up some things in `zip_iterator`.
* `zip` is now a thing: if it takes all iterators - returns an iterator. If it takes at least one range, will return a range.

Next step is to do all of the proper deductions, like cardinal and such traits.

**NOTE:**
It makes sense in the context of what I'm doing that `zip` is non-owning.
But is it confusing in the C++ sense? Should it be called smth else?