### PR TITLE
convert: improve u64 => u32 when using AVX2

### DIFF
--- a/include/eve/module/real/core/function/regular/simd/x86/convert_256.hpp
+++ b/include/eve/module/real/core/function/regular/simd/x86/convert_256.hpp
@@ -31,11 +31,11 @@ namespace eve::detail
       return v0;
     }
     else if constexpr( current_api >= avx2 && (N::value == 4)
-                       && std::is_integral_v<In> && (sizeof(In) == 8)
-                       && std::is_integral_v<Out> && (sizeof(Out) == 4) )
+                       && std::integral<In> && (sizeof(In) == 8)
+                       && std::integral<Out> && (sizeof(Out) == 4) )
     {
       // u64 to u32
-      const auto p = _mm256_permutevar8x32_epi32(v0, _mm256_set_epi32(7, 5, 3, 1, 6, 4, 2, 0));
+      auto const p = _mm256_permutevar8x32_epi32(v0, _mm256_set_epi32(7, 5, 3, 1, 6, 4, 2, 0));
       return _mm256_extractf128_si256(p, 0);
     }
     else

--- a/include/eve/module/real/core/function/regular/simd/x86/convert_256.hpp
+++ b/include/eve/module/real/core/function/regular/simd/x86/convert_256.hpp
@@ -36,7 +36,7 @@ namespace eve::detail
     {
       // u64 to u32
       auto const p = _mm256_permutevar8x32_epi32(v0, _mm256_set_epi32(7, 5, 3, 1, 6, 4, 2, 0));
-      return _mm256_extractf128_si256(p, 0);
+      return _mm256_castsi256_si128(p);
     }
     else
     {


### PR DESCRIPTION
Preliminary benchmarks (using
https://github.com/aguinet/eve/commit/38599cf6ad77d1bd6dcbb99970ed2332a97a5eaf):

Before patch:
 ```
| ns/element |           element/s |    err% |     total | benchmark
| 0.21       |    4,782,929,097.42 |    0.2% |      0.00 | `convert_downgrade(eve::avx_abi_v0::wide<long unsigned int, eve::fixed<4> >)`
 ```

After patch:
 ```
| ns/element |           element/s |    err% |     total | benchmark
| 0.16       |    6,402,093,057.96 |    0.1% |      0.00 | `convert_downgrade(eve::avx_abi_v0::wide<long unsigned int, eve::fixed<4> >)`
 ```