### PR TITLE
Fix wide so that wide<tuple> has correct sizeof

### DIFF
--- a/include/eve/arch/cpu/base.hpp
+++ b/include/eve/arch/cpu/base.hpp
@@ -66,31 +66,6 @@ namespace eve::detail
     protected:
     Storage data_;
   };
-
-  //================================================================================================
-  //! @brief Cardinal-only element of wide/logical
-  //!
-  //! wide_cardinal acts as a wrapper for the information about the number of lanes in a wide.
-  //! This separate class is meant to limit compile-time by being instantiated
-  //! once even if multiple wide instance requires the cardinal.
-  //!
-  //! @tparam Size Type encoding the cardinal of a wide
-  //================================================================================================
-  template<typename Size> struct wide_cardinal
-  {
-    //! Type describing the number of lanes of current wide
-    using cardinal_type = Size;
-    using size_type     = std::ptrdiff_t;
-
-    //! @brief Size of the wide in number of lanes
-    static EVE_FORCEINLINE constexpr size_type size()     noexcept { return Size::value; }
-
-    //! @brief Maximal number of lanes for a given wide
-    static EVE_FORCEINLINE constexpr size_type max_size() noexcept { return Size::value; }
-
-    //! @brief Check if a wide contains 0 lanes
-    static EVE_FORCEINLINE constexpr bool      empty()    noexcept { return false; }
-  };
 }
 
 #if defined(SPY_COMPILER_IS_GCC)

--- a/include/eve/arch/cpu/logical_wide.hpp
+++ b/include/eve/arch/cpu/logical_wide.hpp
@@ -56,10 +56,8 @@ namespace eve
   //================================================================================================
   template<typename Type, typename Cardinal>
   struct  EVE_MAY_ALIAS  logical<wide<Type,Cardinal>>
-        : detail::wide_cardinal<Cardinal>
-        , detail::wide_storage<as_logical_register_t<Type, Cardinal, abi_t<Type, Cardinal>>>
+        : detail::wide_storage<as_logical_register_t<Type, Cardinal, abi_t<Type, Cardinal>>>
   {
-    using card_base     = detail::wide_cardinal<Cardinal>;
     using storage_base  = detail::wide_storage<as_logical_register_t<Type, Cardinal, abi_t<Type, Cardinal>>>;
 
     public:
@@ -72,8 +70,11 @@ namespace eve
     //! The type used for this register storage
     using storage_type  = typename storage_base::storage_type;
 
-    //! Type for indexing element in a eve::logical
-    using size_type     = typename card_base::size_type;
+    //! Type describing the number of lanes of current wide
+    using cardinal_type = Cardinal;
+
+    //! Type representing the size of the current wide
+    using size_type     = std::ptrdiff_t;
 
     //! Type representing the bits of the logical value
     using bits_type = wide<as_integer_t<Type, unsigned>, Cardinal>;
@@ -141,7 +142,7 @@ namespace eve
     EVE_FORCEINLINE logical(T0 const &v0, T1 const &v1, Ts const &... vs) noexcept
           requires(     std::convertible_to<T0,logical<Type>> && std::convertible_to<T0,logical<Type>>
                     &&  (... && std::convertible_to<Ts,logical<Type>>)
-                    &&  (card_base::size() == 2 + sizeof...(Ts))
+                    &&  (Cardinal::value == 2 + sizeof...(Ts))
                   )
         : storage_base(detail::make(eve::as<logical>{}, v0, v1, vs...))
     {}
@@ -191,7 +192,7 @@ namespace eve
                             , logical<wide<Type, Half>> const &h
                             ) noexcept
 #if !defined(EVE_DOXYGEN_INVOKED)
-    requires( card_base::size() == 2 * Half::value )
+    requires( Cardinal::value == 2 * Half::value )
 #endif
                   : storage_base(detail::combine(EVE_CURRENT_API{}, l, h))
     {}
@@ -228,6 +229,15 @@ namespace eve
     //! @name Indexing and reordering
     //! @{
     //==============================================================================================
+
+    //! @brief Size of the wide in number of lanes
+    static EVE_FORCEINLINE constexpr size_type size()     noexcept { return Cardinal::value; }
+
+    //! @brief Maximal number of lanes for a given wide
+    static EVE_FORCEINLINE constexpr size_type max_size() noexcept { return Cardinal::value; }
+
+    //! @brief Check if a wide contains 0 lanes
+    static EVE_FORCEINLINE constexpr bool      empty()    noexcept { return false; }
 
     //==============================================================================================
     //! @brief Dynamic lookup via lane indexing

--- a/include/eve/arch/cpu/wide.hpp
+++ b/include/eve/arch/cpu/wide.hpp
@@ -60,10 +60,8 @@ namespace eve
   //================================================================================================
   template<typename Type, typename Cardinal>
   struct  EVE_MAY_ALIAS  wide
-        : detail::wide_cardinal<Cardinal>
-        , detail::wide_storage<as_register_t<Type, Cardinal, abi_t<Type, Cardinal>>>
+        : detail::wide_storage<as_register_t<Type, Cardinal, abi_t<Type, Cardinal>>>
   {
-    using card_base     = detail::wide_cardinal<Cardinal>;
     using storage_base  = detail::wide_storage<as_register_t<Type, Cardinal, abi_t<Type, Cardinal>>>;
 
     public:
@@ -77,8 +75,11 @@ namespace eve
     //! The type used for this register storage
     using storage_type  = typename storage_base::storage_type;
 
-    //! Type for indexing element in a eve::wide
-    using size_type     = typename card_base::size_type;
+    //! Type describing the number of lanes of current wide
+    using cardinal_type = Cardinal;
+
+    //! Type representing the size of the current wide
+    using size_type     = std::ptrdiff_t;
 
     //! Opt-in for like concept
     using is_like = value_type;
@@ -90,8 +91,7 @@ namespace eve
     //! Generates a eve::wide type from a different cardinal `N`.
     template<typename N> using rescale = wide<Type,N>;
 
-    // TODO : REMOVE AFTER MERGE
-    static EVE_FORCEINLINE constexpr auto alignment() noexcept { return sizeof(Type)*Cardinal{}; }
+     static EVE_FORCEINLINE constexpr auto alignment() noexcept { return sizeof(Type)*Cardinal{}; }
 
     //==============================================================================================
     //! @name Constructors
@@ -158,7 +158,7 @@ namespace eve
     template<scalar_value S0, scalar_value S1, scalar_value... Ss>
     EVE_FORCEINLINE wide( S0 v0, S1 v1, Ss... vs) noexcept
 #if !defined(EVE_DOXYGEN_INVOKED)
-    requires( card_base::size() == 2 + sizeof...(vs) )
+    requires( Cardinal::value == 2 + sizeof...(vs) )
 #endif
                   : storage_base(detail::make ( eve::as<wide>{}
                                               , static_cast<Type>(v0)
@@ -222,7 +222,7 @@ namespace eve
     template<typename Half>
     EVE_FORCEINLINE wide( wide<Type, Half> const &l, wide<Type, Half> const &h) noexcept
 #if !defined(EVE_DOXYGEN_INVOKED)
-    requires( card_base::size() == 2 * Half::value )
+    requires( Cardinal::value == 2 * Half::value )
 #endif
                   : storage_base(detail::combine(EVE_CURRENT_API{}, l, h))
     {}
@@ -375,6 +375,15 @@ namespace eve
     //! @name Indexing and reordering
     //! @{
     //=============================================================================================
+
+    //! @brief Size of the wide in number of lanes
+    static EVE_FORCEINLINE constexpr size_type size()     noexcept { return Cardinal::value; }
+
+    //! @brief Maximal number of lanes for a given wide
+    static EVE_FORCEINLINE constexpr size_type max_size() noexcept { return Cardinal::value; }
+
+    //! @brief Check if a wide contains 0 lanes
+    static EVE_FORCEINLINE constexpr bool      empty()    noexcept { return false; }
 
     //==============================================================================================
     //! @brief Dynamic lookup via lane indexing

--- a/test/unit/api/regular/swizzle/identity.cpp
+++ b/test/unit/api/regular/swizzle/identity.cpp
@@ -30,7 +30,7 @@ EVE_TEST( "Check behavior of identity swizzle"
   {
     auto f  = [&]<std::size_t N, typename S>(S simd, std::integral_constant<std::size_t,N>)
               {
-                constexpr std::size_t sz = 1ULL << N;
+                constexpr typename S::size_type sz = 1ULL << N;
                 if constexpr(sz <= S::size())
                 {
                   eve::as_wide_t<S,eve::fixed<sz>> ref = [&](auto i, auto) { return simd.get(i); };

--- a/test/unit/api/tuple/wide.cpp
+++ b/test/unit/api/tuple/wide.cpp
@@ -13,6 +13,21 @@ template<typename T>
 using tuple_t = kumi::tuple<std::int8_t,T,double>;
 
 //==================================================================================================
+// Sizeof
+//==================================================================================================
+EVE_TEST_TYPES( "Check eve::wide<tuple> binary size", eve::test::scalar::all_types)
+<typename T>(eve::as<T>)
+{
+  using c_t = eve::cardinal_t<eve::wide<tuple_t<T>>>;
+
+  TTS_EQUAL ( sizeof(eve::wide<kumi::tuple<std::int8_t,T,double>>)
+            , sizeof(kumi::tuple<eve::wide<std::int8_t,c_t>,eve::wide<T,c_t>,eve::wide<double,c_t>>)
+            , REQUIRED
+            );
+
+};
+
+//==================================================================================================
 // Structured bindings
 //==================================================================================================
 EVE_TEST_TYPES( "Check eve::wide<tuple> structured binding behavior", eve::test::scalar::all_types)

--- a/test/unit/api/udt/wide.cpp
+++ b/test/unit/api/udt/wide.cpp
@@ -34,6 +34,26 @@ TTS_CASE("Check User Defined Type properties with respect to SIMDification")
 };
 
 //==================================================================================================
+// Sizeof
+//==================================================================================================
+EVE_TEST_TYPES( "Check eve::wide<tuple> binary size", eve::test::scalar::all_types)
+<typename T>(eve::as<T>)
+{
+  using c_t = eve::cardinal_t<eve::wide<udt::grid2d>>;
+  using d_t = eve::cardinal_t<eve::wide<udt::label_position>>;
+
+  TTS_EQUAL ( sizeof(eve::wide<udt::grid2d>)
+            , sizeof(kumi::tuple<eve::wide<int,c_t>,eve::wide<int,c_t>>)
+            , REQUIRED
+            );
+
+  TTS_EQUAL ( sizeof(eve::wide<udt::label_position>)
+            , sizeof(kumi::tuple<eve::wide<float,d_t>,eve::wide<std::uint8_t,d_t>>)
+            , REQUIRED
+            );
+};
+
+//==================================================================================================
 // Default constructors
 //==================================================================================================
 TTS_CASE("Check eve::wide<udt> default constructor")


### PR DESCRIPTION
The empty cardinal_base struc that wide used lead to extra
byte of data to be added and thus padded.