### PR TITLE
FIX-894: scan(wide, plus, zero)

### DIFF
--- a/include/eve/constant/zero.hpp
+++ b/include/eve/constant/zero.hpp
@@ -54,12 +54,13 @@ namespace eve
     template<typename T>
     EVE_FORCEINLINE T zero_(EVE_SUPPORTS(cpu_), eve::as<T> const &) noexcept
     {
-      if constexpr ( product_type<T> )
+      if constexpr ( kumi::product_type<T> )
       {
         // Can't just T{kumi::map} because that does not work for scalar product types
         T res;
         // This better inline.
         kumi::for_each([](auto& m) { m = zero(as(m)); }, res);
+
         return res;
       }
       else return T(0);

--- a/include/eve/constant/zero.hpp
+++ b/include/eve/constant/zero.hpp
@@ -54,8 +54,14 @@ namespace eve
     template<typename T>
     EVE_FORCEINLINE T zero_(EVE_SUPPORTS(cpu_), eve::as<T> const &) noexcept
     {
-      // This better inline.
-      if constexpr ( product_type<T> ) return T{kumi::map([](auto m) { return zero(as(m)); }, T{})};
+      if constexpr ( product_type<T> )
+      {
+        // Can't just T{kumi::map} because that does not work for scalar product types
+        T res;
+        // This better inline.
+        kumi::for_each([](auto& m) { m = zero(as(m)); }, res);
+        return res;
+      }
       else return T(0);
     }
   }

--- a/include/eve/constant/zero.hpp
+++ b/include/eve/constant/zero.hpp
@@ -52,9 +52,11 @@ namespace eve
   namespace detail
   {
     template<typename T>
-    EVE_FORCEINLINE auto zero_(EVE_SUPPORTS(cpu_), eve::as<T> const &) noexcept
+    EVE_FORCEINLINE T zero_(EVE_SUPPORTS(cpu_), eve::as<T> const &) noexcept
     {
-      return T(0);
+      // This better inline.
+      if constexpr ( product_type<T> ) return T{kumi::map([](auto m) { return zero(as(m)); }, T{})};
+      else return T(0);
     }
   }
 }

--- a/include/eve/detail/function/simd/common/slide_right.hpp
+++ b/include/eve/detail/function/simd/common/slide_right.hpp
@@ -17,6 +17,16 @@ namespace eve::detail
   inline constexpr
   auto slide_right_pattern = fix_pattern<N>( [](auto i, auto ){ return i<Shift ? na_ : i-Shift;} );
 
+
+  template <std::ptrdiff_t Shift>
+  struct slide_right_lambda
+  {
+    EVE_FORCEINLINE auto operator()(auto ... xs) const
+    {
+      return slide_right(xs..., index<Shift>);
+    }
+  };
+
   template<simd_value Wide, std::ptrdiff_t Shift>
   EVE_FORCEINLINE auto slide_right_(EVE_SUPPORTS(cpu_), Wide v, index_t<Shift>) noexcept
   requires(Shift <= Wide::size() )
@@ -32,7 +42,7 @@ namespace eve::detail
     }
     else if constexpr( is_bundle_v<typename Wide::abi_type> )
     {
-      return Wide( kumi::map ( []<typename T>(T m) { return slide_right(m,index<Shift>); }, v) );
+      return Wide( kumi::map ( slide_right_lambda<Shift>{}, v) );
     }
     else
     {
@@ -48,7 +58,7 @@ namespace eve::detail
     else if constexpr ( Shift == Wide::size()      ) return x;
     else if constexpr( is_bundle_v<typename Wide::abi_type> )
     {
-      return Wide( kumi::map ( []<typename T>(T mx, T my) { return slide_right(mx, my, index<Shift>); }, x, y) );
+      return Wide( kumi::map ( slide_right_lambda<Shift>{}, x, y) );
     }
     else if constexpr ( has_aggregated_abi_v<Wide> )
     {

--- a/include/eve/function/reduce.hpp
+++ b/include/eve/function/reduce.hpp
@@ -20,7 +20,7 @@ namespace eve
   //!
   //! **Required header:** `#include <eve/function/reduce.hpp>`
   //!
-  //! #### Members Functions
+  //! #### Member Functions
   //!
   //! | Member       | Effect                                                     |
   //! |:-------------|:-----------------------------------------------------------|

--- a/include/eve/function/scan.hpp
+++ b/include/eve/function/scan.hpp
@@ -1,0 +1,66 @@
+//==================================================================================================
+/*
+  EVE - Expressive Vector Engine
+  Copyright : EVE Contributors & Maintainers
+  SPDX-License-Identifier: MIT
+*/
+//==================================================================================================
+#pragma once
+
+#include <eve/detail/overload.hpp>
+
+namespace eve
+{
+  //================================================================================================
+  //! @addtogroup scan
+  //! !{
+  //! @var scan
+  //!
+  //! @brief Callabel object computing a generalized scan operation.
+  //!
+  //! **Required header:** `#include <eve/function/scan.hpp>`
+  //!
+  //! #### Member Functions
+  //!
+  //! | Member       | Effect                                          |
+  //! |:-------------|:------------------------------------------------|
+  //! | `operator()` | the computation of a generalized scan operation |
+  //!
+  //! ---
+  //!
+  //!  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
+  //!  template<simd_value T, Callable F, typename Zero> auto operator()( T v, F binary_op, Zero zero ) const noexcept;
+  //!  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  //!
+  //! **Parameters**
+  //!
+  //!`v`:   [simd value](@ref eve::simd_value) to scan.
+  //!
+  //!`binary_op`:   Binary callable object that perform a binary, commutative and associative operation.
+  //!
+  //! `zero`  :   An identity elelement for `binary_op` (binary_op(zero, v) == v) for any v.
+  //!             Acceptable:
+  //!                T
+  //!                anything convertible to T
+  //!                eve::zero
+  //!
+  //! `eve::zero`
+  //!
+  //! **Return value**
+  //!
+  //! Generalized scan of `v.get(0)`, `v.get(1)`, ... `v.get(v.size()-1)` over `binary_op`,
+  //!   T(v.get(0), binary_op(v.get(0), v.get(1)), binary_op(binary_op(v.get(0), v.get(1)), v.get(2)) ...)
+  //!
+  //!  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
+  //!  template<simd_value T> auto operator()( T v ) const noexcept;
+  //!  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  //!
+  //!   Same as scan(v, eve::plus, eve::zero)
+  //!
+  //!  @}
+
+  EVE_MAKE_CALLABLE(scan_, scan);
+}
+
+#include <eve/arch.hpp>
+#include <eve/module/real/algorithm/function/regular/generic/scan.hpp>

--- a/include/eve/function/scan.hpp
+++ b/include/eve/function/scan.hpp
@@ -64,3 +64,7 @@ namespace eve
 
 #include <eve/arch.hpp>
 #include <eve/module/real/algorithm/function/regular/generic/scan.hpp>
+
+#if defined(EVE_INCLUDE_X86_HEADER)
+#  include <eve/module/real/algorithm/function/regular/simd/x86/scan.hpp>
+#endif

--- a/include/eve/module/real/algorithm/function/regular/generic/scan.hpp
+++ b/include/eve/module/real/algorithm/function/regular/generic/scan.hpp
@@ -1,0 +1,69 @@
+//==================================================================================================
+/*
+  EVE - Expressive Vector Engine
+  Copyright : EVE Contributors & Maintainers
+  SPDX-License-Identifier: MIT
+*/
+//==================================================================================================
+#pragma once
+
+#include <eve/constant/zero.hpp>
+#include <eve/function/plus.hpp>
+#include <eve/function/slide_right.hpp>
+
+namespace eve::detail
+{
+  template <int group_size, simd_value Wide, typename Op>
+  EVE_FORCEINLINE Wide scan_common_impl(Wide x, Op op)
+  {
+    if constexpr (group_size == 1) return x;
+    else
+    {
+      x = scan_common_impl<group_size / 2>(x, op);
+      return op(x, slide_right(x, eve::index<group_size / 2>));
+    }
+  }
+
+  template <int group_size, simd_value Wide, typename Op>
+  EVE_FORCEINLINE Wide scan_common_impl(Wide x, Op op, Wide z)
+  {
+    if constexpr (group_size == 1) return x;
+    else
+    {
+      x = scan_common_impl<group_size / 2>(x, op, z);
+      return op(x, slide_right(z, x, eve::index<group_size / 2>));
+    }
+  }
+
+  template<simd_value Wide, typename Op, typename Zero>
+  EVE_FORCEINLINE Wide scan_(EVE_SUPPORTS(cpu_), Wide v, Op op, Zero z) noexcept
+  {
+         if constexpr ( Wide::size() == 1 ) return v;
+    else if constexpr ( has_emulated_abi_v<Wide> )
+    {
+      auto sum = v.get(0);
+
+      for (int i = 1; i != Wide::size(); ++i) {
+        sum = op(sum, v.get(i));
+        v.set(i, sum);
+      }
+
+      return v;
+    }
+    else if constexpr ( std::same_as<Zero, callable_zero_> )
+    {
+      return scan_common_impl<Wide::size()>(v, op);
+    }
+    else
+    {
+      return scan_common_impl<Wide::size()>(v, op, Wide{z});
+    }
+  }
+
+  template<simd_value Wide>
+  EVE_FORCEINLINE Wide scan_(EVE_SUPPORTS(cpu_), Wide v) noexcept
+  {
+    return scan(v, plus, eve::zero);
+  }
+
+}

--- a/include/eve/module/real/algorithm/function/regular/simd/x86/scan.hpp
+++ b/include/eve/module/real/algorithm/function/regular/simd/x86/scan.hpp
@@ -15,16 +15,32 @@ namespace eve::detail
 {
 
 template <typename T, typename N, std::ptrdiff_t Shift>
+EVE_FORCEINLINE wide<T, N> slide_right_in_lanes(wide<T, N> x, wide<T, N> y, index_t<Shift>);
+
+template <std::ptrdiff_t Shift>
+struct slide_right_in_lanes_lambda
+{
+  EVE_FORCEINLINE auto operator()(auto ... x) const
+  {
+    return slide_right_in_lanes(x..., index<Shift>);
+  }
+};
+
+template <typename T, typename N, std::ptrdiff_t Shift>
 EVE_FORCEINLINE wide<T, N> slide_right_in_lanes(wide<T, N> x, wide<T, N> y, index_t<Shift>)
   requires (current_api == avx2)
 {
-  using i_t = as_integer_t<wide<T,N>, unsigned>;
+  if constexpr ( is_bundle_v<abi_t<T, N>> ) return wide<T, N>{kumi::map(slide_right_in_lanes_lambda<Shift>{}, x, y)};
+  else
+  {
+    using i_t = as_integer_t<wide<T,N>, unsigned>;
 
   i_t lhs = eve::bit_cast(x, eve::as<i_t>{});
   i_t rhs = eve::bit_cast(y, eve::as<i_t>{});
   i_t res = _mm256_alignr_epi8(rhs, lhs, 16 - Shift * sizeof(T));
 
   return eve::bit_cast(res, eve::as(x));
+  }
 }
 
 template <simd_value Wide, std::ptrdiff_t Shift>
@@ -46,17 +62,33 @@ EVE_FORCEINLINE Wide scan_in_lanes(Wide x, Op op, Wide z)
   }
 }
 
+template <simd_value Wide>
+auto use_scan_in_lanes(Wide) {
+       if constexpr ( std::same_as<typename Wide::abi_type, x86_256_> ) return std::true_type{};
+  else if constexpr ( is_bundle_v<typename Wide::abi_type> )
+  {
+    return kumi::fold_right([]<bool so_far, typename T>(std::bool_constant<so_far>, T) {
+      return std::bool_constant<so_far && decltype(use_scan_in_lanes(T{}))::value>{};
+    }, Wide{}, std::true_type{});
+  }
+  else return std::false_type{};
+}
+
 template <simd_value Wide, typename Op, typename Zero>
 EVE_FORCEINLINE auto scan_(EVE_SUPPORTS(avx2_), Wide v, Op op, Zero z_)
-  requires (current_api == avx2 && std::same_as<typename Wide::abi_type, x86_256_> )
+  requires (current_api == avx2 )
 {
-  Wide z;
-  if constexpr ( std::same_as<Zero, callable_zero_> ) z = z_(as<Wide>{});
-  else                                                z = z_;
+  if constexpr ( decltype(use_scan_in_lanes(v))::value )
+  {
+    Wide z;
+    if constexpr ( std::same_as<Zero, callable_zero_> ) z = z_(as<Wide>{});
+    else                                                z = z_;
 
-  v = scan_in_lanes<Wide::size() / 2>(v, op, z);
-  Wide left_sum = broadcast(v, index<Wide::size() / 2 - 1>);
-  return op(v, slide_right(z, left_sum, index<Wide::size() / 2>));
+    v = scan_in_lanes<Wide::size() / 2>(v, op, z);
+    Wide left_sum = broadcast(v, index<Wide::size() / 2 - 1>);
+    return op(v, slide_right(z, left_sum, index<Wide::size() / 2>));
+  }
+  else return scan_(EVE_RETARGET(cpu_), v, op, z_);
 }
 
 }

--- a/include/eve/module/real/algorithm/function/regular/simd/x86/scan.hpp
+++ b/include/eve/module/real/algorithm/function/regular/simd/x86/scan.hpp
@@ -1,0 +1,62 @@
+//==================================================================================================
+/**
+  EVE - Expressive Vector Engine
+  Copyright : EVE Contributors & Maintainers
+  SPDX-License-Identifier: MIT
+**/
+//==================================================================================================
+#pragma once
+
+#include <eve/detail/implementation.hpp>
+
+#include <eve/function/broadcast.hpp>
+
+namespace eve::detail
+{
+
+template <typename T, typename N, std::ptrdiff_t Shift>
+EVE_FORCEINLINE wide<T, N> slide_right_in_lanes(wide<T, N> x, wide<T, N> y, index_t<Shift>)
+  requires (current_api == avx2)
+{
+  using i_t = as_integer_t<wide<T,N>, unsigned>;
+
+  i_t lhs = eve::bit_cast(x, eve::as<i_t>{});
+  i_t rhs = eve::bit_cast(y, eve::as<i_t>{});
+  i_t res = _mm256_alignr_epi8(rhs, lhs, 16 - Shift * sizeof(T));
+
+  return eve::bit_cast(res, eve::as(x));
+}
+
+template <simd_value Wide, std::ptrdiff_t Shift>
+EVE_FORCEINLINE logical<Wide> slide_right_in_lanes(logical<Wide> x
+                                                 , logical<Wide> y
+                                                 , index_t<Shift> s)
+{
+  return bit_cast(slide_right_in_lanes(x.bits(), y.bits(), s), as<logical<Wide>>{});
+}
+
+template <int group_size, simd_value Wide, typename Op>
+EVE_FORCEINLINE Wide scan_in_lanes(Wide x, Op op, Wide z)
+{
+  if constexpr (group_size == 1) return x;
+  else
+  {
+    x = scan_in_lanes<group_size / 2>(x, op, z);
+    return op(x, slide_right_in_lanes(z, x, eve::index<group_size / 2>));
+  }
+}
+
+template <simd_value Wide, typename Op, typename Zero>
+EVE_FORCEINLINE auto scan_(EVE_SUPPORTS(avx2_), Wide v, Op op, Zero z_)
+  requires (current_api == avx2 && std::same_as<typename Wide::abi_type, x86_256_> )
+{
+  Wide z;
+  if constexpr ( std::same_as<Zero, callable_zero_> ) z = z_(as<Wide>{});
+  else                                                z = z_;
+
+  v = scan_in_lanes<Wide::size() / 2>(v, op, z);
+  Wide left_sum = broadcast(v, index<Wide::size() / 2 - 1>);
+  return op(v, slide_right(z, left_sum, index<Wide::size() / 2>));
+}
+
+}

--- a/test/unit/api/tuple/CMakeLists.txt
+++ b/test/unit/api/tuple/CMakeLists.txt
@@ -8,6 +8,7 @@
 ## Wide API tests
 make_unit("unit.api.tuple"  comparison.cpp                    )
 make_unit("unit.api.tuple"  conditional.cpp                   )
+make_unit("unit.api.tuple"  algorithm/scan.cpp                )
 make_unit("unit.api.tuple"  swizzle/broadcast.cpp             )
 make_unit("unit.api.tuple"  swizzle/broadcast_group.cpp       )
 make_unit("unit.api.tuple"  swizzle/identity.cpp              )

--- a/test/unit/api/tuple/CMakeLists.txt
+++ b/test/unit/api/tuple/CMakeLists.txt
@@ -9,6 +9,7 @@
 make_unit("unit.api.tuple"  comparison.cpp                    )
 make_unit("unit.api.tuple"  conditional.cpp                   )
 make_unit("unit.api.tuple"  algorithm/scan.cpp                )
+make_unit("unit.api.tuple"  constant/zero.cpp                 )
 make_unit("unit.api.tuple"  swizzle/broadcast.cpp             )
 make_unit("unit.api.tuple"  swizzle/broadcast_group.cpp       )
 make_unit("unit.api.tuple"  swizzle/identity.cpp              )

--- a/test/unit/api/tuple/algorithm/scan.cpp
+++ b/test/unit/api/tuple/algorithm/scan.cpp
@@ -31,7 +31,7 @@ EVE_TEST_TYPES( "Check behavior of scan", eve::test::scalar::all_types)
   w_t actual_1 = eve::scan(x, plus, eve::zero);
   TTS_EQUAL(expected, actual_1);
 
-  w_t actual_2 = eve::scan(x, plus, s_t{0});
+  w_t actual_2 = eve::scan(x, plus, s_t{0, 0, 0});
   TTS_EQUAL(expected, actual_2);
 
   w_t actual_3 = eve::scan(x, plus, eve::zero(eve::as<w_t>{}));
@@ -60,7 +60,7 @@ EVE_TEST_TYPES( "Check behavior of scan, same type", eve::test::scalar::all_type
   w_t actual_1 = eve::scan(x, plus, eve::zero);
   TTS_EQUAL(expected, actual_1);
 
-  w_t actual_2 = eve::scan(x, plus, s_t{0});
+  w_t actual_2 = eve::scan(x, plus, s_t{0, 0, 0});
   TTS_EQUAL(expected, actual_2);
 
   w_t actual_3 = eve::scan(x, plus, eve::zero(eve::as<w_t>{}));

--- a/test/unit/api/tuple/algorithm/scan.cpp
+++ b/test/unit/api/tuple/algorithm/scan.cpp
@@ -1,0 +1,36 @@
+//==================================================================================================
+/**
+  EVE - Expressive Vector Engine
+  Copyright : EVE Contributors & Maintainers
+  SPDX-License-Identifier: MIT
+**/
+//==================================================================================================
+
+#include "test.hpp"
+
+#include <eve/function/scan.hpp>
+
+EVE_TEST_TYPES( "Check behavior of scan", eve::test::scalar::all_types)
+<typename T>(eve::as<T>)
+{
+  using s_t = kumi::tuple<std::int8_t,T,double>;
+  using w_t = eve::wide<s_t>;
+
+  w_t x = [](auto i, auto) { return  s_t { static_cast<std::int8_t>(65+i)
+                                          , static_cast<T>(i + 1)
+                                          , 1.5*(1+i)
+                                          };
+                            };
+
+  w_t expected = kumi::map(eve::scan, x);
+
+  auto plus = [](auto a, auto b) {
+    return kumi::map(eve::plus, a, b);
+  };
+
+  w_t actual_1 = eve::scan(x, plus, eve::zero);
+  TTS_EQUAL(expected, actual_1);
+
+  w_t actual_2 = eve::scan(x, plus, s_t{0});
+  TTS_EQUAL(expected, actual_2);
+};

--- a/test/unit/api/tuple/algorithm/scan.cpp
+++ b/test/unit/api/tuple/algorithm/scan.cpp
@@ -33,4 +33,36 @@ EVE_TEST_TYPES( "Check behavior of scan", eve::test::scalar::all_types)
 
   w_t actual_2 = eve::scan(x, plus, s_t{0});
   TTS_EQUAL(expected, actual_2);
+
+  w_t actual_3 = eve::scan(x, plus, eve::zero(eve::as<w_t>{}));
+  TTS_EQUAL(expected, actual_3);
+};
+
+
+EVE_TEST_TYPES( "Check behavior of scan, same type", eve::test::scalar::all_types)
+<typename T>(eve::as<T>)
+{
+  using s_t = kumi::tuple<T,T,T>;
+  using w_t = eve::wide<s_t>;
+
+  w_t x = [](auto i, auto) { return  s_t {  (T)(i - 1)
+                                          , (T)i
+                                          , (T)(i + 1)
+                                          };
+                            };
+
+  w_t expected = kumi::map(eve::scan, x);
+
+  auto plus = [](auto a, auto b) {
+    return kumi::map(eve::plus, a, b);
+  };
+
+  w_t actual_1 = eve::scan(x, plus, eve::zero);
+  TTS_EQUAL(expected, actual_1);
+
+  w_t actual_2 = eve::scan(x, plus, s_t{0});
+  TTS_EQUAL(expected, actual_2);
+
+  w_t actual_3 = eve::scan(x, plus, eve::zero(eve::as<w_t>{}));
+  TTS_EQUAL(expected, actual_3);
 };

--- a/test/unit/api/tuple/constant/zero.cpp
+++ b/test/unit/api/tuple/constant/zero.cpp
@@ -1,0 +1,22 @@
+//==================================================================================================
+/**
+  EVE - Expressive Vector Engine
+  Copyright : EVE Contributors & Maintainers
+  SPDX-License-Identifier: MIT
+**/
+//==================================================================================================
+
+#include "test.hpp"
+
+#include <eve/constant/zero.hpp>
+
+#include "unit/api/udt/udt.hpp"
+
+TTS_CASE("zero for different tuples")
+{
+  using plain_tuple = kumi::tuple<int, std::int8_t>;
+  TTS_TYPE_IS(plain_tuple, decltype(eve::zero(eve::as<plain_tuple>{})));
+
+  TTS_TYPE_IS(udt::grid2d, decltype(eve::zero(eve::as<udt::grid2d>{})));
+  TTS_TYPE_IS(eve::wide<udt::grid2d>, decltype(eve::zero(eve::as<eve::wide<udt::grid2d>>{})));
+}

--- a/test/unit/module/real/algorithm/CMakeLists.txt
+++ b/test/unit/module/real/algorithm/CMakeLists.txt
@@ -28,3 +28,4 @@ make_all_units(ROOT unit.real.algorithm NAME none        ARCH scalar  simd TYPES
 make_unit("unit.real.algorithm"  maximum.cpp )
 make_unit("unit.real.algorithm"  minimum.cpp )
 make_unit("unit.real.algorithm"  reduce.cpp )
+make_unit("unit.real.algorithm"  scan.cpp )

--- a/test/unit/module/real/algorithm/scan.cpp
+++ b/test/unit/module/real/algorithm/scan.cpp
@@ -1,0 +1,66 @@
+//==================================================================================================
+/**
+  EVE - Expressive Vector Engine
+  Copyright : EVE Contributors & Maintainers
+  SPDX-License-Identifier: MIT
+**/
+//==================================================================================================
+
+#include "test.hpp"
+#include <eve/function/scan.hpp>
+#include <eve/function/min.hpp>
+
+#include <algorithm>
+
+EVE_TEST( "Check behavior of default scan"
+        , eve::test::simd::all_types
+        , eve::test::generate ( eve::test::randoms(-50, 50) )
+        )
+<typename T>(T simd)
+{
+  eve::element_type_t<T> sum = 0;
+  T expected { [&] (int i, int) mutable
+  {
+    sum += simd.get(i);
+    return sum;
+  }};
+
+  T actual = eve::scan(simd);
+
+  if constexpr ( std::floating_point<eve::element_type_t<T>> )
+  {
+    T diff = eve::abs(expected - actual);
+    T eps {0.0001};
+    TTS_EXPECT(eve::all(diff < eps));
+  }
+  else
+  {
+    TTS_EQUAL(expected, actual);
+  }
+};
+
+EVE_TEST( "Check behavior of scan with min"
+        , eve::test::simd::all_types
+        , eve::test::generate ( eve::test::randoms(-50, 50) )
+        )
+<typename T>(T simd)
+{
+  eve::element_type_t<T> sum = simd.get(0);
+  T expected { [&] (int i, int) mutable
+  {
+    sum = std::min(simd.get(i), sum);
+    return sum;
+  }};
+
+  T actual = eve::scan(simd, eve::min, simd.get(0));
+  TTS_EQUAL(expected, actual);
+};
+
+EVE_TEST_TYPES( "Check behavior of scan for logicals", eve::test::simd::all_types)
+<typename T>(eve::as<T>)
+{
+  eve::logical<T> input    {[](int i, int) { return i != 3; }};
+  eve::logical<T> expected {[](int i, int) { return i <  3; }};
+  eve::logical<T> actual = eve::scan(input, eve::logical_and, true);
+  TTS_EQUAL(expected, actual);
+};


### PR DESCRIPTION
* changed `eve::zero` to map for product types. This sort of makes sense and is needed.
* saw missing force inline lambdas in a couple of places.
* wrote the basic scan implementation
* wrote an avx2 specific scan implementation. I actually don't know if it's better, but that's what I have in my code and I don't want to deal with regression later.
* The avx2 version has its own shuffle, we can extract it later. Probably as part of this: https://github.com/jfalcou/eve/issues/929
* We didn't agree on how we want to test the algorithms for tuples, I did smth.