### PR TITLE
Install directory fix

### DIFF
--- a/cmake/config/install.cmake
+++ b/cmake/config/install.cmake
@@ -7,7 +7,7 @@
 ## =================================================================================================
 ## Install target
 ## =================================================================================================
-install(DIRECTORY ${PROJECT_SOURCE_DIR}/include DESTINATION .)
+install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/eve TYPE INCLUDE)
 
 ## =================================================================================================
 ## Exporting target for external use


### PR DESCRIPTION
Single line change to the eve include directory install directive. Targeting `include/eve` and specifying `TYPE INCLUDE` instead of `.` is the way to go to ensure CMake knows we want `include/eve` to be put in the include target.

This effectively allows users to specify the *include* install directory using the `CMAKE_INSTALL_INCLUDEDIR` variable, whereas the old version only allowed to change the install prefix for all the *install targets* as a whole with `CMAKE_INSTALL_PREFIX`.