### PR TITLE
FIX-1104: collapse ptr iterator

### DIFF
--- a/include/eve/algo/README.txt
+++ b/include/eve/algo/README.txt
@@ -65,7 +65,7 @@ The minimum requirements are:
 
 *TODO*
 
-The main model is `aligned_ptr_iterator`
+The main model is `ptr_iterator<aligned_ptr, N>`
 
 This is a `partially_aligned_iterator` but has an extra feature: we can do `unsafe` load.
 When we get to unbounded algorithms it will become important.
@@ -74,7 +74,7 @@ When we get to unbounded algorithms it will become important.
 
 I and partially_aligned_t<I> are the same.
 
-The main model is `aligned_ptr_iterator`, `zip_iterator<aligned_ptr_iterator, unaligned_ptr_iterator>`
+The main model is `aligned_ptr_iterator`, `zip_iterator<ptr_iterator<aligned_ptr, N>, ptr_iterator<T*, N>>`
 
 Loading/Storing is more efficient than doing the same from `unaligned`. We can only step in `iterator_cardinal_v<I>` divisible steps.
 
@@ -82,7 +82,7 @@ Loading/Storing is more efficient than doing the same from `unaligned`. We can o
 
 I and unaligned_t<I> are the same.
 
-The main model is `unaligned_ptr_iterator`
+The main model is `ptr_iterator<T*, N>`
 
 iterator that can represent any position in the underlying range.
 
@@ -216,8 +216,7 @@ A tuple of iterators with the same cardinal.
 
 ### ptr_iterator
 
-* `aligned_ptr_iterator`
-* `unaligned_ptr_iterator`
+* `ptr_iterator`
 
 A pointer + cardinal with the `iterator` interface.
 

--- a/include/eve/algo/README.txt
+++ b/include/eve/algo/README.txt
@@ -74,7 +74,7 @@ When we get to unbounded algorithms it will become important.
 
 I and partially_aligned_t<I> are the same.
 
-The main model is `aligned_ptr_iterator`, `zip_iterator<ptr_iterator<aligned_ptr, N>, ptr_iterator<T*, N>>`
+The main model is `ptr_iterator<aligned_ptr, N>`, `zip_iterator<ptr_iterator<aligned_ptr, N>, ptr_iterator<T*, N>>`
 
 Loading/Storing is more efficient than doing the same from `unaligned`. We can only step in `iterator_cardinal_v<I>` divisible steps.
 

--- a/include/eve/algo/preprocess_range.hpp
+++ b/include/eve/algo/preprocess_range.hpp
@@ -25,14 +25,14 @@ namespace eve::algo
     template <typename T, typename A>
     EVE_FORCEINLINE auto ptr_to_iterator(eve::aligned_ptr<T, A> ptr)
     {
-      return aligned_ptr_iterator<T, A>{ptr};
+      return ptr_iterator<eve::aligned_ptr<T, A>, A>{ptr};
     }
 
     template <typename T>
     EVE_FORCEINLINE auto ptr_to_iterator(T* ptr)
     {
       using N          = eve::fixed<eve::expected_cardinal_v<std::remove_const_t<T>>>;
-      return unaligned_ptr_iterator<T, N>{ptr};
+      return ptr_iterator<T*, N>{ptr};
     }
 
     template <typename Traits, typename I>

--- a/include/eve/algo/ptr_iterator.hpp
+++ b/include/eve/algo/ptr_iterator.hpp
@@ -144,7 +144,4 @@ namespace eve::algo
 
     Ptr ptr;
   };
-
-  template <typename T, typename Cardinal>
-  using aligned_ptr_iterator = ptr_iterator<aligned_ptr<T, Cardinal>, Cardinal>;
 }

--- a/include/eve/algo/ptr_iterator.hpp
+++ b/include/eve/algo/ptr_iterator.hpp
@@ -146,8 +146,5 @@ namespace eve::algo
   };
 
   template <typename T, typename Cardinal>
-  using unaligned_ptr_iterator = ptr_iterator<T*, Cardinal>;
-
-  template <typename T, typename Cardinal>
   using aligned_ptr_iterator = ptr_iterator<aligned_ptr<T, Cardinal>, Cardinal>;
 }

--- a/include/eve/algo/ptr_iterator.hpp
+++ b/include/eve/algo/ptr_iterator.hpp
@@ -7,6 +7,7 @@
 //==================================================================================================
 #pragma once
 
+#include <eve/algo/concepts/value_type.hpp>
 #include <eve/algo/iterator_helpers.hpp>
 
 #include <eve/function/load.hpp>
@@ -15,188 +16,138 @@
 
 namespace eve::algo
 {
-  template <typename T, typename Cardinal>
-  struct aligned_ptr_iterator;
+  //================================================================================================
+  //! @addtogroup eve.algo
+  //! @{
+  //!   @struct ptr_iterator
+  //!   @brief An eve iterator on top of pointer or aligned pointer.
+  //!
+  //!   This should not be created directly but rather constructed from preprocess_range.
+  //!
+  //!   When ptr is aligned, the alignment should match the cardinal.
+  //!
+  //!    **Required header:** `#include <eve/algo/ptr_iterator.hpp>`
+  //! @}
+  //================================================================================================
+  template <typename Ptr, typename Cardinal>
+  struct ptr_iterator;
 
-  template <typename T, typename Cardinal>
-  struct unaligned_ptr_iterator : operations_with_distance
+  namespace detail
   {
-    using value_type      = std::remove_const_t<T>;
-    using wv_type = eve::wide<value_type, Cardinal>;
+    template <typename Ptr, typename Cardinal>
+    constexpr bool check_aligned_ptr_validity()
+    {
+      if constexpr (!detail::instance_of<Ptr, aligned_ptr>) return true;
+      else return sizeof(value_type_t<Ptr>) * Cardinal{}() == Ptr::alignment();
+    }
+  }
 
-    unaligned_ptr_iterator() = default;
-    explicit unaligned_ptr_iterator(T* ptr) : ptr(ptr) {}
+  template <typename Ptr, typename Cardinal>
+  struct ptr_iterator : operations_with_distance
+  {
+    static_assert(detail::check_aligned_ptr_validity<Ptr, Cardinal>());
 
-    unaligned_ptr_iterator unaligned() const { return *this; }
+    using value_type = value_type_t<Ptr>;
+    using ptr_type   = Ptr;
+
+    // internal helpers
+    using reference_type = decltype(*Ptr{});
+    using cv_value_type  = std::remove_reference_t<reference_type>;
+    using wv_type        = eve::wide<value_type, Cardinal>;
+    using unaligned_me   = ptr_iterator<unaligned_t<Ptr>, Cardinal>;
+
+    ptr_iterator() = default;
+    explicit ptr_iterator(Ptr ptr) : ptr(ptr) {}
+
+    auto unaligned()        const { return unaligned_me{ unalign(ptr) }; }
+    operator unaligned_me() const { return unaligned(); }
 
     auto previous_partially_aligned() const
     {
-      return aligned_ptr_iterator<T, Cardinal>{eve::previous_aligned_address(ptr, Cardinal{})};
+      if constexpr (detail::instance_of<Ptr, aligned_ptr> ) return *this;
+      else
+      {
+        auto a_ptr = eve::previous_aligned_address(ptr, Cardinal{});
+        return ptr_iterator<decltype(a_ptr), Cardinal>{a_ptr};
+      }
     }
 
     auto next_partially_aligned() const
     {
-      return aligned_ptr_iterator<T, Cardinal>{eve::next_aligned_address(ptr, Cardinal{})};
+      if constexpr (detail::instance_of<Ptr, aligned_ptr> ) return *this;
+      else
+      {
+        auto a_ptr = eve::next_aligned_address(ptr, Cardinal{});
+        return ptr_iterator<decltype(a_ptr), Cardinal>{a_ptr};
+      }
     }
-
-    static Cardinal iterator_cardinal() { return {}; }
-
-    template <typename _Cardinal>
-    auto cardinal_cast(_Cardinal) const { return unaligned_ptr_iterator<T, _Cardinal>{ptr}; }
-
-    auto& operator*() const { return *ptr; }
-
-    unaligned_ptr_iterator& operator+=(std::ptrdiff_t n) { ptr += n; return *this; }
-    friend std::ptrdiff_t   operator-(unaligned_ptr_iterator x, unaligned_ptr_iterator y) { return x.ptr - y.ptr; }
-
-    bool operator==(unaligned_ptr_iterator const &x) const { return ptr == x.ptr; }
-    auto operator<=>(unaligned_ptr_iterator const &x) const { return ptr <=> x.ptr; }
-
-    template< relative_conditional_expr C, decorator S>
-    EVE_FORCEINLINE friend auto tagged_dispatch ( eve::tag::load_, C const& c, S const& s
-                                , eve::as<wv_type> const&, unaligned_ptr_iterator self
-                                )
-    {
-      return eve::load(c, s, self.ptr, Cardinal{});
-    }
-
-    template <relative_conditional_expr C>
-    EVE_FORCEINLINE friend void tagged_dispatch(
-      eve::tag::store_, C cond, wv_type v, unaligned_ptr_iterator self )
-      requires (!std::is_const_v<T>)
-    {
-      eve::store[cond](v, self.ptr);
-    }
-
-    EVE_FORCEINLINE friend void tagged_dispatch( eve::tag::store_, wv_type v, unaligned_ptr_iterator self )
-      requires ( !std::is_const_v<T> )
-    {
-      eve::store(v, self.ptr);
-    }
-
-    template <relative_conditional_expr C, decorator Decorator, typename U>
-      requires ( !std::is_const_v<T> )
-    EVE_FORCEINLINE friend auto tagged_dispatch(
-      eve::tag::compress_store_, C c, Decorator d, wv_type v,
-      logical<wide<U, Cardinal>> m, unaligned_ptr_iterator self)
-    {
-      return unaligned_ptr_iterator{eve::compress_store(c, d, v, m, self.ptr)};
-    }
-
-    T* ptr;
-  };
-
-  template <typename T, typename Cardinal>
-  struct aligned_ptr_iterator : operations_with_distance
-  {
-    using value_type        = std::remove_const_t<T>;
-    using aligned_ptr_type  = eve::aligned_ptr<T, Cardinal>;
-    using wv_type   = eve::wide<value_type, Cardinal>;
-
-    aligned_ptr_iterator() = default;
-    explicit aligned_ptr_iterator(aligned_ptr_type ptr) : ptr{ptr} {}
-
-    // Need this for totally ordered.
-    operator unaligned_ptr_iterator<T, Cardinal>() const {
-      return unaligned_ptr_iterator<T, Cardinal>{ptr.get()};
-    }
-
-    auto& operator*() const { return *ptr; }
-    auto get() const { return ptr.get(); }
-    auto unaligned() const { return unaligned_ptr_iterator<T, Cardinal>{ptr.get()}; }
-    auto previous_partially_aligned() const { return *this; }
-    auto next_partially_aligned()     const { return *this; }
 
     static Cardinal iterator_cardinal() { return {}; }
 
     template <typename _Cardinal>
     auto cardinal_cast(_Cardinal c) const
     {
-      if constexpr (_Cardinal{}() > Cardinal{}()) return unaligned().cardinal_cast(c);
+           if constexpr (!detail::instance_of<Ptr, aligned_ptr> ) return ptr_iterator<Ptr, _Cardinal>(ptr);
+      else if constexpr (_Cardinal{}() > Cardinal{}()           ) return unaligned().cardinal_cast(c);
       else
       {
-        using other_it  = aligned_ptr_iterator<T, _Cardinal>;
-        using other_ptr = typename other_it::aligned_ptr_type;
+        using other_ptr = aligned_ptr<cv_value_type, _Cardinal>;
+        using other_it  = ptr_iterator<other_ptr, _Cardinal>;
         return other_it{other_ptr{ptr.get()}};
       }
     }
 
-    aligned_ptr_iterator& operator+=(std::ptrdiff_t n) { ptr += n; return *this; }
+    auto& operator*() const { return *ptr; }
 
-    template <typename T1, typename N1>
-    bool operator==(aligned_ptr_iterator<T1, N1> y) const
-    {
-      return unaligned() == y.unaligned();
-    }
+    ptr_iterator& operator+=(std::ptrdiff_t n) { ptr += n; return *this; }
 
-    template <typename T1, typename N1>
-    bool operator==(unaligned_ptr_iterator<T1, N1> y) const
-    {
-      return unaligned() == y;
-    }
+    template <typename OtherPtr>
+    friend std::ptrdiff_t operator-(ptr_iterator x, ptr_iterator<OtherPtr, Cardinal> y) { return x.ptr - y.ptr; }
 
-    template <typename T1, typename N1>
-    auto operator<=>(aligned_ptr_iterator<T1, N1> y) const
-    {
-      return unaligned() <=> y.unaligned();
-    }
+    template <typename OtherPtr>
+    bool operator==(ptr_iterator<OtherPtr, Cardinal> const &x) const { return ptr == x.ptr; }
 
-    template <typename T1, typename N1>
-    auto operator<=>(unaligned_ptr_iterator<T1, N1> y) const
-    {
-      return unaligned() <=> y;
-    }
-
-    template <typename T1, typename N1>
-    std::ptrdiff_t operator-(aligned_ptr_iterator<T1, N1> y) const
-    {
-      return unaligned() - y.unaligned();
-    }
-
-    template <typename T1, typename N1>
-    std::ptrdiff_t operator-(unaligned_ptr_iterator<T1, N1> y) const
-    {
-      return unaligned() - y;
-    }
-
-    template <typename T1, typename N1>
-    friend std::ptrdiff_t operator-(unaligned_ptr_iterator<T1, N1> x, aligned_ptr_iterator y)
-    {
-      return x - y.unaligned();
-    }
-
+    template <typename OtherPtr>
+    auto operator<=>(ptr_iterator<OtherPtr, Cardinal> const &x) const { return ptr <=> x.ptr; }
 
     template< relative_conditional_expr C, decorator S>
     EVE_FORCEINLINE friend auto tagged_dispatch ( eve::tag::load_, C const& c, S const& s
-                                , eve::as<wv_type> const&, aligned_ptr_iterator self
-                                )
+                                                , eve::as<wv_type> const&, ptr_iterator self
+                                                )
     {
       return eve::load(c, s, self.ptr, Cardinal{});
     }
 
     template <relative_conditional_expr C>
-    EVE_FORCEINLINE friend void tagged_dispatch(
-      eve::tag::store_, C cond, wv_type v, aligned_ptr_iterator self )
-      requires ( !std::is_const_v<T> )
+    EVE_FORCEINLINE friend void tagged_dispatch(eve::tag::store_,
+                                                C cond, wv_type v,
+                                                ptr_iterator self )
+      requires (!std::is_const_v<cv_value_type>)
     {
-      return eve::store[cond](v, self.ptr);
+      eve::store[cond](v, self.ptr);
     }
 
-    EVE_FORCEINLINE friend void tagged_dispatch( eve::tag::store_, wv_type v, aligned_ptr_iterator self )
-      requires ( !std::is_const_v<T> )
+    EVE_FORCEINLINE friend void tagged_dispatch( eve::tag::store_, wv_type v, ptr_iterator self )
+      requires (!std::is_const_v<cv_value_type>)
     {
-      return eve::store(v, self.ptr);
+      eve::store(v, self.ptr);
     }
 
     template <relative_conditional_expr C, decorator Decorator, typename U>
-      requires ( !std::is_const_v<T> )
+      requires (!std::is_const_v<cv_value_type>)
     EVE_FORCEINLINE friend auto tagged_dispatch(
       eve::tag::compress_store_, C c, Decorator d, wv_type v,
-      logical<wide<U, Cardinal>> m, aligned_ptr_iterator self)
+      logical<wide<U, Cardinal>> m, ptr_iterator self)
     {
-      return unaligned_ptr_iterator<T, Cardinal>{eve::compress_store(c, d, v, m, self.ptr)};
+      return unaligned_me{eve::compress_store(c, d, v, m, self.ptr)};
     }
 
-    aligned_ptr_type ptr;
+    Ptr ptr;
   };
+
+  template <typename T, typename Cardinal>
+  using unaligned_ptr_iterator = ptr_iterator<T*, Cardinal>;
+
+  template <typename T, typename Cardinal>
+  using aligned_ptr_iterator = ptr_iterator<aligned_ptr<T, Cardinal>, Cardinal>;
 }

--- a/include/eve/algo/views/convert.hpp
+++ b/include/eve/algo/views/convert.hpp
@@ -151,7 +151,7 @@ namespace eve::algo::views
 
     EVE_FORCEINLINE auto unaligned() const { return convert(unalign(base), as<T>{}); }
 
-    operator unaligned_me() const { return unaligned(); }
+    EVE_FORCEINLINE operator unaligned_me() const { return unaligned(); }
 
     EVE_FORCEINLINE friend auto tagged_dispatch(eve::tag::read_, converting_iterator self)
     {

--- a/test/unit/algo/concepts.cpp
+++ b/test/unit/algo/concepts.cpp
@@ -21,7 +21,7 @@ TTS_CASE("concepts, value type")
   TTS_TYPE_IS(eve::algo::value_type_t<int*>, int);
   TTS_TYPE_IS(eve::algo::value_type_t<const int*>, int);
 
-  using u_p = eve::algo::unaligned_ptr_iterator<int const, eve::fixed<2>>;
+  using u_p = eve::algo::ptr_iterator<int const*, eve::fixed<2>>;
   TTS_TYPE_IS(eve::algo::value_type_t<u_p>, int);
 
   std::vector<int> v1, v2;

--- a/test/unit/algo/for_each_iteration.cpp
+++ b/test/unit/algo/for_each_iteration.cpp
@@ -27,8 +27,9 @@ namespace
 
     auto aligned_begin() const
     {
-      return eve::algo::aligned_ptr_iterator<const int, eve::fixed<4>> {
-        eve::aligned_ptr<const int, eve::fixed<4>>(data.begin())
+      using ap = eve::aligned_ptr<const int, eve::fixed<4>>;
+      return eve::algo::ptr_iterator<ap, eve::fixed<4>> {
+        ap(data.begin())
       };
     }
 

--- a/test/unit/algo/preprocess_range.cpp
+++ b/test/unit/algo/preprocess_range.cpp
@@ -170,7 +170,7 @@ EVE_TEST_TYPES("Check preprocess_range for eve ptr iterators", algo_test::select
 
   auto run_test = [&] <typename U>(U* f, U* l) {
     using aligned_it = eve::algo::aligned_ptr_iterator<U, N>;
-    using aligned_p = typename aligned_it::aligned_ptr_type;
+    using aligned_p = typename aligned_it::ptr_type;
 
     eve::algo::unaligned_ptr_iterator<U, N> u_f(f);
     eve::algo::unaligned_ptr_iterator<U, N> u_l(l);

--- a/test/unit/algo/preprocess_range.cpp
+++ b/test/unit/algo/preprocess_range.cpp
@@ -58,9 +58,11 @@ EVE_TEST_TYPES("Check preprocess_range for contiguous iterators", algo_test::sel
 
   // aligned_pointer
   {
+    using ap = eve::aligned_ptr<e_t, N>;
+
     auto processed = common_test(
-      eve::aligned_ptr<e_t>{arr.begin()}, arr.end(),
-      eve::algo::aligned_ptr_iterator<e_t, N>{},
+      ap{arr.begin()}, arr.end(),
+      eve::algo::ptr_iterator<ap, N>{},
       u_it{}
     );
     TTS_CONSTEXPR_EXPECT(decltype(processed.traits())::contains(eve::algo::no_aligning));
@@ -68,9 +70,11 @@ EVE_TEST_TYPES("Check preprocess_range for contiguous iterators", algo_test::sel
 
   // const aligned_pointer
   {
+    using ap = eve::aligned_ptr<e_t const, N>;
+
     auto processed = common_test(
-      eve::aligned_ptr<e_t const>{arr.cbegin()}, arr.cend(),
-      eve::algo::aligned_ptr_iterator<e_t const, N>{},
+      ap{arr.cbegin()}, arr.cend(),
+      eve::algo::ptr_iterator<ap, N>{},
       uc_it{}
     );
     TTS_CONSTEXPR_EXPECT(decltype(processed.traits())::contains(eve::algo::no_aligning));
@@ -78,10 +82,12 @@ EVE_TEST_TYPES("Check preprocess_range for contiguous iterators", algo_test::sel
 
   // two aligned_pointers
   {
+    using ap = eve::aligned_ptr<e_t, N>;
+
     auto processed = common_test(
-      eve::aligned_ptr<e_t>{arr.begin()}, eve::aligned_ptr<e_t>{arr.end()},
-      eve::algo::aligned_ptr_iterator<e_t, N>{},
-      eve::algo::aligned_ptr_iterator<e_t, N>{}
+      ap{arr.begin()}, ap{arr.end()},
+      eve::algo::ptr_iterator<ap, N>{},
+      eve::algo::ptr_iterator<ap, N>{}
     );
     TTS_CONSTEXPR_EXPECT(decltype(processed.traits())::contains(eve::algo::no_aligning));
     TTS_CONSTEXPR_EXPECT(decltype(processed.traits())::contains(eve::algo::divisible_by_cardinal));
@@ -89,10 +95,12 @@ EVE_TEST_TYPES("Check preprocess_range for contiguous iterators", algo_test::sel
 
   // two const aligned_pointers
   {
+    using ap = eve::aligned_ptr<e_t const, N>;
+
     auto processed = common_test(
-      eve::aligned_ptr<e_t const>{arr.cbegin()}, eve::aligned_ptr<e_t const>{arr.cend()},
-      eve::algo::aligned_ptr_iterator<e_t const, N>{},
-      eve::algo::aligned_ptr_iterator<e_t const, N>{}
+      ap{arr.cbegin()}, ap{arr.cend()},
+      eve::algo::ptr_iterator<ap, N>{},
+      eve::algo::ptr_iterator<ap, N>{}
     );
     TTS_CONSTEXPR_EXPECT(decltype(processed.traits())::contains(eve::algo::no_aligning));
     TTS_CONSTEXPR_EXPECT(decltype(processed.traits())::contains(eve::algo::divisible_by_cardinal));
@@ -100,15 +108,18 @@ EVE_TEST_TYPES("Check preprocess_range for contiguous iterators", algo_test::sel
 
   // unaligned/aligned
   {
+    using ap = eve::aligned_ptr<e_t, N>;
+    using acp = eve::aligned_ptr<e_t const, N>;
+
     common_test(
-      arr.begin(), eve::aligned_ptr<e_t>{arr.end()},
+      arr.begin(), ap{arr.end()},
       u_it{},
-      eve::algo::aligned_ptr_iterator<e_t, N>{}
+      eve::algo::ptr_iterator<ap, N>{}
     );
     common_test(
-      arr.cbegin(), eve::aligned_ptr<e_t const>{arr.cend()},
+      arr.cbegin(), acp{arr.cend()},
       uc_it{},
-      eve::algo::aligned_ptr_iterator<e_t const, N>{}
+      eve::algo::ptr_iterator<acp, N>{}
     );
   }
 
@@ -130,8 +141,8 @@ EVE_TEST_TYPES("Check preprocess_range for contiguous iterators", algo_test::sel
   {
     common_test(
       eve::aligned_ptr<e_t, eve::fixed<N{}() * 2>>{arr.begin()}, eve::aligned_ptr<e_t>{arr.end()},
-      eve::algo::aligned_ptr_iterator<e_t, N>{},
-      eve::algo::aligned_ptr_iterator<e_t, N>{}
+      eve::algo::ptr_iterator<eve::aligned_ptr<e_t, N>, N>{},
+      eve::algo::ptr_iterator<eve::aligned_ptr<e_t, N>, N>{}
     );
   }
 
@@ -172,9 +183,7 @@ EVE_TEST_TYPES("Check preprocess_range for eve ptr iterators", algo_test::select
   };
 
   auto run_test = [&] <typename U>(U* f, U* l) {
-    using aligned_it = eve::algo::aligned_ptr_iterator<U, N>;
-    using aligned_p = typename aligned_it::ptr_type;
-
+    using aligned_p = eve::aligned_ptr<U, N>;
 
     eve::algo::ptr_iterator<U*, N>         u_f(f);
     eve::algo::ptr_iterator<U*, N>         u_l(l);

--- a/test/unit/algo/preprocess_range.cpp
+++ b/test/unit/algo/preprocess_range.cpp
@@ -23,6 +23,9 @@ EVE_TEST_TYPES("Check preprocess_range for contiguous iterators", algo_test::sel
   using e_t = eve::element_type_t<T>;
   using N = eve::fixed<eve::expected_cardinal_v<e_t>>;
 
+  using u_it  = eve::algo::ptr_iterator<e_t*, N>;
+  using uc_it = eve::algo::ptr_iterator<e_t const*, N>;
+
   alignas(sizeof(eve::wide<e_t, N>) * 2) std::array<e_t, N{}()> arr{};
 
   std::vector<e_t> vec(100u, 0);
@@ -44,13 +47,13 @@ EVE_TEST_TYPES("Check preprocess_range for contiguous iterators", algo_test::sel
   // pointers
   common_test(
     arr.begin(), arr.end(),
-    eve::algo::unaligned_ptr_iterator<e_t, N>{}, eve::algo::unaligned_ptr_iterator<e_t, N>{});
+    u_it{}, u_it{});
 
   // const pointers
   common_test(
     arr.cbegin(), arr.cend(),
-    eve::algo::unaligned_ptr_iterator<e_t const, N>{},
-    eve::algo::unaligned_ptr_iterator<e_t const, N>{}
+    uc_it{},
+    uc_it{}
   );
 
   // aligned_pointer
@@ -58,7 +61,7 @@ EVE_TEST_TYPES("Check preprocess_range for contiguous iterators", algo_test::sel
     auto processed = common_test(
       eve::aligned_ptr<e_t>{arr.begin()}, arr.end(),
       eve::algo::aligned_ptr_iterator<e_t, N>{},
-      eve::algo::unaligned_ptr_iterator<e_t, N>{}
+      u_it{}
     );
     TTS_CONSTEXPR_EXPECT(decltype(processed.traits())::contains(eve::algo::no_aligning));
   }
@@ -68,7 +71,7 @@ EVE_TEST_TYPES("Check preprocess_range for contiguous iterators", algo_test::sel
     auto processed = common_test(
       eve::aligned_ptr<e_t const>{arr.cbegin()}, arr.cend(),
       eve::algo::aligned_ptr_iterator<e_t const, N>{},
-      eve::algo::unaligned_ptr_iterator<e_t const, N>{}
+      uc_it{}
     );
     TTS_CONSTEXPR_EXPECT(decltype(processed.traits())::contains(eve::algo::no_aligning));
   }
@@ -99,12 +102,12 @@ EVE_TEST_TYPES("Check preprocess_range for contiguous iterators", algo_test::sel
   {
     common_test(
       arr.begin(), eve::aligned_ptr<e_t>{arr.end()},
-      eve::algo::unaligned_ptr_iterator<e_t, N>{},
+      u_it{},
       eve::algo::aligned_ptr_iterator<e_t, N>{}
     );
     common_test(
       arr.cbegin(), eve::aligned_ptr<e_t const>{arr.cend()},
-      eve::algo::unaligned_ptr_iterator<e_t const, N>{},
+      uc_it{},
       eve::algo::aligned_ptr_iterator<e_t const, N>{}
     );
   }
@@ -113,13 +116,13 @@ EVE_TEST_TYPES("Check preprocess_range for contiguous iterators", algo_test::sel
   if constexpr (N{}() > 1) {
     common_test(
       arr.begin(), eve::aligned_ptr<e_t, eve::fixed<1>>{arr.end()},
-      eve::algo::unaligned_ptr_iterator<e_t, N>{},
-      eve::algo::unaligned_ptr_iterator<e_t, N>{}
+      u_it{},
+      u_it{}
     );
     common_test(
       eve::aligned_ptr<e_t, eve::fixed<1>>{arr.begin()}, eve::aligned_ptr<e_t, eve::fixed<1>>{arr.end()},
-      eve::algo::unaligned_ptr_iterator<e_t, N>{},
-      eve::algo::unaligned_ptr_iterator<e_t, N>{}
+      u_it{},
+      u_it{}
     );
   }
 
@@ -135,12 +138,12 @@ EVE_TEST_TYPES("Check preprocess_range for contiguous iterators", algo_test::sel
   // vector::iterator
   common_test(
     vec.begin(), vec.end(),
-    eve::algo::unaligned_ptr_iterator<e_t, N>{}, eve::algo::unaligned_ptr_iterator<e_t, N>{});
+    u_it{}, u_it{});
 
   // vector::const_iterator
   common_test(
     vec.cbegin(), vec.cend(),
-    eve::algo::unaligned_ptr_iterator<e_t const, N>{}, eve::algo::unaligned_ptr_iterator<e_t const, N>{});
+    uc_it{}, uc_it{});
 };
 
 EVE_TEST_TYPES("Check preprocess_range for eve ptr iterators", algo_test::selected_types)
@@ -172,10 +175,11 @@ EVE_TEST_TYPES("Check preprocess_range for eve ptr iterators", algo_test::select
     using aligned_it = eve::algo::aligned_ptr_iterator<U, N>;
     using aligned_p = typename aligned_it::ptr_type;
 
-    eve::algo::unaligned_ptr_iterator<U, N> u_f(f);
-    eve::algo::unaligned_ptr_iterator<U, N> u_l(l);
-    eve::algo::aligned_ptr_iterator<U, N>   a_f(aligned_p{f});
-    eve::algo::aligned_ptr_iterator<U, N>   a_l(aligned_p{l});
+
+    eve::algo::ptr_iterator<U*, N>         u_f(f);
+    eve::algo::ptr_iterator<U*, N>         u_l(l);
+    eve::algo::ptr_iterator<aligned_p, N>  a_f(aligned_p{f});
+    eve::algo::ptr_iterator<aligned_p, N>  a_l(aligned_p{l});
 
     run_one_test(u_f, u_l, eve::algo::traits(eve::algo::unroll<2>));
     run_one_test(u_f, a_l, eve::algo::traits(eve::algo::unroll<2>));
@@ -204,7 +208,7 @@ EVE_TEST_TYPES("contiguous ranges", algo_test::selected_types)
   // empty vector
   {
     std::vector<e_t> v;
-    using u_it = eve::algo::unaligned_ptr_iterator<e_t, N>;
+    using u_it = eve::algo::ptr_iterator<e_t*, N>;
 
     auto processed = eve::algo::preprocess_range(eve::algo::traits(), v);
     TTS_TYPE_IS(decltype(processed.traits()), decltype(eve::algo::traits()));
@@ -216,8 +220,8 @@ EVE_TEST_TYPES("contiguous ranges", algo_test::selected_types)
   auto non_empty_range_test = [](auto&& rng) {
     auto processed = eve::algo::preprocess_range(eve::algo::traits(), rng);
 
-    using u_it = eve::algo::unaligned_ptr_iterator<
-      std::remove_reference_t<decltype(*std::begin(rng))>, N>;
+    using u_it = eve::algo::ptr_iterator<
+      std::remove_reference_t<decltype(*std::begin(rng))>*, N>;
 
     TTS_TYPE_IS(decltype(processed.traits()), decltype(eve::algo::traits()));
     TTS_TYPE_IS(decltype(processed.begin()), u_it);

--- a/test/unit/algo/ptr_iterator.cpp
+++ b/test/unit/algo/ptr_iterator.cpp
@@ -33,7 +33,7 @@ EVE_TEST_TYPES("Check ptr_iterator", algo_test::selected_types)
     using N = eve::fixed<T::size()>;
 
     using aligned_it = eve::algo::aligned_ptr_iterator<U, N>;
-    using aligned_p = typename aligned_it::aligned_ptr_type;
+    using aligned_p = typename aligned_it::ptr_type;
 
     eve::algo::unaligned_ptr_iterator<U, N> u_f(f);
     eve::algo::unaligned_ptr_iterator<U, N> u_l(l);

--- a/test/unit/algo/ptr_iterator.cpp
+++ b/test/unit/algo/ptr_iterator.cpp
@@ -31,14 +31,15 @@ EVE_TEST_TYPES("Check ptr_iterator", algo_test::selected_types)
 
   auto run_test = [&] <typename U>(U* f, U* l) {
     using N = eve::fixed<T::size()>;
+    using aligned_p = eve::aligned_ptr<U, N>;
 
-    using aligned_it = eve::algo::aligned_ptr_iterator<U, N>;
-    using aligned_p = typename aligned_it::ptr_type;
+    using u_it = eve::algo::ptr_iterator<U*, N>;
+    using a_it = eve::algo::ptr_iterator<aligned_p, N>;
 
-    eve::algo::unaligned_ptr_iterator<U, N> u_f(f);
-    eve::algo::unaligned_ptr_iterator<U, N> u_l(l);
-    eve::algo::aligned_ptr_iterator<U, N>   a_f(aligned_p{f});
-    eve::algo::aligned_ptr_iterator<U, N>   a_l(aligned_p{l});
+    u_it u_f(f);
+    u_it u_l(l);
+    a_it a_f(aligned_p{f});
+    a_it a_l(aligned_p{l});
 
     run_test_one_pair(u_f, u_l);
     run_test_one_pair(u_f, a_l);

--- a/test/unit/algo/unalign.cpp
+++ b/test/unit/algo/unalign.cpp
@@ -19,5 +19,5 @@ TTS_CASE("eve::algo::unaligned_t")
   TTS_TYPE_IS(eve::algo::unaligned_t<std::vector<int>::const_iterator>, std::vector<int>::const_iterator);
   TTS_TYPE_IS((eve::algo::unaligned_t<eve::aligned_ptr<const int, eve::fixed<2>>>), const int*);
   TTS_TYPE_IS((eve::algo::unaligned_t<eve::algo::aligned_ptr_iterator<int, eve::fixed<2>>>),
-              (eve::algo::unaligned_ptr_iterator<int, eve::fixed<2>>));
+              (eve::algo::ptr_iterator<int*, eve::fixed<2>>));
 };

--- a/test/unit/algo/unalign.cpp
+++ b/test/unit/algo/unalign.cpp
@@ -18,6 +18,10 @@ TTS_CASE("eve::algo::unaligned_t")
   TTS_TYPE_IS(eve::algo::unaligned_t<int*>, int*);
   TTS_TYPE_IS(eve::algo::unaligned_t<std::vector<int>::const_iterator>, std::vector<int>::const_iterator);
   TTS_TYPE_IS((eve::algo::unaligned_t<eve::aligned_ptr<const int, eve::fixed<2>>>), const int*);
-  TTS_TYPE_IS((eve::algo::unaligned_t<eve::algo::aligned_ptr_iterator<int, eve::fixed<2>>>),
+  TTS_TYPE_IS((eve::algo::unaligned_t<
+               eve::algo::ptr_iterator<
+                  eve::aligned_ptr<int, eve::fixed<2>>,
+                  eve::fixed<2>
+                >>),
               (eve::algo::ptr_iterator<int*, eve::fixed<2>>));
 };

--- a/test/unit/views/backward.cpp
+++ b/test/unit/views/backward.cpp
@@ -68,8 +68,8 @@ TTS_CASE("eve::views::backward, preprocess_range")
 {
   using ap = eve::aligned_ptr<int>;
   using up = int*;
-  using a_it = eve::algo::aligned_ptr_iterator  <int, eve::fixed<eve::expected_cardinal_v<int>>>;
-  using u_it = eve::algo::unaligned_ptr_iterator<int, eve::fixed<eve::expected_cardinal_v<int>>>;
+  using a_it = eve::algo::ptr_iterator<ap, eve::fixed<eve::expected_cardinal_v<int>>>;
+  using u_it = eve::algo::ptr_iterator<up, eve::fixed<eve::expected_cardinal_v<int>>>;
 
   {
     auto processed = eve::algo::preprocess_range(eve::algo::traits{}, eve::views::backward(eve::algo::as_range(ap{}, up{})));

--- a/test/unit/views/backward.cpp
+++ b/test/unit/views/backward.cpp
@@ -43,7 +43,7 @@ TTS_CASE("eve::views::backward, backward of backward")
   }
   // eve::iterator
   {
-    using ap_it = eve::algo::aligned_ptr_iterator<char, eve::fixed<4>>;
+    using ap_it = eve::algo::ptr_iterator<eve::aligned_ptr<char, eve::fixed<4>>, eve::fixed<4>>;
     ap_it                                in;
     eve::views::backward_iterator<ap_it> rev = eve::views::backward(in);
     ap_it                                back = eve::views::backward(rev);

--- a/test/unit/views/backward_eve_iterator.cpp
+++ b/test/unit/views/backward_eve_iterator.cpp
@@ -46,14 +46,15 @@ EVE_TEST_TYPES("Check backward_iterator", algo_test::selected_types)
 
   auto run_test = [&] <typename U>(U* f, U* l) {
     using N = eve::fixed<T::size()>;
+    using aligned_p = eve::aligned_ptr<U, N>;
 
-    using aligned_it = eve::algo::aligned_ptr_iterator<U, N>;
-    using aligned_p = typename aligned_it::ptr_type;
+    using u_it = eve::algo::ptr_iterator<U*, N>;
+    using a_it = eve::algo::ptr_iterator<aligned_p, N>;
 
-    eve::algo::unaligned_ptr_iterator<U, N> u_f(f);
-    eve::algo::unaligned_ptr_iterator<U, N> u_l(l);
-    eve::algo::aligned_ptr_iterator<U, N>   a_f(aligned_p{f});
-    eve::algo::aligned_ptr_iterator<U, N>   a_l(aligned_p{l});
+    u_it u_f(f);
+    u_it u_l(l);
+    a_it a_f(aligned_p{f});
+    a_it a_l(aligned_p{l});
 
     run_test_one_pair(u_f, u_l);
     run_test_one_pair(u_f, a_l);

--- a/test/unit/views/backward_eve_iterator.cpp
+++ b/test/unit/views/backward_eve_iterator.cpp
@@ -48,7 +48,7 @@ EVE_TEST_TYPES("Check backward_iterator", algo_test::selected_types)
     using N = eve::fixed<T::size()>;
 
     using aligned_it = eve::algo::aligned_ptr_iterator<U, N>;
-    using aligned_p = typename aligned_it::aligned_ptr_type;
+    using aligned_p = typename aligned_it::ptr_type;
 
     eve::algo::unaligned_ptr_iterator<U, N> u_f(f);
     eve::algo::unaligned_ptr_iterator<U, N> u_l(l);

--- a/test/unit/views/convert.cpp
+++ b/test/unit/views/convert.cpp
@@ -64,7 +64,7 @@ TTS_CASE("eve::views::convert, preprocess test")
   };
 
   {
-    using u_it = eve::algo::unaligned_ptr_iterator<From, N>;
+    using u_it = eve::algo::ptr_iterator<From*, N>;
 
     std::vector<From> v;
     common_test(v, eve::as<To>{}, eve::algo::traits{}, u_it{}, u_it{}, eve::algo::traits{});
@@ -79,7 +79,7 @@ TTS_CASE("eve::views::convert, preprocess test")
                u_it{}, u_it{},    eve::algo::traits{eve::algo::no_aligning});
   }
   {
-    using u_it = eve::algo::unaligned_ptr_iterator<From const, N>;
+    using u_it = eve::algo::ptr_iterator<From const*, N>;
 
     const std::vector<From> v;
     common_test(v, eve::as<To>{}, eve::algo::traits{}, u_it{}, u_it{}, eve::algo::traits{});
@@ -90,7 +90,7 @@ TTS_CASE("eve::views::convert, preprocess test")
   }
   {
     using a_it = eve::algo::aligned_ptr_iterator  <From, N>;
-    using u_it = eve::algo::unaligned_ptr_iterator<From, N>;
+    using u_it = eve::algo::ptr_iterator<From*, N>;
 
     eve::aligned_ptr<From> f;
     From* l = nullptr;

--- a/test/unit/views/convert.cpp
+++ b/test/unit/views/convert.cpp
@@ -89,7 +89,7 @@ TTS_CASE("eve::views::convert, preprocess test")
                 eve::as<To>{}, eve::algo::traits{}, u_it{}, u_it{}, eve::algo::traits{});
   }
   {
-    using a_it = eve::algo::aligned_ptr_iterator  <From, N>;
+    using a_it = eve::algo::ptr_iterator<eve::aligned_ptr<From, N>, N>;
     using u_it = eve::algo::ptr_iterator<From*, N>;
 
     eve::aligned_ptr<From> f;
@@ -114,8 +114,8 @@ TTS_CASE("eve.algo.views.convert to/from")
   }
   // eve::iterator
   {
-    using ap_it = eve::algo::aligned_ptr_iterator<char, eve::fixed<4>>;
-    ap_it                                        chars{};
+    using ap_it = eve::algo::ptr_iterator<eve::aligned_ptr<char, eve::fixed<4>>, eve::fixed<4>>;
+    ap_it                                         chars{};
     eve::views::converting_iterator<ap_it, int>   ints   = eve::views::convert(chars,  eve::as<int>{});
     eve::views::converting_iterator<ap_it, short> shorts = eve::views::convert(ints,   eve::as<short>{});
     ap_it                                         chars2 = eve::views::convert(shorts, eve::as<char>{});

--- a/test/unit/views/converting_eve_iterator.cpp
+++ b/test/unit/views/converting_eve_iterator.cpp
@@ -38,14 +38,15 @@ EVE_TEST_TYPES("Check converting_iterator", algo_test::selected_types)
 
   auto run_test = [&] <typename U>(U* f, U* l) {
     using N = eve::fixed<T::size()>;
+    using aligned_p = eve::aligned_ptr<U, N>;
 
-    using aligned_it = eve::algo::aligned_ptr_iterator<U, N>;
-    using aligned_p = typename aligned_it::ptr_type;
+    using u_it = eve::algo::ptr_iterator<U*, N>;
+    using a_it = eve::algo::ptr_iterator<aligned_p, N>;
 
-    eve::algo::unaligned_ptr_iterator<U, N> u_f(f);
-    eve::algo::unaligned_ptr_iterator<U, N> u_l(l);
-    eve::algo::aligned_ptr_iterator<U, N>   a_f(aligned_p{f});
-    eve::algo::aligned_ptr_iterator<U, N>   a_l(aligned_p{l});
+    u_it u_f(f);
+    u_it u_l(l);
+    a_it a_f(aligned_p{f});
+    a_it a_l(aligned_p{l});
 
     run_test_one_pair(u_f, u_l);
     run_test_one_pair(u_f, a_l);

--- a/test/unit/views/converting_eve_iterator.cpp
+++ b/test/unit/views/converting_eve_iterator.cpp
@@ -40,7 +40,7 @@ EVE_TEST_TYPES("Check converting_iterator", algo_test::selected_types)
     using N = eve::fixed<T::size()>;
 
     using aligned_it = eve::algo::aligned_ptr_iterator<U, N>;
-    using aligned_p = typename aligned_it::aligned_ptr_type;
+    using aligned_p = typename aligned_it::ptr_type;
 
     eve::algo::unaligned_ptr_iterator<U, N> u_f(f);
     eve::algo::unaligned_ptr_iterator<U, N> u_l(l);

--- a/test/unit/views/preprocess_zip_range.cpp
+++ b/test/unit/views/preprocess_zip_range.cpp
@@ -28,7 +28,7 @@ TTS_CASE("zip_iterator, preprocess range, scalar end")
   using zip_vi = eve::views::zip_iterator<v_i, v_i>;
 
   using N = eve::fixed<eve::expected_cardinal_v<int>>;
-  using ui_it = eve::algo::unaligned_ptr_iterator<int, N>;
+  using ui_it = eve::algo::ptr_iterator<int*, N>;
   using zip_ui = eve::views::zip_iterator<ui_it, ui_it>;
 
   zip_vi zf{v1.begin(), v2.begin()};
@@ -49,8 +49,8 @@ TTS_CASE("zip_iterator, preprocess range, zip end")
   using zip_uu = eve::views::zip_iterator<u, u>;
 
   using N = eve::fixed<eve::expected_cardinal_v<int>>;
-  using a_it = eve::algo::aligned_ptr_iterator  <int const, N>;
-  using u_it = eve::algo::unaligned_ptr_iterator<int const, N>;
+  using a_it = eve::algo::ptr_iterator<a, N>;
+  using u_it = eve::algo::ptr_iterator<u, N>;
   using zip_au_it = eve::views::zip_iterator<a_it, u_it>;
   using zip_uu_it = eve::views::zip_iterator<u_it, u_it>;
 
@@ -102,10 +102,15 @@ TTS_CASE("zip_iterator, preprocess range, zip end")
 TTS_CASE("preprocess zip range, traits")
 {
   using N = eve::fixed<eve::expected_cardinal_v<std::uint32_t>>;
-  using uc_it = eve::algo::unaligned_ptr_iterator<std::int8_t, N>;
-  using ui_it = eve::algo::unaligned_ptr_iterator<std::uint32_t, N>;
-  using ac_it = eve::algo::aligned_ptr_iterator<std::int8_t, N>;
-  using ai_it = eve::algo::aligned_ptr_iterator<std::uint32_t, N>;
+  using uc = std::int8_t*;
+  using ac = eve::aligned_ptr<std::int8_t, N>;
+  using ui = std::uint32_t*;
+  using ai = eve::aligned_ptr<std::uint32_t>;
+
+  using uc_it = eve::algo::ptr_iterator<uc, N>;
+  using ui_it = eve::algo::ptr_iterator<ui, N>;
+  using ac_it = eve::algo::ptr_iterator<ac, N>;
+  using ai_it = eve::algo::ptr_iterator<ai, N>;
 
   using zip_uc_it_ui_it = eve::views::zip_iterator<uc_it, ui_it>;
 
@@ -205,8 +210,8 @@ TTS_CASE("preprocess zip range, common_type")
 
   {
     using N           = eve::fixed<eve::expected_cardinal_v<std::uint32_t>>;
-    using uc_it       = eve::algo::unaligned_ptr_iterator<std::int8_t, N>;
-    using ui_it       = eve::algo::unaligned_ptr_iterator<std::uint32_t, N>;
+    using uc_it       = eve::algo::ptr_iterator<std::int8_t*, N>;
+    using ui_it       = eve::algo::ptr_iterator<std::uint32_t*, N>;
     using conv_uc_it  = eve::views::converting_iterator<uc_it, std::uint32_t>;
     using expected_it = eve::views::zip_iterator<conv_uc_it, ui_it>;
 
@@ -220,8 +225,8 @@ TTS_CASE("preprocess zip range, common_type")
 
   {
     using N           = eve::fixed<2>;
-    using uc_it       = eve::algo::unaligned_ptr_iterator<std::int8_t, N>;
-    using ui_it       = eve::algo::unaligned_ptr_iterator<std::uint32_t, N>;
+    using uc_it       = eve::algo::ptr_iterator<std::int8_t*, N>;
+    using ui_it       = eve::algo::ptr_iterator<std::uint32_t*, N>;
     using conv_uc_it  = eve::views::converting_iterator<uc_it, float>;
     using conv_ui_it  = eve::views::converting_iterator<ui_it, float>;
     using expected_it = eve::views::zip_iterator<conv_uc_it, conv_ui_it>;

--- a/test/unit/views/reverse.cpp
+++ b/test/unit/views/reverse.cpp
@@ -71,8 +71,8 @@ TTS_CASE("eve::views::reverse, preprocess_range")
 {
   using ap = eve::aligned_ptr<int>;
   using up = int*;
-  using a_it = eve::algo::aligned_ptr_iterator  <int, eve::fixed<eve::expected_cardinal_v<int>>>;
-  using u_it = eve::algo::unaligned_ptr_iterator<int, eve::fixed<eve::expected_cardinal_v<int>>>;
+  using a_it = eve::algo::ptr_iterator<ap, eve::fixed<eve::expected_cardinal_v<int>>>;
+  using u_it = eve::algo::ptr_iterator<up, eve::fixed<eve::expected_cardinal_v<int>>>;
 
   {
     auto processed = eve::algo::preprocess_range(eve::algo::traits{}, eve::views::reverse(eve::algo::as_range(ap{}, up{})));

--- a/test/unit/views/reverse.cpp
+++ b/test/unit/views/reverse.cpp
@@ -46,7 +46,7 @@ TTS_CASE("eve::views::reverse, reverse of reverse")
   }
   // eve::iterator
   {
-    using ap_it = eve::algo::aligned_ptr_iterator<char, eve::fixed<4>>;
+    using ap_it = eve::algo::ptr_iterator<eve::aligned_ptr<char, eve::fixed<4>>, eve::fixed<4>>;
     ap_it                               in;
     eve::views::reverse_iterator<ap_it> rev = eve::views::reverse(in);
     ap_it                               back = eve::views::reverse(rev);

--- a/test/unit/views/reverse_eve_iterator.cpp
+++ b/test/unit/views/reverse_eve_iterator.cpp
@@ -32,14 +32,15 @@ EVE_TEST_TYPES("Check reverse_iterator", algo_test::selected_types)
 
   auto run_test = [&] <typename U>(U* f, U* l) {
     using N = eve::fixed<T::size()>;
+    using aligned_p = eve::aligned_ptr<U, N>;
 
-    using aligned_it = eve::algo::aligned_ptr_iterator<U, N>;
-    using aligned_p = typename aligned_it::ptr_type;
+    using u_it = eve::algo::ptr_iterator<U*, N>;
+    using a_it = eve::algo::ptr_iterator<aligned_p, N>;
 
-    eve::algo::unaligned_ptr_iterator<U, N> u_f(f);
-    eve::algo::unaligned_ptr_iterator<U, N> u_l(l);
-    eve::algo::aligned_ptr_iterator<U, N>   a_f(aligned_p{f});
-    eve::algo::aligned_ptr_iterator<U, N>   a_l(aligned_p{l});
+    u_it u_f(f);
+    u_it u_l(l);
+    a_it a_f(aligned_p{f});
+    a_it a_l(aligned_p{l});
 
     run_test_one_pair(u_f, u_l);
     run_test_one_pair(u_f, a_l);

--- a/test/unit/views/reverse_eve_iterator.cpp
+++ b/test/unit/views/reverse_eve_iterator.cpp
@@ -34,7 +34,7 @@ EVE_TEST_TYPES("Check reverse_iterator", algo_test::selected_types)
     using N = eve::fixed<T::size()>;
 
     using aligned_it = eve::algo::aligned_ptr_iterator<U, N>;
-    using aligned_p = typename aligned_it::aligned_ptr_type;
+    using aligned_p = typename aligned_it::ptr_type;
 
     eve::algo::unaligned_ptr_iterator<U, N> u_f(f);
     eve::algo::unaligned_ptr_iterator<U, N> u_l(l);

--- a/test/unit/views/zip_iterator.cpp
+++ b/test/unit/views/zip_iterator.cpp
@@ -23,7 +23,7 @@ TTS_CASE("zip_iterator for not eve iterators")
   std::vector<std::uint8_t> c {1, 2, 3, 4};
   std::vector<int> v{1, 2, 3};
   std::array<float, 4> f { 1, 2, 3, 4};
-  using u_f = eve::algo::unaligned_ptr_iterator<float, eve::fixed<4>>;
+  using u_f = eve::algo::ptr_iterator<float*, eve::fixed<4>>;
 
   eve::views::zip_iterator zf{ c.begin(), v.begin(), u_f{f.begin()} };
   eve::views::zip_iterator zl{ c.end(), v.end(), u_f{f.end()} };
@@ -71,18 +71,23 @@ TTS_CASE("zip_iterator for not eve iterators, unaligned")
 
 TTS_CASE("zip_iterator, sanity check, types test")
 {
-  using unaligned_float = eve::algo::unaligned_ptr_iterator<float, eve::fixed<8>>;
-  using aligned_float   = eve::algo::aligned_ptr_iterator  <float, eve::fixed<8>>;
-  using unaligned_short = eve::algo::unaligned_ptr_iterator<short, eve::fixed<8>>;
-  using aligned_short   = eve::algo::aligned_ptr_iterator  <short, eve::fixed<8>>;
+  using uf = float*;
+  using af = eve::aligned_ptr<float, eve::fixed<8>>;
+  using us = short*;
+  using as = eve::aligned_ptr<short, eve::fixed<8>>;
+
+  using unaligned_float = eve::algo::ptr_iterator<uf, eve::fixed<8>>;
+  using aligned_float   = eve::algo::ptr_iterator<af, eve::fixed<8>>;
+  using unaligned_short = eve::algo::ptr_iterator<us, eve::fixed<8>>;
+  using aligned_short   = eve::algo::ptr_iterator<as, eve::fixed<8>>;
 
   using zip_a_a = eve::views::zip_iterator<aligned_float,   aligned_short>;
   using zip_u_a = eve::views::zip_iterator<unaligned_float, aligned_short>;
   using zip_a_u = eve::views::zip_iterator<aligned_float,   unaligned_short>;
   using zip_u_u = eve::views::zip_iterator<unaligned_float, unaligned_short>;
 
-  using aligned_float_4   = eve::algo::aligned_ptr_iterator  <float, eve::fixed<4>>;
-  using unaligned_short_4 = eve::algo::unaligned_ptr_iterator<short, eve::fixed<4>>;
+  using aligned_float_4   = eve::algo::ptr_iterator<eve::aligned_ptr<float, eve::fixed<4>>, eve::fixed<4>>;
+  using unaligned_short_4 = eve::algo::ptr_iterator<short*, eve::fixed<4>>;
 
   using zip_a_u_4 = eve::views::zip_iterator<aligned_float_4, unaligned_short_4>;
 
@@ -140,10 +145,15 @@ TTS_CASE("zip_iterator, sanity check, types test")
 
 TTS_CASE("zip_iterator, main iterator")
 {
-  using unaligned_float = eve::algo::unaligned_ptr_iterator<float, eve::fixed<8>>;
-  using aligned_float   = eve::algo::aligned_ptr_iterator  <float, eve::fixed<8>>;
-  using unaligned_short = eve::algo::unaligned_ptr_iterator<short, eve::fixed<8>>;
-  using aligned_short   = eve::algo::aligned_ptr_iterator  <short, eve::fixed<8>>;
+  using uf = float*;
+  using af = eve::aligned_ptr<float, eve::fixed<8>>;
+  using us = short*;
+  using as = eve::aligned_ptr<short, eve::fixed<8>>;
+
+  using unaligned_float = eve::algo::ptr_iterator<uf, eve::fixed<8>>;
+  using aligned_float   = eve::algo::ptr_iterator<af, eve::fixed<8>>;
+  using unaligned_short = eve::algo::ptr_iterator<us, eve::fixed<8>>;
+  using aligned_short   = eve::algo::ptr_iterator<as, eve::fixed<8>>;
 
   using iota            = decltype(eve::views::iota(0).cardinal_cast(eve::lane<8>));
 
@@ -210,9 +220,9 @@ EVE_TEST_TYPES("Check zip_iterator", algo_test::selected_types)
     algo_test::iterator_supports_compress(f, values, replace);
   };
 
-  eve::algo::unaligned_ptr_iterator<t1, N> u_f_1{data_1.begin()};
-  eve::algo::unaligned_ptr_iterator<t2, N> u_f_2{data_2.begin()};
-  eve::algo::unaligned_ptr_iterator<t3, N> u_f_3{data_3.begin()};
+  eve::algo::ptr_iterator<t1*, N> u_f_1{data_1.begin()};
+  eve::algo::ptr_iterator<t2*, N> u_f_2{data_2.begin()};
+  eve::algo::ptr_iterator<t3*, N> u_f_3{data_3.begin()};
 
   auto u_l_1 = u_f_1 + T::size();
 


### PR DESCRIPTION
Merge unaligned and aligned ptr iterators into one to later make conversions simpler