### PR TITLE
FIX-923: use forceinline structs instead of lambdas in algorithms.

### DIFF
--- a/include/eve/algo/all_of.hpp
+++ b/include/eve/algo/all_of.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <eve/algo/array_utils.hpp>
+#include <eve/algo/common_forceinline_lambdas.hpp>
 #include <eve/algo/concepts.hpp>
 #include <eve/algo/for_each_iteration.hpp>
 #include <eve/algo/preprocess_range.hpp>
@@ -39,7 +40,7 @@ namespace eve::algo
       template <typename I, std::size_t size>
       EVE_FORCEINLINE bool unrolled_step(std::array<I, size> arr)
       {
-        auto tests = array_map(arr, [&](I it) { return p(eve::load(it)); });
+        auto tests = array_map(arr, load_and_apply{p});
         auto overall = array_reduce(tests, eve::logical_and);
         res = eve::all(overall);
         return !res;

--- a/include/eve/algo/any_of.hpp
+++ b/include/eve/algo/any_of.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <eve/algo/array_utils.hpp>
+#include <eve/algo/common_forceinline_lambdas.hpp>
 #include <eve/algo/concepts.hpp>
 #include <eve/algo/for_each_iteration.hpp>
 #include <eve/algo/preprocess_range.hpp>
@@ -39,7 +40,7 @@ namespace eve::algo
       template <typename I, std::size_t size>
       EVE_FORCEINLINE bool unrolled_step(std::array<I, size> arr)
       {
-        auto tests = array_map(arr, [&](I it) { return p(eve::load(it)); });
+        auto tests = array_map(arr, load_and_apply{p});
         auto overall = array_reduce(tests, eve::logical_or);
         res = eve::any(overall);
         return res;

--- a/include/eve/algo/common_forceinline_lambdas.hpp
+++ b/include/eve/algo/common_forceinline_lambdas.hpp
@@ -1,0 +1,65 @@
+//==================================================================================================
+/*
+  EVE - Expressive Vector Engine
+  Copyright : EVE Contributors & Maintainers
+  SPDX-License-Identifier: MIT
+*/
+//==================================================================================================
+#pragma once
+
+#include <eve/function/load.hpp>
+
+namespace eve::algo
+{
+  template <typename Op>
+  struct apply_to_zip_pair
+  {
+    Op op;
+
+    explicit apply_to_zip_pair(Op op) : op(op) {}
+
+    EVE_FORCEINLINE auto operator()(auto x_y) const
+    {
+      return op(get<0>(x_y), get<1>(x_y));
+    }
+  };
+
+  template <typename P>
+  struct not_p
+  {
+    P p;
+
+    explicit not_p(P p) : p(p) {}
+
+    EVE_FORCEINLINE auto operator()(auto ... x) const
+    {
+      return !p(x ...);
+    }
+  };
+
+  template <typename Op>
+  struct load_and_apply
+  {
+    Op op;
+
+    explicit load_and_apply(Op op) : op(op) {}
+
+    EVE_FORCEINLINE auto operator()(auto it) const
+    {
+      return op(eve::load(it));
+    }
+  };
+
+  template <typename T>
+  struct equal_to
+  {
+    T v;
+
+    explicit equal_to(T v) : v(v) {}
+
+    EVE_FORCEINLINE auto operator()(auto x) const
+    {
+      return x == v;
+    }
+  };
+}

--- a/include/eve/algo/common_forceinline_lambdas.hpp
+++ b/include/eve/algo/common_forceinline_lambdas.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <eve/function/load.hpp>
+#include <eve/conditional.hpp>
 
 namespace eve::algo
 {
@@ -47,6 +48,19 @@ namespace eve::algo
     EVE_FORCEINLINE auto operator()(auto it) const
     {
       return op(eve::load(it));
+    }
+  };
+
+  template <typename Delegate>
+  struct call_single_step
+  {
+    Delegate* delegate;
+
+    explicit call_single_step(Delegate* delegate) : delegate(delegate) {}
+
+    EVE_FORCEINLINE bool operator()(auto it) const
+    {
+      return delegate->step(it, eve::ignore_none, eve::index<0>);
     }
   };
 

--- a/include/eve/algo/equal.hpp
+++ b/include/eve/algo/equal.hpp
@@ -7,8 +7,9 @@
 //==================================================================================================
 #pragma once
 
-#include <eve/algo/concepts.hpp>
 #include <eve/algo/all_of.hpp>
+#include <eve/algo/common_forceinline_lambdas.hpp>
+#include <eve/algo/concepts.hpp>
 #include <eve/algo/traits.hpp>
 #include <eve/algo/zip.hpp>
 
@@ -24,11 +25,8 @@ namespace eve::algo
     template <zipped_range_pair R, typename P>
     EVE_FORCEINLINE bool operator()(R&& r, P p) const
     {
-      return algo::all_of[TraitsSupport::get_traits()]
-       (std::forward<R>(r), [p](auto x_y) {
-         auto [x, y] = x_y;
-         return p(x, y);
-       });
+      return algo::all_of[TraitsSupport::get_traits()](std::forward<R>(r),
+                                                       apply_to_zip_pair{p});
     }
 
     template <zipped_range_pair R>

--- a/include/eve/algo/find.hpp
+++ b/include/eve/algo/find.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <eve/algo/array_utils.hpp>
+#include <eve/algo/common_forceinline_lambdas.hpp>
 #include <eve/algo/concepts.hpp>
 #include <eve/algo/for_each_iteration.hpp>
 #include <eve/algo/preprocess_range.hpp>
@@ -59,7 +60,7 @@ namespace eve::algo
       template <typename I, std::size_t size>
       EVE_FORCEINLINE bool unrolled_step(std::array<I, size> arr)
       {
-        auto tests = array_map(arr, [&](I it) { return p(eve::load(it)); });
+        auto tests = array_map(arr, load_and_apply{p});
 
         auto overall = array_reduce(tests, eve::logical_or);
         if (!eve::any(overall)) return false;
@@ -101,7 +102,7 @@ namespace eve::algo
     template <relaxed_range Rng, typename T>
     EVE_FORCEINLINE auto operator()(Rng&& rng, T v) const
     {
-      return find_if[TraitsSupport::get_traits()](std::forward<Rng>(rng), [v](auto x) { return x == v; });
+      return find_if[TraitsSupport::get_traits()](std::forward<Rng>(rng), equal_to{v});
     }
   };
 

--- a/include/eve/algo/find.hpp
+++ b/include/eve/algo/find.hpp
@@ -107,4 +107,16 @@ namespace eve::algo
   };
 
   inline constexpr auto find = function_with_traits<find_>[find_if.get_traits()];
+
+  template <typename TraitsSupport>
+  struct find_if_not_ : TraitsSupport
+  {
+    template <relaxed_range Rng, typename P>
+    EVE_FORCEINLINE auto operator()(Rng&& rng, P p) const
+    {
+      return find_if[TraitsSupport::get_traits()](std::forward<Rng>(rng), not_p{p});
+    }
+  };
+
+  inline constexpr auto find_if_not = function_with_traits<find_if_not_>[find_if.get_traits()];
 }

--- a/include/eve/algo/mismatch.hpp
+++ b/include/eve/algo/mismatch.hpp
@@ -24,8 +24,8 @@ namespace eve::algo
     template <zipped_range_pair R, typename P>
     EVE_FORCEINLINE auto operator()(R&& r, P p) const
     {
-      return algo::find_if[TraitsSupport::get_traits()]
-        (std::forward<R>(r), apply_to_zip_pair{not_p{p}});
+      return algo::find_if_not[TraitsSupport::get_traits()]
+        (std::forward<R>(r), apply_to_zip_pair{p});
     }
 
     template <zipped_range_pair R>

--- a/include/eve/algo/mismatch.hpp
+++ b/include/eve/algo/mismatch.hpp
@@ -25,11 +25,7 @@ namespace eve::algo
     EVE_FORCEINLINE auto operator()(R&& r, P p) const
     {
       return algo::find_if[TraitsSupport::get_traits()]
-        (std::forward<R>(r), [p](auto x_y) {
-          auto [x, y] = x_y;
-          return !p(x, y);
-        }
-      );
+        (std::forward<R>(r), apply_to_zip_pair{not_p{p}});
     }
 
     template <zipped_range_pair R>

--- a/include/eve/algo/remove.hpp
+++ b/include/eve/algo/remove.hpp
@@ -9,6 +9,7 @@
 
 #include <eve/algo/array_utils.hpp>
 #include <eve/algo/concepts.hpp>
+#include <eve/algo/common_forceinline_lambdas.hpp>
 #include <eve/algo/for_each_iteration.hpp>
 #include <eve/algo/preprocess_range.hpp>
 #include <eve/algo/traits.hpp>
@@ -39,7 +40,7 @@ namespace eve::algo
       template <typename I, std::size_t size>
       EVE_FORCEINLINE bool unrolled_step(std::array<I, size> arr)
       {
-        array_map(arr, [&](auto it) { return step(it, eve::ignore_none, eve::index<0>); });
+        array_map(arr, call_single_step(this));
         return false;
       }
 
@@ -70,7 +71,7 @@ namespace eve::algo
     template <relaxed_range Rng, typename T>
     EVE_FORCEINLINE auto operator()(Rng&& rng, T v) const
     {
-      return remove_if[TraitsSupport::get_traits()](std::forward<Rng>(rng), [v](auto x) { return x == v; });
+      return remove_if[TraitsSupport::get_traits()](std::forward<Rng>(rng), equal_to{v});
     }
   };
 

--- a/test/unit/algo/CMakeLists.txt
+++ b/test/unit/algo/CMakeLists.txt
@@ -35,6 +35,7 @@ make_unit("unit.algo" any_of_generic.cpp)
 make_unit("unit.algo" none_of_generic.cpp)
 
 make_unit("unit.algo" find_if_generic.cpp)
+make_unit("unit.algo" find_if_not_generic.cpp)
 
 make_unit("unit.algo" equal_generic.cpp)
 make_unit("unit.algo" mismatch_generic.cpp)

--- a/test/unit/algo/find_if_not_generic.cpp
+++ b/test/unit/algo/find_if_not_generic.cpp
@@ -1,0 +1,35 @@
+//==================================================================================================
+/**
+  EVE - Expressive Vector Engine
+  Copyright : EVE Contributors & Maintainers
+  SPDX-License-Identifier: MIT
+**/
+//==================================================================================================
+
+#include "algo_test.hpp"
+
+#include <eve/algo/find.hpp>
+
+#include "find_generic_test.hpp"
+
+template <typename TraitsSupport>
+struct find_if_with_find_if_not_ : TraitsSupport
+{
+  template <typename Rng, typename P>
+  EVE_FORCEINLINE auto operator()(Rng&& rng, P p) const
+  {
+    return eve::algo::find_if_not[TraitsSupport::get_traits()](std::forward<Rng>(rng),
+      [p](auto x) { return !p(x); });
+  }
+};
+
+inline constexpr auto find_if_with_find_if_not = eve::algo::function_with_traits<find_if_with_find_if_not_>;
+
+EVE_TEST_TYPES("eve.algo.find_if generic", algo_test::selected_types)
+<typename T>(eve::as<T> as_t)
+{
+  algo_test::find_generic_test(as_t, find_if_with_find_if_not,
+  [](auto, auto, auto expected, auto actual) {
+    TTS_EQUAL(actual, expected);
+  });
+};

--- a/test/unit/algo/find_like_special_cases.cpp
+++ b/test/unit/algo/find_like_special_cases.cpp
@@ -41,6 +41,10 @@ TTS_CASE("eve.algo.all/any/none/find_if, empty")
     (std::find_if(v.begin(), v.end(), p))
   );
   TTS_EQUAL(
+    (eve::algo::find_if_not(v, p)),
+    (std::find_if_not(v.begin(), v.end(), p))
+  );
+  TTS_EQUAL(
     (eve::algo::find(v, 1)),
     (std::find(v.begin(), v.end(), 1))
   );
@@ -51,6 +55,22 @@ TTS_CASE("eve.algo.find value")
   std::vector<int> const v{1, 2, 3, 4};
   std::vector<int>::const_iterator found = eve::algo::find[eve::algo::no_aligning](v, 3);
   TTS_EQUAL((found - v.begin()), 2);
+}
+
+TTS_CASE("eve.algo.find_if not in radius")
+{
+  std::vector<int> x {1, -1, 2, -10};
+  std::vector<int> y {0,  1, 2,   5};
+
+  int r = 6;
+
+  auto within_radius = [r_square = r * r](auto x_y) {
+    auto [x, y] = x_y;
+    return x * x + y * y <= r_square;
+  };
+
+  auto found = eve::algo::find_if_not(eve::algo::zip(x, y), within_radius);
+  TTS_EQUAL(eve::read(found), (kumi::tuple{-10, 5}));
 }
 
 TTS_CASE("eve.algo.mismatch example, use previous result") {


### PR DESCRIPTION
Those lambdas would most def not inline at some point and cause an issue.

Also, I was missing a `find_if_not` - added.