### PR TITLE
FIX-947: compress switch

### DIFF
--- a/include/eve/detail/function/compress_store_impl_switch.hpp
+++ b/include/eve/detail/function/compress_store_impl_switch.hpp
@@ -1,0 +1,34 @@
+//==================================================================================================
+/*
+  EVE - Expressive Vector Engine
+  Copyright : EVE Contributors & Maintainers
+  SPDX-License-Identifier: MIT
+*/
+//==================================================================================================
+#pragma once
+
+#include <eve/arch.hpp>
+#include <eve/detail/implementation.hpp>
+
+// compress_store_impl_switch
+//
+// This is an implementation of `compress_store_impl` for sse2 only.
+
+namespace eve
+{
+  EVE_REGISTER_CALLABLE(compress_store_impl_switch_)
+  EVE_DECLARE_CALLABLE(compress_store_impl_switch_, compress_store_impl_switch)
+
+  namespace detail
+  {
+    EVE_ALIAS_CALLABLE(compress_store_impl_switch_, compress_store_impl_switch);
+  }
+
+  EVE_CALLABLE_API(compress_store_impl_switch_, compress_store_impl_switch)
+}
+
+#include <eve/detail/function/simd/common/compress_store_impl_switch.hpp>
+
+#if defined(EVE_INCLUDE_X86_HEADER)
+#  include <eve/detail/function/simd/x86/compress_store_impl_switch.hpp>
+#endif

--- a/include/eve/detail/function/compress_store_swizzle_mask_num.hpp
+++ b/include/eve/detail/function/compress_store_swizzle_mask_num.hpp
@@ -32,7 +32,6 @@
 //
 // The second returned value is:
 //   for a regular one - number of elements selected
-//   for a partial one - a bool if the last element is set.
 //
 // Example:
 //   mask:            [ false, true, false, false]
@@ -61,22 +60,17 @@
 // Returns {num, count} twice for both halves.
 //
 
-
 namespace eve
 {
   EVE_REGISTER_CALLABLE(compress_store_swizzle_mask_num_)
-  EVE_REGISTER_CALLABLE(compress_store_swizzle_mask_num_partial_)
   EVE_DECLARE_CALLABLE(compress_store_swizzle_mask_num_, compress_store_swizzle_mask_num)
-  EVE_DECLARE_CALLABLE(compress_store_swizzle_mask_num_partial_, compress_store_swizzle_mask_num_partial)
 
   namespace detail
   {
     EVE_ALIAS_CALLABLE(compress_store_swizzle_mask_num_, compress_store_swizzle_mask_num);
-    EVE_ALIAS_CALLABLE(compress_store_swizzle_mask_num_partial_, compress_store_swizzle_mask_num_partial);
   }
 
   EVE_CALLABLE_API(compress_store_swizzle_mask_num_, compress_store_swizzle_mask_num)
-  EVE_CALLABLE_API(compress_store_swizzle_mask_num_partial_, compress_store_swizzle_mask_num_partial)
 }
 
 #include <eve/detail/function/simd/common/compress_store_swizzle_mask_num.hpp>

--- a/include/eve/detail/function/simd/arm/neon/compress_store_swizzle_mask_num.hpp
+++ b/include/eve/detail/function/simd/arm/neon/compress_store_swizzle_mask_num.hpp
@@ -89,27 +89,6 @@ namespace eve::detail
   }
 
   template<eve::relative_conditional_expr C, typename T>
-  EVE_FORCEINLINE std::pair<int, bool>
-  compress_store_swizzle_mask_num_partial_(EVE_SUPPORTS(neon128_), C c, logical<wide<T, fixed<4>>> mask)
-  {
-         if constexpr ( C::is_complete && !C::is_inverted ) return {0, false};
-    else if constexpr ( !C::is_complete                   ) return compress_store_swizzle_mask_num_partial(ignore_none, mask && c.mask(as(mask)));
-    else
-    {
-      using l_t = logical<wide<T, fixed<4>>>;
-
-      using bits_type = typename l_t::bits_type;
-
-      bits_type bits = mask.bits();
-      bits_type elements_bit{1, 2, 4, 8};
-      bits &= elements_bit;
-
-      auto sum = sum4(bits);
-      return {(sum & 7), (sum & 8)};
-    }
-  }
-
-  template<eve::relative_conditional_expr C, typename T>
   EVE_FORCEINLINE std::pair<int, int>
   compress_store_swizzle_mask_num_(EVE_SUPPORTS(neon128_), C c, logical<wide<T, fixed<4>>> mask)
   {

--- a/include/eve/detail/function/simd/common/compress_store_impl_switch.hpp
+++ b/include/eve/detail/function/simd/common/compress_store_impl_switch.hpp
@@ -23,7 +23,7 @@ namespace eve::detail
                                  logical<wide<U, N>> mask,
                                  Ptr ptr) noexcept
   {
-    constexpr bool has_aggregation = has_aggregated_abi_v<wide<T, N>> || has_aggregated_abi_v<wide<U, N>> || N() > 4;
+    constexpr bool has_aggregation = has_aggregated_abi_v<wide<T, N>> || has_aggregated_abi_v<wide<U, N>> || N() > 8;
 
          if constexpr ( C::is_complete  && !C::is_inverted ) return as_raw_pointer(ptr);
     else if constexpr ( has_aggregation && !C::is_complete )
@@ -82,6 +82,48 @@ namespace eve::detail
         count += last_set ? 1 : 0;
         store(v, ptr);
         return as_raw_pointer(ptr) + count;
+      }
+      else if constexpr ( N() == 8 )
+      {
+        const int  num1       = mmask & 7;
+        const bool last_set1  = (bool) (mmask & 8);
+        const int  num2       = (mmask & 0x70);
+        const bool last_set2  = (bool) (mmask & 0x80);
+
+        int count1, count2;
+
+        switch (num1) {
+          case 0b000: { count1 = 0; v = v[pattern<3, 0, 0, 0, 4, 5, 6, 7>]; break; }
+          case 0b001: { count1 = 1; v = v[pattern<0, 3, 0, 0, 4, 5, 6, 7>]; break; }
+          case 0b010: { count1 = 1; v = v[pattern<1, 3, 0, 0, 4, 5, 6, 7>]; break; }
+          case 0b011: { count1 = 2; v = v[pattern<0, 1, 3, 0, 4, 5, 6, 7>]; break; }
+          case 0b100: { count1 = 1; v = v[pattern<2, 3, 0, 0, 4, 5, 6, 7>]; break; }
+          case 0b101: { count1 = 2; v = v[pattern<0, 2, 3, 0, 4, 5, 6, 7>]; break; }
+          case 0b110: { count1 = 2; v = v[pattern<1, 2, 3, 0, 4, 5, 6, 7>]; break; }
+          case 0b111: { count1 = 3;                                         break; }
+          #if defined(SPY_COMPILER_IS_CLANG) or defined(SPY_COMPILER_IS_GCC)
+          default: __builtin_unreachable();
+          #endif
+        }
+        switch (num2) {
+          case 0b000'0000: { count2 = 0; v = v[pattern<0, 1, 2, 3, 7, 7, 7, 7>]; break; }
+          case 0b001'0000: { count2 = 1; v = v[pattern<0, 1, 2, 3, 4, 7, 7, 7>]; break; }
+          case 0b010'0000: { count2 = 1; v = v[pattern<0, 1, 2, 3, 5, 7, 7, 7>]; break; }
+          case 0b011'0000: { count2 = 2; v = v[pattern<0, 1, 2, 3, 4, 5, 7, 7>]; break; }
+          case 0b100'0000: { count2 = 1; v = v[pattern<0, 1, 2, 3, 6, 7, 7, 7>]; break; }
+          case 0b101'0000: { count2 = 2; v = v[pattern<0, 1, 2, 3, 4, 6, 7, 7>]; break; }
+          case 0b110'0000: { count2 = 2; v = v[pattern<0, 1, 2, 3, 5, 6, 7, 7>]; break; }
+          case 0b111'0000: { count2 = 3;                                         break; }
+          #if defined(SPY_COMPILER_IS_CLANG) or defined(SPY_COMPILER_IS_GCC)
+          default: __builtin_unreachable();
+          #endif
+        }
+
+        eve::store(v, ptr);
+        T* after_first = as_raw_pointer(ptr) + count1 + (last_set1 ? 1 : 0);
+
+        eve::store(v.slice(upper_), after_first);
+        return after_first + count2 + (last_set2 ? 1 : 0);
       }
     }
   }

--- a/include/eve/detail/function/simd/common/compress_store_impl_switch.hpp
+++ b/include/eve/detail/function/simd/common/compress_store_impl_switch.hpp
@@ -23,14 +23,14 @@ namespace eve::detail
                                  logical<wide<U, N>> mask,
                                  Ptr ptr) noexcept
   {
-    constexpr bool has_aggregation = has_aggregated_abi_v<wide<T, N>> || has_aggregated_abi_v<wide<U, N>> || N() > 8;
+    constexpr bool like_aggregate = has_aggregated_abi_v<wide<T, N>> || has_aggregated_abi_v<wide<U, N>> || N() > 8;
 
          if constexpr ( C::is_complete  && !C::is_inverted ) return as_raw_pointer(ptr);
-    else if constexpr ( has_aggregation && !C::is_complete )
+    else if constexpr ( like_aggregate && !C::is_complete )
     {
       return compress_store_impl_switch(ignore_none, v, mask && c.mask(as(mask)), ptr);
     }
-    else if constexpr ( has_aggregation )
+    else if constexpr ( like_aggregate )
     {
       auto [l, h] = v.slice();
       auto [ml, mh] = mask.slice();

--- a/include/eve/detail/function/simd/common/compress_store_impl_switch.hpp
+++ b/include/eve/detail/function/simd/common/compress_store_impl_switch.hpp
@@ -1,0 +1,88 @@
+//==================================================================================================
+/*
+  EVE - Expressive Vector Engine
+  Copyright : EVE Contributors & Maintainers
+  SPDX-License-Identifier: MIT
+*/
+//==================================================================================================
+#pragma once
+
+#include <eve/concept/value.hpp>
+#include <eve/function/slide_left.hpp>
+#include <eve/function/count_true.hpp>
+
+#include <eve/detail/top_bits.hpp>
+
+namespace eve::detail
+{
+  template<relative_conditional_expr C, typename T, typename U, typename N, simd_compatible_ptr<wide<T, N>> Ptr>
+  EVE_FORCEINLINE
+  T* compress_store_impl_switch_(EVE_SUPPORTS(cpu_),
+                                 C c,
+                                 wide<T, N> v,
+                                 logical<wide<U, N>> mask,
+                                 Ptr ptr) noexcept
+  {
+    constexpr bool has_aggregation = has_aggregated_abi_v<wide<T, N>> || has_aggregated_abi_v<wide<U, N>> || N() > 4;
+
+         if constexpr ( C::is_complete  && !C::is_inverted ) return as_raw_pointer(ptr);
+    else if constexpr ( has_aggregation && !C::is_complete )
+    {
+      return compress_store_impl_switch(ignore_none, v, mask && c.mask(as(mask)), ptr);
+    }
+    else if constexpr ( has_aggregation )
+    {
+      auto [l, h] = v.slice();
+      auto [ml, mh] = mask.slice();
+
+      T* ptr1 = compress_store_impl_switch(ignore_none, l, ml, ptr);
+      return compress_store_impl_switch(ignore_none, h, mh, ptr1);
+    }
+    else
+    {
+      using l_t = logical<wide<U, N>>;
+      static_assert(top_bits<l_t>::bits_per_element == 1);
+
+      const int mmask = top_bits{mask, c}.as_int();
+
+      if constexpr ( N() == 1 )
+      {
+        eve::store(v, ptr);
+        return as_raw_pointer(ptr) + mmask;
+      }
+      else if constexpr ( N() == 2 )
+      {
+        if (mmask == 2) v = eve::slide_left( v, eve::index<1> );
+        eve::store(v, ptr);
+        T* res = as_raw_pointer(ptr);
+        res += mmask & 1;
+        res += (mmask & 2) >> 1;
+        return res;
+      }
+      else if constexpr ( N() == 4 )
+      {
+        const int  num       = mmask & 7;
+        const bool last_set  = (bool) (mmask & 8);
+
+        int count;
+
+        switch (num) {
+          case 0b000: { count = 0; v = v[pattern<3, 0, 0, 0>]; break; }
+          case 0b001: { count = 1; v = v[pattern<0, 3, 0, 0>]; break; }
+          case 0b010: { count = 1; v = v[pattern<1, 3, 0, 0>]; break; }
+          case 0b011: { count = 2; v = v[pattern<0, 1, 3, 0>]; break; }
+          case 0b100: { count = 1; v = v[pattern<2, 3, 0, 0>]; break; }
+          case 0b101: { count = 2; v = v[pattern<0, 2, 3, 0>]; break; }
+          case 0b110: { count = 2; v = v[pattern<1, 2, 3, 0>]; break; }
+          case 0b111: { count = 3;                             break; }
+          #if defined(SPY_COMPILER_IS_CLANG) or defined(SPY_COMPILER_IS_GCC)
+          default: __builtin_unreachable();
+          #endif
+        }
+        count += last_set ? 1 : 0;
+        store(v, ptr);
+        return as_raw_pointer(ptr) + count;
+      }
+    }
+  }
+}

--- a/include/eve/detail/function/simd/common/compress_store_swizzle_mask_num.hpp
+++ b/include/eve/detail/function/simd/common/compress_store_swizzle_mask_num.hpp
@@ -17,26 +17,6 @@
 namespace eve::detail
 {
   template<eve::relative_conditional_expr C, typename T>
-  EVE_FORCEINLINE std::pair<int, bool>
-  compress_store_swizzle_mask_num_partial_(EVE_SUPPORTS(cpu_), C c, logical<wide<T, fixed<4>>> mask)
-  {
-    using w_t = wide<T, fixed<4>>;
-    using l_t = logical<wide<T>>;
-
-    // can only be for 64 bit numbers on 128 bit register
-    if constexpr (has_aggregated_abi_v<w_t>)
-    {
-      return compress_store_swizzle_mask_num_partial(c, convert(mask, as<logical<std::uint32_t>>{}));
-    }
-    else
-    {
-      static_assert(top_bits<l_t>::bits_per_element == 1);
-      int mmask = top_bits{mask, c}.as_int();
-      return {(mmask & 7), (mmask & 8)};
-    }
-  }
-
-  template<eve::relative_conditional_expr C, typename T>
   EVE_FORCEINLINE std::pair<int, int>
   compress_store_swizzle_mask_num_(EVE_SUPPORTS(cpu_), C c, logical<wide<T, fixed<4>>> mask)
   {

--- a/include/eve/detail/function/simd/x86/compress_store_impl.hpp
+++ b/include/eve/detail/function/simd/x86/compress_store_impl.hpp
@@ -11,6 +11,8 @@
 #include <eve/detail/function/compress_store_swizzle_mask_num.hpp>
 #include <eve/function/count_true.hpp>
 
+#include <eve/detail/function/compress_store_impl_switch.hpp>
+
 #include <array>
 #include <bit>
 
@@ -19,35 +21,6 @@
 
 namespace eve::detail
 {
-
-  template<relative_conditional_expr C, typename T, typename U>
-  EVE_FORCEINLINE
-  auto compress_store_impl_switch_4(C c,
-                                    wide<T, fixed<4>> v,
-                                    logical<wide<U, fixed<4>>> mask
-                                    )
-  {
-    auto [num, last_set] = compress_store_swizzle_mask_num_partial[c](mask);
-    int count;
-
-    switch (num) {
-      case 0b000: { count = 0; v = v[pattern<3, 0, 0, 0>]; break; }
-      case 0b001: { count = 1; v = v[pattern<0, 3, 0, 0>]; break; }
-      case 0b010: { count = 1; v = v[pattern<1, 3, 0, 0>]; break; }
-      case 0b011: { count = 2; v = v[pattern<0, 1, 3, 0>]; break; }
-      case 0b100: { count = 1; v = v[pattern<2, 3, 0, 0>]; break; }
-      case 0b101: { count = 2; v = v[pattern<0, 2, 3, 0>]; break; }
-      case 0b110: { count = 2; v = v[pattern<1, 2, 3, 0>]; break; }
-      case 0b111: { count = 3;                             break; }
-      #if defined(SPY_COMPILER_IS_CLANG) or defined(SPY_COMPILER_IS_GCC)
-      default: __builtin_unreachable();
-      #endif
-    }
-    count += last_set ? 1 : 0;
-
-    return std::pair{v, count};
-  }
-
   template<relative_conditional_expr C, typename T, typename U, typename N, simd_compatible_ptr<wide<T, N>> Ptr>
   EVE_FORCEINLINE
   T* compress_store_impl_(EVE_SUPPORTS(sse2_),
@@ -55,28 +28,10 @@ namespace eve::detail
                           wide<T, N> v,
                           logical<wide<U, N>> mask,
                           Ptr ptr) noexcept
-    requires x86_abi<abi_t<T, N>> && ( N() == 4 ) && (current_api < ssse3)
+    requires (current_api < ssse3)
   {
-    int count;
-    if constexpr ( sizeof(T) == 1 )
-    {
-      // We have to convert to shorts here. Does not optimise well without.
-      auto shorts = convert(v, eve::as<std::uint16_t>{});
-      auto [shuffled, count_] = compress_store_impl_switch_4(c, shorts, mask);
-      v = eve::convert(shuffled, eve::as<T>{});
-      count = count_;
-    }
-    else
-    {
-      auto [shuffled, count_] = compress_store_impl_switch_4(c, v, mask);
-      v = shuffled;
-      count = count_;
-    }
-
-    store(v, ptr);
-    return as_raw_pointer(ptr) + count;
+    return compress_store_impl_switch[c](v, mask, ptr);
   }
-
 }
 
 // ssse3 -> avx2 (no bmi) ---------------------------------------------------------

--- a/include/eve/detail/function/simd/x86/compress_store_impl_switch.hpp
+++ b/include/eve/detail/function/simd/x86/compress_store_impl_switch.hpp
@@ -1,0 +1,26 @@
+//==================================================================================================
+/*
+  EVE - Expressive Vector Engine
+  Copyright : EVE Contributors & Maintainers
+  SPDX-License-Identifier: MIT
+*/
+//==================================================================================================
+#pragma once
+
+#include <eve/function/convert.hpp>
+
+namespace eve::detail
+{
+
+  template<relative_conditional_expr C, typename T, typename U, typename N, simd_compatible_ptr<wide<T, N>> Ptr>
+  EVE_FORCEINLINE
+  T* compress_store_impl_switch_(EVE_SUPPORTS(sse2_),
+                                 C c,
+                                 wide<T, N> v,
+                                 logical<wide<U, N>> mask,
+                                 Ptr ptr) noexcept
+    requires (sizeof(U) == 2)
+  {
+    return compress_store_impl_switch(c, v, convert(mask, as<logical<std::uint8_t>>{}), ptr);
+  }
+}

--- a/include/eve/detail/function/simd/x86/compress_store_swizzle_mask_num.hpp
+++ b/include/eve/detail/function/simd/x86/compress_store_swizzle_mask_num.hpp
@@ -12,16 +12,6 @@
 namespace eve::detail
 {
   template<eve::relative_conditional_expr C, typename T>
-  EVE_FORCEINLINE std::pair<int, bool>
-  compress_store_swizzle_mask_num_partial_(EVE_SUPPORTS(sse2_), C c, logical<wide<T, fixed<4>>> mask)
-    requires (current_api < avx512) && (sizeof(T) == 2)
-  {
-    static_assert(top_bits<logical<wide<T, fixed<4>>>>::bits_per_element == 2);
-    auto to_bytes = eve::convert(mask, eve::as<eve::logical<std::uint8_t>>{});
-    return compress_store_swizzle_mask_num_partial(c, to_bytes);
-  }
-
-  template<eve::relative_conditional_expr C, typename T>
   EVE_FORCEINLINE std::pair<int, int>
   compress_store_swizzle_mask_num_(EVE_SUPPORTS(sse2_), C c, logical<wide<T, fixed<4>>> mask)
     requires (current_api < avx512) && (sizeof(T) <= 4)

--- a/test/unit/internals/compress_store_swizzle_mask_num.cpp
+++ b/test/unit/internals/compress_store_swizzle_mask_num.cpp
@@ -37,15 +37,6 @@ EVE_TEST_TYPES("compress_store_swizzle_mask_num 4 elements",
 
             int expected_num = expected_shuffle_num(mask_with_ignore);
 
-            // partial
-            {
-              auto [actual_num, actual_4th] = eve::detail::compress_store_swizzle_mask_num_partial(ignore, mask);
-              TTS_EQUAL(expected_num, actual_num);
-
-              if (ignore.roffset(eve::as(mask)) == 0) TTS_EQUAL(m3, actual_4th);
-              else                                    TTS_EQUAL(false, actual_4th);
-            }
-
             // complete
             {
               auto [actual_num, actual_count] = eve::detail::compress_store_swizzle_mask_num(ignore, mask);


### PR DESCRIPTION
Extracted `compress_store_impl` switch one into it's own thing, so we don't have to think about it anymore.

it's mostly like what it should be.

There is a question of maybe we should do 16 elements but maybe not as well and it should just aggregate.

I have also this idea of having just `store` in iterators but that is difficult.
So lets just do this for now.

I will close the story once I measure.