### PR TITLE
FIX-#719: zip traits.

### DIFF
--- a/include/eve/algo/README.txt
+++ b/include/eve/algo/README.txt
@@ -225,8 +225,24 @@ _TODO_ `step_unrolled(iterator)` if the `unroll` trait is bigger than 1.
 `unalign`
 `uunaligned/unaligned_t`
 
-
 A small helper.
 For contigious iterators -> returns themselves
 For aligned_ptr -> returns a raw ptr
 For everything else -> returns .unaligned()
+
+### zip
+
+`zip`
+`zip[common_type]`
+`zip[divisible_by_cardinal]`
+`zip[common_with_types<double>]`
+
+`zip` is an entry point for everything over parallel arrays.
+You can `zip` multiple `relaxed_iterator` which will give you a `zip_iterator` of them.
+You can also `zip` multiple `relaxed_range` with some traits - this gives you a `zip_range`.
+It's also OK to `zip` iterators and ranges together, which will give you a range (we will compute the end based on the range length).
+All ranges passed to `zip` have to have the same length.
+
+The traits supported are `common_type` - converts all the individual iterators to the biggest type.
+`common_with_types<types...>` - same as common_type only will take the listed types into account.
+`divisible_by_cardinal` - just if you know that this range is `divisible` - this will be propagated up.

--- a/include/eve/algo/detail/preprocess_zip_range.hpp
+++ b/include/eve/algo/detail/preprocess_zip_range.hpp
@@ -16,19 +16,41 @@ namespace eve::algo
 
   namespace detail
   {
-    template <typename Traits, typename ...Rngs>
-    auto preprocess_zip_range(Traits tr, kumi::tuple<Rngs...> rngs) {
+    template <typename Traits, typename ZipTraits, typename ...Rngs>
+    auto preprocess_zip_range_traits_support(Traits tr, ZipTraits, kumi::tuple<Rngs...>)
+    {
       using value_type = kumi::tuple<std::remove_reference_t<decltype(*std::declval<Rngs>().begin())>...>;
-      using N = forced_cardinal_t<Traits, value_type>;
+      using N = forced_cardinal_t<decltype(tr), value_type>;
 
-      auto tr_with_cardinal = default_to(tr, traits{force_cardinal<N{}()>});
+      auto tr_external = [&] {
+        if constexpr (ZipTraits::contains(eve::algo::divisible_by_cardinal))
+        {
+          return default_to(tr, eve::algo::traits(eve::algo::divisible_by_cardinal));
+        }
+        else
+        {
+          return tr;
+        }
+      }();
 
-      auto processed_components = kumi::map([tr_with_cardinal](auto rng) { return preprocess_range(tr_with_cardinal, rng); }, rngs);
+      auto tr_internal = default_to(tr_external, eve::algo::traits{force_cardinal<N{}()>});
+
+      return std::pair{tr_external, tr_internal};
+    }
+
+    template <typename Traits, typename ZipTraits, typename ...Rngs>
+    auto preprocess_zip_range(Traits tr, ZipTraits zip_tr, kumi::tuple<Rngs...> rngs) {
+      auto tr_pair = preprocess_zip_range_traits_support(tr, zip_tr, rngs);
+      // Bindings don't work with captures
+      auto tr_external = tr_pair.first;
+      auto tr_internal = tr_pair.second;
+
+      auto processed_components = kumi::map([&](auto rng) { return preprocess_range(tr_internal, rng); }, rngs);
 
       auto f = zip_iterator(kumi::map([](auto r) { return r.begin(); }, processed_components));
       auto l = zip_iterator(kumi::map([](auto r) { return r.end(); }, processed_components));
 
-      auto as_eve_its = preprocess_eve_it_sentinel(tr, f, l);
+      auto as_eve_its = preprocess_eve_it_sentinel(tr_external, f, l);
 
       return enhance_to_output(as_eve_its, [processed_components](auto i) {
           return zip_iterator{

--- a/include/eve/algo/detail/preprocess_zip_range.hpp
+++ b/include/eve/algo/detail/preprocess_zip_range.hpp
@@ -39,9 +39,9 @@ namespace eve::algo
       }();
 
       auto common_with_types = [&] {
-        if constexpr (ZipTraits::contains(common_with_type_key))
+        if constexpr (ZipTraits::contains(common_with_types_key))
         {
-          using Param = rbr::get_type_t<ZipTraits, common_with_type_key>;
+          using Param = rbr::get_type_t<ZipTraits, common_with_types_key>;
           return []<typename... ParamTypes, typename... ZipTypes>(std::common_type<ParamTypes...>,
                                                                   std::common_type<ZipTypes...>)
           {
@@ -54,6 +54,8 @@ namespace eve::algo
           return eve::algo::traits{};
         }
       }();
+
+      static_assert(!Traits::contains(algo::common_with_types_key), "FIX-#880");
 
       auto tr_external = default_to(tr, divisible_by_cardinal);
 

--- a/include/eve/algo/preprocess_range.hpp
+++ b/include/eve/algo/preprocess_range.hpp
@@ -140,6 +140,12 @@ namespace eve::algo
     }
 
     template <typename Traits, typename Rng>
+      requires eve::detail::tag_dispatchable<preprocess_range_, Traits, Rng>
+    auto operator()(Traits traits_, Rng&& rng) const {
+      return tagged_dispatch(*this, traits_, std::forward<Rng>(rng));
+    }
+
+    template <typename Traits, typename Rng>
     auto operator()(Traits traits_, Rng&& rng) const {
       return operator()(traits_, rng.begin(), rng.end());
     }

--- a/include/eve/algo/preprocess_range.hpp
+++ b/include/eve/algo/preprocess_range.hpp
@@ -55,6 +55,56 @@ namespace eve::algo
         [update, prev](auto it) { return update(prev.to_output_iterator(it)); }
       );
     }
+
+    // Base case. Should validate that I, S are a valid iterator pair
+    template <typename Traits, iterator I, sentinel_for<I> S>
+    auto preprocess_eve_it_sentinel(Traits traits_, I f, S l)
+    {
+      if constexpr ( !std::same_as<typename I::value_type, iteration_type_t<Traits, I>> )
+      {
+        using T = iteration_type_t<Traits, I>;
+        auto f_ = eve::algo::convert(f, eve::as<T>{});
+        auto l_ = eve::algo::convert(l, eve::as<T>{});
+        return detail::enhance_to_output(
+          preprocess_eve_it_sentinel(traits_, f_, l_),
+          [](unaligned_t<decltype(f_)> i)
+          {
+            return eve::algo::convert(i, eve::as<typename I::value_type>{});
+          }
+        );
+      }
+      else if constexpr ( typename I::cardinal{}() > forced_cardinal_t<Traits, typename I::value_type>{}() )
+      {
+        using N = forced_cardinal_t<Traits, typename I::value_type>;
+        auto f_ = f.cardinal_cast(N{});
+        return detail::enhance_to_output(
+          preprocess_eve_it_sentinel(traits_, f_, l.cardinal_cast(N{})),
+          [](unaligned_t<decltype(f_)> i)
+          {
+            return i.cardinal_cast(typename I::cardinal{});
+          });
+      }
+      else
+      {
+        auto deduced = [] {
+          if constexpr (partially_aligned_iterator<I>)
+          {
+            if constexpr ( std::same_as<I, S> && !always_aligned_iterator<I> ) return algo::traits(no_aligning, divisible_by_cardinal);
+            else                                                               return algo::traits(no_aligning);
+          }
+          else
+          {
+            return algo::traits();
+          }
+        }();
+
+        return detail::preprocess_range_result{
+          default_to(traits_, deduced), f, l,
+          [](unaligned_t<I> i) { return i; }
+        };
+      }
+    }
+
   }
 
   template <typename Traits, typename T>
@@ -122,49 +172,7 @@ namespace eve::algo
     template <typename Traits, iterator I, sentinel_for<I> S>
     auto operator()(Traits traits_, I f, S l) const
     {
-      if constexpr ( !std::same_as<typename I::value_type, iteration_type_t<Traits, I>> )
-      {
-        using T = iteration_type_t<Traits, I>;
-        auto f_ = eve::algo::convert(f, eve::as<T>{});
-        auto l_ = eve::algo::convert(l, eve::as<T>{});
-        return detail::enhance_to_output(
-          operator()(traits_, f_, l_),
-          [](unaligned_t<decltype(f_)> i)
-          {
-            return eve::algo::convert(i, eve::as<typename I::value_type>{});
-          }
-        );
-      }
-      else if constexpr ( typename I::cardinal{}() > forced_cardinal_t<Traits, typename I::value_type>{}() )
-      {
-        using N = forced_cardinal_t<Traits, typename I::value_type>;
-        auto f_ = f.cardinal_cast(N{});
-        return detail::enhance_to_output(
-          operator()(traits_, f_, l.cardinal_cast(N{})),
-          [](unaligned_t<decltype(f_)> i)
-          {
-            return i.cardinal_cast(typename I::cardinal{});
-          });
-      }
-      else
-      {
-        auto deduced = [] {
-          if constexpr (partially_aligned_iterator<I>)
-          {
-            if constexpr ( std::same_as<I, S> && !always_aligned_iterator<I> ) return algo::traits(no_aligning, divisible_by_cardinal);
-            else                                                               return algo::traits(no_aligning);
-          }
-          else
-          {
-            return algo::traits();
-          }
-        }();
-
-        return detail::preprocess_range_result{
-          default_to(traits_, deduced), f, l,
-          [](unaligned_t<I> i) { return i; }
-        };
-      }
+      return detail::preprocess_eve_it_sentinel(traits_, f, l);
     }
 
   } inline constexpr preprocess_range;

--- a/include/eve/algo/traits.hpp
+++ b/include/eve/algo/traits.hpp
@@ -61,6 +61,8 @@ namespace eve::algo
   template <typename ...Ts>
   inline constexpr auto common_with_types = (common_with_type_key = std::common_type<Ts...>{});
 
+  inline constexpr auto common_type = common_with_types<>;
+
   struct divisible_by_cardinal_tag {};
   inline constexpr auto divisible_by_cardinal = ::rbr::flag( divisible_by_cardinal_tag{} );
 

--- a/include/eve/algo/traits.hpp
+++ b/include/eve/algo/traits.hpp
@@ -55,11 +55,11 @@ namespace eve::algo
   inline constexpr force_cardinal_key_t force_cardinal_key = {};
   template<int N> inline constexpr auto force_cardinal = (force_cardinal_key = eve::fixed<N>{});
 
-  struct common_with_type_key_t {};
-  inline constexpr auto common_with_type_key = ::rbr::keyword( common_with_type_key_t{} );
+  struct common_with_types_key_t {};
+  inline constexpr auto common_with_types_key = ::rbr::keyword( common_with_types_key_t{} );
 
   template <typename ...Ts>
-  inline constexpr auto common_with_types = (common_with_type_key = std::common_type<Ts...>{});
+  inline constexpr auto common_with_types = (common_with_types_key = std::common_type<Ts...>{});
 
   inline constexpr auto common_type = common_with_types<>;
 
@@ -81,10 +81,10 @@ namespace eve::algo
   {
     template <typename Traits, typename I>
     auto iterator_type_impl() {
-      if constexpr (!Traits::contains(common_with_type_key)) return typename I::value_type{};
+      if constexpr (!Traits::contains(common_with_types_key)) return typename I::value_type{};
       else
       {
-        using Param = typename rbr::get_type_t<Traits, common_with_type_key>::type;
+        using Param = typename rbr::get_type_t<Traits, common_with_types_key>::type;
         return std::common_type_t<Param, typename I::value_type>{};
       }
     }

--- a/include/eve/algo/zip.hpp
+++ b/include/eve/algo/zip.hpp
@@ -18,9 +18,10 @@
 
 namespace eve::algo
 {
-  template <typename ...Rngs>
+  template <typename ZipTraits, typename ...Rngs>
   struct zip_range
   {
+    ZipTraits zip_tr;
     kumi::tuple<Rngs...> ranges;
 
     auto begin() const
@@ -34,14 +35,14 @@ namespace eve::algo
     }
 
     template <typename Traits>
-    friend auto tagged_dispatch(preprocess_range_, Traits traits, zip_range self)
+    friend auto tagged_dispatch(preprocess_range_, Traits tr, zip_range self)
     {
-      return preprocess_zip_range(traits, self.ranges);
+      return preprocess_zip_range(tr, self.zip_tr, self.ranges);
     }
   };
 
-  template <typename ...Rngs>
-  zip_range(kumi::tuple<Rngs...>) -> zip_range<Rngs...>;
+  template <typename ZipTraits, typename ...Rngs>
+  zip_range(ZipTraits zip_tr, kumi::tuple<Rngs...>) -> zip_range<ZipTraits, Rngs...>;
 
   namespace detail
   {
@@ -117,7 +118,7 @@ namespace eve::algo
       else
       {
         std::ptrdiff_t distance = compute_distance(components...);
-        return zip_range{perform_replacements(distance, components...)};
+        return zip_range{TraitsSupport::get_traits(), perform_replacements(distance, components...)};
       }
     }
   };

--- a/include/eve/algo/zip_iterator.hpp
+++ b/include/eve/algo/zip_iterator.hpp
@@ -125,7 +125,7 @@ namespace eve::algo
           return as_range(f_, l_);
         }, self, other);
 
-        return preprocess_zip_range(traits, ranges);
+        return preprocess_zip_range(traits, eve::algo::traits(), ranges);
       }
 
       template<typename Traits, std::derived_from<zip_iterator_common> Self,

--- a/test/unit/algo/preprocess_zip_range.cpp
+++ b/test/unit/algo/preprocess_zip_range.cpp
@@ -178,6 +178,34 @@ TTS_CASE("preprocess zip range, traits")
     TTS_TYPE_IS(decltype(processed.end()), zip_ac_it_ui_it);
   }
 
+  // force cardinal (not supported by zip itself)
+  {
+    eve::algo::traits tr{ eve::algo::force_cardinal<2> };
+
+    auto zipped = eve::algo::zip(c, i);
+    auto processed = eve::algo::preprocess_range(tr, zipped);
+    TTS_TYPE_IS(decltype(processed.traits()), decltype(tr));
+    TTS_TYPE_IS(decltype(processed.begin())::cardinal, eve::fixed<2>);
+  }
+
+  // divisible by cardinal (propagates)
+  {
+    eve::algo::traits tr{ eve::algo::divisible_by_cardinal };
+
+    {
+      auto zipped = eve::algo::zip(c, i);
+
+      auto processed = eve::algo::preprocess_range(tr, zipped);
+      TTS_TYPE_IS(decltype(processed.traits()), decltype(tr));
+    }
+
+    {
+      auto zipped = eve::algo::zip[eve::algo::divisible_by_cardinal](c, i);
+
+      auto processed = eve::algo::preprocess_range(eve::algo::traits{}, zipped);
+      TTS_TYPE_IS(decltype(processed.traits()), decltype(tr));
+    }
+  }
 }
 
 TTS_CASE("missmatch prototype")


### PR DESCRIPTION
Now we can `zip` ranges of different types.
I think at this point, the next step is `equal` and/or `mismatch` - they should work.