### PR TITLE
FIX-1111: copy backward assert

### DIFF
--- a/include/eve/algo/copy.hpp
+++ b/include/eve/algo/copy.hpp
@@ -53,6 +53,27 @@ namespace eve::algo
 
   inline constexpr auto copy = function_with_traits<copy_>[default_simple_algo_traits];
 
+  //================================================================================================
+  //! @addtogroup algo
+  //! @{
+  //!  @var copy_backward
+  //!
+  //!  @brief version of std::copy_backward
+  //!    * Accepts two things zipping together to range of pair but the optput cannot be an iterator.
+  //!      The restriction on the output is that we'd have to accept first, while the standard accepts last.
+  //!    * Also can accept a `zipped_range_pair`.
+  //!    * returns void.
+  //!    * default unrolling is 4.
+  //!    * will align by default.
+  //!    * for copying to the same scalar type consider using `std::memmove` instead.
+  //!    * will do conversions if necessary.
+  //!
+  //!   **Required header:** `#include <eve/algo/copy.hpp>`
+  //!
+  //! @}
+  //================================================================================================
+
+
   template <typename TraitsSupport>
   struct copy_backward_ : TraitsSupport
   {
@@ -67,6 +88,10 @@ namespace eve::algo
       requires zip_to_range<R1, R2>
     EVE_FORCEINLINE void operator()(R1&& r1, R2&& r2) const
     {
+      static_assert(!relaxed_iterator<R2>, "Behavior of std::copy_backward and eve::algo::copy_backward"
+                                           " would differ for a second parameter iterator."
+                                           " Use eve::algo::copy_backward(zip(r, it))"
+                                           " or pass a range as a second parameter.");
       operator()(views::zip(EVE_FWD(r1), EVE_FWD(r2)));
     }
   };

--- a/test/unit/algo/algorithm/all_of_generic.cpp
+++ b/test/unit/algo/algorithm/all_of_generic.cpp
@@ -18,7 +18,7 @@ struct any_with_all_ : TraitsSupport
   template <typename Rng, typename P>
   EVE_FORCEINLINE bool operator()(Rng&& rng, P p) const
   {
-    return !eve::algo::all_of[TraitsSupport::get_traits()](std::forward<Rng>(rng),
+    return !eve::algo::all_of[TraitsSupport::get_traits()](EVE_FWD(rng),
       [p](auto x) { return !p(x); });
   }
 };

--- a/test/unit/algo/algorithm/copy_back.cpp
+++ b/test/unit/algo/algorithm/copy_back.cpp
@@ -27,11 +27,12 @@ EVE_TEST_TYPES("Check that we can copy to an address after beginning (copy/copy_
     for (int j = i; j != T::size() * 2; ++j) {
       auto from = page.begin() + i;
       auto to = page.begin() + j;
-      auto r = eve::algo::as_range(from, from + r_size);
+      auto from_r = eve::algo::as_range(from, from + r_size);
+      auto to_r = eve::algo::as_range(to, to + r_size);
 
       std::vector<eve::element_type_t<T>> expected(from, from + r_size);
 
-      eve::algo::copy_backward[eve::algo::force_cardinal<T::size()>](r, to);
+      eve::algo::copy_backward[eve::algo::force_cardinal<T::size()>](from_r, to_r);
 
       std::vector<eve::element_type_t<T>> actual(to, to + r_size);
 

--- a/test/unit/algo/algorithm/copy_backward_generic.cpp
+++ b/test/unit/algo/algorithm/copy_backward_generic.cpp
@@ -9,17 +9,39 @@
 #include "unit/algo/algo_test.hpp"
 
 #include <eve/algo/copy.hpp>
+#include <eve/views/zip.hpp>
 
 #include "transform_to_generic_test.hpp"
 
 #include <algorithm>
+
+template <typename TraitsSupport>
+struct copy_backward_no_static_assert_ : TraitsSupport
+{
+  template <typename R1, typename R2>
+  EVE_FORCEINLINE void operator()(R1&& from, R2&& to) const
+  {
+    if constexpr (eve::algo::relaxed_iterator<R2>)
+    {
+      auto zipped = eve::views::zip(EVE_FWD(from), EVE_FWD(to));
+      eve::algo::copy_backward[TraitsSupport::get_traits()](zipped);
+    }
+    else
+    {
+      eve::algo::copy_backward[TraitsSupport::get_traits()](EVE_FWD(from), EVE_FWD(to));
+    }
+  }
+};
+
+inline constexpr auto copy_backward_no_static_assert = eve::algo::function_with_traits<copy_backward_no_static_assert_>[eve::algo::copy_backward.get_traits()];
+
 
 EVE_TEST_TYPES("Check copy to a different range", algo_test::selected_pairs_types)
 <typename T>(eve::as<T> tgt)
 {
   algo_test::transform_to_generic_test(
     tgt,
-    eve::algo::copy_backward,
+    copy_backward_no_static_assert,
     [](auto f, auto l, auto o) {
       std::copy(f, l, o);
     }


### PR DESCRIPTION
Asserting to avoid accidental runtime bugs.