### PR TITLE
Fix codegen for aggregated operator<< and >>

### DIFF
--- a/include/eve/detail/function/simd/common/bit_compounds.hpp
+++ b/include/eve/detail/function/simd/common/bit_compounds.hpp
@@ -25,8 +25,10 @@ namespace eve::detail
   {
     auto ss = []<typename V>(V a, auto b) { return static_cast<V>(a << b); };
 
-    if constexpr(has_aggregated_abi_v<T> || has_aggregated_abi_v<U>)  v = aggregate(ss, v, s);
-    else                                                              v = map(ss, v, s);
+    if constexpr(   is_aggregated_v<abi_t<T, N>>
+                &&  is_aggregated_v<abi_t<U, N>>
+                )                                     v = aggregate(ss, v, s);
+    else                                              v = map(ss, v, s);
 
     return v;
   }
@@ -36,8 +38,8 @@ namespace eve::detail
   {
     auto ss = []<typename V>(V a, auto b) { return static_cast<V>(a << b); };
 
-    if constexpr(has_aggregated_abi_v<T>) v = aggregate(ss, v, s);
-    else                                  v = map(ss, v, s);
+    if constexpr(is_aggregated_v<abi_t<T, N>>) v = aggregate(ss, v, s);
+    else                                          v = map(ss, v, s);
 
     return v;
   }
@@ -50,8 +52,10 @@ namespace eve::detail
   {
     auto ss = []<typename V>(V a, auto b) { return static_cast<V>(a >> b); };
 
-    if constexpr(has_aggregated_abi_v<T> || has_aggregated_abi_v<U>)  v = aggregate(ss, v, s);
-    else                                                              v = map(ss, v, s);
+    if constexpr(   is_aggregated_v<abi_t<T, N>>
+                &&  is_aggregated_v<abi_t<U, N>>
+                )                                     v = aggregate(ss, v, s);
+    else                                              v = map(ss, v, s);
 
     return v;
   }
@@ -61,8 +65,8 @@ namespace eve::detail
   {
     auto ss = []<typename V>(V a, auto b) { return static_cast<V>(a >> b); };
 
-    if constexpr(has_aggregated_abi_v<T>) v = aggregate(ss, v, s);
-    else                                  v = map(ss, v, s);
+    if constexpr(is_aggregated_v<abi_t<T, N>>) v = aggregate(ss, v, s);
+    else                                          v = map(ss, v, s);
 
     return v;
   }


### PR DESCRIPTION
A call to `has_aggregated_abi` instead of `is_aggregated` lead to suboptimal codegen for operator<< and >> on aggregated wides.