### PR TITLE
FIX-938: consider types

### DIFF
--- a/include/eve/algo/README.txt
+++ b/include/eve/algo/README.txt
@@ -107,6 +107,7 @@ algorithm traits
 * `force_cardinal`
 * `no_aligning`
 * `unroll`
+* `consider_types`
 
 zip traits
 * `common_with_types`

--- a/include/eve/algo/concepts.hpp
+++ b/include/eve/algo/concepts.hpp
@@ -9,5 +9,6 @@
 
 #include <eve/algo/concepts/eve_iterator.hpp>
 #include <eve/algo/concepts/relaxed.hpp>
+#include <eve/algo/concepts/types_to_consider.hpp>
 #include <eve/algo/concepts/value_type.hpp>
 #include <eve/algo/concepts/zip_to_range.hpp>

--- a/include/eve/algo/concepts/types_to_consider.hpp
+++ b/include/eve/algo/concepts/types_to_consider.hpp
@@ -1,0 +1,31 @@
+//==================================================================================================
+/*
+  EVE - Expressive Vector Engine
+  Copyright : EVE Contributors & Maintainers
+  SPDX-License-Identifier: MIT
+*/
+//==================================================================================================
+#pragma once
+
+#include <eve/algo/concepts/value_type.hpp>
+
+#include <eve/detail/kumi.hpp>
+
+namespace eve::algo
+{
+  template <typename RorI>
+  struct types_to_consider_for
+  {
+    using type = kumi::tuple<value_type_t<RorI>>;
+  };
+
+  template <typename RorI>
+  requires requires(RorI) { typename RorI::types_to_consider; }
+  struct types_to_consider_for<RorI>
+  {
+    using type = typename RorI::types_to_consider;
+  };
+
+  template <typename RorI>
+  using types_to_consider_for_t = typename types_to_consider_for<RorI>::type;
+}

--- a/include/eve/algo/convert.hpp
+++ b/include/eve/algo/convert.hpp
@@ -10,6 +10,7 @@
 #include <eve/algo/detail/convert.hpp>
 
 #include <eve/algo/concepts/relaxed.hpp>
+#include <eve/algo/concepts/types_to_consider.hpp>
 #include <eve/algo/concepts/value_type.hpp>
 #include <eve/algo/detail/converting_iterator.hpp>
 #include <eve/algo/range_ref.hpp>
@@ -60,6 +61,9 @@ namespace eve::algo
     R base;
 
     using is_non_owning = void;
+
+    using types_to_consider = kumi::result::cat_t<
+      kumi::tuple<T>, types_to_consider_for_t<R>>;
 
     EVE_FORCEINLINE auto begin() const { return convert(base.begin(), eve::as<T>{}); }
     EVE_FORCEINLINE auto end()   const { return convert(base.end(),   eve::as<T>{}); }

--- a/include/eve/algo/convert.hpp
+++ b/include/eve/algo/convert.hpp
@@ -71,11 +71,10 @@ namespace eve::algo
     template<typename Traits>
     EVE_FORCEINLINE friend auto tagged_dispatch(preprocess_range_, Traits tr, converting_range self)
     {
-      auto tr_with_cardinal = default_to(tr, traits {force_cardinal_as<T>});
+      auto tr_with_cardinal = default_to(tr, traits {consider_types<T>});
       auto processed        = preprocess_range(tr_with_cardinal, self.base);
 
-      auto ret_tr =
-          drop_key_if<!has_cardinal_overrides_v<Traits>>(force_cardinal_key, processed.traits());
+      auto ret_tr = drop_key(consider_types_key, processed.traits());
 
       return preprocess_range_result {
           ret_tr, convert(processed.begin(), as<T>{}), convert(processed.end(), as<T>{})

--- a/include/eve/algo/detail/converting_iterator.hpp
+++ b/include/eve/algo/detail/converting_iterator.hpp
@@ -34,6 +34,7 @@ namespace eve::algo
     {
       I base;
       using value_type = T;
+      using types_to_consider = kumi::result::cat_t<kumi::tuple<T>, types_to_consider_for_t<I>>;
 
       converting_iterator_common() = default;
 

--- a/include/eve/algo/detail/preprocess_zip_range.hpp
+++ b/include/eve/algo/detail/preprocess_zip_range.hpp
@@ -19,18 +19,16 @@ namespace eve::algo
   {
     template <typename Traits, typename ...Rngs>
     EVE_FORCEINLINE auto preprocess_zip_range(Traits tr, kumi::tuple<Rngs...> rngs) {
-      auto tr_internal = [&]{
-        using N = iteration_cardinal_t<Traits, kumi::tuple<value_type_t<Rngs>...>>;
-        auto force_cardinal = algo::traits{algo::force_cardinal<N{}()>};
-
-        return default_to(tr, force_cardinal);
-      }();
+      // So far decided not to return types to consider in resulting traits.
+      // Maybe we should.
+      eve::algo::traits types_to_consider{ consider_types_key = kumi::result::cat_t<types_to_consider_for_t<Rngs> ...>{} };
+      auto tr_internal = default_to(tr, types_to_consider);
 
       auto components = kumi::map([&](auto rng) { return preprocess_range(tr_internal, rng); }, rngs);
 
       auto tr2 = kumi::fold_right(
           default_to,
-          kumi::map([](auto r) { return drop_key(force_cardinal_key, r.traits()); }, components),
+          kumi::map([](auto r) { return drop_key(consider_types_key, r.traits()); }, components),
           tr);
 
       auto f = zip_iterator(kumi::map([](auto r) { return r.begin(); }, components));

--- a/include/eve/algo/inclusive_scan.hpp
+++ b/include/eve/algo/inclusive_scan.hpp
@@ -81,7 +81,7 @@ namespace eve::algo
     EVE_FORCEINLINE void operator()(Rng&& rng, std::pair<Op, Zero> op_zero, U init) const
     {
       detail::inclusive_scan_common<inplace_load_store>{}(
-        TraitsSupport::get_traits(), std::forward<Rng>(rng), op_zero, init);
+        TraitsSupport::get_traits(), eve::algo::convert(std::forward<Rng>(rng), eve::as<U>{}), op_zero, init);
     }
 
     template <relaxed_range Rng, typename U>
@@ -100,7 +100,7 @@ namespace eve::algo
     EVE_FORCEINLINE void operator()(R r, std::pair<Op, Zero> op_zero, U init) const
     {
       detail::inclusive_scan_common<to_load_store>{}(
-        TraitsSupport::get_traits(), r[common_type], op_zero, init);
+        TraitsSupport::get_traits(), r[force_type<U>], op_zero, init);
     }
 
     template <zipped_range_pair R, typename U>

--- a/include/eve/algo/preprocess_range.hpp
+++ b/include/eve/algo/preprocess_range.hpp
@@ -38,9 +38,9 @@ namespace eve::algo
     template <typename Traits, typename I>
     EVE_FORCEINLINE auto fix_up_cardinal(Traits, I i)
     {
-      if constexpr( typename I::cardinal {}() != iteration_cardinal_t<Traits, value_type_t<I>> {}() )
+      if constexpr( typename I::cardinal {}() != iteration_cardinal_t<Traits, I> {}() )
       {
-        using N = iteration_cardinal_t<Traits, value_type_t<I>>;
+        using N = iteration_cardinal_t<Traits, I>;
         auto i_ = i.cardinal_cast(N {});
         return i_;
       }

--- a/include/eve/algo/reduce.hpp
+++ b/include/eve/algo/reduce.hpp
@@ -66,10 +66,7 @@ namespace eve::algo
     template <typename Rng, typename Op, typename Zero, typename U>
     EVE_FORCEINLINE U operator()(Rng&& rng, std::pair<Op, Zero> op_zero, U init) const
     {
-      // FIX-#938: this should not be a common type actually, should just be U.
-      using T = common_type_t<value_type_t<std::remove_cvref_t<Rng>>, U>;
-
-      auto cvt_rng = eve::algo::convert(std::forward<Rng>(rng), as<T>{});
+      auto cvt_rng = eve::algo::convert(std::forward<Rng>(rng), as<U>{});
       auto processed = preprocess_range(TraitsSupport::get_traits(), cvt_rng);
 
       using I = decltype(processed.begin());
@@ -83,7 +80,7 @@ namespace eve::algo
       delegate<Op, Zero, wide_t> d{op_zero.first, op_zero.second, init_as_wide};
 
       algo::for_each_iteration(processed.traits(), processed.begin(), processed.end())(d);
-      return eve::convert(d.finish(), eve::as<U>{});
+      return d.finish();
     }
 
     template <typename Rng, typename U>

--- a/include/eve/algo/traits.hpp
+++ b/include/eve/algo/traits.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <eve/algo/concepts/value_type.hpp>
+#include <eve/algo/concepts/types_to_consider.hpp>
 
 #include <eve/detail/raberu.hpp>
 
@@ -83,10 +84,18 @@ namespace eve::algo
     return rbr::get_type_t<Traits, unroll_key, eve::fixed<1>>{}();
   }
 
-  template <typename Traits, typename T>
+  template <typename Traits>
+  using extra_types_to_consider = rbr::get_type_t<Traits, consider_types_key, kumi::tuple<>>;
+
+  template <typename Traits, typename RorI>
+  using get_types_to_consider_for =
+    kumi::result::cat_t<extra_types_to_consider<Traits>, types_to_consider_for_t<RorI>>;
+
+  template <typename Traits, typename RorI>
   using iteration_cardinal_t =
     rbr::get_type_t<Traits, force_cardinal_key,
-    expected_cardinal_t<T>>;
+                    expected_cardinal_t<get_types_to_consider_for<Traits, RorI>>
+                   >;
 
   inline constexpr auto default_to =
      []<typename User, typename Default>(traits<User> const& user, traits<Default> const& defaults)

--- a/include/eve/algo/zip.hpp
+++ b/include/eve/algo/zip.hpp
@@ -8,9 +8,10 @@
 #pragma once
 
 #include <eve/algo/as_range.hpp>
-#include <eve/algo/range_ref.hpp>
 #include <eve/algo/concepts/relaxed.hpp>
+#include <eve/algo/concepts/types_to_consider.hpp>
 #include <eve/algo/preprocess_range.hpp>
+#include <eve/algo/range_ref.hpp>
 #include <eve/algo/traits.hpp>
 #include <eve/algo/zip_iterator.hpp>
 
@@ -122,6 +123,7 @@ namespace eve::algo
   struct zip_range : kumi::tuple<Rngs...>
   {
     using is_non_owning = void;
+    using types_to_consider = kumi::result::cat_t<types_to_consider_for_t<Rngs>...>;
 
     EVE_FORCEINLINE zip_range(kumi::tuple<Rngs...> ranges):
       kumi::tuple<Rngs...>(ranges)

--- a/include/eve/algo/zip_iterator.hpp
+++ b/include/eve/algo/zip_iterator.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <eve/algo/as_range.hpp>
+#include <eve/algo/concepts/types_to_consider.hpp>
 #include <eve/algo/iterator_helpers.hpp>
 #include <eve/algo/preprocess_range.hpp>
 
@@ -58,8 +59,9 @@ namespace eve::algo
     template<typename... Is>
     struct zip_iterator_common : operations_with_distance
     {
-      using value_type = kumi::tuple<typename pointer_traits<Is>::value_type...>;
-      using tuple_type = kumi::tuple<Is...>;
+      using value_type        = kumi::tuple<typename pointer_traits<Is>::value_type...>;
+      using tuple_type        = kumi::tuple<Is...>;
+      using types_to_consider = kumi::result::cat_t<types_to_consider_for_t<Is>...>;
 
       // tuple opt in
       using is_product_type = void;

--- a/include/eve/detail/kumi.hpp
+++ b/include/eve/detail/kumi.hpp
@@ -799,12 +799,12 @@ namespace kumi
 
   namespace result
   {
-    template<product_type T, product_type... Tuples> struct cat
+    template<product_type... Tuples> struct cat
     {
-      using type = decltype( kumi::cat( std::declval<T>(), std::declval<Tuples>()... ) );
+      using type = decltype( kumi::cat( std::declval<Tuples>()... ) );
     };
 
-    template<product_type T, product_type... Tuples> using cat_t  = typename cat<T,Tuples...>::type;
+    template<product_type... Tuples> using cat_t  = typename cat<Tuples...>::type;
   }
 
   //================================================================================================

--- a/test/unit/algo/algorithm/inclusive_scan_to_generic.cpp
+++ b/test/unit/algo/algorithm/inclusive_scan_to_generic.cpp
@@ -19,8 +19,7 @@
 EVE_TEST_TYPES("Check inlclusive_scan_to", algo_test::selected_pairs_types)
 <typename T>(eve::as<T> tgt)
 {
-  using e_t = eve::element_type_t<T>;
-  using init_t = eve::common_type_t<std::tuple_element_t<0,e_t>, std::tuple_element_t<1,e_t>>;
+  using init_t = std::tuple_element_t<1, eve::element_type_t<T>>;
 
   algo_test::transform_to_generic_test(
     tgt,

--- a/test/unit/algo/algorithm/sums_special_cases.cpp
+++ b/test/unit/algo/algorithm/sums_special_cases.cpp
@@ -69,13 +69,15 @@ TTS_CASE("eve.algo.inclusive_scan complex numbers")
   std::vector<float> real_copy = real;
   std::vector<float> img_copy  = img;
 
+  kumi::tuple<float, float> init{0.0, 0.0};
+
   eve::algo::inclusive_scan_to(
     eve::algo::zip(real, img),
     eve::algo::zip(real_copy, img_copy),
     std::pair{plus, eve::zero},
-    eve::zero);
+    init);
 
-  eve::algo::inclusive_scan_inplace(eve::algo::zip(real, img), std::pair{plus, eve::zero}, eve::zero);
+  eve::algo::inclusive_scan_inplace(eve::algo::zip(real, img), std::pair{plus, eve::zero}, init);
 
   std::vector<float> expected_real = { 0.0,  0.1,  0.3,  0.6 };
   std::vector<float> expected_img  = { 0.0, -0.1, -0.3, -0.6 };

--- a/test/unit/algo/concepts.cpp
+++ b/test/unit/algo/concepts.cpp
@@ -10,6 +10,7 @@
 
 #include <eve/algo/concepts.hpp>
 
+#include <eve/algo/convert.hpp>
 #include <eve/algo/ptr_iterator.hpp>
 #include <eve/algo/zip.hpp>
 
@@ -35,4 +36,33 @@ TTS_CASE("concepts, relaxed")
   TTS_CONSTEXPR_EXPECT(eve::algo::relaxed_iterator<int*>);
   TTS_CONSTEXPR_EXPECT_NOT(eve::algo::relaxed_range<int*>);
   TTS_CONSTEXPR_EXPECT(eve::algo::relaxed_range<std::vector<int>>);
+}
+
+TTS_CASE("concepts, types_to_consider_for")
+{
+  TTS_TYPE_IS(eve::algo::types_to_consider_for_t<int*>,             kumi::tuple<int>);
+  TTS_TYPE_IS(eve::algo::types_to_consider_for_t<int const*>,       kumi::tuple<int>);
+  TTS_TYPE_IS(eve::algo::types_to_consider_for_t<std::vector<int>>, kumi::tuple<int>);
+
+  std::vector<int>   v_i;
+  std::vector<short> v_s;
+
+  auto c_v_i_r = eve::algo::convert(v_i,         eve::as<double>{});
+  auto c_v_i_i = eve::algo::convert(v_i.begin(), eve::as<double>{});
+
+
+  TTS_TYPE_IS(eve::algo::types_to_consider_for_t<decltype(c_v_i_r)>, (kumi::tuple<double, int>));
+  TTS_TYPE_IS(eve::algo::types_to_consider_for_t<decltype(c_v_i_i)>, (kumi::tuple<double, int>));
+
+
+  auto zip_s_i_i = eve::algo::zip(v_s, v_i, v_i);
+
+  // This should probably be a type set but w/e
+  TTS_TYPE_IS(eve::algo::types_to_consider_for_t<decltype(zip_s_i_i)        >, (kumi::tuple<short, int, int>));
+  TTS_TYPE_IS(eve::algo::types_to_consider_for_t<decltype(zip_s_i_i.begin())>, (kumi::tuple<short, int, int>));
+
+  auto zip_c_i_s = eve::algo::zip(c_v_i_r, v_s);
+
+  TTS_TYPE_IS(eve::algo::types_to_consider_for_t<decltype(zip_c_i_s)        >, (kumi::tuple<double, int, short>));
+  TTS_TYPE_IS(eve::algo::types_to_consider_for_t<decltype(zip_c_i_s.begin())>, (kumi::tuple<double, int, short>));
 }

--- a/test/unit/algo/convert.cpp
+++ b/test/unit/algo/convert.cpp
@@ -34,9 +34,10 @@ TTS_CASE("eve::algo::convert, read/write")
 
 TTS_CASE("eve::algo::convert, preprocess test")
 {
-  using From = float;
-  using To   = int;
-  using N    = eve::fixed<eve::expected_cardinal_v<To>>;
+  using From      = float;
+  using To        = int;
+  using SmallerTo = short;
+  using N         = eve::fixed<eve::expected_cardinal_v<To>>;
 
   auto common_test = []<typename R, typename T,
                         typename ExpectedRawF,
@@ -71,6 +72,8 @@ TTS_CASE("eve::algo::convert, preprocess test")
                 eve::as<To>{}, eve::algo::traits{}, u_it{}, u_it{}, eve::algo::traits{});
     common_test(eve::algo::as_range(u_it{}, u_it{}),
                 eve::as<To>{}, eve::algo::traits{}, u_it{}, u_it{}, eve::algo::traits{});
+    common_test(eve::algo::as_range(u_it{}, u_it{}),
+                eve::as<SmallerTo>{}, eve::algo::traits{}, u_it{}, u_it{}, eve::algo::traits{});
 
     common_test(v, eve::as<To>{}, eve::algo::traits{eve::algo::no_aligning},
                u_it{}, u_it{},    eve::algo::traits{eve::algo::no_aligning});
@@ -96,7 +99,6 @@ TTS_CASE("eve::algo::convert, preprocess test")
                 eve::as<To>{}, eve::algo::traits{}, a_it{}, u_it{},
                 eve::algo::traits{eve::algo::no_aligning});
   }
-
 }
 
 TTS_CASE("eve.algo.convert to/from")

--- a/test/unit/algo/preprocess_range.cpp
+++ b/test/unit/algo/preprocess_range.cpp
@@ -264,12 +264,13 @@ EVE_TEST_TYPES("cardinal/type manipulation", algo_test::selected_types)
   using e_t = eve::element_type_t<T>;
 
   std::vector<e_t> v;
+  std::vector<double> v_d;
   {
     auto processed = eve::algo::preprocess_range(
     eve::algo::traits(eve::algo::force_cardinal<T::size()>), v);
 
     using I = decltype(processed.begin());
-    TTS_CONSTEXPR_EXPECT((std::same_as<typename I::wide_value_type, T>));
+    TTS_TYPE_IS(typename I::wide_value_type, T);
   }
 
   {
@@ -288,9 +289,25 @@ EVE_TEST_TYPES("cardinal/type manipulation", algo_test::selected_types)
       eve::algo::convert(v, eve::as<double>{}));
 
     using I = decltype(processed.begin());
-    TTS_CONSTEXPR_EXPECT((std::same_as<
-      typename I::wide_value_type,
-      eve::wide<double, eve::fixed<T::size()>>
-    >));
+    TTS_TYPE_IS(typename I::wide_value_type,
+                (eve::wide<double, eve::fixed<T::size()>>));
+  }
+
+  {
+    auto processed = eve::algo::preprocess_range(
+      eve::algo::traits(eve::algo::consider_types<double>), v);
+
+    using I = decltype(processed.begin());
+    TTS_TYPE_IS(typename I::wide_value_type,
+                (eve::wide<e_t, eve::fixed<eve::expected_cardinal_v<double>>>));
+  }
+
+  {
+    auto processed = eve::algo::preprocess_range(
+      eve::algo::traits{}, eve::algo::convert(v_d, eve::as<e_t>{}));
+
+    using I = decltype(processed.begin());
+    TTS_TYPE_IS(typename I::wide_value_type,
+                (eve::wide<e_t, eve::fixed<eve::expected_cardinal_v<double>>>));
   }
 };

--- a/test/unit/algo/traits.cpp
+++ b/test/unit/algo/traits.cpp
@@ -88,6 +88,29 @@ struct func_ : TraitsSupport
   }
 };
 
+TTS_CASE("eve.algo.traits consider types")
+{
+  eve::algo::traits expected{ eve::algo::consider_types<double, int, char> };
+  {
+    eve::algo::traits tr;
+    eve::algo::traits def{eve::algo::consider_types<double, int, char>};
+    auto actual = eve::algo::default_to(tr, def);
+    TTS_TYPE_IS(decltype(expected), decltype(actual));
+  }
+  {
+    eve::algo::traits tr{eve::algo::consider_types<double, int, char>};
+    eve::algo::traits def;
+    auto actual = eve::algo::default_to(tr, def);
+    TTS_TYPE_IS(decltype(expected), decltype(actual));
+  }
+  {
+    eve::algo::traits tr{eve::algo::consider_types<double>};
+    eve::algo::traits def{eve::algo::consider_types<int, char>};
+    auto actual = eve::algo::default_to(tr, def);
+    TTS_TYPE_IS(decltype(expected), decltype(actual));
+  }
+}
+
 inline constexpr auto func = eve::algo::function_with_traits<func_>;
 
 TTS_CASE("eve.algo.support_traits") {

--- a/test/unit/algo/traits.cpp
+++ b/test/unit/algo/traits.cpp
@@ -58,36 +58,6 @@ TTS_CASE("eve.algo defaulting")
   }
 }
 
-TTS_CASE("eve.algo.traits, type and cardinal")
-{
-  {
-    eve::algo::traits tr;
-    TTS_TYPE_IS((eve::algo::iteration_cardinal_t<decltype(tr), int>), eve::fixed<eve::expected_cardinal_v<int>>);
-  }
-  {
-    eve::algo::traits tr{eve::algo::force_cardinal<2>};
-    TTS_TYPE_IS((eve::algo::iteration_cardinal_t<decltype(tr), int>), eve::fixed<2>);
-  }
-}
-
-// Funciton with traits support
-
-template <typename TraitsSupport>
-struct func_ : TraitsSupport
-{
-  using traits_type = typename TraitsSupport::traits_type;
-
-  constexpr std::ptrdiff_t get_unrolling() const
-  {
-    return eve::algo::get_unrolling<traits_type>();
-  }
-
-  constexpr bool is_divisible_by_cardinal() const
-  {
-    return traits_type::contains(eve::algo::divisible_by_cardinal);
-  }
-};
-
 TTS_CASE("eve.algo.traits consider types")
 {
   eve::algo::traits expected{ eve::algo::consider_types<double, int, char> };
@@ -109,7 +79,49 @@ TTS_CASE("eve.algo.traits consider types")
     auto actual = eve::algo::default_to(tr, def);
     TTS_TYPE_IS(decltype(expected), decltype(actual));
   }
+  {
+    eve::algo::traits tr;
+    TTS_TYPE_IS((eve::algo::get_types_to_consider_for<decltype(tr), int*>), kumi::tuple<int>);
+  }
+  {
+    eve::algo::traits tr{eve::algo::consider_types<double>};
+    TTS_TYPE_IS((eve::algo::get_types_to_consider_for<decltype(tr), int*>), (kumi::tuple<double, int>));
+  }
 }
+
+TTS_CASE("eve.algo.traits, type and cardinal")
+{
+  {
+    eve::algo::traits tr;
+    TTS_TYPE_IS((eve::algo::iteration_cardinal_t<decltype(tr), int*>), eve::fixed<eve::expected_cardinal_v<int>>);
+  }
+  {
+    eve::algo::traits tr{eve::algo::force_cardinal<2>};
+    TTS_TYPE_IS((eve::algo::iteration_cardinal_t<decltype(tr), int*>), eve::fixed<2>);
+  }
+  {
+    eve::algo::traits tr{eve::algo::consider_types<double>};
+    TTS_TYPE_IS((eve::algo::iteration_cardinal_t<decltype(tr), int*>), eve::fixed<eve::expected_cardinal_v<double>>);
+  }
+}
+
+// Funciton with traits support
+
+template <typename TraitsSupport>
+struct func_ : TraitsSupport
+{
+  using traits_type = typename TraitsSupport::traits_type;
+
+  constexpr std::ptrdiff_t get_unrolling() const
+  {
+    return eve::algo::get_unrolling<traits_type>();
+  }
+
+  constexpr bool is_divisible_by_cardinal() const
+  {
+    return traits_type::contains(eve::algo::divisible_by_cardinal);
+  }
+};
 
 inline constexpr auto func = eve::algo::function_with_traits<func_>;
 


### PR DESCRIPTION
Now an iterator can use more than one type to compute cardinal.
This allows to do conversions to a smaller type: `converting_iterator<int*, short>` will have cardinal of int.

We can also pass extra types to consider in a trait.

This:
*  fixes `reduce/inclusive_scan` incorrect type selection issue.
* simplifies `collect_indexes` example.
* opens the road to transform.

