### PR TITLE
FIX-946: convert from non-const to const for iterators

### DIFF
--- a/include/eve/algo/container/soa_vector.hpp
+++ b/include/eve/algo/container/soa_vector.hpp
@@ -142,13 +142,23 @@ namespace eve::algo
     //! @brief Removes an element from the container.
     //! Has the same invalidation semantics as std::vector.
     //! end() iterator is not a valid pos.
-    iterator erase(iterator       pos) { return erase_impl(begin(),  pos); }
-    iterator erase(const_iterator pos) { return erase_impl(cbegin(), pos); }
+    iterator erase(const_iterator pos)
+    {
+      std::ptrdiff_t distance = pos - cbegin();
+      kumi::for_each([&](auto& m) { return m.erase(m.begin() + distance); }, storage);
+      return begin() + distance;
+    }
 
     //! @brief Removes the elements in the range [first, last)
     //! Empty range is OK, does nothing
-    iterator erase(iterator       f,       iterator l) { return erase_impl(begin(),  f, l); }
-    iterator erase(const_iterator f, const_iterator l) { return erase_impl(cbegin(), f, l); }
+    iterator erase(const_iterator f, const_iterator l)
+    {
+      std::ptrdiff_t distance_f = f - cbegin();
+      std::ptrdiff_t distance_l = l - cbegin();
+      kumi::for_each([&](auto& m) {
+        return m.erase(m.begin() + distance_f, m.begin() + distance_l); }, storage);
+      return begin() + distance_f;
+    }
 
     //! @brief Appends the given element value to the end of the container.
     //! If the new size() is greater than capacity() then all iterators and references (including
@@ -305,20 +315,6 @@ namespace eve::algo
     }
 
     private:
-
-    auto erase_impl(auto base, auto pos) {
-      std::ptrdiff_t distance = pos - base;
-      kumi::for_each([&](auto& m) { return m.erase(m.begin() + distance); }, storage);
-      return begin() + distance;
-    }
-
-    auto erase_impl(auto base, auto pos_f, auto pos_l) {
-      std::ptrdiff_t distance_f = pos_f - base;
-      std::ptrdiff_t distance_l = pos_l - base;
-      kumi::for_each([&](auto& m) {
-        return m.erase(m.begin() + distance_f, m.begin() + distance_l); }, storage);
-      return begin() + distance_f;
-    };
 
     storage_type storage;
   };

--- a/include/eve/algo/ptr_iterator.hpp
+++ b/include/eve/algo/ptr_iterator.hpp
@@ -59,8 +59,10 @@ namespace eve::algo
     ptr_iterator() = default;
     explicit ptr_iterator(Ptr ptr) : ptr(ptr) {}
 
-    auto unaligned()        const { return unaligned_me{ unalign(ptr) }; }
-    operator unaligned_me() const { return unaligned(); }
+    template <std::convertible_to<Ptr> UPtr>
+    ptr_iterator(ptr_iterator<UPtr, Cardinal> const& x) : ptr(x.ptr) {}
+
+    auto unaligned() const { return unaligned_me{ unalign(ptr) }; }
 
     auto previous_partially_aligned() const
     {

--- a/include/eve/algo/views/backward.hpp
+++ b/include/eve/algo/views/backward.hpp
@@ -114,8 +114,10 @@ namespace eve::algo::views
 
     EVE_FORCEINLINE explicit backward_iterator(I base) : base(base) {}
 
+    template <std::convertible_to<I> I1>
+    EVE_FORCEINLINE backward_iterator(backward_iterator<I1> x) : base(x.base) {}
+
     EVE_FORCEINLINE auto unaligned() const { return backward(unalign(base)); }
-    operator unaligned_me() const { return unaligned(); }
 
     EVE_FORCEINLINE friend auto tagged_dispatch(eve::tag::read_, backward_iterator self)
     {

--- a/include/eve/algo/views/convert.hpp
+++ b/include/eve/algo/views/convert.hpp
@@ -149,9 +149,10 @@ namespace eve::algo::views
 
     EVE_FORCEINLINE explicit converting_iterator(I base) : base(base) {}
 
-    EVE_FORCEINLINE auto unaligned() const { return convert(unalign(base), as<T>{}); }
+    template <std::convertible_to<I> I1>
+    converting_iterator(converting_iterator<I1, T> x) : base(x.base) {}
 
-    EVE_FORCEINLINE operator unaligned_me() const { return unaligned(); }
+    EVE_FORCEINLINE auto unaligned() const { return convert(unalign(base), as<T>{}); }
 
     EVE_FORCEINLINE friend auto tagged_dispatch(eve::tag::read_, converting_iterator self)
     {

--- a/include/eve/algo/views/reverse.hpp
+++ b/include/eve/algo/views/reverse.hpp
@@ -107,8 +107,10 @@ namespace eve::algo::views
 
     EVE_FORCEINLINE explicit reverse_iterator(I base) : base(base) {}
 
+    template <std::convertible_to<I> I1>
+    EVE_FORCEINLINE reverse_iterator(reverse_iterator<I1> x) : base(x.base) {}
+
     EVE_FORCEINLINE auto unaligned() const { return reverse(unalign(base)); }
-    operator unaligned_me() const { return unaligned(); }
 
     EVE_FORCEINLINE friend auto tagged_dispatch(eve::tag::read_, reverse_iterator self)
     {

--- a/include/eve/algo/views/zip_iterator.hpp
+++ b/include/eve/algo/views/zip_iterator.hpp
@@ -128,9 +128,11 @@ namespace eve::algo::views
 
       template <typename ...I1s>
         requires (std::convertible_to<I1s, Is> && ...)
-      zip_iterator_common(zip_iterator<I1s...> x) :
-        storage(x.storage)
+      zip_iterator_common(zip_iterator<I1s...> x)
       {
+        storage = kumi::map([]<typename I1, typename I>(I1 from, I) -> I { return from; },
+                            x.storage,
+                            storage);
       }
 
       EVE_FORCEINLINE friend auto tagged_dispatch(eve::tag::read_, zip_iterator<Is...> self)

--- a/include/eve/algo/views/zip_iterator.hpp
+++ b/include/eve/algo/views/zip_iterator.hpp
@@ -126,6 +126,13 @@ namespace eve::algo::views
 
       explicit zip_iterator_common(Is... is) : storage {is...} {}
 
+      template <typename ...I1s>
+        requires (std::convertible_to<I1s, Is> && ...)
+      zip_iterator_common(zip_iterator<I1s...> x) :
+        storage(x.storage)
+      {
+      }
+
       EVE_FORCEINLINE friend auto tagged_dispatch(eve::tag::read_, zip_iterator<Is...> self)
       {
         return kumi::map(eve::read, self.storage);

--- a/include/eve/memory/aligned_ptr.hpp
+++ b/include/eve/memory/aligned_ptr.hpp
@@ -234,11 +234,6 @@ namespace eve
     //! Dereferences pointer to the held object
     decltype(auto) operator-> ()        noexcept { return pointer_; }
 
-    //! Indexed array to the underlying array
-    Type const &operator[](std::size_t i) const noexcept { return pointer_[ i ]; }
-
-    //! Indexed array to the underlying array
-    Type &      operator[](std::size_t i)       noexcept { return pointer_[ i ]; }
     //==============================================================================================
     //! @}
     //==============================================================================================

--- a/test/unit/algo/container/soa_vector.cpp
+++ b/test/unit/algo/container/soa_vector.cpp
@@ -265,6 +265,9 @@ TTS_CASE("Check types")
   TTS_TYPE_IS(v::const_iterator,         (eve::algo::views::converting_iterator<v::const_pointer,         T>));
   TTS_TYPE_IS(v::iterator_aligned,       (eve::algo::views::converting_iterator<v::pointer_aligned,       T>));
   TTS_TYPE_IS(v::const_iterator_aligned, (eve::algo::views::converting_iterator<v::const_pointer_aligned, T>));
+
+  TTS_CONSTEXPR_EXPECT((std::convertible_to<v::iterator, v::const_iterator>));
+  TTS_CONSTEXPR_EXPECT((std::convertible_to<v::pointer,  v::const_pointer>));
 };
 
 TTS_CASE("erase(pos)")

--- a/test/unit/algo/ptr_iterator.cpp
+++ b/test/unit/algo/ptr_iterator.cpp
@@ -58,3 +58,19 @@ EVE_TEST_TYPES("Check ptr_iterator", algo_test::selected_types)
   run_test(data.begin(), data.end());
   run_test(data.cbegin(), data.cend());
 };
+
+
+TTS_CASE("eve.algo non const to const")
+{
+  using N = eve::fixed<4>;
+  using aligned_p  = eve::aligned_ptr<int, N>;
+  using aligned_cp = eve::aligned_ptr<int const, N>;
+
+  using u_it  = eve::algo::ptr_iterator <int*      , N>;
+  using uc_it = eve::algo::ptr_iterator<int const*, N>;
+  using a_it  = eve::algo::ptr_iterator<aligned_p, N>;
+  using ac_it = eve::algo::ptr_iterator<aligned_cp, N>;
+
+  TTS_CONSTEXPR_EXPECT( (std::convertible_to<u_it, uc_it>) );
+  TTS_CONSTEXPR_EXPECT( (std::convertible_to<a_it, ac_it>) );
+};

--- a/test/unit/memory/aligned_ptr.cpp
+++ b/test/unit/memory/aligned_ptr.cpp
@@ -28,6 +28,48 @@ TTS_CASE("aligned_ptr constructor from nullptr")
   TTS_EQUAL(nullptr_constructed_ptr       , nullptr);
 };
 
+TTS_CASE("aligned_ptr constructor from more resticted")
+{
+  TTS_CONSTEXPR_EXPECT( (
+    std::convertible_to<
+                        eve::aligned_ptr<int, eve::fixed<4>>,
+                        eve::aligned_ptr<int, eve::fixed<2>>
+                       >) );
+  TTS_CONSTEXPR_EXPECT( (
+    std::convertible_to<
+                        eve::aligned_ptr<int const, eve::fixed<4>>,
+                        eve::aligned_ptr<int const, eve::fixed<2>>
+                       >) );
+  TTS_CONSTEXPR_EXPECT( (
+    std::convertible_to<
+                        eve::aligned_ptr<int,       eve::fixed<4>>,
+                        eve::aligned_ptr<int const, eve::fixed<4>>
+                       >) );
+  TTS_CONSTEXPR_EXPECT( (
+    std::convertible_to<
+                        eve::aligned_ptr<int,       eve::fixed<4>>,
+                        eve::aligned_ptr<int const, eve::fixed<2>>
+                       >) );
+
+  TTS_CONSTEXPR_EXPECT_NOT( (
+    std::convertible_to<
+                        eve::aligned_ptr<int, eve::fixed<2>>,
+                        eve::aligned_ptr<int, eve::fixed<4>>
+                       >) );
+
+  TTS_CONSTEXPR_EXPECT_NOT( (
+    std::convertible_to<
+                        eve::aligned_ptr<int const, eve::fixed<2>>,
+                        eve::aligned_ptr<int const, eve::fixed<4>>
+                       >) );
+
+  TTS_CONSTEXPR_EXPECT_NOT( (
+    std::convertible_to<
+                        eve::aligned_ptr<int const, eve::fixed<4>>,
+                        eve::aligned_ptr<int      , eve::fixed<4>>
+                       >) );
+};
+
 TTS_CASE("aligned_ptr factory functions - Default SIMD alignment")
 {
   constexpr auto size = EVE_CURRENT_ABI::bytes;
@@ -53,8 +95,8 @@ TTS_CASE("aligned_ptr factory functions - Specific alignment")
 TTS_CASE("aligned_ptr ordering")
 {
   std::byte                      values[ 2 ];
-  eve::aligned_ptr<std::byte, eve::fixed<1>> ptr = &values[ 0 ];
-  eve::aligned_ptr<std::byte, eve::fixed<1>> ptr1= ptr;
+  eve::aligned_ptr<std::byte, eve::fixed<1>> ptr { &values[ 0 ] };
+  eve::aligned_ptr<std::byte, eve::fixed<1>> ptr1 = ptr;
 
   ptr1++;
   TTS_EXPECT(ptr < ptr1);
@@ -69,7 +111,7 @@ TTS_CASE("aligned_ptr ordering")
 TTS_CASE("aligned_ptr pre/post increment & decrement")
 {
   std::byte                            values[ 2 ];
-  eve::aligned_ptr<std::byte, eve::fixed<1>> ptr = &values[ 0 ];
+  eve::aligned_ptr<std::byte, eve::fixed<1>> ptr { &values[ 0 ] };
 
   ptr++;
   TTS_EQUAL(ptr.get(), &values[ 1 ]);
@@ -97,9 +139,9 @@ TTS_CASE("aligned_ptr provides pointer-like interface")
     type values[2] = {{42},{17}};
     alignas(8) type extra_aligned_value{87};
 
-    eve::aligned_ptr<type, eve::fixed<1>> ptr           = &values[0];
-    eve::aligned_ptr<type, eve::fixed<1>> other_ptr     = &values[1];
-    eve::aligned_ptr<type, eve::fixed<8>> realigned_ptr = &extra_aligned_value;
+    eve::aligned_ptr<type, eve::fixed<1>> ptr           { &values[0] };
+    eve::aligned_ptr<type, eve::fixed<1>> other_ptr     { &values[1] };
+    eve::aligned_ptr<type, eve::fixed<8>> realigned_ptr { &extra_aligned_value };
 
     TTS_AND_THEN("we check the proper default alignment")
     {
@@ -117,7 +159,7 @@ TTS_CASE("aligned_ptr provides pointer-like interface")
 
     TTS_AND_THEN("we check re-assignment from raw pointer")
     {
-      ptr = &values[1];
+      ptr = decltype(ptr)(&values[1]);
       TTS_EQUAL(ptr->method(), &values[1]);
       TTS_EQUAL(ptr->member, 17);
       ptr->member = 101;

--- a/test/unit/views/backward_eve_iterator.cpp
+++ b/test/unit/views/backward_eve_iterator.cpp
@@ -71,3 +71,11 @@ EVE_TEST_TYPES("Check backward_iterator", algo_test::selected_types)
   run_test(data.begin(), data.end());
   run_test(data.cbegin(), data.cend());
 };
+
+TTS_CASE("backward iterators const/non-const")
+{
+  using from = eve::views::backward_iterator<int*>;
+  using to   = eve::views::backward_iterator<int const*>;
+
+  TTS_CONSTEXPR_EXPECT( (std::convertible_to<from, to>) );
+};

--- a/test/unit/views/convert.cpp
+++ b/test/unit/views/convert.cpp
@@ -136,3 +136,13 @@ TTS_CASE("eve.algo.views.convert to/from")
 
   TTS_PASS("all types ok");
 };
+
+TTS_CASE("eve.algo.views.convert_iterator const/non-const")
+{
+  using ap             = eve::aligned_ptr<char>;
+  using acp            = eve::aligned_ptr<char const>;
+  using converting_it  = eve::views::converting_iterator<ap,  int>;
+  using converting_cit = eve::views::converting_iterator<acp, int>;
+
+  TTS_CONSTEXPR_EXPECT( (std::convertible_to<converting_it, converting_cit>) );
+};

--- a/test/unit/views/reverse_eve_iterator.cpp
+++ b/test/unit/views/reverse_eve_iterator.cpp
@@ -57,3 +57,11 @@ EVE_TEST_TYPES("Check reverse_iterator", algo_test::selected_types)
   run_test(data.begin(), data.end());
   run_test(data.cbegin(), data.cend());
 };
+
+TTS_CASE("reverse iterators const/non-const")
+{
+  using from = eve::views::reverse_iterator<int*>;
+  using to   = eve::views::reverse_iterator<int const*>;
+
+  TTS_CONSTEXPR_EXPECT( (std::convertible_to<from, to>) );
+};

--- a/test/unit/views/zip_iterator.cpp
+++ b/test/unit/views/zip_iterator.cpp
@@ -11,10 +11,10 @@
 
 #include <eve/views/zip.hpp>
 
+#include <eve/views/convert.hpp>
 #include <eve/views/iota.hpp>
 
 #include <eve/algo/ptr_iterator.hpp>
-
 
 #include <algorithm>
 
@@ -233,4 +233,15 @@ EVE_TEST_TYPES("Check zip_iterator", algo_test::selected_types)
   run_test_one_pair(u_f_1, u_f_2, u_f_3, u_l_1);
   run_test_one_pair(a_f_1, a_f_2, a_f_3, u_l_1);
   run_test_one_pair(u_f_1, a_f_2, u_f_3, u_l_1);
+};
+
+TTS_CASE("zip iterators const/non-const")
+{
+  using cvt       = eve::views::converting_iterator<char*      , int>;
+  using cvt_const = eve::views::converting_iterator<char const*, int>;
+
+  using from      = eve::views::zip_iterator<int*      , cvt>;
+  using to        = eve::views::zip_iterator<int const*, cvt_const>;
+
+  TTS_CONSTEXPR_EXPECT( (std::convertible_to<from, to>) );
 };


### PR DESCRIPTION
Had to make a few changes in `aligned_ptr` - construction from pointer has to be `explicit`, conversion to `pointer` - implicit.
This is to allow for `equality_comparible_with`.

Also - due to conversion to `pointer` from `aligned_pointer` now being implicit, had to remove `operator[]` since it somehow conflicted with a built in `operator[]` on gcc for arm-v7 (and only there).

The functionality still works.
I can disable with a macro if you prefer.