### PR TITLE
Remove remnant of restricted_types

### DIFF
--- a/test/types.hpp
+++ b/test/types.hpp
@@ -88,36 +88,9 @@ namespace eve::detail
                               >;
   };
 
-  template<typename L> struct restricted_wides;
-  template<typename... Ts> struct restricted_wides<types<Ts...>>
-  {
-    // Precomputed # of repetitions based on ABI and sizeof(T)
-    static constexpr std::array<std::size_t,9> cardinal_map()
-    {
-      // This is a precomputed map of the maximum number of cardinal to generate depending
-      // on the current ABI bits size. This prevents us to use std::bit_width and other complex
-      // computations.
-      switch(EVE_CURRENT_ABI::bits)
-      {
-        case 64 : return {0,5,4,0,3,0,0,0,2};
-        case 128: return {0,6,5,0,4,0,0,0,3};
-        case 256: return {0,7,6,0,5,0,0,0,4};
-        case 512: return {0,7,6,0,5,0,0,0,4}; // no aggregation on AVX512 for now
-        default : return {};
-      };
-    };
-
-    using type = concatenate_t< to_wide_t < Ts
-                                          , std::make_index_sequence<cardinal_map()[sizeof(Ts)]>
-                                          >...
-                              >;
-  };
-
   // Prevent calling remove_cvref_t
   template<typename L> struct wides<L const>            : wides<L>            {};
   template<typename L> struct wides<L&>                 : wides<L>            {};
-  template<typename L> struct restricted_wides<L const> : restricted_wides<L> {};
-  template<typename L> struct restricted_wides<L&>      : restricted_wides<L> {};
 }
 
 namespace eve::test::simd
@@ -139,51 +112,6 @@ namespace eve::test::simd
   inline constexpr detail::wides< decltype(scalar::signed_types) >::type      signed_types      {};
   inline constexpr auto                                   unsigned_types    = unsigned_integers;
   inline constexpr detail::wides< decltype(scalar::all_types) >::type         all_types         {};
-
-  using detail::types;
-  inline constexpr types< std::integral_constant<int,    8>
-                        , std::integral_constant<int,   16>
-                        , std::integral_constant<int,   32>
-                        , std::integral_constant<int,   64>
-                        , std::integral_constant<int,  128>
-                        , std::integral_constant<int,  256>
-                        , std::integral_constant<int,  512>
-                        , std::integral_constant<int, 1024>
-                        > sizes = {};
-
-  inline constexpr types< eve::fixed<   1>
-                        , eve::fixed<   2>
-                        , eve::fixed<   4>
-                        , eve::fixed<   8>
-                        , eve::fixed<  16>
-                        , eve::fixed<  32>
-                        , eve::fixed<  64>
-                        , eve::fixed< 128>
-                        , eve::fixed< 256>
-                        , eve::fixed< 512>
-                        , eve::fixed<1024>
-                        > cardinals = {};
-}
-
-namespace eve::test::simd::restricted
-{
-  inline constexpr detail::restricted_wides< decltype(scalar::signed_integers) >::type   signed_integers   {};
-  inline constexpr detail::restricted_wides< decltype(scalar::unsigned_integers) >::type unsigned_integers {};
-  inline constexpr detail::restricted_wides< decltype(scalar::integers) >::type          integers          {};
-  inline constexpr detail::restricted_wides< decltype(scalar::ieee_reals) >::type        ieee_reals        {};
-  inline constexpr detail::restricted_wides< decltype(scalar::ieee_floats) >::type       ieee_floats       {};
-  inline constexpr detail::restricted_wides< decltype(scalar::ieee_doubles) >::type      ieee_doubles      {};
-  inline constexpr detail::restricted_wides< decltype(scalar::uints_64) >::type          uints_64          {};
-  inline constexpr detail::restricted_wides< decltype(scalar::uints_32) >::type          uints_32          {};
-  inline constexpr detail::restricted_wides< decltype(scalar::uints_16) >::type          uints_16          {};
-  inline constexpr detail::restricted_wides< decltype(scalar::uints_8 ) >::type          uints_8           {};
-  inline constexpr detail::restricted_wides< decltype(scalar::ints_64) >::type           ints_64           {};
-  inline constexpr detail::restricted_wides< decltype(scalar::ints_32) >::type           ints_32           {};
-  inline constexpr detail::restricted_wides< decltype(scalar::ints_16) >::type           ints_16           {};
-  inline constexpr detail::restricted_wides< decltype(scalar::ints_8 ) >::type           ints_8            {};
-  inline constexpr detail::restricted_wides< decltype(scalar::signed_types) >::type      signed_types      {};
-  inline constexpr auto                                   unsigned_types    = unsigned_integers;
-  inline constexpr detail::restricted_wides< decltype(scalar::all_types) >::type         all_types         {};
 
   using detail::types;
   inline constexpr types< std::integral_constant<int,    8>

--- a/test/unit/api/regular/shuffle/slide_left.cpp
+++ b/test/unit/api/regular/shuffle/slide_left.cpp
@@ -6,19 +6,16 @@
 **/
 //==================================================================================================
 #include "test.hpp"
-
 #include <eve/function/slide_left.hpp>
-
 
 //==================================================================================================
 // slide_left test
 //==================================================================================================
-
-
 EVE_TEST_TYPES("Check behavior of slide_left shuffle", eve::test::simd::all_types)
 <typename T>(eve::as<T>)
 {
-  T x{[](int i, int) { return i; }};
+  using v_t = eve::element_type_t<T>;
+  T x{[](int i, int)      { return i; }};
   T y{[](int i, int size) { return i + size; }};
 
   eve::logical<T> lx = x < 2;
@@ -32,7 +29,7 @@ EVE_TEST_TYPES("Check behavior of slide_left shuffle", eve::test::simd::all_type
 
     eve::logical<T> lexpected([](int i, int size) {
       if ( i < size - Shift ) return (i + Shift) < 2;
-      else                    return (i + Shift) < 6;
+      else                    return v_t(i + Shift) < 6;
     });
     eve::logical<T> lactual = eve::slide_left(lx, ly, eve::index<Shift>);
 

--- a/test/unit/api/regular/shuffle/slide_left.cpp
+++ b/test/unit/api/regular/shuffle/slide_left.cpp
@@ -15,7 +15,7 @@
 //==================================================================================================
 
 
-EVE_TEST_TYPES("Check behavior of slide_left shuffle", eve::test::simd::restricted::all_types)
+EVE_TEST_TYPES("Check behavior of slide_left shuffle", eve::test::simd::all_types)
 <typename T>(eve::as<T>)
 {
   T x{[](int i, int) { return i; }};

--- a/test/unit/api/regular/shuffle/slide_right.cpp
+++ b/test/unit/api/regular/shuffle/slide_right.cpp
@@ -13,7 +13,7 @@
 // slide_right test
 //==================================================================================================
 
-EVE_TEST_TYPES("Check behavior of slide_right shuffle", eve::test::simd::restricted::all_types)
+EVE_TEST_TYPES("Check behavior of slide_right shuffle", eve::test::simd::all_types)
 <typename T>(eve::as<T>)
 {
   T x{[](int i, int size) { return i - size; }};

--- a/test/unit/constant/as_value.cpp
+++ b/test/unit/constant/as_value.cpp
@@ -58,7 +58,7 @@ EVE_TEST_TYPES( "Check behavior of arithmetic as_value", eve::test::simd::all_ty
   }
 };
 
-EVE_TEST_TYPES( "Check behavior of logical as_value", eve::test::simd::restricted::all_types)
+EVE_TEST_TYPES( "Check behavior of logical as_value", eve::test::simd::all_types)
 <typename T>(eve::as<T>)
 {
   {

--- a/test/unit/module/real/core/logical_xor.cpp
+++ b/test/unit/module/real/core/logical_xor.cpp
@@ -15,7 +15,7 @@
 //== Types tests
 //==================================================================================================
 EVE_TEST_TYPES( "Check return types of eve::logical_xor(simd)"
-              , eve::test::simd::restricted::all_types
+              , eve::test::simd::all_types
               )
 <typename T>(eve::as<T>)
 {
@@ -36,7 +36,7 @@ EVE_TEST_TYPES( "Check return types of eve::logical_xor(simd)"
 //== Tests for eve::logical_xor
 //==================================================================================================
 EVE_TEST( "Check behavior of eve::logical_xor(simd)"
-        , eve::test::simd::restricted::all_types
+        , eve::test::simd::all_types
         , eve::test::generate (eve::test::logicals(0, 3)
                               , eve::test::logicals(1, 2)
                               , eve::test::randoms(0, 2))

--- a/test/unit/module/real/core/rem.cpp
+++ b/test/unit/module/real/core/rem.cpp
@@ -63,7 +63,7 @@ EVE_TEST_TYPES( "Check return types of rem"
 auto mini = [] < typename T > (eve::as<T> const &){ return std::is_signed_v<eve::element_type_t<T>> ? -100 : 0;};
 
 EVE_TEST( "Check behavior of rem on wide"
-        , eve::test::simd::restricted::ieee_reals//all_types
+        , eve::test::simd::ieee_reals//all_types
         , eve::test::generate ( eve::test::randoms(mini, 100)
                               , eve::test::randoms(mini, 100)
                               )

--- a/test/unit/module/real/core/rem.cpp
+++ b/test/unit/module/real/core/rem.cpp
@@ -73,9 +73,12 @@ EVE_TEST( "Check behavior of rem on wide"
   using eve::rem;
   using eve::pedantic;
   using eve::detail::map;
-  TTS_ULP_EQUAL( pedantic(rem)(a0, a1), map([](auto e, auto f) { return eve::rem(e, f); }, a0, a1), 32);//fma not avail scalar double it seems
+
+  auto thrs = std::same_as<eve::element_type_t<T>,float> ? 5e-4 : 5e-13;
+  TTS_RELATIVE_EQUAL( pedantic(rem)(a0, a1), map([](auto e, auto f) { return eve::rem(e, f); }, a0, a1), thrs);
+
   a1 =  eve::if_else(eve::is_eqz(a1), eve::one, a1);
-  TTS_ULP_EQUAL( rem(a0, a1), map([](auto e, auto f) { return eve::rem(e, f); }, a0, a1), 32);
+  TTS_RELATIVE_EQUAL( rem(a0, a1), map([](auto e, auto f) { return eve::rem(e, f); }, a0, a1), thrs);
 };
 
 

--- a/test/unit/module/real/core/remdiv.cpp
+++ b/test/unit/module/real/core/remdiv.cpp
@@ -38,7 +38,7 @@ EVE_TEST_TYPES( "Check return types of remdiv"
 auto mini = [] < typename T > (eve::as<T> const &){ return std::is_signed_v<eve::element_type_t<T>> ? -100 : 1;};
 
 EVE_TEST( "Check behavior of remdiv on wide"
-        , eve::test::simd::restricted::all_types
+        , eve::test::simd::all_types
         , eve::test::generate ( eve::test::randoms(mini, 100)
                               , eve::test::randoms(mini, 100)
                               )

--- a/test/unit/module/real/core/remdiv.cpp
+++ b/test/unit/module/real/core/remdiv.cpp
@@ -50,11 +50,19 @@ EVE_TEST( "Check behavior of remdiv on wide"
   using eve::toward_zero;
   a1 = eve::if_else(eve::is_eqz(a1), eve::one, a1);
   auto [r, d] = eve::remdiv(a0, a1);
-  TTS_ULP_EQUAL( r, map([](auto e, auto f) { return eve::rem(e, f); }, a0, a1), 32);//fma not avail scalar double it seems
-  TTS_ULP_EQUAL( d, map([](auto e, auto f) { return toward_zero(eve::div)(e, f); }, a0, a1), 32);//fma not avail scalar double it seems
 
+  if constexpr(eve::integral_simd_value<T>)
+  {
+    TTS_EQUAL( r, map([](auto e, auto f) { return eve::rem(e, f); }, a0, a1));
+    TTS_EQUAL( d, map([](auto e, auto f) { return toward_zero(eve::div)(e, f); }, a0, a1));
+  }
+  else
+  {
+    auto thrs = std::same_as<eve::element_type_t<T>,float> ? 5e-4 : 5e-13;
+    TTS_RELATIVE_EQUAL( r, map([](auto e, auto f) { return eve::rem(e, f); }, a0, a1), thrs);//fma not avail scalar double it seems
+    TTS_RELATIVE_EQUAL( d, map([](auto e, auto f) { return toward_zero(eve::div)(e, f); }, a0, a1), thrs);//fma not avail scalar double it seems
+  }
 };
-
 
 //==================================================================================================
 //== Test for fixed values

--- a/test/unit/module/real/math/cotd.cpp
+++ b/test/unit/module/real/math/cotd.cpp
@@ -48,7 +48,7 @@ auto mmed   = []<typename T>(eve::as<T> const & ){  return -5000; };
 auto med    = []<typename T>(eve::as<T> const & ){  return  5000; };
 
 EVE_TEST( "Check behavior of cotd on wide"
-        , eve::test::simd::restricted::ieee_reals
+        , eve::test::simd::ieee_reals
         , eve::test::generate( eve::test::randoms(mquarter_c, quarter_c)
                              , eve::test::randoms(mhalf_c, half_c)
                              , eve::test::randoms(mmed, med)

--- a/test/unit/module/real/math/cotd.cpp
+++ b/test/unit/module/real/math/cotd.cpp
@@ -62,13 +62,13 @@ EVE_TEST( "Check behavior of cotd on wide"
   using eve::deginrad;
   using v_t = eve::element_type_t<T>;
   auto ref = [](auto e) -> v_t { auto d = eve::sind(e); return d ? eve::cosd(e)/eve::sind(e): eve::nan(eve::as(e)); };
-  TTS_ULP_EQUAL(eve::quarter_circle(cotd)(a0)      , map(ref, a0), 2);
-  TTS_ULP_EQUAL(eve::half_circle(cotd)(a0)           , map(ref, a0), 2);
-  TTS_ULP_EQUAL(eve::half_circle(cotd)(a1)           , map(ref, a1), 40);
-  TTS_ULP_EQUAL(cotd(a0)                       , map(ref, a0), 2);
-  TTS_ULP_EQUAL(cotd(a1)                       , map(ref, a1), 40);
-  TTS_ULP_EQUAL(cotd(a2)                       , map(ref, a2), 300);
-  TTS_ULP_EQUAL(cotd(a3)                       , map(ref, a3), 2);
+  TTS_ULP_EQUAL(eve::quarter_circle(cotd)(a0)  , map(ref, a0), 2);
+  TTS_ULP_EQUAL(eve::half_circle(cotd)(a0)     , map(ref, a0), 2);
+  TTS_ULP_EQUAL(eve::half_circle(cotd)(a1)     , map(ref, a1), 40);
+  TTS_ULP_EQUAL(eve::cotd(a0)                  , map(ref, a0), 2);
+  TTS_ULP_EQUAL(eve::cotd(a1)                  , map(ref, a1), 40);
+  TTS_ULP_EQUAL(eve::cotd(a2)                  , map(ref, a2), 1600);
+  TTS_ULP_EQUAL(eve::cotd(a3)                  , map(ref, a3), 2);
   auto dinr = 1.7453292519943295769236907684886127134428718885417e-2l;
 
   TTS_ULP_EQUAL(diff(cotd)(a0), map([dinr](auto e) -> v_t { return  -dinr*eve::sqr(eve::cscd(e)); }, a0), 4);

--- a/test/unit/module/real/math/cscd.cpp
+++ b/test/unit/module/real/math/cscd.cpp
@@ -57,12 +57,12 @@ EVE_TEST( "Check behavior of cscd on wide"
   using eve::deginrad;
   using v_t = eve::element_type_t<T>;
   auto ref = [](auto e) -> v_t { auto d = eve::sind(e);return d ? 1.0/d : eve::nan(eve::as(e)); };
-  TTS_ULP_EQUAL(eve::quarter_circle(cscd)(a0)      , map(ref, a0), 2);
-  TTS_ULP_EQUAL(eve::half_circle(cscd)(a0)           , map(ref, a0), 2);
-  TTS_ULP_EQUAL(eve::half_circle(cscd)(a1)           , map(ref, a1), 2);
-  TTS_ULP_EQUAL(cscd(a0)                       , map(ref, a0), 2);
-  TTS_ULP_EQUAL(cscd(a1)                       , map(ref, a1), 2);
-  TTS_ULP_EQUAL(cscd(a2)                       , map(ref, a2), 300);
+  TTS_ULP_EQUAL(eve::quarter_circle(cscd)(a0)  , map(ref, a0), 2);
+  TTS_ULP_EQUAL(eve::half_circle(cscd)(a0)     , map(ref, a0), 2);
+  TTS_ULP_EQUAL(eve::half_circle(cscd)(a1)     , map(ref, a1), 2);
+  TTS_ULP_EQUAL(eve::cscd(a0)                  , map(ref, a0), 2);
+  TTS_ULP_EQUAL(eve::cscd(a1)                  , map(ref, a1), 2);
+  TTS_ULP_EQUAL(eve::cscd(a2)                  , map(ref, a2), 1600);
   auto dinr = 1.7453292519943295769236907684886127134428718885417e-2l;
 
   TTS_ULP_EQUAL(diff(cscd)(a0), map([dinr](auto e) -> v_t { return  -dinr*cscd(e)*eve::cotd(e); }, a0), 2);

--- a/test/unit/module/real/math/cscd.cpp
+++ b/test/unit/module/real/math/cscd.cpp
@@ -44,7 +44,7 @@ auto mmed   = []<typename T>(eve::as<T> const & ){  return -5000; };
 auto med    = []<typename T>(eve::as<T> const & ){  return  5000; };
 
 EVE_TEST( "Check behavior of cscd on wide"
-        , eve::test::simd::restricted::ieee_reals
+        , eve::test::simd::ieee_reals
         , eve::test::generate( eve::test::randoms(mquarter_c, quarter_c)
                              , eve::test::randoms(mhalf_c, half_c)
                              , eve::test::randoms(mmed, med))


### PR DESCRIPTION
Some tests were still using the old AVX512 fixed test types. This removes the restricted:: namespace and fi the tests.