### PR TITLE
FIX-868: extract logical computations

### DIFF
--- a/include/eve/detail/function/compress_store_impl.hpp
+++ b/include/eve/detail/function/compress_store_impl.hpp
@@ -21,8 +21,8 @@
 
 namespace eve
 {
-  EVE_REGISTER_CALLABLE(compress_store_impl_)
-  EVE_DECLARE_CALLABLE(compress_store_impl_, compress_store_impl)
+  EVE_REGISTER_CALLABLE(compress_store_impl_);
+  EVE_DECLARE_CALLABLE(compress_store_impl_, compress_store_impl);
 
   namespace detail
   {

--- a/include/eve/detail/function/compress_store_swizzle_mask_num.hpp
+++ b/include/eve/detail/function/compress_store_swizzle_mask_num.hpp
@@ -25,6 +25,7 @@
 // 4 elements
 // ================
 // For 4 elements we do a complete shuffle of the first 3 elements
+// 4 elements version also accepts ignore (none of the others do).
 // the last one is always written.
 // We also return a bool if the last element is set.
 // (compiler will optimize that computation away,

--- a/include/eve/detail/function/compress_store_swizzle_mask_num.hpp
+++ b/include/eve/detail/function/compress_store_swizzle_mask_num.hpp
@@ -1,0 +1,56 @@
+//==================================================================================================
+/*
+  EVE - Expressive Vector Engine
+  Copyright : EVE Contributors & Maintainers
+  SPDX-License-Identifier: MIT
+*/
+//==================================================================================================
+#pragma once
+
+#include <eve/arch.hpp>
+#include <eve/detail/implementation.hpp>
+
+// compress_store_swizzle_mask_num
+//
+// For compress stores implemented as a swizzle, extracted logic
+// to compute a number of the mask.
+//
+// Depending on the number of elements, this is a different number
+// and a different extra information.
+//
+// For 4 elements we do a complete shuffle of the first 3 elements
+// the last one is always written.
+// We also return a bool if the last element is set.
+// (compiler will optimize that computation away,
+// if the caller just calls popcount and not use it).
+//
+//
+// Example:
+//   mask:            [ false, true, false, false]
+//   shuffle we want: [     1,    3,     _,     _]
+//   the number of the shuffle is 0100 -> 2
+//   is last set:     false
+//
+
+namespace eve
+{
+  EVE_REGISTER_CALLABLE(compress_store_swizzle_mask_num_);
+  EVE_DECLARE_CALLABLE(compress_store_swizzle_mask_num_, compress_store_swizzle_mask_num);
+
+  namespace detail
+  {
+    EVE_ALIAS_CALLABLE(compress_store_swizzle_mask_num_, compress_store_swizzle_mask_num);
+  }
+
+  EVE_CALLABLE_API(compress_store_swizzle_mask_num_, compress_store_swizzle_mask_num)
+}
+
+#include <eve/detail/function/simd/common/compress_store_swizzle_mask_num.hpp>
+
+#if defined(EVE_INCLUDE_X86_HEADER)
+#  include <eve/detail/function/simd/x86/compress_store_swizzle_mask_num.hpp>
+#endif
+
+#if defined(EVE_INCLUDE_ARM_HEADER)
+# include <eve/detail/function/simd/arm/neon/compress_store_swizzle_mask_num.hpp>
+#endif

--- a/include/eve/detail/function/compress_store_swizzle_mask_num.hpp
+++ b/include/eve/detail/function/compress_store_swizzle_mask_num.hpp
@@ -22,6 +22,8 @@
 // Depending on the number of elements, this is a different number
 // and a different extra information.
 //
+// 4 elements
+// ================
 // For 4 elements we do a complete shuffle of the first 3 elements
 // the last one is always written.
 // We also return a bool if the last element is set.
@@ -34,11 +36,11 @@
 //   the number of the shuffle is 0100 -> 2
 //   is last set:     false
 //
-// For 8 elements.
-// Credit goes to @aqrit.
-//
-// We << 1 && 1.
-// Whih means last 2 elements are OK to store.
+// 8 elements.
+// ==================
+// In compress store we first do << 1 and if_else(mask, x, slide_left(x, 1));
+// This reduces variativity.
+// Last 2 elements are OK to store.
 // For all previous pairs we reduce the number of options from 4 to 3.
 // [0, 0], [1, 0] and [0, 1], [1, 1].
 //
@@ -47,6 +49,11 @@
 // as a base3 number: each 2 elements are a base 3 digit.
 // This is a popcount for 2 elements.
 // We also return popcount.
+//
+// 16 elements
+// ==================
+// 16 elements are twice 8 but sometimes we can do them faster.
+// Returns {num, count} twice for both halves.
 //
 
 

--- a/include/eve/detail/function/compress_store_swizzle_mask_num.hpp
+++ b/include/eve/detail/function/compress_store_swizzle_mask_num.hpp
@@ -12,6 +12,10 @@
 
 // compress_store_swizzle_mask_num
 //
+// The idea from: https://gist.github.com/aqrit/6e73ca6ff52f72a2b121d584745f89f3#file-despace-cpp-L141
+// Was shown to me by: @aqrit
+// Stack Overflow discussion: https://chat.stackoverflow.com/rooms/212510/discussion-between-denis-yaroshevskiy-and-peter-cordes
+//
 // For compress stores implemented as a swizzle, extracted logic
 // to compute a number of the mask.
 //
@@ -24,13 +28,27 @@
 // (compiler will optimize that computation away,
 // if the caller just calls popcount and not use it).
 //
-//
 // Example:
 //   mask:            [ false, true, false, false]
 //   shuffle we want: [     1,    3,     _,     _]
 //   the number of the shuffle is 0100 -> 2
 //   is last set:     false
 //
+// For 8 elements.
+// Credit goes to @aqrit.
+//
+// We << 1 && 1.
+// Whih means last 2 elements are OK to store.
+// For all previous pairs we reduce the number of options from 4 to 3.
+// [0, 0], [1, 0] and [0, 1], [1, 1].
+//
+// This means we have 3 * 3 * 3 options.
+// The easiest way to convert from a mask to a 27 options is to interpet it
+// as a base3 number: each 2 elements are a base 3 digit.
+// This is a popcount for 2 elements.
+// We also return popcount.
+//
+
 
 namespace eve
 {

--- a/include/eve/detail/function/simd/arm/neon/compress_store_swizzle_mask_num.hpp
+++ b/include/eve/detail/function/simd/arm/neon/compress_store_swizzle_mask_num.hpp
@@ -88,20 +88,25 @@ namespace eve::detail
     }
   }
 
-  template<typename T>
+  template<eve::relative_conditional_expr C, typename T>
   EVE_FORCEINLINE std::pair<int, bool>
-  compress_store_swizzle_mask_num_(EVE_SUPPORTS(neon128_), logical<wide<T, fixed<4>>> mask)
+  compress_store_swizzle_mask_num_(EVE_SUPPORTS(neon128_), C c, logical<wide<T, fixed<4>>> mask)
   {
-    using l_t = logical<wide<T, fixed<4>>>;
+         if constexpr ( C::is_complete && !C::is_inverted ) return {0, false};
+    else if constexpr ( !C::is_complete                   ) return compress_store_swizzle_mask_num(ignore_none, mask && c.mask(as(mask)));
+    else
+    {
+      using l_t = logical<wide<T, fixed<4>>>;
 
-    using bits_type = typename l_t::bits_type;
+      using bits_type = typename l_t::bits_type;
 
-    bits_type bits = mask.bits();
-    bits_type elements_bit{1, 2, 4, 8};
-    bits &= elements_bit;
+      bits_type bits = mask.bits();
+      bits_type elements_bit{1, 2, 4, 8};
+      bits &= elements_bit;
 
-    auto sum = sum4(bits);
-    return {(sum & 7), (sum & 8)};
+      auto sum = sum4(bits);
+      return {(sum & 7), (sum & 8)};
+    }
   }
 
   template<typename T>

--- a/include/eve/detail/function/simd/arm/neon/compress_store_swizzle_mask_num.hpp
+++ b/include/eve/detail/function/simd/arm/neon/compress_store_swizzle_mask_num.hpp
@@ -1,0 +1,83 @@
+//==================================================================================================
+/*
+  EVE - Expressive Vector Engine
+  Copyright : EVE Contributors & Maintainers
+  SPDX-License-Identifier: MIT
+*/
+//==================================================================================================
+#pragma once
+
+#include <concepts>
+
+namespace eve::detail
+{
+  // FIX-#965: most of this should be in reduce, except for 64 bits on arm-v7
+  template <std::unsigned_integral T>
+  EVE_FORCEINLINE T sum4(wide<T, eve::fixed<4>> v)
+  {
+    if constexpr ( current_api >= asimd )
+    {
+           if constexpr ( sizeof(T) == 1 ) return vaddv_u8 (v);
+      else if constexpr ( sizeof(T) == 2 ) return vaddv_u16(v);
+      else if constexpr ( sizeof(T) == 4 ) return vaddvq_u32(v);
+      else if constexpr ( sizeof(T) == 8 )
+      {
+        // aggregated
+        auto [l, h] = v.slice();
+        l           = vaddq_u64(l, h);
+        return vaddvq_u64(l);
+      }
+    }
+    else
+    {
+      if constexpr( sizeof(T) == 1 )
+      {
+        v = vpadd_u8(v, v);
+        v = vpadd_u8(v, v);
+        return v.get(0);
+      }
+      else if constexpr( sizeof(T) == 2 )
+      {
+        v = vpadd_u16(v, v);
+        v = vpadd_u16(v, v);
+        return v.get(0);
+      }
+      else if constexpr( sizeof(T) == 4 )
+      {
+        // No usable horrisontal add for 4 ints
+        // (the long one does not do it, because unclear
+        // what to do with uint64x2
+        auto [l, h] = v.slice();
+
+        l = vadd_u32(l, h);
+        l = vpadd_u32(l, h);
+        return l.get(0);
+      }
+      // aggregated
+      else if constexpr( sizeof(T) == 8 )
+      {
+        auto [l, h]       = v.slice();
+        l                 = vaddq_u64(l, h);
+        uint32x2_t halved = vqmovn_u64(l);
+        halved            = vpadd_u32(halved, halved);
+        return vget_lane_u32(halved, 0);
+      }
+    }
+  }
+
+  template<typename T>
+  EVE_FORCEINLINE std::pair<int, bool>
+  compress_store_swizzle_mask_num_(EVE_SUPPORTS(neon128_), logical<wide<T, fixed<4>>> mask)
+  {
+    using l_t = logical<wide<T, fixed<4>>>;
+
+    using bits_type = typename l_t::bits_type;
+
+    bits_type bits = mask.bits();
+    bits_type elements_bit{1, 2, 4, 8};
+    bits &= elements_bit;
+
+    auto sum = sum4(bits);
+    return {(sum & 7), (sum & 8)};
+  }
+}

--- a/include/eve/detail/function/simd/arm/neon/compress_store_swizzle_mask_num.hpp
+++ b/include/eve/detail/function/simd/arm/neon/compress_store_swizzle_mask_num.hpp
@@ -65,6 +65,29 @@ namespace eve::detail
     }
   }
 
+  // FIX-#965: most of this should be in reduce, except for uint8_t
+  template <std::unsigned_integral T>
+  EVE_FORCEINLINE auto sum8(wide<T, eve::fixed<8>> v)
+  {
+    if constexpr ( sizeof(T) == 1 )
+    {
+      using u16_4 = typename wide<T, fixed<8>>::template rebind<std::uint16_t, fixed<4>>;
+      return sum4(u16_4(vpaddl_u8(v)));
+    }
+    else if constexpr ( current_api >= asimd && sizeof(T) == 2 ) return vaddvq_u16(v);
+    else if constexpr ( sizeof(T) == 2 )
+    {
+      using u32_4 = typename wide<T, fixed<8>>::template rebind<std::uint32_t, fixed<4>>;
+      return sum4(u32_4(vpaddlq_u16(v)));
+    }
+    else // aggrgated
+    {
+      auto [l, h] = v.slice();
+      l += h;
+      return sum4(l);
+    }
+  }
+
   template<typename T>
   EVE_FORCEINLINE std::pair<int, bool>
   compress_store_swizzle_mask_num_(EVE_SUPPORTS(neon128_), logical<wide<T, fixed<4>>> mask)
@@ -79,5 +102,27 @@ namespace eve::detail
 
     auto sum = sum4(bits);
     return {(sum & 7), (sum & 8)};
+  }
+
+  template<typename T>
+  EVE_FORCEINLINE std::pair<int, int>
+  compress_store_swizzle_mask_num_(EVE_SUPPORTS(neon128_), logical<wide<T, fixed<8>>> mask)
+  {
+    // the sums we do won't fit into a char - needs to be converted to short
+    using l_t = logical<wide<T, fixed<8>>>;
+
+    using bits_type = typename l_t::bits_type;
+
+    // See comments in the x86 version for chars
+    bits_type bits = mask.bits();
+
+    bits_type elements_bit{0x81, 0x81, 0x83, 0x83, 0x89, 0x89, 0x80, 0x80};
+    bits &= elements_bit;
+
+    int desc = sum8(bits);
+
+    int num      = desc & 0x1f;
+    int popcount = desc >> 7;
+    return {num, popcount};
   }
 }

--- a/include/eve/detail/function/simd/common/compress_store_swizzle_mask_num.hpp
+++ b/include/eve/detail/function/simd/common/compress_store_swizzle_mask_num.hpp
@@ -49,4 +49,22 @@ namespace eve::detail
     sum += 9 * mask.get(5);
     return std::pair{sum, eve::count_true(mask)};
   }
+
+  template<typename T>
+  EVE_FORCEINLINE auto
+  compress_store_swizzle_mask_num_(EVE_SUPPORTS(cpu_), logical<wide<T, fixed<16>>> mask)
+  {
+    auto [l, h] = mask.slice();
+    auto [l_num, l_count] = compress_store_swizzle_mask_num(l);
+    auto [h_num, h_count] = compress_store_swizzle_mask_num(h);
+
+    struct res {
+      int l_num;
+      int l_count;
+      int h_num;
+      int h_count;
+    };
+
+    return res{l_num, l_count, h_num, h_count};
+  }
 }

--- a/include/eve/detail/function/simd/common/compress_store_swizzle_mask_num.hpp
+++ b/include/eve/detail/function/simd/common/compress_store_swizzle_mask_num.hpp
@@ -16,9 +16,9 @@
 
 namespace eve::detail
 {
-  template<typename T>
+  template<eve::relative_conditional_expr C, typename T>
   EVE_FORCEINLINE std::pair<int, bool>
-  compress_store_swizzle_mask_num_(EVE_SUPPORTS(cpu_), logical<wide<T, fixed<4>>> mask)
+  compress_store_swizzle_mask_num_(EVE_SUPPORTS(cpu_), C c, logical<wide<T, fixed<4>>> mask)
   {
     using w_t = wide<T, fixed<4>>;
     using l_t = logical<wide<T>>;
@@ -26,12 +26,12 @@ namespace eve::detail
     // can only be for 64 bit numbers on 128 bit register
     if constexpr (has_aggregated_abi_v<w_t>)
     {
-      return compress_store_swizzle_mask_num(convert(mask, as<logical<std::uint32_t>>{}));
+      return compress_store_swizzle_mask_num(c, convert(mask, as<logical<std::uint32_t>>{}));
     }
     else
     {
       static_assert(top_bits<l_t>::bits_per_element == 1);
-      int mmask = top_bits{mask}.as_int();
+      int mmask = top_bits{mask, c}.as_int();
       return {(mmask & 7), (mmask & 8)};
     }
   }

--- a/include/eve/detail/function/simd/common/compress_store_swizzle_mask_num.hpp
+++ b/include/eve/detail/function/simd/common/compress_store_swizzle_mask_num.hpp
@@ -1,0 +1,37 @@
+//==================================================================================================
+/*
+  EVE - Expressive Vector Engine
+  Copyright : EVE Contributors & Maintainers
+  SPDX-License-Identifier: MIT
+*/
+//==================================================================================================
+#pragma once
+
+#include <eve/detail/top_bits.hpp>
+
+#include <eve/function/convert.hpp>
+
+#include <utility>
+
+namespace eve::detail
+{
+  template<typename T>
+  EVE_FORCEINLINE std::pair<int, bool>
+  compress_store_swizzle_mask_num_(EVE_SUPPORTS(cpu_), logical<wide<T, fixed<4>>> mask)
+  {
+    using w_t = wide<T, fixed<4>>;
+    using l_t = logical<wide<T>>;
+
+    // can only be for 64 bit numbers on 128 bit register
+    if constexpr (has_aggregated_abi_v<w_t>)
+    {
+      return compress_store_swizzle_mask_num(convert(mask, as<logical<std::uint32_t>>{}));
+    }
+    else
+    {
+      static_assert(top_bits<l_t>::bits_per_element == 1);
+      int mmask = top_bits{mask}.as_int();
+      return {(mmask & 7), (mmask & 8)};
+    }
+  }
+}

--- a/include/eve/detail/function/simd/common/compress_store_swizzle_mask_num.hpp
+++ b/include/eve/detail/function/simd/common/compress_store_swizzle_mask_num.hpp
@@ -10,6 +10,7 @@
 #include <eve/detail/top_bits.hpp>
 
 #include <eve/function/convert.hpp>
+#include <eve/function/count_true.hpp>
 
 #include <utility>
 
@@ -33,5 +34,19 @@ namespace eve::detail
       int mmask = top_bits{mask}.as_int();
       return {(mmask & 7), (mmask & 8)};
     }
+  }
+
+  template<typename T>
+  EVE_FORCEINLINE std::pair<int, int>
+  compress_store_swizzle_mask_num_(EVE_SUPPORTS(cpu_), logical<wide<T, fixed<8>>> mask)
+  {
+    int sum = 0;
+    sum += mask.get(0);
+    sum += mask.get(1);
+    sum += 3 * mask.get(2);
+    sum += 3 * mask.get(3);
+    sum += 9 * mask.get(4);
+    sum += 9 * mask.get(5);
+    return std::pair{sum, eve::count_true(mask)};
   }
 }

--- a/include/eve/detail/function/simd/x86/compress_store_swizzle_mask_num.hpp
+++ b/include/eve/detail/function/simd/x86/compress_store_swizzle_mask_num.hpp
@@ -1,0 +1,23 @@
+//==================================================================================================
+/*
+  EVE - Expressive Vector Engine
+  Copyright : EVE Contributors & Maintainers
+  SPDX-License-Identifier: MIT
+*/
+//==================================================================================================
+#pragma once
+
+#include <eve/function/convert.hpp>
+
+namespace eve::detail
+{
+  template<typename T>
+  EVE_FORCEINLINE std::pair<int, bool>
+  compress_store_swizzle_mask_num_(EVE_SUPPORTS(cpu_), logical<wide<T, fixed<4>>> mask)
+    requires (current_api < avx512) && (sizeof(T) == 2)
+  {
+    static_assert(top_bits<logical<wide<T, fixed<4>>>>::bits_per_element == 2);
+    auto to_bytes = eve::convert(mask, eve::as<eve::logical<std::uint8_t>>{});
+    return compress_store_swizzle_mask_num(to_bytes);
+  }
+}

--- a/include/eve/detail/function/simd/x86/compress_store_swizzle_mask_num.hpp
+++ b/include/eve/detail/function/simd/x86/compress_store_swizzle_mask_num.hpp
@@ -11,14 +11,14 @@
 
 namespace eve::detail
 {
-  template<typename T>
+  template<eve::relative_conditional_expr C, typename T>
   EVE_FORCEINLINE std::pair<int, bool>
-  compress_store_swizzle_mask_num_(EVE_SUPPORTS(sse2_), logical<wide<T, fixed<4>>> mask)
+  compress_store_swizzle_mask_num_(EVE_SUPPORTS(sse2_), C c, logical<wide<T, fixed<4>>> mask)
     requires (current_api < avx512) && (sizeof(T) == 2)
   {
     static_assert(top_bits<logical<wide<T, fixed<4>>>>::bits_per_element == 2);
     auto to_bytes = eve::convert(mask, eve::as<eve::logical<std::uint8_t>>{});
-    return compress_store_swizzle_mask_num(to_bytes);
+    return compress_store_swizzle_mask_num(c, to_bytes);
   }
 
   template<typename T>

--- a/include/eve/detail/function/simd/x86/compress_store_swizzle_mask_num.hpp
+++ b/include/eve/detail/function/simd/x86/compress_store_swizzle_mask_num.hpp
@@ -27,10 +27,11 @@ namespace eve::detail
     requires (current_api < avx512)
   {
     // aggregated
-    if constexpr ( sizeof(T) == 8 )
+    if constexpr ( eve::has_aggregated_abi_v<wide<T, fixed<8>>> )
     {
-      auto to_u32 = eve::convert(mask, eve::as<logical<std::uint32_t>>{});
-      return compress_store_swizzle_mask_num(to_u32);
+      using half_t = make_integer_t<sizeof(T) / 2, unsigned>;
+      auto half = eve::convert(mask, eve::as<logical<half_t>>{});
+      return compress_store_swizzle_mask_num(half);
     }
     else if constexpr ( sizeof(T) == 4 )
     {
@@ -93,7 +94,7 @@ namespace eve::detail
       auto to_bytes = eve::convert(mask, eve::as<eve::logical<std::uint8_t>>{});
       return compress_store_swizzle_mask_num(to_bytes);
     }
-    else if constexpr ( sizeof(T) == 1)
+    else if constexpr ( sizeof(T) == 1 )
     {
       __m128i sad_mask = _mm_set_epi64x(0x8080898983838181, 0x8080898983838181);
       __m128i sum      = _mm_sad_epu8(_mm_andnot_si128(mask, sad_mask), sad_mask);

--- a/include/eve/detail/function/simd/x86/compress_store_swizzle_mask_num.hpp
+++ b/include/eve/detail/function/simd/x86/compress_store_swizzle_mask_num.hpp
@@ -20,4 +20,65 @@ namespace eve::detail
     auto to_bytes = eve::convert(mask, eve::as<eve::logical<std::uint8_t>>{});
     return compress_store_swizzle_mask_num(to_bytes);
   }
+
+  template<typename T>
+  EVE_FORCEINLINE std::pair<int, int>
+  compress_store_swizzle_mask_num_(EVE_SUPPORTS(cpu_), logical<wide<T, fixed<8>>> mask)
+    requires (current_api < avx512)
+  {
+    // aggregated
+    if constexpr ( sizeof(T) == 8 )
+    {
+      auto to_u32 = eve::convert(mask, eve::as<logical<std::uint32_t>>{});
+      return compress_store_swizzle_mask_num(to_u32);
+    }
+    else if constexpr ( sizeof(T) == 4 )
+    {
+      // Get 4 bits per integer
+      // We want 1 + 1 + 3 + 3 + 9 + 9
+      // We can almost achieve this with popcount
+      // 0001 for 1
+      // 0111 for 3
+      // Can't do 9.
+      // But we can mask and add
+      //
+      // sum from popcount:   [ 1, 1, 3, 3, 4, 1]
+      // sum from extra mask: [ 0, 0, 0, 0, 5, 8]
+
+      using u8_32 = typename wide<T, fixed<8>>::template rebind<std::uint8_t, eve::fixed<32>>;
+      auto as_bytes = eve::bit_cast(mask, as<logical<u8_32>>{});
+
+      std::uint32_t mmask = top_bits{as_bytes}.as_int();
+      std::uint32_t idx_base_3 = std::popcount(mmask & 0x001f7711);
+      std::uint32_t extra_mask = (mmask >> 17) & 0b1'101;
+
+      idx_base_3 += extra_mask;
+
+      return {(int)idx_base_3, std::popcount(mmask) / 4};
+    }
+    else if constexpr ( sizeof(T) == 2 )
+    {
+      // Alternative for shorts is to compute both halves
+      // But that implies using _mm_extract_epi16 which has latency 3
+      // as oppose to latency 1 for _mm_packs_epi16
+      auto to_bytes = eve::convert(mask, eve::as<eve::logical<std::uint8_t>>{});
+      return compress_store_swizzle_mask_num(to_bytes);
+    }
+    else if constexpr ( sizeof(T) == 1 )
+    {
+      // The problem is there is not really a good instruction to reduce 8 chars.
+      // The closest we come is `_mm_sad_epu8`, it sums absolute differences for bytes.
+      // We could use a zero mask.
+      // But instead we can use the same mask we got to mask the 1, 3, 9.
+      // The top is responisble for popcount.
+
+      __m128i sad_mask = _mm_set_epi64x(0, 0x8080898983838181);
+      __m128i sum      = _mm_sad_epu8(_mm_andnot_si128(mask, sad_mask), sad_mask);
+
+      int desc     = _mm_cvtsi128_si32(sum);
+      int num      = desc & 0x1f;
+      int popcount = desc >> 7;
+      return {num, popcount};
+    }
+  }
 }

--- a/test/unit/internals/CMakeLists.txt
+++ b/test/unit/internals/CMakeLists.txt
@@ -13,9 +13,10 @@ add_dependencies(unit.simd.exe unit.internals.exe )
 ##==================================================================================================
 ## List internal tests
 ##==================================================================================================
-make_unit( "unit.internals" aggregation.cpp       )
-make_unit( "unit.internals" dispatch.cpp          )
-make_unit( "unit.internals" meta.cpp              )
-make_unit( "unit.internals" optimize_pattern.cpp  )
-make_unit( "unit.internals" to_logical.cpp        )
-make_unit( "unit.internals" top_bits.cpp          )
+make_unit( "unit.internals" aggregation.cpp                     )
+make_unit( "unit.internals" compress_store_swizzle_mask_num.cpp )
+make_unit( "unit.internals" dispatch.cpp                        )
+make_unit( "unit.internals" meta.cpp                            )
+make_unit( "unit.internals" optimize_pattern.cpp                )
+make_unit( "unit.internals" to_logical.cpp                      )
+make_unit( "unit.internals" top_bits.cpp                        )

--- a/test/unit/internals/compress_store_swizzle_mask_num.cpp
+++ b/test/unit/internals/compress_store_swizzle_mask_num.cpp
@@ -1,0 +1,42 @@
+//==================================================================================================
+/**
+  EVE - Expressive Vector Engine
+  Copyright : EVE Contributors & Maintainers
+  SPDX-License-Identifier: MIT
+**/
+//==================================================================================================
+#include "test.hpp"
+
+#include <eve/detail/function/compress_store_swizzle_mask_num.hpp>
+
+EVE_TEST_TYPES("compress_store_swizzle_mask_num 4 elements",
+               eve::test::scalar::all_types)
+<typename T>(eve::as<T>)
+{
+  using mask_t = eve::logical<eve::wide<T, eve::fixed<4>>>;
+
+  auto expected_shuffle_num = [](mask_t mask) {
+    int res = 0;
+    if (mask.get(0)) res += 1;
+    if (mask.get(1)) res += 2;
+    if (mask.get(2)) res += 4;
+    return res;
+  };
+
+  for (bool m0 : {false, true}) {
+    for (bool m1 : {false, true}) {
+      for (bool m2 : {false, true}) {
+        for (bool m3 : {false, true}) {
+          mask_t mask{m0, m1, m2, m3};
+
+          auto [actual_num, actual_4th] = eve::detail::compress_store_swizzle_mask_num(mask);
+
+          int expected_num = expected_shuffle_num(mask);
+
+          TTS_EQUAL(expected_num, actual_num);
+          TTS_EQUAL(m3, actual_4th);
+        }
+      }
+    }
+  }
+};

--- a/test/unit/internals/compress_store_swizzle_mask_num.cpp
+++ b/test/unit/internals/compress_store_swizzle_mask_num.cpp
@@ -120,6 +120,12 @@ EVE_TEST_TYPES("compress_store_swizzle_mask_num 16 elements",
 {
   using mask_t = eve::logical<eve::wide<T, eve::fixed<16>>>;
 
+  if (eve::current_api == eve::avx512 && eve::has_aggregated_abi_v<eve::wide<T, eve::fixed<16>>>)
+  {
+    TTS_PASS("aggregated on avx512");
+    return;
+  }
+
   std::array<int, 1000> test_cases;
 
   std::mt19937 gen;

--- a/test/unit/internals/compress_store_swizzle_mask_num.cpp
+++ b/test/unit/internals/compress_store_swizzle_mask_num.cpp
@@ -9,6 +9,8 @@
 
 #include <eve/detail/function/compress_store_swizzle_mask_num.hpp>
 
+#include <bit>
+
 EVE_TEST_TYPES("compress_store_swizzle_mask_num 4 elements",
                eve::test::scalar::all_types)
 <typename T>(eve::as<T>)
@@ -37,6 +39,65 @@ EVE_TEST_TYPES("compress_store_swizzle_mask_num 4 elements",
           TTS_EQUAL(m3, actual_4th);
         }
       }
+    }
+  }
+};
+
+EVE_TEST_TYPES("compress_store_swizzle_mask_num 8 elements",
+               eve::test::scalar::all_types)<typename T>(eve::as<T>)
+{
+  using mask_t = eve::logical<eve::wide<T, eve::fixed<8>>>;
+
+  std::array<int, 6> count_for_element {1, 1, 3, 3, 9, 9};
+
+  for( std::uint32_t i = 0; i < (1 << 6); ++i )
+  {
+    mask_t l {false};
+
+    int num   = 0;
+    int count = std::popcount(i);
+
+    for( std::uint32_t bit = 0; bit != 6; ++bit )
+    {
+      if( i & (1 << bit) )
+      {
+        l.set(bit, true);
+        num += count_for_element[bit];
+      }
+    }
+
+    {
+      auto [actual_num, actual_count] = eve::detail::compress_store_swizzle_mask_num(l);
+      TTS_EQUAL(num, actual_num);
+      TTS_EQUAL(count, actual_count);
+    }
+
+    ++count;
+
+    {
+      l.set(6, true);
+      auto [actual_num, actual_count] = eve::detail::compress_store_swizzle_mask_num(l);
+      TTS_EQUAL(num, actual_num);
+      TTS_EQUAL(count, actual_count);
+      l.set(6, false);
+    }
+
+    {
+      l.set(7, true);
+      auto [actual_num, actual_count] = eve::detail::compress_store_swizzle_mask_num(l);
+      TTS_EQUAL(num, actual_num);
+      TTS_EQUAL(count, actual_count);
+      l.set(7, false);
+    }
+
+    ++count;
+
+    {
+      l.set(6, true);
+      l.set(7, true);
+      auto [actual_num, actual_count] = eve::detail::compress_store_swizzle_mask_num(l);
+      TTS_EQUAL(num, actual_num);
+      TTS_EQUAL(count, actual_count);
     }
   }
 };

--- a/test/unit/internals/compress_store_swizzle_mask_num.cpp
+++ b/test/unit/internals/compress_store_swizzle_mask_num.cpp
@@ -26,22 +26,34 @@ EVE_TEST_TYPES("compress_store_swizzle_mask_num 4 elements",
     return res;
   };
 
-  for (bool m0 : {false, true}) {
-    for (bool m1 : {false, true}) {
-      for (bool m2 : {false, true}) {
-        for (bool m3 : {false, true}) {
-          mask_t mask{m0, m1, m2, m3};
+  auto run = [&](auto ignore)
+  {
+    for( bool m0 : {false, true} ) {
+      for( bool m1 : {false, true} ) {
+        for( bool m2 : {false, true} ) {
+          for( bool m3 : {false, true} ) {
+            mask_t mask {m0, m1, m2, m3};
 
-          auto [actual_num, actual_4th] = eve::detail::compress_store_swizzle_mask_num(mask);
+            auto [actual_num, actual_4th] = eve::detail::compress_store_swizzle_mask_num(ignore, mask);
 
-          int expected_num = expected_shuffle_num(mask);
+            int expected_num = expected_shuffle_num(mask && ignore.mask(eve::as(mask)));
 
-          TTS_EQUAL(expected_num, actual_num);
-          TTS_EQUAL(m3, actual_4th);
+            TTS_EQUAL(expected_num, actual_num);
+
+            if (ignore.roffset(eve::as(mask)) == 0) TTS_EQUAL(m3, actual_4th);
+            else                                    TTS_EQUAL(false, actual_4th);
+          }
         }
       }
     }
-  }
+  };
+
+  run(eve::ignore_none);
+  run(eve::ignore_all);
+  run(eve::ignore_first(2));
+  run(eve::ignore_extrema(1, 1));
+  run(eve::ignore_extrema(0, 2));
+  run(eve::ignore_last(2));
 };
 
 EVE_TEST_TYPES("compress_store_swizzle_mask_num 8 elements",

--- a/test/unit/internals/compress_store_swizzle_mask_num.cpp
+++ b/test/unit/internals/compress_store_swizzle_mask_num.cpp
@@ -10,6 +10,7 @@
 #include <eve/detail/function/compress_store_swizzle_mask_num.hpp>
 
 #include <bit>
+#include <random>
 
 EVE_TEST_TYPES("compress_store_swizzle_mask_num 4 elements",
                eve::test::scalar::all_types)
@@ -99,5 +100,46 @@ EVE_TEST_TYPES("compress_store_swizzle_mask_num 8 elements",
       TTS_EQUAL(num, actual_num);
       TTS_EQUAL(count, actual_count);
     }
+  }
+};
+
+EVE_TEST_TYPES("compress_store_swizzle_mask_num 16 elements",
+               eve::test::scalar::all_types)<typename T>(eve::as<T>)
+{
+  using mask_t = eve::logical<eve::wide<T, eve::fixed<16>>>;
+
+  std::array<int, 1000> test_cases;
+
+  std::mt19937 gen;
+  std::uniform_int_distribution<> dis{0, 1 << 16};
+
+  std::generate(test_cases.begin(), test_cases.end(), [&]()mutable{
+    return dis(gen);
+  });
+
+  for( int test_case : test_cases) {
+    mask_t l {false};
+
+    for( std::uint32_t bit = 0; bit != 16; ++bit )
+    {
+      if( test_case & (1 << bit) )
+      {
+        l.set(bit, true);
+      }
+    }
+
+    // For basic case a little bit testing itself but this is what we expect
+    // and if there is an actual problem it will pop up in a upper layer test.
+
+    auto [num1, count1, num2, count2] = eve::detail::compress_store_swizzle_mask_num(l);
+
+    auto [lo, hi] = l.slice();
+    auto [expected_num1, expected_count1] = eve::detail::compress_store_swizzle_mask_num(lo);
+    auto [expected_num2, expected_count2] = eve::detail::compress_store_swizzle_mask_num(hi);
+
+    TTS_EQUAL(expected_num1,     num1);
+    TTS_EQUAL(expected_num2,     num2);
+    TTS_EQUAL(expected_count1, count1);
+    TTS_EQUAL(expected_count2, count2);
   }
 };


### PR DESCRIPTION
Now the logic of `compute the index of shuffle we are suppose to perform` is extracted and tested thoroughly.
I also potred it to arm, where we will be able to utilise for compress store at some point.
Resulting function has a so-so semantics, but what can you do.

Given that the function itself is tested, we now can drastically reduce the testing for different logical/wide combinations.