### PR TITLE
FIX-989: compress store arm.

### DIFF
--- a/include/eve/detail/function/compress_store_impl.hpp
+++ b/include/eve/detail/function/compress_store_impl.hpp
@@ -37,3 +37,7 @@ namespace eve
 #if defined(EVE_INCLUDE_X86_HEADER)
 #  include <eve/detail/function/simd/x86/compress_store_impl.hpp>
 #endif
+
+#if defined(EVE_INCLUDE_ARM_HEADER)
+#    include <eve/detail/function/simd/arm/neon/compress_store_impl.hpp>
+#endif

--- a/include/eve/detail/function/compress_store_swizzle_mask_num.hpp
+++ b/include/eve/detail/function/compress_store_swizzle_mask_num.hpp
@@ -25,17 +25,21 @@
 // 4 elements
 // ================
 // For 4 elements we do a complete shuffle of the first 3 elements
-// 4 elements version also accepts ignore (none of the others do).
-// the last one is always written.
-// We also return a bool if the last element is set.
-// (compiler will optimize that computation away,
-// if the caller just calls popcount and not use it).
+// 4 elements version also accepts ignore (none of the others do),
+// because we can do use it efficiently on x86.
+//
+// The last one element is always written.
+//
+// The second returned value is:
+//   for a regular one - number of elements selected
+//   for a partial one - a bool if the last element is set.
 //
 // Example:
 //   mask:            [ false, true, false, false]
 //   shuffle we want: [     1,    3,     _,     _]
 //   the number of the shuffle is 0100 -> 2
 //   is last set:     false
+//   count      :     1
 //
 // 8 elements.
 // ==================
@@ -61,14 +65,18 @@
 namespace eve
 {
   EVE_REGISTER_CALLABLE(compress_store_swizzle_mask_num_);
+  EVE_REGISTER_CALLABLE(compress_store_swizzle_mask_num_partial_);
   EVE_DECLARE_CALLABLE(compress_store_swizzle_mask_num_, compress_store_swizzle_mask_num);
+  EVE_DECLARE_CALLABLE(compress_store_swizzle_mask_num_partial_, compress_store_swizzle_mask_num_partial);
 
   namespace detail
   {
     EVE_ALIAS_CALLABLE(compress_store_swizzle_mask_num_, compress_store_swizzle_mask_num);
+    EVE_ALIAS_CALLABLE(compress_store_swizzle_mask_num_partial_, compress_store_swizzle_mask_num_partial);
   }
 
-  EVE_CALLABLE_API(compress_store_swizzle_mask_num_, compress_store_swizzle_mask_num)
+  EVE_CALLABLE_API(compress_store_swizzle_mask_num_, compress_store_swizzle_mask_num);
+  EVE_CALLABLE_API(compress_store_swizzle_mask_num_partial_, compress_store_swizzle_mask_num_partial);
 }
 
 #include <eve/detail/function/simd/common/compress_store_swizzle_mask_num.hpp>

--- a/include/eve/detail/function/simd/arm/neon/compress_store_impl.hpp
+++ b/include/eve/detail/function/simd/arm/neon/compress_store_impl.hpp
@@ -1,0 +1,59 @@
+//==================================================================================================
+/*
+  EVE - Expressive Vector Engine
+  Copyright : EVE Contributors & Maintainers
+  SPDX-License-Identifier: MIT
+*/
+//==================================================================================================
+#pragma once
+
+#include <eve/detail/function/compress_store_swizzle_mask_num.hpp>
+
+namespace eve::detail
+{
+  template <typename N>
+  EVE_FORCEINLINE
+  eve::wide<std::uint8_t, N> byte_shuffle(eve::wide<std::uint8_t, N> what,
+                                          eve::wide<std::uint8_t, N> pattern)
+  {
+         if constexpr ( N() <= 8 ) return vtbl1_u8  (what, pattern);
+    else if constexpr ( eve::current_api == eve::asimd ) return vqtbl1q_u8(what, pattern);
+    else
+    {
+      uint8x8x2_t lh  = {{ vget_low_u8(what), vget_high_u8(what) }};
+      return vcombine_u8(
+        vtbl2_u8(lh, vget_low_u8(pattern)), vtbl2_u8(lh, vget_high_u8(pattern))
+      );
+    }
+  }
+
+  template <typename T, typename U, typename N, simd_compatible_ptr<wide<T, N>> Ptr>
+  EVE_FORCEINLINE
+  T* compress_store_impl_(EVE_SUPPORTS(neon128_),
+                          wide<T, N> v,
+                          logical<wide<U, N>> mask,
+                          Ptr ptr)
+    requires arm_abi<abi_t<T, N>> && ( N() == 4 )
+  {
+    using u_t   = eve::as_integer_t<T, unsigned>;
+    using bytes = typename wide<T, N>::template rebind<std::uint8_t, fixed<sizeof(T) * N{}()>>;
+
+    alignas(sizeof(T) * 4) auto patterns = pattern_4_elements(idxs_bytes<u_t>);
+
+    auto [num, count] = compress_store_swizzle_mask_num[ignore_none](mask);
+
+    // load pattern
+    u_t const* pattern_p = patterns[num].data();
+    auto     * bytes_p   = (std::uint8_t const*) (pattern_p);
+    auto       bytes_ap  = eve::as_aligned(bytes_p, eve::fixed<bytes::size()>{});
+    bytes pattern{bytes_ap};
+
+    bytes bytes_v = bit_cast(v, eve::as<bytes>{});
+          bytes_v = byte_shuffle(bytes_v, pattern);
+
+    v = bit_cast(bytes_v, as(v));
+
+    store(v, ptr);
+    return as_raw_pointer(ptr) + count;
+  }
+}

--- a/include/eve/detail/function/simd/arm/neon/compress_store_impl.hpp
+++ b/include/eve/detail/function/simd/arm/neon/compress_store_impl.hpp
@@ -9,12 +9,16 @@
 
 #include <eve/detail/function/compress_store_swizzle_mask_num.hpp>
 
+#include <eve/function/if_else.hpp>
+#include <eve/function/slide_left.hpp>
+
 namespace eve::detail
 {
+  // See comments in compress_store_num and x86 impl
+
   template <typename N>
-  EVE_FORCEINLINE
-  eve::wide<std::uint8_t, N> byte_shuffle(eve::wide<std::uint8_t, N> what,
-                                          eve::wide<std::uint8_t, N> pattern)
+  EVE_FORCEINLINE eve::wide<std::uint8_t, N>
+  byte_shuffle(eve::wide<std::uint8_t, N> what, eve::wide<std::uint8_t, N> pattern)
   {
          if constexpr ( N() <= 8 ) return vtbl1_u8  (what, pattern);
     else if constexpr ( eve::current_api == eve::asimd ) return vqtbl1q_u8(what, pattern);
@@ -36,9 +40,9 @@ namespace eve::detail
     requires arm_abi<abi_t<T, N>> && ( N() == 4 )
   {
     using u_t   = eve::as_integer_t<T, unsigned>;
-    using bytes = typename wide<T, N>::template rebind<std::uint8_t, fixed<sizeof(T) * N{}()>>;
+    using bytes = typename wide<T, N>::template rebind<std::uint8_t, fixed<sizeof(T) * 4>>;
 
-    alignas(sizeof(T) * 4) auto patterns = pattern_4_elements(idxs_bytes<u_t>);
+    alignas(sizeof(T) * 4) constexpr auto patterns = pattern_4_elements(idxs_bytes<u_t>);
 
     auto [num, count] = compress_store_swizzle_mask_num[ignore_none](mask);
 
@@ -49,10 +53,45 @@ namespace eve::detail
     bytes pattern{bytes_ap};
 
     bytes bytes_v = bit_cast(v, eve::as<bytes>{});
-          bytes_v = byte_shuffle(bytes_v, pattern);
+    bytes_v       = byte_shuffle(bytes_v, pattern);
+    v             = bit_cast(bytes_v, as(v));
 
-    v = bit_cast(bytes_v, as(v));
+    store(v, ptr);
+    return as_raw_pointer(ptr) + count;
+  }
 
+  template <typename T, typename U, typename N, simd_compatible_ptr<wide<T, N>> Ptr>
+  EVE_FORCEINLINE
+  T* compress_store_impl_(EVE_SUPPORTS(neon128_),
+                          wide<T, N> v,
+                          logical<wide<U, N>> mask,
+                          Ptr ptr)
+    requires arm_abi<abi_t<T, N>> && ( N() == 8 ) && (sizeof(T) == 2)
+  {
+    using u_t   = eve::as_integer_t<T, unsigned>;
+    using bytes = typename wide<T, N>::template rebind<std::uint8_t, fixed<sizeof(T) * 8>>;
+
+    // Reduce variations: in each pair from 4 to 3. 10 and 01 become the same.
+    // Two last elements don't matter.
+    auto to_left = eve::slide_left(v, eve::index<1>);
+    v = eve::if_else[mask]( v, to_left );
+
+    // Find pattern
+    alignas(sizeof(T) * 8) constexpr auto patterns = pattern_8_elements(idxs_bytes<u_t>);
+
+    auto [num, count] = compress_store_swizzle_mask_num(mask);
+
+    u_t const* pattern_p = patterns[num].data();
+    auto     * bytes_p   = (std::uint8_t const*) (pattern_p);
+    auto       bytes_ap  = eve::as_aligned(bytes_p, eve::fixed<bytes::size()>{});
+    bytes pattern{bytes_ap};
+
+    // Shuffle
+    bytes bytes_v = bit_cast(v, eve::as<bytes>{});
+    bytes_v       = byte_shuffle(bytes_v, pattern);
+    v             = bit_cast(bytes_v, as(v));
+
+    // store
     store(v, ptr);
     return as_raw_pointer(ptr) + count;
   }

--- a/include/eve/detail/function/simd/arm/neon/compress_store_impl.hpp
+++ b/include/eve/detail/function/simd/arm/neon/compress_store_impl.hpp
@@ -42,12 +42,10 @@ namespace eve::detail
     using u_t   = eve::as_integer_t<T, unsigned>;
     using bytes = typename wide<T, N>::template rebind<std::uint8_t, fixed<sizeof(T) * 4>>;
 
-    alignas(sizeof(T) * 4) constexpr auto patterns = pattern_4_elements(idxs_bytes<u_t>);
-
     auto [num, count] = compress_store_swizzle_mask_num[ignore_none](mask);
 
     // load pattern
-    u_t const* pattern_p = patterns[num].data();
+    u_t const* pattern_p = pattern_4_elements_bytes_v<u_t>[num].data();
     auto     * bytes_p   = (std::uint8_t const*) (pattern_p);
     auto       bytes_ap  = eve::as_aligned(bytes_p, eve::fixed<bytes::size()>{});
     bytes pattern{bytes_ap};
@@ -77,11 +75,9 @@ namespace eve::detail
     v = eve::if_else[mask]( v, to_left );
 
     // Find pattern
-    alignas(sizeof(T) * 8) constexpr auto patterns = pattern_8_elements(idxs_bytes<u_t>);
-
     auto [num, count] = compress_store_swizzle_mask_num(mask);
 
-    u_t const* pattern_p = patterns[num].data();
+    u_t const* pattern_p = pattern_8_elements_bytes_v<u_t>[num].data();
     auto     * bytes_p   = (std::uint8_t const*) (pattern_p);
     auto       bytes_ap  = eve::as_aligned(bytes_p, eve::fixed<bytes::size()>{});
     bytes pattern{bytes_ap};

--- a/include/eve/detail/function/simd/arm/neon/compress_store_swizzle_mask_num.hpp
+++ b/include/eve/detail/function/simd/arm/neon/compress_store_swizzle_mask_num.hpp
@@ -90,10 +90,10 @@ namespace eve::detail
 
   template<eve::relative_conditional_expr C, typename T>
   EVE_FORCEINLINE std::pair<int, bool>
-  compress_store_swizzle_mask_num_(EVE_SUPPORTS(neon128_), C c, logical<wide<T, fixed<4>>> mask)
+  compress_store_swizzle_mask_num_partial_(EVE_SUPPORTS(neon128_), C c, logical<wide<T, fixed<4>>> mask)
   {
          if constexpr ( C::is_complete && !C::is_inverted ) return {0, false};
-    else if constexpr ( !C::is_complete                   ) return compress_store_swizzle_mask_num(ignore_none, mask && c.mask(as(mask)));
+    else if constexpr ( !C::is_complete                   ) return compress_store_swizzle_mask_num_partial(ignore_none, mask && c.mask(as(mask)));
     else
     {
       using l_t = logical<wide<T, fixed<4>>>;

--- a/include/eve/detail/function/simd/arm/neon/compress_store_swizzle_mask_num.hpp
+++ b/include/eve/detail/function/simd/arm/neon/compress_store_swizzle_mask_num.hpp
@@ -109,6 +109,28 @@ namespace eve::detail
     }
   }
 
+  template<eve::relative_conditional_expr C, typename T>
+  EVE_FORCEINLINE std::pair<int, int>
+  compress_store_swizzle_mask_num_(EVE_SUPPORTS(neon128_), C c, logical<wide<T, fixed<4>>> mask)
+  {
+         if constexpr ( C::is_complete && !C::is_inverted ) return {0, 0};
+    else if constexpr ( !C::is_complete                   ) return compress_store_swizzle_mask_num(ignore_none, mask && c.mask(as(mask)));
+    else
+    {
+      using l_t = logical<wide<T, fixed<4>>>;
+      using bits_type = typename l_t::bits_type;
+
+      bits_type bits = mask.bits();
+      // last element doesn't participate in the mask
+      bits_type elements_bit{0x11, 0x12, 0x14, 0x10};
+      bits &= elements_bit;
+      int desc     = sum4(bits);
+      int num      = desc & 0xf;
+      int popcount = desc >> 4;
+      return {num, popcount};
+    }
+  }
+
   template<typename T>
   EVE_FORCEINLINE std::pair<int, int>
   compress_store_swizzle_mask_num_(EVE_SUPPORTS(neon128_), logical<wide<T, fixed<8>>> mask)

--- a/include/eve/detail/function/simd/common/compress_store_impl.hpp
+++ b/include/eve/detail/function/simd/common/compress_store_impl.hpp
@@ -37,6 +37,40 @@ namespace eve::detail
     };
   }
 
+  // See compress_store_num for explanation
+  template <std::unsigned_integral T>
+  EVE_FORCEINLINE constexpr auto pattern_8_elements(std::array<T, 8> idxs)
+  {
+    using row = std::array<T, 8>;
+
+    std::array<row, 27> res = {};
+
+    for (unsigned i = 0; i != 27; ++i)
+    {
+      unsigned number_of_9s = 0, number_of_3s = 0, number_of_1s = 0;
+      unsigned base_3_value = i;
+
+      if (base_3_value >= 9) ++number_of_9s, base_3_value -= 9;
+      if (base_3_value >= 9) ++number_of_9s, base_3_value -= 9;
+      if (base_3_value >= 3) ++number_of_3s, base_3_value -= 3;
+      if (base_3_value >= 3) ++number_of_3s, base_3_value -= 3;
+      if (base_3_value >= 1) ++number_of_1s, base_3_value -= 1;
+      if (base_3_value >= 1) ++number_of_1s, base_3_value -= 1;
+
+      auto* it = res[i].begin();
+      if (number_of_1s) *it++ = idxs[0], --number_of_1s;
+      if (number_of_1s) *it++ = idxs[1], --number_of_1s;
+      if (number_of_3s) *it++ = idxs[2], --number_of_3s;
+      if (number_of_3s) *it++ = idxs[3], --number_of_3s;
+      if (number_of_9s) *it++ = idxs[4], --number_of_9s;
+      if (number_of_9s) *it++ = idxs[5], --number_of_9s;
+      *it++ = idxs[6];
+      *it++ = idxs[7];
+    }
+
+    return res;
+  }
+
   template <std::unsigned_integral T>
   constexpr auto idxs_bytes = [] {
     std::array<T, 8> res = {};

--- a/include/eve/detail/function/simd/common/compress_store_impl.hpp
+++ b/include/eve/detail/function/simd/common/compress_store_impl.hpp
@@ -18,6 +18,52 @@
 
 namespace eve::detail
 {
+  // permutation masks ------------------
+
+  template <std::unsigned_integral T>
+  EVE_FORCEINLINE constexpr auto pattern_4_elements(std::array<T, 8> idxs)
+  {
+    using row = std::array<T, 4>;
+
+    return std::array {
+      row{ idxs[3],       0,       0,       0 },  // 000
+      row{ idxs[0], idxs[3],       0,       0 },  // 001
+      row{ idxs[1], idxs[3],       0,       0 },  // 010
+      row{ idxs[0], idxs[1], idxs[3],       0 },  // 011
+      row{ idxs[2], idxs[3],       0,       0 },  // 100
+      row{ idxs[0], idxs[2], idxs[3],       0 },  // 101
+      row{ idxs[1], idxs[2], idxs[3],       0 },  // 110
+      row{ idxs[0], idxs[1], idxs[2], idxs[3] },  // 111
+    };
+  }
+
+  template <std::unsigned_integral T>
+  constexpr auto idxs_bytes = [] {
+    std::array<T, 8> res = {};
+
+    for (unsigned i = 0; i != 8; ++i)
+    {
+      unsigned byte_idx = i * sizeof(T);
+
+      if constexpr ( sizeof(T) == 4 )
+      {
+        res[i] = (byte_idx + 3) << 24 | (byte_idx + 2) << 16 | (byte_idx + 1) << 8 | byte_idx;
+      }
+      else if constexpr ( sizeof(T) == 2 )
+      {
+        res[i] = (byte_idx + 1) << 8 | byte_idx;
+      }
+      else if constexpr ( sizeof(T) == 1 )
+      {
+        res[i] = byte_idx;
+      }
+    }
+
+    return res;
+  }();
+
+  // generic impl ------------------
+
   template<real_scalar_value T, typename N, typename U, simd_compatible_ptr<wide<T, N>> Ptr>
   EVE_FORCEINLINE
   T* compress_store_impl_aggregated(wide<T, N> v,

--- a/include/eve/detail/function/simd/common/compress_store_impl.hpp
+++ b/include/eve/detail/function/simd/common/compress_store_impl.hpp
@@ -96,6 +96,14 @@ namespace eve::detail
     return res;
   }();
 
+  template <std::unsigned_integral T>
+  constexpr auto pattern_4_elements_bytes_v alignas(sizeof(T) * 4) =
+    pattern_4_elements(idxs_bytes<T>);
+
+  template <std::unsigned_integral T>
+  constexpr auto pattern_8_elements_bytes_v alignas(sizeof(T) * 8) =
+    pattern_8_elements(idxs_bytes<T>);
+
   // generic impl ------------------
 
   template<real_scalar_value T, typename N, typename U, simd_compatible_ptr<wide<T, N>> Ptr>

--- a/include/eve/detail/function/simd/common/compress_store_swizzle_mask_num.hpp
+++ b/include/eve/detail/function/simd/common/compress_store_swizzle_mask_num.hpp
@@ -46,7 +46,7 @@ namespace eve::detail
     // can only be for 64 bit numbers on 128 bit register
     if constexpr (has_aggregated_abi_v<w_t>)
     {
-      return compress_store_swizzle_mask_num_partial(c, convert(mask, as<logical<std::uint32_t>>{}));
+      return compress_store_swizzle_mask_num(c, convert(mask, as<logical<std::uint32_t>>{}));
     }
     else
     {

--- a/include/eve/detail/function/simd/common/compress_store_swizzle_mask_num.hpp
+++ b/include/eve/detail/function/simd/common/compress_store_swizzle_mask_num.hpp
@@ -18,7 +18,7 @@ namespace eve::detail
 {
   template<eve::relative_conditional_expr C, typename T>
   EVE_FORCEINLINE std::pair<int, bool>
-  compress_store_swizzle_mask_num_(EVE_SUPPORTS(cpu_), C c, logical<wide<T, fixed<4>>> mask)
+  compress_store_swizzle_mask_num_partial_(EVE_SUPPORTS(cpu_), C c, logical<wide<T, fixed<4>>> mask)
   {
     using w_t = wide<T, fixed<4>>;
     using l_t = logical<wide<T>>;
@@ -26,7 +26,7 @@ namespace eve::detail
     // can only be for 64 bit numbers on 128 bit register
     if constexpr (has_aggregated_abi_v<w_t>)
     {
-      return compress_store_swizzle_mask_num(c, convert(mask, as<logical<std::uint32_t>>{}));
+      return compress_store_swizzle_mask_num_partial(c, convert(mask, as<logical<std::uint32_t>>{}));
     }
     else
     {

--- a/include/eve/detail/function/simd/common/compress_store_swizzle_mask_num.hpp
+++ b/include/eve/detail/function/simd/common/compress_store_swizzle_mask_num.hpp
@@ -36,6 +36,26 @@ namespace eve::detail
     }
   }
 
+  template<eve::relative_conditional_expr C, typename T>
+  EVE_FORCEINLINE std::pair<int, int>
+  compress_store_swizzle_mask_num_(EVE_SUPPORTS(cpu_), C c, logical<wide<T, fixed<4>>> mask)
+  {
+    using w_t = wide<T, fixed<4>>;
+    using l_t = logical<wide<T>>;
+
+    // can only be for 64 bit numbers on 128 bit register
+    if constexpr (has_aggregated_abi_v<w_t>)
+    {
+      return compress_store_swizzle_mask_num_partial(c, convert(mask, as<logical<std::uint32_t>>{}));
+    }
+    else
+    {
+      static_assert(top_bits<l_t>::bits_per_element == 1);
+      int mmask = top_bits{mask, c}.as_int();
+      return {(mmask & 7), std::popcount(static_cast<std::uint32_t>(mmask))};
+    }
+  }
+
   template<typename T>
   EVE_FORCEINLINE std::pair<int, int>
   compress_store_swizzle_mask_num_(EVE_SUPPORTS(cpu_), logical<wide<T, fixed<8>>> mask)

--- a/include/eve/detail/function/simd/x86/compress_store_impl.hpp
+++ b/include/eve/detail/function/simd/x86/compress_store_impl.hpp
@@ -221,40 +221,6 @@ namespace eve::detail
     else return compress_store_impl[eve::ignore_none](v, mask, ptr);
   }
 
-  // See base_3_mask for explanation
-  template <std::unsigned_integral T>
-  EVE_FORCEINLINE constexpr auto pattern_8_elements(std::array<T, 8> idxs)
-  {
-    using row = std::array<T, 8>;
-
-    std::array<row, 27> res = {};
-
-    for (unsigned i = 0; i != 27; ++i)
-    {
-      unsigned number_of_9s = 0, number_of_3s = 0, number_of_1s = 0;
-      unsigned base_3_value = i;
-
-      if (base_3_value >= 9) ++number_of_9s, base_3_value -= 9;
-      if (base_3_value >= 9) ++number_of_9s, base_3_value -= 9;
-      if (base_3_value >= 3) ++number_of_3s, base_3_value -= 3;
-      if (base_3_value >= 3) ++number_of_3s, base_3_value -= 3;
-      if (base_3_value >= 1) ++number_of_1s, base_3_value -= 1;
-      if (base_3_value >= 1) ++number_of_1s, base_3_value -= 1;
-
-      auto* it = res[i].begin();
-      if (number_of_1s) *it++ = idxs[0], --number_of_1s;
-      if (number_of_1s) *it++ = idxs[1], --number_of_1s;
-      if (number_of_3s) *it++ = idxs[2], --number_of_3s;
-      if (number_of_3s) *it++ = idxs[3], --number_of_3s;
-      if (number_of_9s) *it++ = idxs[4], --number_of_9s;
-      if (number_of_9s) *it++ = idxs[5], --number_of_9s;
-      *it++ = idxs[6];
-      *it++ = idxs[7];
-    }
-
-    return res;
-  }
-
   template<typename T, typename U, typename N, simd_compatible_ptr<wide<T, N>> Ptr>
   EVE_FORCEINLINE
   T* compress_store_impl_(EVE_SUPPORTS(ssse3_),

--- a/include/eve/detail/function/simd/x86/compress_store_swizzle_mask_num.hpp
+++ b/include/eve/detail/function/simd/x86/compress_store_swizzle_mask_num.hpp
@@ -21,6 +21,16 @@ namespace eve::detail
     return compress_store_swizzle_mask_num_partial(c, to_bytes);
   }
 
+  template<eve::relative_conditional_expr C, typename T>
+  EVE_FORCEINLINE std::pair<int, int>
+  compress_store_swizzle_mask_num_(EVE_SUPPORTS(sse2_), C c, logical<wide<T, fixed<4>>> mask)
+    requires (current_api < avx512) && (sizeof(T) == 2)
+  {
+    static_assert(top_bits<logical<wide<T, fixed<4>>>>::bits_per_element == 2);
+    auto to_bytes = eve::convert(mask, eve::as<eve::logical<std::uint8_t>>{});
+    return compress_store_swizzle_mask_num(c, to_bytes);
+  }
+
   template<typename T>
   EVE_FORCEINLINE std::pair<int, int>
   compress_store_swizzle_mask_num_(EVE_SUPPORTS(sse2_), logical<wide<T, fixed<8>>> mask)

--- a/include/eve/detail/function/simd/x86/compress_store_swizzle_mask_num.hpp
+++ b/include/eve/detail/function/simd/x86/compress_store_swizzle_mask_num.hpp
@@ -13,12 +13,12 @@ namespace eve::detail
 {
   template<eve::relative_conditional_expr C, typename T>
   EVE_FORCEINLINE std::pair<int, bool>
-  compress_store_swizzle_mask_num_(EVE_SUPPORTS(sse2_), C c, logical<wide<T, fixed<4>>> mask)
+  compress_store_swizzle_mask_num_partial_(EVE_SUPPORTS(sse2_), C c, logical<wide<T, fixed<4>>> mask)
     requires (current_api < avx512) && (sizeof(T) == 2)
   {
     static_assert(top_bits<logical<wide<T, fixed<4>>>>::bits_per_element == 2);
     auto to_bytes = eve::convert(mask, eve::as<eve::logical<std::uint8_t>>{});
-    return compress_store_swizzle_mask_num(c, to_bytes);
+    return compress_store_swizzle_mask_num_partial(c, to_bytes);
   }
 
   template<typename T>

--- a/include/eve/module/real/core/function/regular/simd/arm/neon/convert.hpp
+++ b/include/eve/module/real/core/function/regular/simd/arm/neon/convert.hpp
@@ -163,6 +163,7 @@ namespace eve::detail
     else if constexpr( catin == category::int8x8 )
     {
            if constexpr( catou == category::int16x8 ) return vmovl_s8(v0);
+      else if constexpr( catou == category::int16x4 ) return vget_low_s16(vmovl_s8(v0));
       else                                            return convert_(EVE_RETARGET(simd_), v0, tgt);
     }
     //==============================================================================================
@@ -170,7 +171,7 @@ namespace eve::detail
     else if constexpr( catin == category::uint8x8 )
     {
            if constexpr( catou == category::uint16x8 )  return vmovl_u8(v0);
-      else if constexpr( catou == category::int8x8 )    return vreinterpret_s8_u8(v0);
+      else if constexpr( catou == category::uint16x4 )  return vget_low_u16(vmovl_u8(v0));
       else                                              return convert_(EVE_RETARGET(simd_), v0, tgt);
     }
     //==============================================================================================

--- a/test/unit/internals/compress_store_swizzle_mask_num.cpp
+++ b/test/unit/internals/compress_store_swizzle_mask_num.cpp
@@ -34,7 +34,7 @@ EVE_TEST_TYPES("compress_store_swizzle_mask_num 4 elements",
           for( bool m3 : {false, true} ) {
             mask_t mask {m0, m1, m2, m3};
 
-            auto [actual_num, actual_4th] = eve::detail::compress_store_swizzle_mask_num(ignore, mask);
+            auto [actual_num, actual_4th] = eve::detail::compress_store_swizzle_mask_num_partial(ignore, mask);
 
             int expected_num = expected_shuffle_num(mask && ignore.mask(eve::as(mask)));
 


### PR DESCRIPTION
Tagging @aqrit - port of his algorithm to arm.

### Added missing conversions 8 chars to 8 shorts. This is actually one instruction.

### extracted `compress_store_swizzle_mask_num_partial`/`compress_store_swizzle_mask_num` for 4 elements.

On x86 we mostly use `compress_store_swizzle_mask_num_partial`: it does not compute the count, just the bool if the last element is set or not (except for 4 doubles, since there is a shuffle of ints which does not allow to store popcount in the mask).

The proper `compress_store_swizzle_mask_num` returns the mask number and the popcount.
On arm we use a sum with mask to get it.

### compress store for 4/8 elements.

We still don't have arm benches but here is the asm.

remove ints, arm-v8

```
.L6:
	ldr	q1, [x2], 16
	cmeq	v0.4s, v1.4s, #0
	bic	v0.16b, v2.16b, v0.16b
	addv	s0, v0.4s
	umov	w0, v0.s[0]
	ubfiz	x3, x0, 4, 4
	asr	w0, w0, 4
	ldr	q0, [x23, x3]
#APP
// 11270 "/usr/lib/gcc-cross/aarch64-linux-gnu/10/include/arm_neon.h" 1
	tbl v1.16b, {v1.16b}, v0.16b
// 0 "" 2
#NO_APP
	str	q1, [x19]
	add	x19, x19, x0, sxtw 2
	cmp	x20, x2
	bne	.L6
```

remove shorts, arm-v8

```
.L6:
	ldr	q2, [x2], 16
	cmeq	v1.8h, v2.8h, #0
	ext	v3.16b, v2.16b, v4.16b, #2
	not	v0.16b, v1.16b
	and	v1.16b, v0.16b, v5.16b
	bsl	v0.16b, v2.16b, v3.16b
	addv	h1, v1.8h
	umov	w0, v1.h[0]
	ubfiz	x3, x0, 4, 5
	ubfx	x0, x0, 7, 9
	ldr	q1, [x23, x3]
#APP
// 11270 "/usr/lib/gcc-cross/aarch64-linux-gnu/10/include/arm_neon.h" 1
	tbl v0.16b, {v0.16b}, v1.16b
// 0 "" 2
#NO_APP
	str	q0, [x19]
	add	x19, x19, x0, lsl 1
	cmp	x20, x2
	bne	.L6
```

Chars have some volume, but seem OK too.