### PR TITLE
FIX-896: simplifications to preprocess_range.

### DIFF
--- a/include/eve/algo/detail/preprocess_range.hpp
+++ b/include/eve/algo/detail/preprocess_range.hpp
@@ -52,21 +52,19 @@ namespace eve::algo
 
   inline constexpr preprocess_range_ preprocess_range;
 
-  template<typename Traits, typename I, typename S, typename ToOutput>
+  template<typename Traits, typename I, typename S>
   struct preprocess_range_result
   {
     private:
     Traits   traits_;
     I        f_;
     S        l_;
-    ToOutput to_output_;
 
     public:
-    preprocess_range_result(Traits traits, I f, S l, ToOutput to_output)
+    preprocess_range_result(Traits traits, I f, S l)
         : traits_(traits)
         , f_(f)
         , l_(l)
-        , to_output_(to_output)
     {
     }
 
@@ -74,21 +72,5 @@ namespace eve::algo
 
     I begin() const { return f_; }
     S end() const { return l_; }
-
-    template<typename I_> EVE_FORCEINLINE auto to_output_iterator(I_ it) const
-    {
-      return to_output_(it);
-    }
   };
-
-  template<typename Traits, typename I, typename S, typename ToOutput, typename Update>
-  EVE_FORCEINLINE auto enhance_to_output(preprocess_range_result<Traits, I, S, ToOutput> prev,
-                                         Update                                          update)
-  {
-    return preprocess_range_result(prev.traits(),
-                                   prev.begin(),
-                                   prev.end(),
-                                   [update, prev](auto it)
-                                   { return update(prev.to_output_iterator(it)); });
-  }
 }

--- a/include/eve/algo/detail/preprocess_zip_range.hpp
+++ b/include/eve/algo/detail/preprocess_zip_range.hpp
@@ -73,14 +73,7 @@ namespace eve::algo
       auto f = zip_iterator(kumi::map([](auto r) { return r.begin(); }, processed_components));
       auto l = zip_iterator(kumi::map([](auto r) { return r.end(); }, processed_components));
 
-      auto as_eve_its = preprocess_range(tr_external, f, l);
-
-      return enhance_to_output(as_eve_its, [processed_components](auto i) {
-          return zip_iterator{
-            kumi::map([](auto r_i, auto i_i) { return r_i.to_output_iterator(i_i);},
-            processed_components, i)
-          };
-        });
+      return preprocess_range(tr_external, f, l);
     }
   }
 }

--- a/include/eve/algo/preprocess_range.hpp
+++ b/include/eve/algo/preprocess_range.hpp
@@ -7,8 +7,10 @@
 //==================================================================================================
 #pragma once
 
-#include <eve/algo/converting_iterator.hpp>
 #include <eve/algo/detail/preprocess_range.hpp>
+
+#include <eve/algo/concepts/value_type.hpp>
+#include <eve/algo/converting_iterator.hpp>
 #include <eve/algo/ptr_iterator.hpp>
 
 #include <iterator>
@@ -18,87 +20,89 @@
 
 namespace eve::algo
 {
+  namespace detail
+  {
+    template <typename T, typename A>
+    EVE_FORCEINLINE auto ptr_to_iterator(eve::aligned_ptr<T, A> ptr)
+    {
+      return aligned_ptr_iterator<T, A>{ptr};
+    }
+
+    template <typename T>
+    EVE_FORCEINLINE auto ptr_to_iterator(T* ptr)
+    {
+      using N          = eve::fixed<eve::expected_cardinal_v<std::remove_const_t<T>>>;
+      return unaligned_ptr_iterator<T, N>{ptr};
+    }
+
+    template <typename Traits, typename I>
+    EVE_FORCEINLINE auto fix_up_type_and_cardinal(Traits traits_, I i)
+    {
+      if constexpr( !std::same_as<typename I::value_type, iteration_type_t<Traits, I>> )
+      {
+        using T = iteration_type_t<Traits, I>;
+        auto i_ = convert(i, eve::as<T> {});
+        return fix_up_type_and_cardinal(traits_, i_);
+      }
+      else if constexpr( typename I::cardinal {}() !=
+                         forced_cardinal_t<Traits, typename I::value_type> {}() )
+      {
+        using N = forced_cardinal_t<Traits, typename I::value_type>;
+        auto i_ = i.cardinal_cast(N {});
+        return fix_up_type_and_cardinal(traits_, i_);
+      }
+      else
+      {
+        return i;
+      }
+    }
+  }
+
+  template <typename Traits, typename I_, typename S_>
+    requires detail::pointer_iterator_sentinel<I_, S_>
+  EVE_FORCEINLINE auto preprocess_range_::operator()(Traits traits_, I_ f_, S_ l_) const
+  {
+    // We have to force cardinal here, because iterators
+    // with different cardinals don't form a valid range.
+    auto f = detail::fix_up_type_and_cardinal(traits_, detail::ptr_to_iterator(f_));
+    auto l = detail::fix_up_type_and_cardinal(traits_, detail::ptr_to_iterator(l_));
+
+    return operator()(traits_, f, l);
+  }
+
   template<typename Traits, std::contiguous_iterator I, typename S>
+    requires ( !std::is_pointer_v<I> )
   EVE_FORCEINLINE auto preprocess_range_::operator()(Traits traits_, I f, S l) const
   {
     auto* raw_f = std::to_address(f);
     auto* raw_l = raw_f + (l - f);
 
-    using T = typename std::iterator_traits<I>::value_type;
-
-    using it = unaligned_ptr_iterator<
-        std::remove_reference_t<decltype(*raw_f)>,
-        forced_cardinal_t<Traits, T>>;
-
-    return operator()(traits_, it {raw_f}, it {raw_l});
-  }
-
-  template<typename Traits, typename T, typename A>
-  EVE_FORCEINLINE auto
-  preprocess_range_::operator()(Traits traits_, eve::aligned_ptr<T, A> f, T *l) const
-  {
-    using N = forced_cardinal_t<Traits, T>;
-
-    if constexpr( N {}() > A {}() ) return operator()(traits_, f.get(), l);
-    else
-    {
-      using aligned_it   = aligned_ptr_iterator<T, N>;
-      using unaligned_it = unaligned_ptr_iterator<T, N>;
-
-      return operator()(traits_, aligned_it(f), unaligned_it(l));
-    }
-  }
-
-  template<typename Traits, typename T, typename A1, typename A2>
-  EVE_FORCEINLINE auto
-  preprocess_range_::operator()(Traits traits_, eve::aligned_ptr<T, A1> f, eve::aligned_ptr<T, A2> l) const
-  {
-    using N = forced_cardinal_t<Traits, T>;
-
-         if constexpr( N {}() > A2 {}() ) return operator()(traits_, f, l.get());
-    else if constexpr( N {}() > A1 {}() ) return operator()(traits_, f.get(), l);
-    else
-    {
-      using aligned_it = aligned_ptr_iterator<T, forced_cardinal_t<Traits, T>>;
-
-      return operator()(traits_, aligned_it(f), aligned_it(l));
-    }
+    return operator()(traits_, raw_f, raw_l);
   }
 
   // Base case. Should validate that I, S are a valid iterator pair
-  template<typename Traits, iterator I, sentinel_for<I> S>
-  EVE_FORCEINLINE auto preprocess_range_::operator()(Traits traits_, I f, S l) const
+  template<typename Traits, iterator I_, sentinel_for<I_> S_>
+  EVE_FORCEINLINE auto preprocess_range_::operator()(Traits traits_, I_ f_, S_ l_) const
   {
-    if constexpr( !std::same_as<typename I::value_type, iteration_type_t<Traits, I>> )
-    {
-      using T = iteration_type_t<Traits, I>;
-      auto f_ = convert(f, eve::as<T> {});
-      auto l_ = convert(l, eve::as<T> {});
-      return preprocess_range(traits_, f_, l_);
-    }
-    else if constexpr( typename I::cardinal {}()
-                       != forced_cardinal_t<Traits, typename I::value_type> {}() )
-    {
-      using N = forced_cardinal_t<Traits, typename I::value_type>;
-      auto f_ = f.cardinal_cast(N {});
-      return preprocess_range(traits_, f_, l.cardinal_cast(N {}));
-    }
-    else
-    {
-      auto deduced = []
-      {
-        if constexpr( !partially_aligned_iterator<I> )
-          return traits {};
-        else
-        {
-          if constexpr( std::same_as<I, S> && !always_aligned_iterator<I> )
-            return algo::traits(no_aligning, divisible_by_cardinal);
-          else
-            return algo::traits(no_aligning);
-        }
-      }();
+    auto f = detail::fix_up_type_and_cardinal(traits_, f_);
+    auto l = detail::fix_up_type_and_cardinal(traits_, l_);
 
-      return preprocess_range_result { default_to(traits_, deduced), f, l};
-    }
+    using I = decltype(f);
+    using S = decltype(l);
+
+    auto deduced = []
+    {
+      if constexpr( !partially_aligned_iterator<I> )
+        return traits {};
+      else
+      {
+        if constexpr( std::same_as<I, S> && !always_aligned_iterator<I> )
+          return algo::traits(no_aligning, divisible_by_cardinal);
+        else
+          return algo::traits(no_aligning);
+      }
+    }();
+
+    return preprocess_range_result { default_to(traits_, deduced), f, l};
   }
 }

--- a/include/eve/algo/preprocess_range.hpp
+++ b/include/eve/algo/preprocess_range.hpp
@@ -77,7 +77,7 @@ namespace eve::algo
       return preprocess_range(traits_, f_, l_);
     }
     else if constexpr( typename I::cardinal {}()
-                       > forced_cardinal_t<Traits, typename I::value_type> {}() )
+                       != forced_cardinal_t<Traits, typename I::value_type> {}() )
     {
       using N = forced_cardinal_t<Traits, typename I::value_type>;
       auto f_ = f.cardinal_cast(N {});

--- a/include/eve/algo/ptr_iterator.hpp
+++ b/include/eve/algo/ptr_iterator.hpp
@@ -100,11 +100,15 @@ namespace eve::algo
     auto previous_partially_aligned() const { return *this; }
 
     template <typename _Cardinal>
-    auto cardinal_cast(_Cardinal) const
+    auto cardinal_cast(_Cardinal c) const
     {
-      using other_it  = aligned_ptr_iterator<T, _Cardinal>;
-      using other_ptr = typename other_it::aligned_ptr_type;
-      return other_it{other_ptr{ptr.get()}};
+      if constexpr (_Cardinal{}() > Cardinal{}()) return unaligned().cardinal_cast(c);
+      else
+      {
+        using other_it  = aligned_ptr_iterator<T, _Cardinal>;
+        using other_ptr = typename other_it::aligned_ptr_type;
+        return other_it{other_ptr{ptr.get()}};
+      }
     }
 
     aligned_ptr_iterator& operator+=(std::ptrdiff_t n) { ptr += n; return *this; }

--- a/test/unit/algo/iterator_concept_test.hpp
+++ b/test/unit/algo/iterator_concept_test.hpp
@@ -88,13 +88,13 @@ namespace algo_test
     TTS_TYPE_IS(typename decltype(res)::cardinal, eve::fixed<1>);
   }
 
-  // void is_relaxed_test(eve::algo::relaxed_iterator auto, eve::algo::relaxed_iterator auto) {}
+  void is_relaxed_test(eve::algo::relaxed_iterator auto, eve::algo::relaxed_iterator auto) {}
 
   template <eve::algo::readable_iterator I, eve::algo::sentinel_for<I> S, typename T, typename ReplaceIgnored>
   void iterator_sentinel_test(I f, S l, T v, ReplaceIgnored replace)
   {
     eve::algo::preprocess_range(eve::algo::traits{}, f, f);
-    // is_relaxed_test(f, l);
+    is_relaxed_test(f, l);
     iterator_sentinel_test_one_pair(f, l, v, replace);
     unaligned_iteration_test(f.unaligned(), l);
 

--- a/test/unit/algo/preprocess_range.cpp
+++ b/test/unit/algo/preprocess_range.cpp
@@ -99,12 +99,12 @@ EVE_TEST_TYPES("Check preprocess_range for contiguous iterators", algo_test::sel
     common_test(
       arr.begin(), eve::aligned_ptr<e_t>{arr.end()},
       eve::algo::unaligned_ptr_iterator<e_t, N>{},
-      eve::algo::unaligned_ptr_iterator<e_t, N>{}
+      eve::algo::aligned_ptr_iterator<e_t, N>{}
     );
     common_test(
       arr.cbegin(), eve::aligned_ptr<e_t const>{arr.cend()},
       eve::algo::unaligned_ptr_iterator<e_t const, N>{},
-      eve::algo::unaligned_ptr_iterator<e_t const, N>{}
+      eve::algo::aligned_ptr_iterator<e_t const, N>{}
     );
   }
 
@@ -276,11 +276,8 @@ EVE_TEST_TYPES("cardinal/type manipulation", algo_test::selected_types)
       eve::algo::traits(eve::algo::common_with_types<double, char>), v);
 
     using I = decltype(processed.begin());
-    TTS_CONSTEXPR_EXPECT((std::same_as<typename I::value_type, double>));
-    if constexpr ( T::size() >= eve::cardinal_v<double> )
-    {
-      TTS_CONSTEXPR_EXPECT((std::same_as<typename I::wide_value_type, eve::wide<double>>));
-    }
+    TTS_TYPE_IS(typename I::value_type, double);
+    TTS_TYPE_IS(typename I::wide_value_type, eve::wide<double>);
   }
 
   {

--- a/test/unit/algo/preprocess_range.cpp
+++ b/test/unit/algo/preprocess_range.cpp
@@ -34,13 +34,8 @@ EVE_TEST_TYPES("Check preprocess_range for contiguous iterators", algo_test::sel
 
     TTS_EQUAL((processed.end() - processed.begin()), (eve::algo::unalign(l) - eve::algo::unalign(f)));
 
-    auto back_to_f = processed.to_output_iterator(processed.begin().unaligned());
-    TTS_EQUAL(back_to_f, f);
-
     auto processed_empty = eve::algo::preprocess_range(eve::algo::traits(eve::algo::unroll<2>), f, f);
     TTS_EQUAL(processed_empty.begin(), processed_empty.end());
-    back_to_f = processed_empty.to_output_iterator(processed_empty.begin().unaligned());
-    TTS_EQUAL(back_to_f, f);
 
     return processed;
   };
@@ -169,14 +164,8 @@ EVE_TEST_TYPES("Check preprocess_range for eve ptr iterators", algo_test::select
     TTS_EQUAL(processed.begin(), f_);
     TTS_EQUAL(processed.end(), l_);
 
-    auto back_to_f = processed.to_output_iterator(processed.begin().unaligned());
-    TTS_TYPE_IS(decltype(back_to_f), eve::algo::unaligned_t<I>);
-    TTS_EQUAL(back_to_f, f);
-
     auto processed_empty = eve::algo::preprocess_range(eve::algo::traits(eve::algo::unroll<2>), f, f);
     TTS_EQUAL(processed_empty.begin(), processed_empty.end());
-    back_to_f = processed_empty.to_output_iterator(processed_empty.begin().unaligned());
-    TTS_EQUAL(back_to_f, f);
   };
 
   auto run_test = [&] <typename U>(U* f, U* l) {
@@ -214,10 +203,6 @@ EVE_TEST_TYPES("contiguous ranges", algo_test::selected_types)
     TTS_TYPE_IS(decltype(processed.begin()), u_it);
     TTS_TYPE_IS(decltype(processed.end()), u_it);
     TTS_EQUAL(processed.begin(), processed.end());
-
-    auto back_to_f = processed.to_output_iterator(processed.begin().unaligned());
-    TTS_TYPE_IS(decltype(back_to_f), typename std::vector<e_t>::iterator);
-    TTS_EQUAL(back_to_f, v.begin());
   }
 
   auto non_empty_range_test = [](auto&& rng) {
@@ -229,10 +214,6 @@ EVE_TEST_TYPES("contiguous ranges", algo_test::selected_types)
     TTS_TYPE_IS(decltype(processed.traits()), decltype(eve::algo::traits()));
     TTS_TYPE_IS(decltype(processed.begin()), u_it);
     TTS_TYPE_IS(decltype(processed.end()), u_it);
-
-    auto back_to_f = processed.to_output_iterator(processed.begin().unaligned());
-    TTS_TYPE_IS(decltype(back_to_f), decltype(std::begin(rng)));
-    TTS_EQUAL(back_to_f, std::begin(rng));
   };
 
   {

--- a/test/unit/algo/preprocess_range.cpp
+++ b/test/unit/algo/preprocess_range.cpp
@@ -142,13 +142,12 @@ EVE_TEST_TYPES("Check preprocess_range for contiguous iterators", algo_test::sel
     eve::algo::unaligned_ptr_iterator<e_t const, N>{}, eve::algo::unaligned_ptr_iterator<e_t const, N>{});
 };
 
-
 EVE_TEST_TYPES("Check preprocess_range for eve ptr iterators", algo_test::selected_types)
 <typename T>(eve::as<T>)
 {
   using e_t = eve::element_type_t<T>;
   using N = eve::fixed<T::size()>;
-  using expected_N = eve::fixed<std::min(T::size(), eve::expected_cardinal_v<e_t>)>;
+  using expected_N = eve::fixed<eve::expected_cardinal_v<e_t>>;
 
   alignas(sizeof(T)) std::array<e_t, T::size()> arr;
 
@@ -179,8 +178,16 @@ EVE_TEST_TYPES("Check preprocess_range for eve ptr iterators", algo_test::select
 
     run_one_test(u_f, u_l, eve::algo::traits(eve::algo::unroll<2>));
     run_one_test(u_f, a_l, eve::algo::traits(eve::algo::unroll<2>));
-    run_one_test(a_f, a_l, eve::algo::traits(eve::algo::unroll<2>, eve::algo::no_aligning, eve::algo::divisible_by_cardinal));
-    run_one_test(a_f, u_l, eve::algo::traits(eve::algo::unroll<2>, eve::algo::no_aligning));
+    if constexpr ( N{}() >= expected_N{}())
+    {
+      run_one_test(a_f, a_l, eve::algo::traits(eve::algo::unroll<2>, eve::algo::no_aligning, eve::algo::divisible_by_cardinal));
+      run_one_test(a_f, u_l, eve::algo::traits(eve::algo::unroll<2>, eve::algo::no_aligning));
+    }
+    else
+    {
+      run_one_test(a_f, a_l, eve::algo::traits(eve::algo::unroll<2>));
+      run_one_test(a_f, u_l, eve::algo::traits(eve::algo::unroll<2>));
+    }
   };
 
   run_test(arr.begin(), arr.end());

--- a/test/unit/algo/preprocess_zip_range.cpp
+++ b/test/unit/algo/preprocess_zip_range.cpp
@@ -38,9 +38,6 @@ TTS_CASE("zip_iterator, preprocess range, scalar end")
   zip_ui processed_l = processed.end();
 
   TTS_EQUAL((processed_l - processed_f), 3);
-
-  zip_vi back_zf = processed.to_output_iterator(processed_f);
-  TTS_EQUAL(back_zf, zf);
 }
 
 TTS_CASE("zip_iterator, preprocess range, zip end")


### PR DESCRIPTION
Part of the effort for reading objects.

* dropped `to_output`. Since `unalign` is now a generic function, we can just `unalign(r.begin()) + distance`
* simplified logic around pointers.
* now iterator cardinal is just a property but not an information to action, we only use: type + user overrides to determine cardinals. The `eve` iterators should never really be used outside of algorithms, they are just needed for looping.
* alignment s now preserved for the sentinel as well. This I believe is a correct solution.
