### PR TITLE
FIX-1170: deinterleave groups for 2,4 wides + emulation

### DIFF
--- a/include/eve/detail/function/simd/common/deinterleave_groups.hpp
+++ b/include/eve/detail/function/simd/common/deinterleave_groups.hpp
@@ -20,7 +20,7 @@ namespace eve::detail
     EVE_FORCEINLINE auto select_every_step_from_tuple(T t)
     {
       return [&]<std::size_t ...i>(std::index_sequence<i...>) {
-        return kumi::make_tuple(get<first + i * step>(t) ...);
+        return kumi::reorder<(first + i * step)...>(t);
       }(std::make_index_sequence<std::tuple_size_v<T> / step>{});
     }
 

--- a/include/eve/detail/function/simd/common/deinterleave_groups.hpp
+++ b/include/eve/detail/function/simd/common/deinterleave_groups.hpp
@@ -9,22 +9,100 @@
 
 #include <eve/product_type.hpp>
 #include <eve/function/deinterleave_groups_shuffle.hpp>
+#include <eve/function/swap_adjacent_groups.hpp>
+#include <eve/function/shuffle.hpp>
 
 namespace eve::detail
 {
+  namespace _deinterleave_groups
+  {
+    template <std::size_t first, std::size_t step, kumi::product_type T>
+    EVE_FORCEINLINE auto select_every_step_from_tuple(T t)
+    {
+      return [&]<std::size_t ...i>(std::index_sequence<i...>) {
+        return kumi::make_tuple(get<first + i * step>(t) ...);
+      }(std::make_index_sequence<std::tuple_size_v<T> / step>{});
+    }
+
+    template <std::ptrdiff_t G>
+    struct recurse
+    {
+      EVE_FORCEINLINE auto operator()(auto ... x) const
+      {
+        return deinterleave_groups(lane<G>, x...);
+      }
+      EVE_FORCEINLINE auto operator()(kumi::product_type auto t) const
+      {
+        return kumi::apply(*this, t);
+      }
+    };
+  }
+
   template<std::ptrdiff_t G, simd_value T, std::same_as<T>... Ts>
   EVE_FORCEINLINE
   kumi::tuple<T, Ts...>
   deinterleave_groups_(EVE_SUPPORTS(cpu_), eve::fixed<G> g, T v0, Ts... vs) noexcept
-    requires (( T::size() * (sizeof...(Ts) + 1)) >= G)
+    requires ( T::size() >= G)
   {
     auto const values = kumi::make_tuple(v0,vs...);
+    constexpr std::size_t n_vs      = sizeof...(Ts) + 1;
+    constexpr std::size_t t_g_size  = T::size() / g;
 
-         if constexpr ( sizeof...(Ts) == 0 ) return {deinterleave_groups_shuffle(v0, g)};
-    else if constexpr ( sizeof...(Ts) == 1 )
+         // The number of fields is determined by the number of total registers.
+         // We have one register.
+         if constexpr ( n_vs == 1 ) return values;
+    else if constexpr ( n_vs == 2 )
     {
       auto [l, h] = deinterleave_groups_shuffle(v0, get<1>(values), g).slice();
       return {l, h};
+    }
+    else if constexpr ( T::size() == G) return values;
+    else if constexpr ( n_vs > t_g_size && (n_vs & 1) == 0 )  // we can select every other
+    {
+      auto even = _deinterleave_groups::select_every_step_from_tuple<0, 2>(values);
+      auto odd  = _deinterleave_groups::select_every_step_from_tuple<1, 2>(values);
+      _deinterleave_groups::recurse<G> r;
+
+      return kumi::cat(r(even), r(odd));
+    }
+    else if constexpr ( T::size() == G ) return {v0, vs...};
+    else if constexpr ( n_vs == 4 && !has_emulated_abi_v<T> )
+    {
+      T v1 = get<1>(values);
+      T v2 = get<2>(values);
+      T v3 = get<3>(values);
+
+      kumi::tie(v0, v1) = deinterleave_groups(g, v0, v1);
+      kumi::tie(v2, v3) = deinterleave_groups(g, v2, v3);
+      // acac bdbd acac bdbd
+
+      kumi::tie(v0, v2) = deinterleave_groups(g, v0, v2);
+      kumi::tie(v1, v3) = deinterleave_groups(g, v1, v3);
+      return {v0, v1, v2, v3};
+    }
+    else
+    {
+      constexpr auto prev_idx = [](std::size_t field_idx, std::size_t in_idx)
+      {
+        int group_in_field   = in_idx / G;
+        int prev_group       = field_idx + group_in_field * n_vs;
+        int idx_in_group     = in_idx % G;
+        int prev_total       = prev_group * G + idx_in_group;
+
+        return prev_total;
+      };
+
+      auto one_field = [&]<std::size_t field>(std::integral_constant<std::size_t, field>)
+      {
+        return [&]<std::size_t... in>(std::index_sequence<in...>) {
+          return T { kumi::get<prev_idx(field, in) / T::size()>(values).get(prev_idx(field, in) % T::size())... };
+        }(std::make_index_sequence<T::size()>{});
+      };
+
+      return [&]<std::size_t... fields>(std::index_sequence<fields...>)
+      {
+        return kumi::make_tuple(one_field(std::integral_constant<std::size_t, fields>{}) ...);
+      }(std::make_index_sequence<n_vs> {});
     }
   }
 }

--- a/include/eve/detail/function/simd/common/deinterleave_groups.hpp
+++ b/include/eve/detail/function/simd/common/deinterleave_groups.hpp
@@ -1,0 +1,30 @@
+//==================================================================================================
+/*
+  EVE - Expressive Vector Engine
+  Copyright : EVE Contributors & Maintainers
+  SPDX-License-Identifier: MIT
+*/
+//==================================================================================================
+#pragma once
+
+#include <eve/product_type.hpp>
+#include <eve/function/deinterleave_groups_shuffle.hpp>
+
+namespace eve::detail
+{
+  template<std::ptrdiff_t G, simd_value T, std::same_as<T>... Ts>
+  EVE_FORCEINLINE
+  kumi::tuple<T, Ts...>
+  deinterleave_groups_(EVE_SUPPORTS(cpu_), eve::fixed<G> g, T v0, Ts... vs) noexcept
+    requires (( T::size() * (sizeof...(Ts) + 1)) >= G)
+  {
+    auto const values = kumi::make_tuple(v0,vs...);
+
+         if constexpr ( sizeof...(Ts) == 0 ) return {deinterleave_groups_shuffle(v0, g)};
+    else if constexpr ( sizeof...(Ts) == 1 )
+    {
+      auto [l, h] = deinterleave_groups_shuffle(v0, get<1>(values), g).slice();
+      return {l, h};
+    }
+  }
+}

--- a/include/eve/function/deinterleave_groups.hpp
+++ b/include/eve/function/deinterleave_groups.hpp
@@ -1,0 +1,46 @@
+//==================================================================================================
+/**
+  EVE - Expressive Vector Engine
+  Copyright : EVE Contributors & Maintainers
+  SPDX-License-Identifier: MIT
+**/
+//==================================================================================================
+#pragma once
+
+#include <eve/arch.hpp>
+#include <eve/detail/overload.hpp>
+
+namespace eve
+{
+  //================================================================================================
+  //! @addtogroup shuffle
+  //! @{
+  //!    @var deinterleave_groups
+  //!
+  //!    @brief Callabe object that deinterleaves values in n wides
+  //!
+  //!    This is a generalization of deinterleave_groups_shuffle for n wides.
+  //!
+  //!    The different name comes from for 2 wides - this returns a tuple of 2 wides and a shuffle returns an aggregate
+  //!
+  //!    First parameter is fixed<N> group_size - how many elements we consider one element
+  //!    After that you pass n simd values.
+  //!    Together those n simd values have interleaved values.
+  //!    We return a tuple of wides, where all values are separated between individual wides.
+  //!
+  //!    NOTE: you can think of this function as AoS to SoA, where all fields have the same size.
+  //!          group is the size of the field in wide elements.
+  //!
+  //!    Examples (one letter is a group - first parameter, group order is preserved):
+  //!      ABAB'ABAB ABAB'ABAB  => [AAAA'AAAA BBBB'BBBB]
+  //!      ABCA BCAB CABC       => [AAAA BBBB CCCC]
+  //!      ABCD'EABC DEAB'CDEA BCDE'ABCD EABC'DEA BCDE'ABCD => [Ax8 Bx8 Cx8 Dx8 Ex8]
+  //!
+  //!    **Required header:** `#include <eve/function/deinterleave_groups.hpp>`
+  //!
+  //! @}
+  //================================================================================================
+  EVE_MAKE_CALLABLE(deinterleave_groups_, deinterleave_groups);
+}
+
+#include <eve/detail/function/simd/common/deinterleave_groups.hpp>

--- a/test/unit/api/regular/CMakeLists.txt
+++ b/test/unit/api/regular/CMakeLists.txt
@@ -29,8 +29,9 @@ make_unit("unit.api.regular"  shuffle/slide_right.cpp                  )
 
 ##==================================================================================================
 ## Wide related tools
-make_unit( "unit.api.regular" conditional.cpp  )
-make_unit( "unit.api.regular" pattern.cpp      )
-make_unit( "unit.api.regular" replace.cpp      )
-make_unit( "unit.api.regular" swap_if.cpp      )
-make_unit( "unit.api.regular" interleave.cpp   )
+make_unit( "unit.api.regular" conditional.cpp         )
+make_unit( "unit.api.regular" pattern.cpp             )
+make_unit( "unit.api.regular" replace.cpp             )
+make_unit( "unit.api.regular" swap_if.cpp             )
+make_unit( "unit.api.regular" deinterleave_groups.cpp )
+make_unit( "unit.api.regular" interleave.cpp          )

--- a/test/unit/api/regular/deinterleave_groups.cpp
+++ b/test/unit/api/regular/deinterleave_groups.cpp
@@ -1,0 +1,103 @@
+//==================================================================================================
+/**
+  EVE - Expressive Vector Engine
+  Copyright : EVE Contributors & Maintainers
+  SPDX-License-Identifier: MIT
+**/
+//==================================================================================================
+#include "test.hpp"
+
+#include <eve/function/deinterleave_groups.hpp>
+
+#include <array>
+#include <numeric>
+
+template <typename T, std::size_t how_many>
+auto read_ts(eve::element_type_t<T> const* ptr)
+{
+  auto read_and_advance = [&] () mutable {
+    T res{ptr};
+    ptr += T::size();
+    return res;
+  };
+
+  return [&]<std::size_t... i>(std::index_sequence<i...>) {
+    return kumi::tuple{ ((void)i, read_and_advance()) ... };
+  }(std::make_index_sequence<how_many>{});
+}
+
+template <std::ptrdiff_t G, std::ptrdiff_t FieldCount, typename T>
+void deinterleave_groups_test()
+{
+  constexpr std::ptrdiff_t block_size = (G < T::size()) ? T::size() : G;
+  constexpr std::ptrdiff_t total_size = block_size * FieldCount;
+
+  using e_t = eve::element_type_t<T>;
+  using data_t = std::array<e_t, total_size>;
+
+  constexpr auto elem = [](int field_num, int in_field_num) {
+    if constexpr ( FieldCount <= 6 ) field_num += 0xa;
+
+    constexpr int field_offset = sizeof(e_t) > 1 ? 8 : 4;
+
+    constexpr int in_field_num_mask = (1 << field_offset) - 1;
+
+    return (field_num << field_offset) | (in_field_num_mask & in_field_num);
+  };
+
+  data_t const aos = [&]{
+    data_t res;
+
+    int i = 0;
+
+    int field_num = 0;
+    for (int group_num = 0; group_num != total_size / G; ++group_num)
+    {
+      for (int in_group_num = 0; in_group_num != G; ++in_group_num)
+      {
+        int field_repeat = group_num / FieldCount;
+        int in_field_num = field_repeat * G + in_group_num;
+        res[i++] = elem(field_num, in_field_num);
+      }
+      field_num = (field_num + 1) % FieldCount;
+    }
+
+    return res;
+  }();
+
+  data_t const soa = [&]{
+    data_t res;
+
+    int i = 0;
+
+    for (int field_num = 0; field_num != FieldCount; ++field_num) {
+      for (int in_field_num = 0; in_field_num != total_size / FieldCount; ++in_field_num) {
+        res[i++] = elem(field_num, in_field_num);
+      }
+    }
+
+    return res;
+  }();
+
+  auto const aos_ts = read_ts<T, total_size / T::size()>(aos.data());
+  auto const soa_ts = read_ts<T, total_size / T::size()>(soa.data());
+
+  auto const res =
+    kumi::apply(
+      [] (auto ... in) { return eve::deinterleave_groups(eve::lane<G>, in...); },
+      aos_ts
+    );
+
+  TTS_EXPECT( eve::all(soa_ts == res) ) << std::hex
+    <<   "aos: " << aos_ts
+    << "\nsoa: " << soa_ts
+    << "\nres: " << res << "\n";
+}
+
+EVE_TEST_TYPES( "Check behavior of deinterleave on arithmetic data"
+              , eve::test::simd::all_types
+              )
+<typename T>(eve::as<T>)
+{
+  deinterleave_groups_test<1, 2, T>();
+};

--- a/test/unit/api/regular/deinterleave_groups.cpp
+++ b/test/unit/api/regular/deinterleave_groups.cpp
@@ -9,6 +9,8 @@
 
 #include <eve/function/deinterleave_groups.hpp>
 
+#include <eve/function/interleave.hpp>
+
 #include <array>
 #include <numeric>
 
@@ -96,6 +98,12 @@ void deinterleave_groups_test()
     << "\nsoa: " << soa_ts
     << "\nres: " << res << "\n"
     << std::dec;
+
+  if constexpr ( G == 1 )
+  {
+    auto back = kumi::apply(eve::interleave, res);
+    TTS_EXPECT( eve::all(aos_ts == back) );
+  }
 }
 
 // To increase the number of cases,

--- a/test/unit/api/regular/deinterleave_groups.cpp
+++ b/test/unit/api/regular/deinterleave_groups.cpp
@@ -111,7 +111,8 @@ EVE_TEST_TYPES( "Check behavior of deinterleave on arithmetic data"
 <typename T>(eve::as<T>)
 {
   constexpr std::ptrdiff_t max_fields_count = 5;
-  constexpr unsigned max_group_size = (T::size() >= 64) ? 4 : T::size();
+  // maybe unsused for gcc bug
+  [[maybe_unused]] constexpr unsigned max_group_size = (T::size() >= 64) ? 4 : T::size();
 
   eve::detail::for_<1, 1, max_fields_count + 1>([](auto fields) {
    eve::detail::for_<0, 1, std::countr_zero(max_group_size) + 1>([&](auto group_size_log) {

--- a/test/unit/api/regular/shuffle/deinterleave_groups_shuffle.cpp
+++ b/test/unit/api/regular/shuffle/deinterleave_groups_shuffle.cpp
@@ -37,15 +37,13 @@ EVE_TEST_TYPES("Check behavior of deinterleave_groups_shuffle group size 1, shuf
 
   auto actual = eve::deinterleave_groups_shuffle(a, b, eve::lane<1>);
 
-#if 0
-  std::cout << std::hex << "a : " << a << std::endl;
-  std::cout << std::hex << "b : " << b << std::endl;
-  std::cout << std::hex << "e : " << expected << std::endl;
-  std::cout << std::hex << "r : " << actual << std::endl;
-  std::cout << std::dec << std::endl;
-#endif
-
-  TTS_EQUAL(expected, actual);
+  TTS_EQUAL(expected, actual)
+    << std::hex
+    << "\na : " << a
+    << "\nb : " << b
+    << "\ne : " << expected
+    << "\nr : " << actual
+    << '\n' << std::dec;
 };
 
 // This is identity
@@ -92,16 +90,14 @@ EVE_TEST_TYPES("Check behavior of deinterleave_groups_shuffle 1 <= G < N, shuffl
 
       auto r = eve::deinterleave_groups_shuffle(a, b, eve::lane<G>);
 
-#if 0
-      std::cout << "G: "    << G << std::endl;
-      std::cout << std::hex << "a : " << a << std::endl;
-      std::cout << std::hex << "b : " << b << std::endl;
-      std::cout << std::hex << "e : " << expected << std::endl;
-      std::cout << std::hex << "r : " << r << std::endl;
-      std::cout << std::dec << std::endl;
-#endif
-
-      TTS_EQUAL(expected, r);
+      TTS_EQUAL(expected, r)
+          << "\nG: " << G
+          << std::hex
+          << "\na : " << a
+          << "\nb : " << b
+          << "\ne : " << expected
+          << "\nr : " << r << "\n"
+          << '\n' << std::dec;
     };
 
     (test( eve::lane<1 << I> ), ... );

--- a/test/unit/api/regular/swizzle/deinterleave_groups_shuffle.cpp
+++ b/test/unit/api/regular/swizzle/deinterleave_groups_shuffle.cpp
@@ -50,13 +50,12 @@ EVE_TEST_TYPES("Check behavior of deinterleave_groups_shuffle size 1, swizzle", 
 
   T res = eve::deinterleave_groups_shuffle(in, eve::lane<1>);
 
-#if 0
-  std::cerr << std::hex << "i : " << in << std::endl;
-  std::cerr << std::hex << "e : " << expected << std::endl;
-  std::cerr << std::hex << "r : " << res << std::endl;
-#endif
-
-  TTS_EQUAL(expected, res);
+  TTS_EQUAL(expected, res)
+    << std::hex
+    << "\ni : " << in
+    << "\ne : " << expected
+    << "\nr : " << res
+    << '\n' << std::dec;
 };
 
 // This is identity
@@ -102,15 +101,13 @@ EVE_TEST_TYPES("Check behavior of deinterleave_groups_shuffle swizzle 1 <= G < N
 
     auto r = eve::deinterleave_groups_shuffle(in, eve::lane<G>);
 
-#if 0
-    std::cout << "G: "    << G << std::endl;
-    std::cout << std::hex << "i : " << in << std::endl;
-    std::cout << std::hex << "e : " << expected << std::endl;
-    std::cout << std::hex << "r : " << r << std::endl;
-    std::cout << std::dec << std::endl;
-#endif
-
-    TTS_EQUAL(expected, r);
+    TTS_EQUAL(expected, r)
+      << std::hex
+      << "\nG: "  << G
+      << "\ni : " << in
+      << "\ne : " << expected
+      << "\nr : " << r
+      << '\n' << std::dec;
   };
 
   [&]<std::size_t... I>( std::index_sequence<I...> )


### PR DESCRIPTION
2 and 4 wides will work well.
Test from 1 to 5.
