### PR TITLE
FIX-896: patch 1.

### DIFF
--- a/include/eve/algo/concepts.hpp
+++ b/include/eve/algo/concepts.hpp
@@ -9,4 +9,5 @@
 
 #include <eve/algo/concepts/eve_iterator.hpp>
 #include <eve/algo/concepts/relaxed.hpp>
+#include <eve/algo/concepts/value_type.hpp>
 #include <eve/algo/concepts/zip_to_range.hpp>

--- a/include/eve/algo/concepts/detail.hpp
+++ b/include/eve/algo/concepts/detail.hpp
@@ -20,4 +20,10 @@ namespace eve::algo::detail
 
   template <typename T, template <typename ...> class Templ>
   concept instance_of = detail::instance_of_impl<T, Templ>::value;
+
+  template <typename R>
+  concept has_begin_end = requires (R&& r) {
+      { r.begin() };
+      { r.end() };
+  };
 }

--- a/include/eve/algo/concepts/relaxed.hpp
+++ b/include/eve/algo/concepts/relaxed.hpp
@@ -7,6 +7,7 @@
 //==================================================================================================
 #pragma once
 
+#include <eve/algo/concepts/detail.hpp>
 #include <eve/algo/preprocess_range.hpp>
 
 namespace eve::algo
@@ -14,15 +15,6 @@ namespace eve::algo
   template <typename I>
   concept relaxed_iterator =
     std::invocable<preprocess_range_, decltype(eve::algo::traits{}), I, I>;
-
-  namespace detail
-  {
-    template <typename R>
-    concept has_begin_end = requires (R&& r) {
-        { r.begin() };
-        { r.end() };
-    };
-  }
 
   template <typename R>
   concept relaxed_range =

--- a/include/eve/algo/concepts/relaxed.hpp
+++ b/include/eve/algo/concepts/relaxed.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 #include <eve/algo/concepts/detail.hpp>
-#include <eve/algo/preprocess_range.hpp>
+#include <eve/algo/detail/preprocess_range.hpp>
 
 namespace eve::algo
 {

--- a/include/eve/algo/concepts/value_type.hpp
+++ b/include/eve/algo/concepts/value_type.hpp
@@ -1,0 +1,37 @@
+//==================================================================================================
+/*
+  EVE - Expressive Vector Engine
+  Copyright : EVE Contributors & Maintainers
+  SPDX-License-Identifier: MIT
+*/
+//==================================================================================================
+#pragma once
+
+#include <eve/algo/concepts/detail.hpp>
+
+#include <eve/traits.hpp>
+
+#include <type_traits>
+
+namespace eve::algo
+{
+  namespace detail
+  {
+    template <typename T>
+    constexpr auto value_type_impl()
+    {
+           if constexpr ( has_begin_end<T>            ) return value_type_impl<decltype(std::declval<T>().begin())>();
+      else if constexpr ( std::contiguous_iterator<T> ) return std::type_identity<typename std::iterator_traits<T>::value_type>{};
+      else                                              return std::type_identity<typename eve::pointer_traits<T>::value_type>{};
+    }
+  }
+
+  template <typename T>
+  struct value_type
+  {
+    using type = typename decltype(detail::value_type_impl<T>())::type;
+  };
+
+  template <typename T>
+  using value_type_t = typename value_type<T>::type;
+}

--- a/include/eve/algo/detail/preprocess_range.hpp
+++ b/include/eve/algo/detail/preprocess_range.hpp
@@ -17,122 +17,10 @@
 
 namespace eve::algo
 {
-  template <typename T, typename Cardinal>
-  struct aligned_ptr_iterator;
-
-  template <typename T, typename Cardinal>
-  struct unaligned_ptr_iterator;
-
-  namespace detail
-  {
-    template <typename Traits, typename I, typename S, typename ToOutput>
-    struct preprocess_range_result
-    {
-     private:
-      Traits traits_;
-      I f_;
-      S l_;
-      ToOutput to_output_;
-     public:
-      preprocess_range_result(Traits traits, I f, S l, ToOutput to_output):
-        traits_(traits),
-        f_(f),
-        l_(l),
-        to_output_(to_output)
-      {}
-
-      Traits traits() const { return traits_; }
-
-      I begin() const { return f_; }
-      S end()   const { return l_; }
-
-      template <typename I_>
-      EVE_FORCEINLINE auto to_output_iterator(I_ it) const { return to_output_(it); }
-    };
-
-    template <typename Traits, typename I, typename S, typename ToOutput, typename Update>
-    EVE_FORCEINLINE auto enhance_to_output(preprocess_range_result<Traits, I, S, ToOutput> prev, Update update )
-    {
-      return preprocess_range_result(
-        prev.traits(),
-        prev.begin(),
-        prev.end(),
-        [update, prev](auto it) { return update(prev.to_output_iterator(it)); }
-      );
-    }
-
-    // Base case. Should validate that I, S are a valid iterator pair
-    template <typename Traits, iterator I, sentinel_for<I> S>
-    EVE_FORCEINLINE auto preprocess_eve_it_sentinel(Traits traits_, I f, S l)
-    {
-      if constexpr ( !std::same_as<typename I::value_type, iteration_type_t<Traits, I>> )
-      {
-        using T = iteration_type_t<Traits, I>;
-        auto f_ = convert(f, eve::as<T>{});
-        auto l_ = convert(l, eve::as<T>{});
-        return detail::enhance_to_output(
-          preprocess_eve_it_sentinel(traits_, f_, l_),
-          [](unaligned_t<decltype(f_)> i)
-          {
-            return convert(i, eve::as<typename I::value_type>{});
-          }
-        );
-      }
-      else if constexpr ( typename I::cardinal{}() > forced_cardinal_t<Traits, typename I::value_type>{}() )
-      {
-        using N = forced_cardinal_t<Traits, typename I::value_type>;
-        auto f_ = f.cardinal_cast(N{});
-        return detail::enhance_to_output(
-          preprocess_eve_it_sentinel(traits_, f_, l.cardinal_cast(N{})),
-          [](unaligned_t<decltype(f_)> i)
-          {
-            return i.cardinal_cast(typename I::cardinal{});
-          });
-      }
-      else
-      {
-        auto deduced = [] {
-          if constexpr (partially_aligned_iterator<I>)
-          {
-            if constexpr ( std::same_as<I, S> && !always_aligned_iterator<I> ) return algo::traits(no_aligning, divisible_by_cardinal);
-            else                                                               return algo::traits(no_aligning);
-          }
-          else
-          {
-            return algo::traits();
-          }
-        }();
-
-        return detail::preprocess_range_result{
-          default_to(traits_, deduced), f, l,
-          [](unaligned_t<I> i) { return i; }
-        };
-      }
-    }
-  }
-
   struct preprocess_range_
   {
     template <typename Traits, std::contiguous_iterator I, typename S>
-    EVE_FORCEINLINE auto operator()(Traits traits_, I f, S l) const
-    {
-      using T = std::remove_reference_t<decltype(*f)>;
-      using it = unaligned_ptr_iterator<T, forced_cardinal_t<Traits, typename std::iterator_traits<I>::value_type>>;
-
-      T* raw_f = nullptr;
-      T* raw_l = raw_f;
-
-      if (f != l)
-      {
-        raw_f = &*f;
-        raw_l = raw_f + (l - f);
-      }
-
-      return detail::enhance_to_output(
-        operator()(traits_, it{raw_f}, it{raw_l}),
-        [f, raw_f](it i) { return f + (i.ptr - raw_f); }
-      );
-    }
+    EVE_FORCEINLINE auto operator()(Traits traits_, I f, S l) const;
 
     template <typename Traits, typename I, typename S>
       requires eve::detail::tag_dispatchable<preprocess_range_, Traits, I, S>
@@ -152,47 +40,55 @@ namespace eve::algo
     }
 
     template <typename Traits, typename T, typename A>
-    EVE_FORCEINLINE auto operator()(Traits traits_, eve::aligned_ptr<T, A> f, T* l) const
-    {
-      using N = forced_cardinal_t<Traits, T>;
-
-      if constexpr (N{}() > A{}()) return operator()(traits_, f.get(), l);
-      else
-      {
-        using aligned_it   = aligned_ptr_iterator<T, N>;
-        using unaligned_it = unaligned_ptr_iterator<T, N>;
-
-        return detail::enhance_to_output(
-          operator()(traits_, aligned_it(f), unaligned_it(l)),
-          [](unaligned_it i) { return i.ptr; }
-        );
-      }
-    }
+    EVE_FORCEINLINE auto operator()(Traits traits_, eve::aligned_ptr<T, A> f, T* l) const;
 
     template <typename Traits, typename T, typename A1, typename A2>
-    EVE_FORCEINLINE auto operator()(Traits traits_, eve::aligned_ptr<T, A1> f, eve::aligned_ptr<T, A2> l) const
-    {
-      using N = forced_cardinal_t<Traits, T>;
-
-           if constexpr ( N{}() > A2{}()) return operator()(traits_, f, l.get());
-      else if constexpr ( N{}() > A1{}()) return operator()(traits_, f.get(), l);
-      else
-      {
-        using aligned_it   = aligned_ptr_iterator<T, forced_cardinal_t<Traits, T>>;
-
-        return detail::enhance_to_output(
-          operator()(traits_, aligned_it(f), aligned_it(l)),
-          [](unaligned_t<aligned_it> i) { return i.ptr; }
-        );
-      }
-    }
+    EVE_FORCEINLINE auto operator()(Traits traits_, eve::aligned_ptr<T, A1> f, eve::aligned_ptr<T, A2> l) const;
 
     // Base case. Should validate that I, S are a valid iterator pair
     template <typename Traits, iterator I, sentinel_for<I> S>
-    EVE_FORCEINLINE auto operator()(Traits traits_, I f, S l) const
+    EVE_FORCEINLINE auto operator()(Traits traits_, I f, S l) const;
+  };
+
+  inline constexpr preprocess_range_ preprocess_range;
+
+  template<typename Traits, typename I, typename S, typename ToOutput>
+  struct preprocess_range_result
+  {
+    private:
+    Traits   traits_;
+    I        f_;
+    S        l_;
+    ToOutput to_output_;
+
+    public:
+    preprocess_range_result(Traits traits, I f, S l, ToOutput to_output)
+        : traits_(traits)
+        , f_(f)
+        , l_(l)
+        , to_output_(to_output)
     {
-      return detail::preprocess_eve_it_sentinel(traits_, f, l);
     }
 
-  } inline constexpr preprocess_range;
+    Traits traits() const { return traits_; }
+
+    I begin() const { return f_; }
+    S end() const { return l_; }
+
+    template<typename I_> EVE_FORCEINLINE auto to_output_iterator(I_ it) const
+    {
+      return to_output_(it);
+    }
+  };
+
+  template<typename Traits, typename I, typename S, typename ToOutput, typename Update>
+  EVE_FORCEINLINE auto enhance_to_output(preprocess_range_result<Traits, I, S, ToOutput> prev,
+                                         Update                                          update)
+  {
+    return preprocess_range_result(prev.traits(),
+                                   prev.begin(),
+                                   prev.end(),
+                                   [update, prev](auto it)
+                                   { return update(prev.to_output_iterator(it)); });
+  }
 }

--- a/include/eve/algo/detail/preprocess_zip_range.hpp
+++ b/include/eve/algo/detail/preprocess_zip_range.hpp
@@ -73,7 +73,7 @@ namespace eve::algo
       auto f = zip_iterator(kumi::map([](auto r) { return r.begin(); }, processed_components));
       auto l = zip_iterator(kumi::map([](auto r) { return r.end(); }, processed_components));
 
-      auto as_eve_its = preprocess_eve_it_sentinel(tr_external, f, l);
+      auto as_eve_its = preprocess_range(tr_external, f, l);
 
       return enhance_to_output(as_eve_its, [processed_components](auto i) {
           return zip_iterator{

--- a/include/eve/algo/detail/preprocess_zip_range.hpp
+++ b/include/eve/algo/detail/preprocess_zip_range.hpp
@@ -7,6 +7,7 @@
 //==================================================================================================
 #pragma once
 
+#include <eve/algo/concepts/value_type.hpp>
 #include <eve/detail/kumi.hpp>
 
 namespace eve::algo
@@ -16,14 +17,10 @@ namespace eve::algo
 
   namespace detail
   {
-    template <typename Rng>
-    using rng_value_type = std::remove_reference_t<decltype(*std::declval<Rng>().begin())>;
-
     template <typename Traits, typename ZipTraits, typename ...Rngs>
     EVE_FORCEINLINE auto preprocess_zip_range_traits_support(Traits tr, ZipTraits, kumi::tuple<Rngs...>)
     {
-      using value_type = kumi::tuple<rng_value_type<Rngs>...>;
-      using N = forced_cardinal_t<decltype(tr), value_type>;
+      using N = forced_cardinal_t<decltype(tr), kumi::tuple<value_type_t<Rngs>...>>;
 
       auto force_cardinal = algo::traits{algo::force_cardinal<N{}()>};
 
@@ -47,7 +44,7 @@ namespace eve::algo
           {
             return algo::traits {algo::common_with_types<ParamTypes..., ZipTypes...>};
           }
-          (Param {}, eve::common_type<rng_value_type<Rngs>...> {});
+          (Param {}, eve::common_type<value_type_t<Rngs>...> {});
         }
         else
         {

--- a/include/eve/algo/iterator_helpers.hpp
+++ b/include/eve/algo/iterator_helpers.hpp
@@ -13,8 +13,6 @@ namespace eve::algo
 {
   struct operations_with_distance
   {
-    friend auto operator<=>(operations_with_distance const&, operations_with_distance const&) = default;
-
     friend auto& operator-=(std::derived_from<operations_with_distance> auto& x, std::ptrdiff_t n) { x += -n; return x; }
     friend auto  operator+ (std::derived_from<operations_with_distance> auto x, std::ptrdiff_t n)  { x += n; return x; }
     friend auto  operator- (std::derived_from<operations_with_distance> auto x, std::ptrdiff_t n)  { x -= n; return x; }

--- a/include/eve/algo/preprocess_range.hpp
+++ b/include/eve/algo/preprocess_range.hpp
@@ -7,10 +7,110 @@
 //==================================================================================================
 #pragma once
 
+#include <eve/algo/converting_iterator.hpp>
+#include <eve/algo/detail/preprocess_range.hpp>
+#include <eve/algo/ptr_iterator.hpp>
+
 #include <iterator>
 #include <type_traits>
 #include <utility>
 
-#include <eve/algo/detail/preprocess_range.hpp>
-#include <eve/algo/converting_iterator.hpp>
-#include <eve/algo/ptr_iterator.hpp>
+namespace eve::algo
+{
+  template<typename Traits, std::contiguous_iterator I, typename S>
+  EVE_FORCEINLINE auto preprocess_range_::operator()(Traits traits_, I f, S l) const
+  {
+    using T  = std::remove_reference_t<decltype(*f)>;
+    using it = unaligned_ptr_iterator<
+        T,
+        forced_cardinal_t<Traits, typename std::iterator_traits<I>::value_type>>;
+
+    T *raw_f = nullptr;
+    T *raw_l = raw_f;
+
+    if( f != l )
+    {
+      raw_f = &*f;
+      raw_l = raw_f + (l - f);
+    }
+
+    return enhance_to_output(operator()(traits_, it {raw_f}, it {raw_l}),
+                             [f, raw_f](it i) { return f + (i.ptr - raw_f); });
+  }
+
+  template<typename Traits, typename T, typename A>
+  EVE_FORCEINLINE auto
+  preprocess_range_::operator()(Traits traits_, eve::aligned_ptr<T, A> f, T *l) const
+  {
+    using N = forced_cardinal_t<Traits, T>;
+
+    if constexpr( N {}() > A {}() ) return operator()(traits_, f.get(), l);
+    else
+    {
+      using aligned_it   = aligned_ptr_iterator<T, N>;
+      using unaligned_it = unaligned_ptr_iterator<T, N>;
+
+      return enhance_to_output(operator()(traits_, aligned_it(f), unaligned_it(l)),
+                               [](unaligned_it i) { return i.ptr; });
+    }
+  }
+
+  template<typename Traits, typename T, typename A1, typename A2>
+  EVE_FORCEINLINE auto
+  preprocess_range_::operator()(Traits traits_, eve::aligned_ptr<T, A1> f, eve::aligned_ptr<T, A2> l) const
+  {
+    using N = forced_cardinal_t<Traits, T>;
+
+         if constexpr( N {}() > A2 {}() ) return operator()(traits_, f, l.get());
+    else if constexpr( N {}() > A1 {}() ) return operator()(traits_, f.get(), l);
+    else
+    {
+      using aligned_it = aligned_ptr_iterator<T, forced_cardinal_t<Traits, T>>;
+
+      return enhance_to_output(operator()(traits_, aligned_it(f), aligned_it(l)),
+                               [](unaligned_t<aligned_it> i) { return i.ptr; });
+    }
+  }
+
+  // Base case. Should validate that I, S are a valid iterator pair
+  template<typename Traits, iterator I, sentinel_for<I> S>
+  EVE_FORCEINLINE auto preprocess_range_::operator()(Traits traits_, I f, S l) const
+  {
+    if constexpr( !std::same_as<typename I::value_type, iteration_type_t<Traits, I>> )
+    {
+      using T = iteration_type_t<Traits, I>;
+      auto f_ = convert(f, eve::as<T> {});
+      auto l_ = convert(l, eve::as<T> {});
+      return enhance_to_output(preprocess_range(traits_, f_, l_),
+                               [](unaligned_t<decltype(f_)> i)
+                               { return convert(i, eve::as<typename I::value_type> {}); });
+    }
+    else if constexpr( typename I::cardinal {}()
+                       > forced_cardinal_t<Traits, typename I::value_type> {}() )
+    {
+      using N = forced_cardinal_t<Traits, typename I::value_type>;
+      auto f_ = f.cardinal_cast(N {});
+      return enhance_to_output(preprocess_range(traits_, f_, l.cardinal_cast(N {})),
+                               [](unaligned_t<decltype(f_)> i)
+                               { return i.cardinal_cast(typename I::cardinal {}); });
+    }
+    else
+    {
+      auto deduced = []
+      {
+        if constexpr( !partially_aligned_iterator<I> )
+          return traits {};
+        else
+        {
+          if constexpr( std::same_as<I, S> && !always_aligned_iterator<I> )
+            return algo::traits(no_aligning, divisible_by_cardinal);
+          else
+            return algo::traits(no_aligning);
+        }
+      }();
+
+      return preprocess_range_result {
+          default_to(traits_, deduced), f, l, [](unaligned_t<I> i) { return i; }};
+    }
+  }
+}

--- a/include/eve/algo/ptr_iterator.hpp
+++ b/include/eve/algo/ptr_iterator.hpp
@@ -43,8 +43,8 @@ namespace eve::algo
     unaligned_ptr_iterator& operator+=(std::ptrdiff_t n) { ptr += n; return *this; }
     friend std::ptrdiff_t   operator-(unaligned_ptr_iterator x, unaligned_ptr_iterator y) { return x.ptr - y.ptr; }
 
-    auto operator<=>(unaligned_ptr_iterator const&) const = default;
-
+    bool operator==(unaligned_ptr_iterator const &x) const { return ptr == x.ptr; }
+    auto operator<=>(unaligned_ptr_iterator const &x) const { return ptr <=> x.ptr; }
 
     template< relative_conditional_expr C, decorator S, typename Pack>
     EVE_FORCEINLINE friend auto tagged_dispatch ( eve::tag::load_, C const& c, S const& s

--- a/include/eve/algo/zip_iterator.hpp
+++ b/include/eve/algo/zip_iterator.hpp
@@ -118,16 +118,6 @@ namespace eve::algo
         return get<0>(x) - get<0>(y);
       }
 
-      template<typename Traits, std::derived_from<zip_iterator_common> Self, compatible_zip_iterators<Self> Other>
-      friend auto tagged_dispatch(preprocess_range_, Traits traits, Self self, Other other)
-      {
-        auto ranges = kumi::map([](auto f_, auto l_) {
-          return as_range(f_, l_);
-        }, self, other);
-
-        return preprocess_zip_range(traits, eve::algo::traits(), ranges);
-      }
-
       template<typename Traits, std::derived_from<zip_iterator_common> Self,
                std::equality_comparable_with<std::tuple_element_t<0, tuple_type>> S>
       friend auto tagged_dispatch(preprocess_range_, Traits traits, Self self, S l)
@@ -156,6 +146,16 @@ namespace eve::algo
   {
     using base = detail::zip_iterator_common<Is...>;
     using base::base;
+
+    template<typename Traits, compatible_zip_iterators<zip_iterator<Is...>> Other>
+    friend auto tagged_dispatch(preprocess_range_, Traits traits, zip_iterator<Is...> self, Other other)
+    {
+      auto ranges = kumi::map([](auto f_, auto l_) {
+        return as_range(f_, l_);
+      }, self, other);
+
+      return detail::preprocess_zip_range(traits, eve::algo::traits(), ranges);
+    }
   };
 
   template <iterator I, iterator ... Is>

--- a/test/unit/algo/CMakeLists.txt
+++ b/test/unit/algo/CMakeLists.txt
@@ -15,6 +15,7 @@ add_custom_target(unit.algo.simd.exe  )
 
 # Components
 make_unit("unit.algo" array_utils.cpp)
+make_unit("unit.algo" concepts.cpp)
 make_unit("unit.algo" converting_iterator.cpp)
 make_unit("unit.algo" for_each_iteration.cpp)
 make_unit("unit.algo" preprocess_range.cpp)

--- a/test/unit/algo/concepts.cpp
+++ b/test/unit/algo/concepts.cpp
@@ -1,0 +1,31 @@
+//==================================================================================================
+/**
+  EVE - Expressive Vector Engine
+  Copyright : EVE Contributors & Maintainers
+  SPDX-License-Identifier: MIT
+**/
+//==================================================================================================
+
+#include "algo_test.hpp"
+
+#include <eve/algo/concepts.hpp>
+
+#include <eve/algo/ptr_iterator.hpp>
+#include <eve/algo/zip.hpp>
+
+#include <vector>
+
+TTS_CASE("concepts, value type")
+{
+  TTS_TYPE_IS(eve::algo::value_type_t<int*>, int);
+  TTS_TYPE_IS(eve::algo::value_type_t<const int*>, int);
+
+  using u_p = eve::algo::unaligned_ptr_iterator<int const, eve::fixed<2>>;
+  TTS_TYPE_IS(eve::algo::value_type_t<u_p>, int);
+
+  std::vector<int> v1, v2;
+
+  TTS_TYPE_IS(eve::algo::value_type_t<decltype(v1)>, int);
+  TTS_TYPE_IS((eve::algo::value_type_t<decltype(eve::algo::zip(v1, v2))>),
+               (kumi::tuple<int, int>));
+}

--- a/test/unit/algo/concepts.cpp
+++ b/test/unit/algo/concepts.cpp
@@ -29,3 +29,10 @@ TTS_CASE("concepts, value type")
   TTS_TYPE_IS((eve::algo::value_type_t<decltype(eve::algo::zip(v1, v2))>),
                (kumi::tuple<int, int>));
 }
+
+TTS_CASE("concepts, relaxed")
+{
+  TTS_CONSTEXPR_EXPECT(eve::algo::relaxed_iterator<int*>);
+  TTS_CONSTEXPR_EXPECT_NOT(eve::algo::relaxed_range<int*>);
+  TTS_CONSTEXPR_EXPECT(eve::algo::relaxed_range<std::vector<int>>);
+}

--- a/test/unit/algo/iterator_concept_test.hpp
+++ b/test/unit/algo/iterator_concept_test.hpp
@@ -88,9 +88,13 @@ namespace algo_test
     TTS_TYPE_IS(typename decltype(res)::cardinal, eve::fixed<1>);
   }
 
+  // void is_relaxed_test(eve::algo::relaxed_iterator auto, eve::algo::relaxed_iterator auto) {}
+
   template <eve::algo::readable_iterator I, eve::algo::sentinel_for<I> S, typename T, typename ReplaceIgnored>
   void iterator_sentinel_test(I f, S l, T v, ReplaceIgnored replace)
   {
+    eve::algo::preprocess_range(eve::algo::traits{}, f, f);
+    // is_relaxed_test(f, l);
     iterator_sentinel_test_one_pair(f, l, v, replace);
     unaligned_iteration_test(f.unaligned(), l);
 

--- a/test/unit/meta/common_type.cpp
+++ b/test/unit/meta/common_type.cpp
@@ -66,6 +66,10 @@ EVE_TEST_TYPES("eve::common_type matches std::common_type", eve::test::scalar::a
 using i32_u32_f64 = kumi::tuple<std::int32_t, std::uint32_t, double>;
 using i32_i32_i32 = kumi::tuple<std::int32_t, std::int32_t,  std::int32_t>;
 
+using i32_x2    = kumi::tuple<std::int32_t, std::int32_t>;
+using i32_x4    = kumi::tuple<std::int32_t, std::int32_t, std::int32_t, std::int32_t>;
+using i32_x2_x2 = kumi::tuple<i32_x2, i32_x2>;
+
 struct product : i32_u32_f64 {};
 template<>              struct eve::is_product_type<product> : std::true_type {};
 template<>              struct std::tuple_size<product>      : std::tuple_size<i32_u32_f64> {};
@@ -76,6 +80,18 @@ template<>              struct eve::is_product_type<smaller_product> : std::true
 template<>              struct std::tuple_size<smaller_product>      : std::tuple_size<i32_i32_i32> {};
 template<std::size_t I> struct std::tuple_element<I,smaller_product> : std::tuple_element<I, i32_i32_i32> {};
 
+struct point : i32_x2 {};
+template<>              struct eve::is_product_type<point> : std::true_type {};
+template<>              struct std::tuple_size<point>      : std::tuple_size<i32_x2> {};
+template<std::size_t I> struct std::tuple_element<I,point> : std::tuple_element<I, i32_x2> {};
+
+using point_x2 = kumi::tuple<point, point>;
+
+struct line : point_x2 {};
+
+template<>              struct eve::is_product_type<line> : std::true_type {};
+template<>              struct std::tuple_size<line>      : std::tuple_size<point_x2> {};
+template<std::size_t I> struct std::tuple_element<I,line> : std::tuple_element<I, point_x2> {};
 
 TTS_CASE("eve::common_type, product type")
 {
@@ -84,8 +100,21 @@ TTS_CASE("eve::common_type, product type")
 
   TTS_TYPE_IS((eve::common_type_t<product, i32_i32_i32>), product);
   TTS_TYPE_IS((eve::common_type_t<i32_i32_i32, product>), product);
+
+  TTS_TYPE_IS((eve::common_type_t<product, i32_u32_f64>), product);
+  TTS_TYPE_IS((eve::common_type_t<i32_u32_f64, product>), product);
+
   TTS_TYPE_IS((eve::common_type_t<product, smaller_product>), product);
   TTS_TYPE_IS((eve::common_type_t<smaller_product, product>), product);
+
+  TTS_TYPE_IS((eve::common_type_t<point_x2, line>), line);
+  TTS_TYPE_IS((eve::common_type_t<line, point_x2>), line);
+
+  TTS_TYPE_IS((eve::common_type_t<line, i32_x4>), line);
+  TTS_TYPE_IS((eve::common_type_t<i32_x4, line>), line);
+
+  TTS_TYPE_IS((eve::common_type_t<line, i32_x2_x2>), line);
+  TTS_TYPE_IS((eve::common_type_t<i32_x2_x2, line>), line);
 }
 
 TTS_CASE("eve::common_type, have_common_type")


### PR DESCRIPTION
First batch of changes to do iteration over objects.

* value_type - a type function that deduces a value type for a range or iterator
* removed <=> from a baseclass helper. Yeah we can't default, but defaulting didn't really work. And it always was selected by accident.
* minimum common type support. At least `tuple<int, int, int, int>` will convert to `line`.
* `preprocess_range`: extracted a proper predeclaration, otherwise the dependencies stumble each other.