### PR TITLE
FIX-888: `like` concept and a CRTP base to ease creating of structs.

### DIFF
--- a/examples/oop/complex_numbers__declaring_an_object_type.cpp
+++ b/examples/oop/complex_numbers__declaring_an_object_type.cpp
@@ -44,7 +44,7 @@
 // So we recommend writing EVE_FORCEINLINE on all functions that are not the outside loop.
 //
 
-struct cmplx : eve::product_type_base<cmplx, float, float>
+struct cmplx : eve::struct_support<cmplx, float, float>
 {
   // Instead of normal getters/setters we suggest to write ADL friend functions.
   // This will also be accessible for `eve::wide<cmplx>`.

--- a/examples/oop/complex_numbers__declaring_an_object_type.cpp
+++ b/examples/oop/complex_numbers__declaring_an_object_type.cpp
@@ -106,7 +106,7 @@ struct cmplx : eve::product_type_base<cmplx, float, float>
   // We find it useful but you do it at your own risk, we are quite likely to break you.
   // Alternatively - use your own functions.
 
-  EVE_FORCEINLINE friend auto tagged_dispatch( eve::tag::abs_, eve::same_value_type<cmplx> auto self)
+  EVE_FORCEINLINE friend auto tagged_dispatch( eve::tag::abs_, eve::like<cmplx> auto self)
   {
     // NOTE: We think this can be done more efficiently, but this is an example.
     return eve::sqrt(re(self) * re(self) + im(self) * im(self));
@@ -140,7 +140,7 @@ void inclusive_scan_complex_components(std::vector<float>& re_parts, std::vector
 
 #include <sstream>
 
-bool rougly_equal(eve::same_value_type<cmplx> auto x, eve::same_value_type<cmplx> auto y)
+bool rougly_equal(eve::like<cmplx> auto x, eve::like<cmplx> auto y)
 {
   auto re_test = eve::abs(re(x) - re(y)) < 0.00001;
   auto im_test = eve::abs(im(x) - im(y)) < 0.00001;

--- a/include/eve/arch/cpu/wide.hpp
+++ b/include/eve/arch/cpu/wide.hpp
@@ -80,6 +80,9 @@ namespace eve
     //! Type for indexing element in a eve::wide
     using size_type     = typename card_base::size_type;
 
+    //! Opt-in for like concept
+    using is_like = value_type;
+
     //! @brief Generates a eve::wide from a different type `T` and cardinal `N`.
     //! If unspecified, `N` is computed as `expected_cardinal_t<T>`.
     template<typename T, typename N = expected_cardinal_t<T>> using rebind = wide<T,N>;

--- a/include/eve/detail/kumi.hpp
+++ b/include/eve/detail/kumi.hpp
@@ -797,12 +797,6 @@ namespace kumi
     return (detail::foldable {cc, KUMI_FWD(t)} << ... << detail::foldable {cc, KUMI_FWD(us)}).value;
   }
 
-  template<product_type T1, product_type T2>
-  [[nodiscard]] constexpr auto operator|(T1 &&t1, T2 &&t2)
-  {
-    return kumi::cat(KUMI_FWD(t1), KUMI_FWD(t2));
-  }
-
   namespace result
   {
     template<product_type T, product_type... Tuples> struct cat

--- a/include/eve/product_type.hpp
+++ b/include/eve/product_type.hpp
@@ -69,4 +69,122 @@ namespace eve
 
   template<typename Type>
   inline constexpr bool supports_ordering_v = supports_ordering<Type>::value;
+
+   //================================================================================================
+  //! @addtogroup struct
+  //! @{
+  //!   @struct supports_like
+  //!   @concept like
+  //!
+  //!   `like<Wrapper, T>` is a concept that describes a wrapper for which most of the functionality
+  //!   for T should be applicable. T is always like T.
+  //!
+  //!   `like< Wrapper, T>` is true if Wrapper defines a typedef `using is_like = T` or
+  //!   specialises `eve::supports_like`.
+  //!
+  //!   Example: `eve::wide<T>` is `like<T>`.
+  //!
+  //!   This is used to work with custom structs in eve, see `oop` section in `examples`.
+  //! @}
+  //================================================================================================
+
+
+  template<typename Wrapper, typename Self> struct supports_like : std::false_type {};
+
+  template <typename Wrapper, typename Self>
+  requires requires(Wrapper) { typename Wrapper::is_like; }
+  struct supports_like<Wrapper, Self> :
+  std::bool_constant<std::same_as<Self, typename std::remove_cvref_t<Wrapper>::is_like>>
+  {};
+
+  template<typename Wrapper, typename Self>
+  concept like = std::same_as<std::remove_cvref_t<Wrapper>, Self> ||
+                 supports_like<std::remove_cvref_t<Wrapper>, Self>::value;
+
+  //================================================================================================
+  //! @addtogroup struct
+  //! @{
+  //!   @struct product_type_base<Self, ...Fields>
+  //!   @brief  a helper CRTP base to declare user defined types easier
+  //!
+  //!   It will generate a member wise equality.
+  //!   It will also generate a lexicographical order for your type, unless !supports_ordering_v<Self>
+  //!
+  //!   It generated the not mutating operator version from a mutating one (like operator+ from operator+=),
+  //!   however does not go further than that (like operator-= b from operator+= and operator-)
+  //!   since simd has an instruction for `-` and you want `operator-=` to be declared separately.
+  //!
+  //! @}
+  template <typename Self, typename ... Fields>
+  struct product_type_base;
+
+  namespace detail
+  {
+    std::false_type derived_from_product_type_base_impl(...);
+
+    template <typename Self, typename ... Fields>
+    std::true_type derived_from_product_type_base_impl(product_type_base<Self, Fields...> const&);
+
+    template <typename Type>
+    concept derived_from_product_type_base = decltype(derived_from_product_type_base_impl(Type{}))::value;
+  }
+
+  template <typename Self, typename ... Fields>
+  struct product_type_base : kumi::tuple<Fields...>
+  {
+    using tuple = kumi::tuple<Fields...>;
+
+    EVE_FORCEINLINE friend auto operator+(eve::like<Self> auto x, eve::like<Self> auto y) requires requires { x += y; }
+    {
+      x += y;
+      return x;
+    }
+
+    EVE_FORCEINLINE friend auto operator-(eve::like<Self> auto x, eve::like<Self> auto y) requires requires { x -= y; }
+    {
+      x -= y;
+      return x;
+    }
+
+    EVE_FORCEINLINE friend auto operator*(eve::like<Self> auto x, eve::like<Self> auto y) requires requires { x *= y; }
+    {
+      x *= y;
+      return x;
+    }
+
+    EVE_FORCEINLINE friend auto operator/(eve::like<Self> auto x, eve::like<Self> auto y) requires requires { x /= y; }
+    {
+      x /= y;
+      return x;
+    }
+
+    EVE_FORCEINLINE friend auto operator%(eve::like<Self> auto x, eve::like<Self> auto y) requires requires { x %= y; }
+    {
+      x %= y;
+      return x;
+    }
+
+    EVE_FORCEINLINE friend auto operator<<(eve::like<Self> auto x, integral_value auto s) requires requires { x <<= s; }
+    {
+      x <<= s;
+      return x;
+    }
+
+    EVE_FORCEINLINE friend auto operator>>(eve::like<Self> auto x, integral_value auto s) requires requires { x >>= s; }
+    {
+      x >>= s;
+      return x;
+    }
+
+    friend auto operator< (eve::like<Self> auto x, eve::like<Self> auto y) requires (!supports_ordering_v<Self>) = delete;
+    friend auto operator<=(eve::like<Self> auto x, eve::like<Self> auto y) requires (!supports_ordering_v<Self>) = delete;
+    friend auto operator> (eve::like<Self> auto x, eve::like<Self> auto y) requires (!supports_ordering_v<Self>) = delete;
+    friend auto operator>=(eve::like<Self> auto x, eve::like<Self> auto y) requires (!supports_ordering_v<Self>) = delete;
+  };
 }
+
+template <eve::detail::derived_from_product_type_base Type>
+struct std::tuple_size<Type> : std::tuple_size<typename Type::tuple> {};
+
+template <std::size_t I, eve::detail::derived_from_product_type_base Type>
+struct std::tuple_element<I, Type> : std::tuple_element<I, typename Type::tuple> {};

--- a/include/eve/product_type.hpp
+++ b/include/eve/product_type.hpp
@@ -104,7 +104,7 @@ namespace eve
   //================================================================================================
   //! @addtogroup struct
   //! @{
-  //!   @struct product_type_base<Self, ...Fields>
+  //!   @struct struct_support<Self, ...Fields>
   //!   @brief  a helper CRTP base to declare user defined types easier
   //!
   //!   It will generate a member wise equality.
@@ -116,23 +116,23 @@ namespace eve
   //!
   //! @}
   template <typename Self, typename ... Fields>
-  struct product_type_base;
+  struct struct_support;
 
   namespace detail
   {
-    std::false_type derived_from_product_type_base_impl(...);
+    std::false_type derived_from_struct_support_impl(...);
 
     template <typename Self, typename ... Fields>
-    std::true_type derived_from_product_type_base_impl(product_type_base<Self, Fields...> const&);
+    std::true_type derived_from_struct_support_impl(struct_support<Self, Fields...> const&);
 
     template <typename Type>
-    concept derived_from_product_type_base = decltype(derived_from_product_type_base_impl(Type{}))::value;
+    concept derived_from_struct_support = decltype(derived_from_struct_support_impl(Type{}))::value;
   }
 
   template <typename Self, typename ... Fields>
-  struct product_type_base : kumi::tuple<Fields...>
+  struct struct_support : kumi::tuple<Fields...>
   {
-    using tuple = kumi::tuple<Fields...>;
+    using tuple_type = kumi::tuple<Fields...>;
 
     EVE_FORCEINLINE friend auto operator+(eve::like<Self> auto x, eve::like<Self> auto y) requires requires { x += y; }
     {
@@ -164,6 +164,24 @@ namespace eve
       return x;
     }
 
+    EVE_FORCEINLINE friend auto operator^(eve::like<Self> auto x, eve::like<Self> auto y) requires requires { x ^= y; }
+    {
+      x ^= y;
+      return x;
+    }
+
+    EVE_FORCEINLINE friend auto operator&(eve::like<Self> auto x, eve::like<Self> auto y) requires requires { x &= y; }
+    {
+      x &= y;
+      return x;
+    }
+
+    EVE_FORCEINLINE friend auto operator|(eve::like<Self> auto x, eve::like<Self> auto y) requires requires { x |= y; }
+    {
+      x |= y;
+      return x;
+    }
+
     EVE_FORCEINLINE friend auto operator<<(eve::like<Self> auto x, integral_value auto s) requires requires { x <<= s; }
     {
       x <<= s;
@@ -183,8 +201,8 @@ namespace eve
   };
 }
 
-template <eve::detail::derived_from_product_type_base Type>
-struct std::tuple_size<Type> : std::tuple_size<typename Type::tuple> {};
+template <eve::detail::derived_from_struct_support Type>
+struct std::tuple_size<Type> : std::tuple_size<typename Type::tuple_type> {};
 
-template <std::size_t I, eve::detail::derived_from_product_type_base Type>
-struct std::tuple_element<I, Type> : std::tuple_element<I, typename Type::tuple> {};
+template <std::size_t I, eve::detail::derived_from_struct_support Type>
+struct std::tuple_element<I, Type> : std::tuple_element<I, typename Type::tuple_type> {};

--- a/test/unit/algo/algorithm/sums_special_cases.cpp
+++ b/test/unit/algo/algorithm/sums_special_cases.cpp
@@ -23,8 +23,8 @@ TTS_CASE("eve.algo.reduce sum complex numbers")
 
   using cmplx = kumi::tuple<float, float>;
 
-  auto plus = [](eve::same_value_type<cmplx> auto x,
-                 eve::same_value_type<cmplx> auto y) {
+  auto plus = [](eve::like<cmplx> auto x,
+                 eve::like<cmplx> auto y) {
     get<0>(x) += get<0>(y);
     get<1>(x) += get<1>(y);
     return x;
@@ -59,8 +59,8 @@ TTS_CASE("eve.algo.inclusive_scan complex numbers")
 
   using cmplx = kumi::tuple<float, float>;
 
-  auto plus = [](eve::same_value_type<cmplx> auto x,
-                 eve::same_value_type<cmplx> auto y) {
+  auto plus = [](eve::like<cmplx> auto x,
+                 eve::like<cmplx> auto y) {
     get<0>(x) += get<0>(y);
     get<1>(x) += get<1>(y);
     return x;

--- a/test/unit/algo/udt.hpp
+++ b/test/unit/algo/udt.hpp
@@ -12,27 +12,15 @@
 namespace udt
 {
 
-using i32_x2    = kumi::tuple<std::int32_t, std::int32_t>;
-
-struct point2D : i32_x2 {
+struct point2D : eve::product_type_base<point2D, std::int32_t, std::int32_t> {
   friend decltype(auto) get_x(eve::same_value_type<point2D> auto&& self) { return get<0>(std::forward<decltype(self)>(self)); }
   friend decltype(auto) get_y(eve::same_value_type<point2D> auto&& self) { return get<1>(std::forward<decltype(self)>(self)); }
 };
 
-using points2D_2 = kumi::tuple<point2D, point2D>;
-
-struct line2D: points2D_2
+struct line2D: eve::product_type_base<line2D, point2D, point2D>
 {
   friend decltype(auto) get_start(eve::same_value_type<line2D> auto&& self) { return get<0>(std::forward<decltype(self)>(self)); }
   friend decltype(auto) get_end  (eve::same_value_type<line2D> auto&& self) { return get<1>(std::forward<decltype(self)>(self)); }
 };
 
 }
-
-template<>              struct eve::is_product_type<udt::point2D> : std::true_type {};
-template<>              struct std::tuple_size<udt::point2D>      : std::tuple_size<udt::i32_x2> {};
-template<std::size_t I> struct std::tuple_element<I,udt::point2D> : std::tuple_element<I, udt::i32_x2> {};
-
-template<>              struct eve::is_product_type<udt::line2D> : std::true_type {};
-template<>              struct std::tuple_size<udt::line2D>      : std::tuple_size<udt::points2D_2> {};
-template<std::size_t I> struct std::tuple_element<I,udt::line2D> : std::tuple_element<I, udt::points2D_2> {};

--- a/test/unit/algo/udt.hpp
+++ b/test/unit/algo/udt.hpp
@@ -13,14 +13,14 @@ namespace udt
 {
 
 struct point2D : eve::product_type_base<point2D, std::int32_t, std::int32_t> {
-  friend decltype(auto) get_x(eve::same_value_type<point2D> auto&& self) { return get<0>(std::forward<decltype(self)>(self)); }
-  friend decltype(auto) get_y(eve::same_value_type<point2D> auto&& self) { return get<1>(std::forward<decltype(self)>(self)); }
+  friend decltype(auto) get_x(eve::like<point2D> auto&& self) { return get<0>(std::forward<decltype(self)>(self)); }
+  friend decltype(auto) get_y(eve::like<point2D> auto&& self) { return get<1>(std::forward<decltype(self)>(self)); }
 };
 
 struct line2D: eve::product_type_base<line2D, point2D, point2D>
 {
-  friend decltype(auto) get_start(eve::same_value_type<line2D> auto&& self) { return get<0>(std::forward<decltype(self)>(self)); }
-  friend decltype(auto) get_end  (eve::same_value_type<line2D> auto&& self) { return get<1>(std::forward<decltype(self)>(self)); }
+  friend decltype(auto) get_start(eve::like<line2D> auto&& self) { return get<0>(std::forward<decltype(self)>(self)); }
+  friend decltype(auto) get_end  (eve::like<line2D> auto&& self) { return get<1>(std::forward<decltype(self)>(self)); }
 };
 
 }

--- a/test/unit/algo/udt.hpp
+++ b/test/unit/algo/udt.hpp
@@ -12,12 +12,12 @@
 namespace udt
 {
 
-struct point2D : eve::product_type_base<point2D, std::int32_t, std::int32_t> {
+struct point2D : eve::struct_support<point2D, std::int32_t, std::int32_t> {
   friend decltype(auto) get_x(eve::like<point2D> auto&& self) { return get<0>(std::forward<decltype(self)>(self)); }
   friend decltype(auto) get_y(eve::like<point2D> auto&& self) { return get<1>(std::forward<decltype(self)>(self)); }
 };
 
-struct line2D: eve::product_type_base<line2D, point2D, point2D>
+struct line2D: eve::struct_support<line2D, point2D, point2D>
 {
   friend decltype(auto) get_start(eve::like<line2D> auto&& self) { return get<0>(std::forward<decltype(self)>(self)); }
   friend decltype(auto) get_end  (eve::like<line2D> auto&& self) { return get<1>(std::forward<decltype(self)>(self)); }

--- a/test/unit/api/udt/CMakeLists.txt
+++ b/test/unit/api/udt/CMakeLists.txt
@@ -7,5 +7,6 @@
 ##==================================================================================================
 ## Wide API tests over User Defined Type
 make_unit("unit.api.udt"  conditional.cpp  )
-make_unit("unit.api.udt"  comparison.cpp  )
-make_unit("unit.api.udt"  wide.cpp        )
+make_unit("unit.api.udt"  comparison.cpp   )
+make_unit("unit.api.udt"  product_type.cpp )
+make_unit("unit.api.udt"  wide.cpp         )

--- a/test/unit/api/udt/product_type.cpp
+++ b/test/unit/api/udt/product_type.cpp
@@ -1,0 +1,162 @@
+//==================================================================================================
+/**
+  EVE - Expressive Vector Engine
+  Copyright : EVE Contributors & Maintainers
+  SPDX-License-Identifier: MIT
+**/
+//==================================================================================================
+#include "test.hpp"
+
+#include <eve/product_type.hpp>
+
+template <typename T>
+struct wrapper
+{
+  using is_like = T;
+};
+
+template<> struct eve::supports_like<wrapper<int>, std::int64_t> : std::true_type {};
+
+TTS_CASE("like concet")
+{
+  { eve::like<int> auto _ = 3; (void)_; }
+  { eve::like<int> auto _ = wrapper<int>{}; (void)_; }
+
+  TTS_CONSTEXPR_EXPECT_NOT((eve::like<wrapper<int>, char>));
+  { eve::like<std::int64_t> auto _ = wrapper<int>{}; (void)_; }
+}
+
+struct supports_all_ops :
+  eve::product_type_base<supports_all_ops, int, std::int64_t>
+{
+  friend decltype(auto) m0(eve::like<supports_all_ops> auto&& self)
+  {
+    return get<0>(std::forward<decltype(self)>(self));
+  }
+
+  friend decltype(auto) m1(eve::like<supports_all_ops> auto&& self)
+  {
+    return get<1>(std::forward<decltype(self)>(self));
+  }
+
+  friend auto& operator+=(eve::like<supports_all_ops> auto& self,
+                          eve::like<supports_all_ops> auto const& other) {
+    m0(self) += m0(other);
+    m1(self) += m1(other);
+    return self;
+  }
+
+  friend auto& operator-=(eve::like<supports_all_ops> auto& self,
+                          eve::like<supports_all_ops> auto const& other) {
+    m0(self) -= m0(other);
+    m1(self) -= m1(other);
+    return self;
+  }
+
+  friend auto& operator*=(eve::like<supports_all_ops> auto& self,
+                          eve::like<supports_all_ops> auto const& other) {
+    m0(self) *= m0(other);
+    m1(self) *= m1(other);
+    return self;
+  }
+
+  friend auto& operator/=(eve::like<supports_all_ops> auto& self,
+                          eve::like<supports_all_ops> auto const& other) {
+    m0(self) /= m0(other);
+    m1(self) /= m1(other);
+    return self;
+  }
+
+  friend auto& operator%=(eve::like<supports_all_ops> auto& self,
+                          eve::like<supports_all_ops> auto const& other) {
+    m0(self) %= m0(other);
+    m1(self) %= m1(other);
+    return self;
+  }
+
+  friend auto& operator<<=(eve::like<supports_all_ops> auto& self,
+                          eve::integral_value auto s) {
+    m0(self) <<= s;
+    m1(self) <<= s;
+    return self;
+  }
+
+  friend auto& operator>>=(eve::like<supports_all_ops> auto& self,
+                           eve::integral_value auto s) {
+    m0(self) >>= s;
+    m1(self) >>= s;
+    return self;
+  }
+};
+
+struct supports_no_ops : eve::product_type_base<supports_no_ops, int, std::int64_t>
+{
+  using eve_disable_ordering = void;
+
+  friend decltype(auto) m0(eve::like<supports_no_ops> auto&& self)
+  {
+    return get<0>(std::forward<decltype(self)>(self));
+  }
+
+  friend decltype(auto) m1(eve::like<supports_no_ops> auto&& self)
+  {
+    return get<1>(std::forward<decltype(self)>(self));
+  }
+};
+
+template <typename T>
+concept operators_test = requires(T x, T y) {
+  { x += y  } -> std::same_as<T&>;
+  { x + y   } -> std::same_as<T>;
+  { x -= y  } -> std::same_as<T&>;
+  { x - y   } -> std::same_as<T>;
+  { x *= y  } -> std::same_as<T&>;
+  { x * y   } -> std::same_as<T>;
+  { x /= y  } -> std::same_as<T&>;
+  { x / y   } -> std::same_as<T>;
+  { x %= y  } -> std::same_as<T&>;
+  { x % y   } -> std::same_as<T>;
+  { x <<= 1 } -> std::same_as<T&>;
+  { x << 1  } -> std::same_as<T>;
+};
+
+template <typename T>
+concept eve_totally_ordered = requires(T x, T y) {
+  { x < y  } -> eve::logical_value;
+  { x <= y } -> eve::logical_value;
+  { x == y } -> eve::logical_value;
+  { x != y } -> eve::logical_value;
+  { x >= y } -> eve::logical_value;
+  { x >  y } -> eve::logical_value;
+};
+
+template <typename T>
+concept supports_plus_test = requires(T x, T y) {
+  { x + y };
+};
+
+TTS_CASE("product_type_base")
+{
+  { eve::product_type    auto _ = supports_all_ops{}; (void)_; }
+  { operators_test       auto _ = supports_all_ops{}; (void)_; }
+  { std::regular         auto _ = supports_all_ops{}; (void)_; }
+  { std::totally_ordered auto _ = supports_all_ops{}; (void)_; }
+  { operators_test       auto _ = eve::wide<supports_all_ops>{}; (void)_; }
+  { eve_totally_ordered  auto _ = eve::wide<supports_all_ops>{}; (void)_; }
+  TTS_PASS("all types check out");
+
+  { eve::product_type auto _ = supports_no_ops{}; (void)_; }
+  { std::semiregular  auto _ = supports_no_ops{}; (void)_; }
+
+  TTS_CONSTEXPR_EXPECT_NOT(supports_plus_test<supports_no_ops>);
+  TTS_CONSTEXPR_EXPECT_NOT(std::totally_ordered<supports_no_ops>);
+  // TTS_CONSTEXPR_EXPECT_NOT(supports_plus_test<eve::wide<supports_no_ops>>);
+  TTS_CONSTEXPR_EXPECT_NOT(std::totally_ordered<eve::wide<supports_no_ops>>);
+}
+
+TTS_CASE("product_type construction")
+{
+  supports_all_ops a{0, 1};
+  TTS_EQUAL(m0(a), 0);
+  TTS_EQUAL(m1(a), 1);
+}

--- a/test/unit/api/udt/product_type.cpp
+++ b/test/unit/api/udt/product_type.cpp
@@ -27,7 +27,7 @@ TTS_CASE("like concet")
 }
 
 struct supports_all_ops :
-  eve::product_type_base<supports_all_ops, int, std::int64_t>
+  eve::struct_support<supports_all_ops, int, std::int64_t>
 {
   friend decltype(auto) m0(eve::like<supports_all_ops> auto&& self)
   {
@@ -74,6 +74,27 @@ struct supports_all_ops :
     return self;
   }
 
+  friend auto& operator^=(eve::like<supports_all_ops> auto& self,
+                          eve::like<supports_all_ops> auto const& other) {
+    m0(self) ^= m0(other);
+    m1(self) ^= m1(other);
+    return self;
+  }
+
+  friend auto& operator&=(eve::like<supports_all_ops> auto& self,
+                          eve::like<supports_all_ops> auto const& other) {
+    m0(self) &= m0(other);
+    m1(self) &= m1(other);
+    return self;
+  }
+
+  friend auto& operator|=(eve::like<supports_all_ops> auto& self,
+                          eve::like<supports_all_ops> auto const& other) {
+    m0(self) |= m0(other);
+    m1(self) |= m1(other);
+    return self;
+  }
+
   friend auto& operator<<=(eve::like<supports_all_ops> auto& self,
                           eve::integral_value auto s) {
     m0(self) <<= s;
@@ -89,7 +110,7 @@ struct supports_all_ops :
   }
 };
 
-struct supports_no_ops : eve::product_type_base<supports_no_ops, int, std::int64_t>
+struct supports_no_ops : eve::struct_support<supports_no_ops, int, std::int64_t>
 {
   using eve_disable_ordering = void;
 
@@ -116,6 +137,12 @@ concept operators_test = requires(T x, T y) {
   { x / y   } -> std::same_as<T>;
   { x %= y  } -> std::same_as<T&>;
   { x % y   } -> std::same_as<T>;
+  { x ^= y  } -> std::same_as<T&>;
+  { x ^ y   } -> std::same_as<T>;
+  { x &= y  } -> std::same_as<T&>;
+  { x & y   } -> std::same_as<T>;
+  { x |= y  } -> std::same_as<T&>;
+  { x | y   } -> std::same_as<T>;
   { x <<= 1 } -> std::same_as<T&>;
   { x << 1  } -> std::same_as<T>;
 };
@@ -135,7 +162,7 @@ concept supports_plus_test = requires(T x, T y) {
   { x + y };
 };
 
-TTS_CASE("product_type_base")
+TTS_CASE("struct_support")
 {
   { eve::product_type    auto _ = supports_all_ops{}; (void)_; }
   { operators_test       auto _ = supports_all_ops{}; (void)_; }

--- a/test/unit/api/udt/udt.hpp
+++ b/test/unit/api/udt/udt.hpp
@@ -55,12 +55,12 @@ namespace udt
   //------------------------------------------------------------------------------------------------
   struct label_position : kumi::tuple<float, std::uint8_t>
   {
-    friend auto&& position(eve::same_value_type<label_position> auto&& self) noexcept
+    friend auto&& position(eve::like<label_position> auto&& self) noexcept
     {
       return get<0>(std::forward<decltype(self)>(self));
     }
 
-    friend auto&& label(eve::same_value_type<label_position> auto&& self) noexcept
+    friend auto&& label(eve::like<label_position> auto&& self) noexcept
     {
       return get<1>(std::forward<decltype(self)>(self));
     }


### PR DESCRIPTION
`same_value_type` accepted way too much, it was not comfortable to talk about that in the talk.
Created `eve::like` (as we discussed) that requires an opt in.

Also created a `product_type_base` crtp helper, because explaining where the `operator+` will be generated for you and where it won't was not comfortable.
And it reduces the example size.