### PR TITLE
FIX-#885: eve::common_type

### DIFF
--- a/include/eve/algo/detail/preprocess_zip_range.hpp
+++ b/include/eve/algo/detail/preprocess_zip_range.hpp
@@ -42,12 +42,12 @@ namespace eve::algo
         if constexpr (ZipTraits::contains(common_with_types_key))
         {
           using Param = rbr::get_type_t<ZipTraits, common_with_types_key>;
-          return []<typename... ParamTypes, typename... ZipTypes>(std::common_type<ParamTypes...>,
-                                                                  std::common_type<ZipTypes...>)
+          return []<typename... ParamTypes, typename... ZipTypes>(eve::common_type<ParamTypes...>,
+                                                                  eve::common_type<ZipTypes...>)
           {
             return algo::traits {algo::common_with_types<ParamTypes..., ZipTypes...>};
           }
-          (Param {}, std::common_type<rng_value_type<Rngs>...> {});
+          (Param {}, eve::common_type<rng_value_type<Rngs>...> {});
         }
         else
         {

--- a/include/eve/algo/traits.hpp
+++ b/include/eve/algo/traits.hpp
@@ -10,6 +10,7 @@
 #include <eve/detail/raberu.hpp>
 
 #include <eve/arch/cardinals.hpp>
+#include <eve/traits.hpp>
 
 #include <type_traits>
 #include <utility>
@@ -59,7 +60,7 @@ namespace eve::algo
   inline constexpr auto common_with_types_key = ::rbr::keyword( common_with_types_key_t{} );
 
   template <typename ...Ts>
-  inline constexpr auto common_with_types = (common_with_types_key = std::common_type<Ts...>{});
+  inline constexpr auto common_with_types = (common_with_types_key = eve::common_type<Ts...>{});
 
   inline constexpr auto common_type = common_with_types<>;
 
@@ -85,7 +86,7 @@ namespace eve::algo
       else
       {
         using Param = typename rbr::get_type_t<Traits, common_with_types_key>::type;
-        return std::common_type_t<Param, typename I::value_type>{};
+        return eve::common_type_t<Param, typename I::value_type>{};
       }
     }
   }

--- a/include/eve/traits.hpp
+++ b/include/eve/traits.hpp
@@ -22,9 +22,12 @@
 
 #include <eve/traits/alignment.hpp>
 #include <eve/traits/as_arithmetic.hpp>
+#include <eve/traits/as_floating_point.hpp>
+#include <eve/traits/as_integer.hpp>
 #include <eve/traits/as_logical.hpp>
 #include <eve/traits/as_wide.hpp>
 #include <eve/traits/cardinal.hpp>
+#include <eve/traits/common_compatible.hpp>
+#include <eve/traits/common_type.hpp>
 #include <eve/traits/element_type.hpp>
 #include <eve/traits/is_logical.hpp>
-

--- a/include/eve/traits/common_type.hpp
+++ b/include/eve/traits/common_type.hpp
@@ -1,0 +1,96 @@
+//==================================================================================================
+/*
+  EVE - Expressive Vector Engine
+  Copyright : EVE Contributors & Maintainers
+  SPDX-License-Identifier: MIT
+*/
+//==================================================================================================
+#pragma once
+
+#include <concepts>
+#include <type_traits>
+
+#include <eve/as.hpp>
+
+namespace eve
+{
+  //================================================================================================
+  //! @addtogroup traits
+  //! @{
+  //!
+  //! @struct common_type
+  //!
+  //! @brief Computes a type that can represent all values in a list of types.
+  //!
+  //! **Required header:** `#include <eve/traits/common_type.hpp>`
+  //!
+  //! Similar to std::common_type.
+  //!
+  //! We cannot use std::common_type because it tends to return a bigger type:
+  //!   For example: `std::int16_t`, `std::int8_t` will return `std::int32_t`: https://godbolt.org/z/vjf9c45E5
+  //!
+  //! We also do not follow standard promotion rules:
+  //!      std::common_type_t<std::int16_t, std::uint16_t> is std::int32_t
+  //! BUT: std::common_type_t<std::int32_t, std::uint32_t> is std::uint32_t
+  //! We always do like 32 bit one: - eve::common_type_t<std::int16_t, std::uint16_t> is std::uint16_t
+  //!
+  //! *NOTE:* for signed unsigned of the same size we return unsigned of this size (same as std).
+  //!
+  //! For product types will compute the common type by field.
+  //! If the result matches one of the specified types, we will return that one.
+  //! Otherwise we'll return a `kumi::tuple` of the result.
+  //!
+  //! @}
+  //================================================================================================
+  template<typename T, typename ...Ts> struct common_type;
+
+  template<typename ...Ts>
+  using common_type_t = typename common_type<Ts...>::type;
+
+  // We don't care for not default constructible types.
+  template <typename ...Ts>
+  concept have_common_type = requires (Ts...) {
+    { common_type_t<Ts...>{} };
+  };
+}
+
+namespace eve::detail
+{
+  struct no_common_type
+  {
+    template <typename U>
+    friend constexpr auto operator+(no_common_type, U) { return no_common_type{}; }
+  };
+
+  template <typename T>
+  struct common_type_reduction
+  {
+    using type = T;
+
+    template <typename U>
+    friend constexpr auto operator+(common_type_reduction<T> self, as<U>) {
+           if constexpr ( std::same_as<T, U>                                 ) return self;
+      else if constexpr ( std::is_arithmetic_v<T> && std::is_arithmetic_v<U> )
+      {
+        common_type_reduction<U> other{};
+
+             if constexpr ( sizeof(U) < sizeof(T)                             ) return other + as<T>{};
+        else if constexpr ( std::floating_point<T> && !std::floating_point<U> ) return self;
+        else if constexpr ( std::floating_point<U> || sizeof(T) < sizeof(U)   ) return other;
+        else if constexpr ( std::unsigned_integral<U>                         ) return other;
+        else                                                                    return self;
+      }
+      else return no_common_type{};
+    }
+  };
+}
+
+namespace eve
+{
+  template<typename T, typename ...Ts> struct common_type
+  {
+    using type = typename decltype(
+                    (detail::common_type_reduction<T>{} + ... + as<Ts>{}))
+                  ::type;
+  };
+}

--- a/include/eve/traits/common_type.hpp
+++ b/include/eve/traits/common_type.hpp
@@ -11,6 +11,7 @@
 #include <type_traits>
 
 #include <eve/as.hpp>
+#include <eve/detail/kumi.hpp>
 
 namespace eve
 {
@@ -63,22 +64,53 @@ namespace eve::detail
   };
 
   template <typename T>
+  struct common_type_reduction;
+
+  template <typename, typename>
+  struct common_kumi_tuple
+  {
+    using type = no_common_type;
+  };
+
+  template <typename ...Ts, typename ...Us>
+  struct common_kumi_tuple<kumi::tuple<Ts...>, kumi::tuple<Us...>>
+  {
+    using type = common_type_reduction<kumi::tuple<eve::common_type_t<Ts, Us> ...>>;
+  };
+
+
+  template <typename T>
   struct common_type_reduction
   {
     using type = T;
 
     template <typename U>
     friend constexpr auto operator+(common_type_reduction<T> self, as<U>) {
+      common_type_reduction<U> other{};
+
            if constexpr ( std::same_as<T, U>                                 ) return self;
       else if constexpr ( std::is_arithmetic_v<T> && std::is_arithmetic_v<U> )
       {
-        common_type_reduction<U> other{};
-
              if constexpr ( sizeof(U) < sizeof(T)                             ) return other + as<T>{};
         else if constexpr ( std::floating_point<T> && !std::floating_point<U> ) return self;
         else if constexpr ( std::floating_point<U> || sizeof(T) < sizeof(U)   ) return other;
         else if constexpr ( std::unsigned_integral<U>                         ) return other;
         else                                                                    return self;
+      }
+      else if constexpr ( kumi::product_type<T> && kumi::product_type<U> )
+      {
+        using t_as_tuple = typename kumi::as_tuple<T>::type;
+        using u_as_tuple = typename kumi::as_tuple<U>::type;
+        using tuple_res = typename common_kumi_tuple<t_as_tuple, u_as_tuple>::type;
+
+        if constexpr ( std::same_as<no_common_type, tuple_res> ) return tuple_res{};
+        else
+        {
+          using type = typename tuple_res::type;
+               if constexpr ( std::same_as<type, t_as_tuple> ) return self;
+          else if constexpr ( std::same_as<type, u_as_tuple> ) return other;
+          else                                                 return tuple_res{};
+        }
       }
       else return no_common_type{};
     }

--- a/include/eve/traits/common_type.hpp
+++ b/include/eve/traits/common_type.hpp
@@ -51,7 +51,7 @@ namespace eve
   // We don't care for not default constructible types.
   template <typename ...Ts>
   concept have_common_type = requires (Ts...) {
-    { common_type_t<Ts...>{} };
+    { typename common_type<Ts...>::type{} };
   };
 }
 
@@ -73,6 +73,7 @@ namespace eve::detail
   };
 
   template <typename ...Ts, typename ...Us>
+    requires (sizeof...(Ts) == sizeof...(Us))
   struct common_kumi_tuple<kumi::tuple<Ts...>, kumi::tuple<Us...>>
   {
     using type = common_type_reduction<kumi::tuple<eve::common_type_t<Ts, Us> ...>>;
@@ -119,10 +120,8 @@ namespace eve::detail
 
 namespace eve
 {
-  template<typename T, typename ...Ts> struct common_type
+  template<typename T, typename ...Ts> struct common_type :
+    decltype((detail::common_type_reduction<T>{} + ... + as<Ts>{}))
   {
-    using type = typename decltype(
-                    (detail::common_type_reduction<T>{} + ... + as<Ts>{}))
-                  ::type;
   };
 }

--- a/include/eve/traits/common_type.hpp
+++ b/include/eve/traits/common_type.hpp
@@ -25,15 +25,15 @@ namespace eve
   //!
   //! **Required header:** `#include <eve/traits/common_type.hpp>`
   //!
-  //! Similar to std::common_type.
+  //! Similar to `std::common_type`.
   //!
-  //! We cannot use std::common_type because it tends to return a bigger type:
+  //! We cannot use `std::common_type` because it tends to return a bigger type:
   //!   For example: `std::int16_t`, `std::int8_t` will return `std::int32_t`: https://godbolt.org/z/vjf9c45E5
   //!
   //! We also do not follow standard promotion rules:
-  //!      std::common_type_t<std::int16_t, std::uint16_t> is std::int32_t
-  //! BUT: std::common_type_t<std::int32_t, std::uint32_t> is std::uint32_t
-  //! We always do like 32 bit one: - eve::common_type_t<std::int16_t, std::uint16_t> is std::uint16_t
+  //!      `std::common_type_t<std::int16_t, std::uint16_t>` is `std::int32_t`
+  //! BUT: `std::common_type_t<std::int32_t, std::uint32_t>` is `std::uint32_t`
+  //! We always do like 32 bit one: - `eve::common_type_t<std::int16_t, std::uint16_t>` is `std::uint16_t`
   //!
   //! *NOTE:* for signed unsigned of the same size we return unsigned of this size (same as std).
   //!
@@ -78,7 +78,6 @@ namespace eve::detail
   {
     using type = common_type_reduction<kumi::tuple<eve::common_type_t<Ts, Us> ...>>;
   };
-
 
   template <typename T>
   struct common_type_reduction

--- a/include/eve/traits/common_type.hpp
+++ b/include/eve/traits/common_type.hpp
@@ -43,7 +43,7 @@ namespace eve
   //!
   //! @}
   //================================================================================================
-  template<typename T, typename ...Ts> struct common_type;
+  template<typename ...Ts> struct common_type;
 
   template<typename ...Ts>
   using common_type_t = typename common_type<Ts...>::type;
@@ -120,7 +120,11 @@ namespace eve::detail
 
 namespace eve
 {
-  template<typename T, typename ...Ts> struct common_type :
+  template <> struct common_type<>
+  {
+  };
+
+  template<typename T, typename ...Ts> struct common_type<T, Ts...> :
     decltype((detail::common_type_reduction<T>{} + ... + as<Ts>{}))
   {
   };

--- a/test/unit/meta/CMakeLists.txt
+++ b/test/unit/meta/CMakeLists.txt
@@ -21,5 +21,6 @@ make_unit( "unit.meta.concept" native_simd_for_abi.cpp )
 ##==================================================================================================
 ## Traits tests
 make_unit( "unit.meta" cardinal.cpp )
+make_unit( "unit.meta" common_type.cpp )
 make_unit( "unit.meta" has_abi.cpp )
 make_unit( "unit.meta" element_type.cpp )

--- a/test/unit/meta/common_type.cpp
+++ b/test/unit/meta/common_type.cpp
@@ -10,6 +10,8 @@
 
 #include <eve/traits/common_type.hpp>
 
+#include <tuple>
+
 TTS_CASE("eve::common_type, small integrals")
 {
   // Explanation
@@ -60,3 +62,29 @@ EVE_TEST_TYPES("eve::common_type matches std::common_type", eve::test::scalar::a
     float       , double
   >{});
 };
+
+using i32_u32_f64 = kumi::tuple<std::int32_t, std::uint32_t, double>;
+using i32_i32_i32 = kumi::tuple<std::int32_t, std::int32_t,  std::int32_t>;
+
+struct product : i32_u32_f64 {};
+template<>              struct eve::is_product_type<product> : std::true_type {};
+template<>              struct std::tuple_size<product>      : std::tuple_size<i32_u32_f64> {};
+template<std::size_t I> struct std::tuple_element<I,product> : std::tuple_element<I, i32_u32_f64> {};
+
+struct smaller_product : i32_i32_i32 {};
+template<>              struct eve::is_product_type<smaller_product> : std::true_type {};
+template<>              struct std::tuple_size<smaller_product>      : std::tuple_size<i32_i32_i32> {};
+template<std::size_t I> struct std::tuple_element<I,smaller_product> : std::tuple_element<I, i32_i32_i32> {};
+
+
+TTS_CASE("eve::common_type, product type")
+{
+  TTS_TYPE_IS(
+    (eve::common_type_t<i32_u32_f64, i32_i32_i32>), i32_u32_f64);
+
+  TTS_TYPE_IS((eve::common_type_t<product, i32_i32_i32>), product);
+  TTS_TYPE_IS((eve::common_type_t<i32_i32_i32, product>), product);
+  TTS_TYPE_IS((eve::common_type_t<product, smaller_product>), product);
+  TTS_TYPE_IS((eve::common_type_t<smaller_product, product>), product);
+
+}

--- a/test/unit/meta/common_type.cpp
+++ b/test/unit/meta/common_type.cpp
@@ -86,5 +86,24 @@ TTS_CASE("eve::common_type, product type")
   TTS_TYPE_IS((eve::common_type_t<i32_i32_i32, product>), product);
   TTS_TYPE_IS((eve::common_type_t<product, smaller_product>), product);
   TTS_TYPE_IS((eve::common_type_t<smaller_product, product>), product);
+}
 
+TTS_CASE("eve::common_type, have_common_type")
+{
+  TTS_CONSTEXPR_EXPECT((eve::have_common_type<int, float>));
+  TTS_CONSTEXPR_EXPECT((eve::have_common_type<product, smaller_product>));
+  TTS_CONSTEXPR_EXPECT_NOT((eve::have_common_type<kumi::tuple<int, int>,
+                                                  kumi::tuple<int, int, int>>));
+}
+
+TTS_CASE("eve::common_type, reduction")
+{
+  TTS_TYPE_IS(
+    (eve::common_type_t<std::int8_t, std::int16_t, std::int32_t>),
+    std::int32_t
+  );
+  TTS_TYPE_IS(
+    (eve::common_type_t<std::int32_t, std::int16_t, std::int8_t>),
+    std::int32_t
+  );
 }

--- a/test/unit/meta/common_type.cpp
+++ b/test/unit/meta/common_type.cpp
@@ -1,0 +1,62 @@
+//==================================================================================================
+/**
+  EVE - Expressive Vector Engine
+  Copyright : EVE Contributors & Maintainers
+  SPDX-License-Identifier: MIT
+**/
+//==================================================================================================
+
+#include "test.hpp"
+
+#include <eve/traits/common_type.hpp>
+
+TTS_CASE("eve::common_type, small integrals")
+{
+  // Explanation
+  TTS_TYPE_IS((std::common_type_t<std::int32_t,  std::uint32_t>), std::uint32_t);
+  TTS_TYPE_IS((std::common_type_t<std::int32_t,  std::uint64_t>), std::uint64_t);
+  TTS_TYPE_IS((std::common_type_t<std::uint32_t, std::int64_t> ), std::int64_t);
+
+  // std::int8_t
+  TTS_TYPE_IS((eve::common_type_t<std::int8_t, std::int8_t>  ), std::int8_t );
+  TTS_TYPE_IS((eve::common_type_t<std::int8_t, std::uint8_t> ), std::uint8_t );
+  TTS_TYPE_IS((eve::common_type_t<std::int8_t, std::int16_t> ), std::int16_t );
+  TTS_TYPE_IS((eve::common_type_t<std::int8_t, std::uint16_t>), std::uint16_t);
+
+  // std::uint8_t
+  TTS_TYPE_IS((eve::common_type_t<std::uint8_t, std::uint8_t> ), std::uint8_t );
+  TTS_TYPE_IS((eve::common_type_t<std::uint8_t, std::int16_t> ), std::int16_t );
+  TTS_TYPE_IS((eve::common_type_t<std::uint8_t, std::uint16_t>), std::uint16_t);
+
+  // std::int16_t
+  TTS_TYPE_IS((eve::common_type_t<std::int16_t, std::int16_t> ), std::int16_t );
+  TTS_TYPE_IS((eve::common_type_t<std::int16_t, std::uint16_t>), std::uint16_t);
+}
+
+EVE_TEST_TYPES("eve::common_type for two types comutes", eve::test::scalar::all_types )
+<typename T>(eve::as<T>)
+{
+  auto one_type = []<typename U> (eve::as<U>) {
+    TTS_TYPE_IS((eve::common_type_t<T, U>), (eve::common_type_t<U, T>));
+  };
+
+  [&]<typename ...Us> (eve::detail::types<Us...>) {
+    (one_type(eve::as<Us>{}), ...);
+  }(eve::test::scalar::all_types);
+};
+
+EVE_TEST_TYPES("eve::common_type matches std::common_type", eve::test::scalar::all_types )
+<typename T>(eve::as<T>)
+{
+  auto one_type = []<typename U> (eve::as<U>) {
+    TTS_TYPE_IS((eve::common_type_t<T, U>), (std::common_type_t<T, U>));
+  };
+
+  [&]<typename ...Us> (eve::detail::types<Us...>) {
+    (one_type(eve::as<Us>{}), ...);
+  }(eve::detail::types<
+    std::int32_t, std::uint32_t,
+    std::int64_t, std::uint64_t,
+    float       , double
+  >{});
+};


### PR DESCRIPTION
Differences from `std::common_type`:
* for ints less than 32 have the same behaviour as for ints >= 32 bits.
* for product types, if they have the same tuple_size, kumi::tuple<common_type>
* if product type matches one of the parameters - make that the common type