### PR TITLE
FIX-1066: reverse

### DIFF
--- a/examples/start_here.cpp
+++ b/examples/start_here.cpp
@@ -117,6 +117,17 @@ void erase_remove_numbers_outisde_of_treshold(
   );
 }
 
+// -------------------------
+// reverse parallel arrays
+
+#include <eve/algo/reverse.hpp>
+#include <eve/views/zip.hpp>
+
+void reverse_parallel_arrays(std::vector<int>& a, std::vector<std::uint8_t>& b)
+{
+  eve::algo::reverse(eve::views::zip(a, b));
+}
+
 // --------------------------------------------
 
 #include "test.hpp"
@@ -215,4 +226,18 @@ TTS_CASE("remove_numbers_outisde_of_treshold")
   erase_remove_numbers_outisde_of_treshold(in, 0, 9);
 
   TTS_EQUAL(expected, in);
+};
+
+TTS_CASE("reverse_parallel_arrays")
+{
+  std::vector<int>          a { -1, -2, -3, -4, -5 };
+  std::vector<std::uint8_t> b {  1,  2,  3,  4,  5 };
+
+  std::vector<int>          expected_a { -5, -4, -3, -2, -1 };
+  std::vector<std::uint8_t> expected_b {  5,  4,  3,  2,  1 };
+
+  reverse_parallel_arrays(a, b);
+
+  TTS_EQUAL(a, expected_a);
+  TTS_EQUAL(b, expected_b);
 };

--- a/include/eve/algo/reverse.hpp
+++ b/include/eve/algo/reverse.hpp
@@ -7,11 +7,50 @@
 //==================================================================================================
 #pragma once
 
+#include <eve/algo/as_range.hpp>
 #include <eve/algo/copy.hpp>
+#include <eve/algo/preprocess_range.hpp>
+#include <eve/algo/swap_ranges.hpp>
 #include <eve/algo/views/reverse.hpp>
 
 namespace eve::algo
 {
+  //================================================================================================
+  //! @addtogroup eve.algo
+  //! @{
+  //!  @var reverse
+  //!
+  //!  @brief version of std::reverse
+  //!    * default unrolling is 1.
+  //!    * will align by default.
+  //!
+  //!   **Required header:** `#include <eve/algo/reverse.hpp>`
+  //!
+  //! @}
+  //================================================================================================
+
+  template <typename TraitsSupport>
+  struct reverse_ : TraitsSupport
+  {
+    template <relaxed_range Rng>
+    EVE_FORCEINLINE void operator()(Rng&& rng) const
+    {
+      if (rng.begin() == rng.end()) return;
+
+      // To utilize extra information from range prerprocessing.
+      auto processed = eve::algo::preprocess_range(TraitsSupport::get_traits(), EVE_FWD(rng));
+      auto f = processed.begin();
+      auto l = processed.end();
+
+      std::ptrdiff_t n = l - f;
+      auto m = unalign(f) + n / 2;
+
+      swap_ranges[processed.traits()](as_range(f, m), views::reverse(l));
+    }
+  };
+
+  inline constexpr auto reverse = function_with_traits<reverse_>[algo::unroll<1>];
+
   //================================================================================================
   //! @addtogroup eve.algo
   //! @{

--- a/include/eve/algo/reverse.hpp
+++ b/include/eve/algo/reverse.hpp
@@ -45,7 +45,10 @@ namespace eve::algo
       std::ptrdiff_t n = l - f;
       auto m = unalign(f) + n / 2;
 
-      swap_ranges[processed.traits()](as_range(f, m), views::reverse(l));
+      // Just because the whole thing is divisible_by_cardinal does not mean
+      // the halve will be.
+      auto tr = drop_key(divisible_by_cardinal, processed.traits());
+      swap_ranges[tr](as_range(f, m), views::reverse(l));
     }
   };
 

--- a/include/eve/algo/swap_ranges.hpp
+++ b/include/eve/algo/swap_ranges.hpp
@@ -1,0 +1,62 @@
+//==================================================================================================
+/*
+  EVE - Expressive Vector Engine
+  Copyright : EVE Contributors & Maintainers
+  SPDX-License-Identifier: MIT
+*/
+//==================================================================================================
+#pragma once
+
+#include <eve/algo/transform.hpp>
+#include <eve/algo/traits.hpp>
+
+#include <eve/function/zip.hpp>
+
+namespace eve::algo
+{
+  //================================================================================================
+  //! @addtogroup eve.algo
+  //! @{
+  //!  @var swap_ranges
+  //!
+  //!  @brief version of std::swap_ranges
+  //!    * Accepts two things zipping together to range of pair.
+  //!    * Also can accept a `zipped_range_pair`.
+  //!    * returns void.
+  //!    * default unrolling is 4.
+  //!    * will align by default.
+  //!    * will do conversions if necessary.
+  //!
+  //!   **Required header:** `#include <eve/algo/swap_ranges.hpp>`
+  //!
+  //! @}
+  //================================================================================================
+
+  template <typename TraitsSupport>
+  struct swap_ranges_ : TraitsSupport
+  {
+    struct op
+    {
+      EVE_FORCEINLINE auto operator()(auto in) const
+      {
+        return eve::zip(get<1>(in), get<0>(in));
+      }
+    };
+
+    template <zipped_range_pair R>
+    EVE_FORCEINLINE void operator()(R r) const
+    {
+      auto rezipped = r[common_type];
+      transform_inplace[TraitsSupport::get_traits()](rezipped, op{});
+    }
+
+    template <typename R1, typename R2>
+      requires zip_to_range<R1, R2>
+    EVE_FORCEINLINE void operator()(R1&& r1, R2&& r2) const
+    {
+      operator()(views::zip(EVE_FWD(r1), EVE_FWD(r2)));
+    }
+  };
+
+  inline constexpr auto swap_ranges = function_with_traits<swap_ranges_>[default_simple_algo_traits];
+}

--- a/test/unit/algo/CMakeLists.txt
+++ b/test/unit/algo/CMakeLists.txt
@@ -51,6 +51,7 @@ make_unit("unit.algo" algorithm/sums_special_cases.cpp)
 
 # shuffles
 make_unit("unit.algo" algorithm/remove.cpp)
+make_unit("unit.algo" algorithm/reverse_generic.cpp)
 
 # transform
 make_unit("unit.algo" algorithm/transform_inplace_generic.cpp)

--- a/test/unit/algo/CMakeLists.txt
+++ b/test/unit/algo/CMakeLists.txt
@@ -61,4 +61,5 @@ make_unit("unit.algo" algorithm/iota_generic.cpp)
 # copy
 make_unit("unit.algo" algorithm/copy_generic.cpp)
 make_unit("unit.algo" algorithm/copy_fwd.cpp)
+make_unit("unit.algo" algorithm/swap_ranges_generic.cpp)
 make_unit("unit.algo" algorithm/reverse_copy_generic.cpp)

--- a/test/unit/algo/algo_test.hpp
+++ b/test/unit/algo/algo_test.hpp
@@ -92,6 +92,22 @@ namespace algo_test
   }
 
   template <typename T, typename Test>
+  void page_ends_test_special_cases(eve::as<T> tgt,
+                                    eve::element_type_t<T>* f,
+                                    eve::element_type_t<T>* l,
+                                    Test test)
+  {
+    if ((l - f) >= T::size())
+    {
+      ptr_range_test(tgt, f, f + T::size(), test);
+    }
+    if ((l - f) >= T::size() * 3)
+    {
+      ptr_range_test(tgt, f, f + 3 * T::size(), test);
+    }
+  }
+
+  template <typename T, typename Test>
   void page_ends_test(eve::as<T> tgt, Test test)
   {
     auto page = allocate_page<eve::element_type_t<T>>();
@@ -105,6 +121,8 @@ namespace algo_test
 
     auto run_f_l = [&] () mutable {
       test.init(page_begin, f, l, page_end);
+
+      page_ends_test_special_cases(tgt, f, l, test);
 
       while( f < l ) {
         ptr_range_test(tgt, f, l, test);

--- a/test/unit/algo/algorithm/inclusive_scan_inplace_generic.cpp
+++ b/test/unit/algo/algorithm/inclusive_scan_inplace_generic.cpp
@@ -15,7 +15,7 @@
 #include <algorithm>
 #include <functional>
 
-EVE_TEST_TYPES("Check inlclusive_scan_inplace", algo_test::selected_types)
+EVE_TEST_TYPES("Check inclusive_scan_inplace", algo_test::selected_types)
 <typename T>(eve::as<T> tgt)
 {
   algo_test::transform_inplace_generic_test(

--- a/test/unit/algo/algorithm/inclusive_scan_to_generic.cpp
+++ b/test/unit/algo/algorithm/inclusive_scan_to_generic.cpp
@@ -16,7 +16,7 @@
 #include <functional>
 #include <vector>
 
-EVE_TEST_TYPES("Check inlclusive_scan_to", algo_test::selected_pairs_types)
+EVE_TEST_TYPES("Check inclusive_scan_to", algo_test::selected_pairs_types)
 <typename T>(eve::as<T> tgt)
 {
   using init_t = std::tuple_element_t<1, eve::element_type_t<T>>;

--- a/test/unit/algo/algorithm/reverse_generic.cpp
+++ b/test/unit/algo/algorithm/reverse_generic.cpp
@@ -1,0 +1,27 @@
+//==================================================================================================
+/**
+  EVE - Expressive Vector Engine
+  Copyright : EVE Contributors & Maintainers
+  SPDX-License-Identifier: MIT
+**/
+//==================================================================================================
+
+#include "unit/algo/algo_test.hpp"
+
+#include <eve/algo/reverse.hpp>
+
+#include "transform_inplace_generic_test.hpp"
+
+#include <algorithm>
+
+EVE_TEST_TYPES("Check reverse inplace", algo_test::selected_types)
+<typename T>(eve::as<T> tgt)
+{
+  algo_test::transform_inplace_generic_test(
+    tgt,
+    eve::algo::reverse,
+    [](auto f, auto l, auto o) {
+      std::reverse_copy(f, l, o);
+    }
+  );
+};

--- a/test/unit/algo/algorithm/swap_ranges_generic.cpp
+++ b/test/unit/algo/algorithm/swap_ranges_generic.cpp
@@ -1,0 +1,76 @@
+//==================================================================================================
+/**
+  EVE - Expressive Vector Engine
+  Copyright : EVE Contributors & Maintainers
+  SPDX-License-Identifier: MIT
+**/
+//==================================================================================================
+
+#include "unit/algo/algo_test.hpp"
+
+#include <eve/algo/swap_ranges.hpp>
+
+#include <algorithm>
+
+template <typename Tgt, typename Alg>
+struct swap_ranges_ptr_test
+{
+  eve::as<Tgt> tgt;
+  Alg alg;
+
+  swap_ranges_ptr_test(eve::as<Tgt> tgt, Alg alg) : tgt(tgt), alg(alg) {}
+
+  void init(auto& page_1, auto& page_2) const
+  {
+    std::fill(page_1.begin(), page_1.end(), 0);
+    std::fill(page_2.begin(), page_2.end(), 1);
+  }
+
+  void generate_answer(auto*, auto*, auto*, auto*) {}
+
+  template <typename R1, typename R2>
+  void run(R1 range_or_it1, R2 range_or_it2)
+  {
+    auto zipped_range = eve::algo::views::zip(range_or_it1, range_or_it2);
+    // To operate with both ends always
+    auto r1 = get<0>(zipped_range);
+    auto r2 = get<1>(zipped_range);
+
+    TTS_EXPECT(std::all_of(eve::algo::unalign(r1.begin()),
+                           eve::algo::unalign(r1.end()),
+                           [](auto x) { return x == 0; }));
+    TTS_EXPECT(std::all_of(eve::algo::unalign(r2.begin()),
+                           eve::algo::unalign(r2.end()),
+                           [](auto x) { return x == 1; }));
+
+    alg(range_or_it1, range_or_it2);
+
+    TTS_EXPECT(std::all_of(eve::algo::unalign(r1.begin()),
+                           eve::algo::unalign(r1.end()),
+                           [](auto x) { return x == 1; }));
+    TTS_EXPECT(std::all_of(eve::algo::unalign(r2.begin()),
+                           eve::algo::unalign(r2.end()),
+                           [](auto x) { return x == 0; }));
+
+    alg(range_or_it1, range_or_it2);
+  }
+};
+
+void swap_ranges_test_page_ends(auto tgt, auto alg)
+{
+  swap_ranges_ptr_test test{tgt, alg};
+  algo_test::two_ranges_test(tgt, test);
+}
+
+EVE_TEST_TYPES("Check swap ranges", algo_test::selected_pairs_types)
+<typename T>(eve::as<T> tgt)
+{
+  using e_t = eve::element_type_t<T>;
+  auto native_tgt = eve::as<eve::wide<e_t>>{};
+
+  swap_ranges_test_page_ends(native_tgt, eve::algo::swap_ranges);
+
+  auto with_cardinal = eve::algo::swap_ranges[eve::algo::force_cardinal<T::size()>];
+
+  swap_ranges_test_page_ends(tgt, with_cardinal[eve::algo::unroll<1>][eve::algo::no_aligning]);
+};

--- a/test/unit/algo/algorithm/transform_inplace_generic_test.hpp
+++ b/test/unit/algo/algorithm/transform_inplace_generic_test.hpp
@@ -41,7 +41,7 @@ namespace algo_test
       if constexpr( std::floating_point<T> )
       {
         for( int i = 0; i != (l - f); ++i ) {
-          TTS_RELATIVE_EQUAL(expected[i], actual[i], 0.0001);
+          TTS_RELATIVE_EQUAL(expected[i], actual[i], 0.0005);
         }
       }
       else

--- a/test/unit/algo/algorithm/transform_special_cases.cpp
+++ b/test/unit/algo/algorithm/transform_special_cases.cpp
@@ -13,6 +13,8 @@
 
 #include <eve/algo/reverse.hpp>
 
+#include <eve/algo/swap_ranges.hpp>
+
 TTS_CASE("eve.algo.transform different type works")
 {
   std::vector<int>   in{1, 4, 9, 16};
@@ -37,15 +39,25 @@ TTS_CASE("eve.algo.transform different type works")
 
 TTS_CASE("eve.algo.reverse_copy, different types")
 {
-  std::vector<int, eve::aligned_allocator<int>>   in {3, 0};
+  std::vector<int>   in {1, 2, 3, 4};
   std::vector<short> out (in.size());
 
-  std::iota(in.begin(), in.end(), 0);
+  eve::algo::reverse_copy(in, out);
 
-  eve::algo::reverse_copy(in, out.begin());
-
-  std::vector<short> expected (in.size());
-  std::iota(expected.rbegin(), expected.rend(), 0);
-
+  std::vector<short> expected {4, 3, 2, 1};
   TTS_EQUAL(out, expected);
+};
+
+TTS_CASE("eve.algo.swap_ranges, different types")
+{
+  std::vector<int>   a {  1,  2,  3,  4};
+  std::vector<short> b { -1, -2, -3, -4};
+
+  eve::algo::swap_ranges(a, b);
+
+  std::vector<int>   expected_a { -1, -2, -3, -4};
+  std::vector<short> expected_b {  1,  2,  3,  4};
+
+  TTS_EQUAL(a, expected_a);
+  TTS_EQUAL(b, expected_b);
 };


### PR DESCRIPTION
* swap_ranges
* reverse

Measurements results.

* unrolling does not help.
* gcc can do reverse in simd by itself but clang can't

### Win over scalar for 1000 bytes

![newplot (43)](https://user-images.githubusercontent.com/11256077/142518991-7bf62634-7d88-4a8b-8878-2be4bab29c49.png)
 9 times for chars, 4 times for shorts, 6.7 times for ints.
 
###  Win over scalar for 10'000 bytes

![newplot (44)](https://user-images.githubusercontent.com/11256077/142519213-4978d616-ef3c-4378-9a59-1ef266fd4b06.png)

16.4 times for chars, 8.2 times for shorts, 6.53 times for ints.

### Can we do better?

My experimental implementation of reverse used a custom iteration pattern.
Here we just use `swap_ranges`.
Custom iteration pattern is better, especially on smaller sizes even though it makes things significantly more difficult to implement. I suspect this is due to masked loads/stores, current implementation requires more of them.

### Custom iteration pattern, 1000 bytes
 
![newplot (45)](https://user-images.githubusercontent.com/11256077/142519645-7e2cd21f-92ee-40ec-816d-83acb5710dfa.png)

Almost two times faster (13ns vs 26 ns) for chars and shorts, 1ns diff for ints, probably noise.

### Custom iteration pattern, 1000 bytes

![newplot (46)](https://user-images.githubusercontent.com/11256077/142519826-cf8682cf-cc1c-4657-98bb-7fc090a2c8fb.png)

Same 13 ns difference for chars and shorts. 

### Conclusion. 

Measure without aligning, maybe the difference will stop being significant, maybe it won't.
If not - implement and test custom aligning in eve.


