### PR TITLE
FIX-1202: interleave 4 bytes

### DIFF
--- a/include/eve/detail/function/simd/common/interleave.hpp
+++ b/include/eve/detail/function/simd/common/interleave.hpp
@@ -20,14 +20,34 @@ namespace eve::detail
   EVE_FORCEINLINE auto interleave_(EVE_SUPPORTS(cpu_),T v0, Ts... vs) noexcept
   {
     auto const values = kumi::make_tuple(v0,vs...);
+    constexpr auto nb   = 1 + sizeof...(Ts);
 
-    if constexpr(T::size() == 1)
+         if constexpr (T::size() == 1) return values;
+    else if constexpr ( nb == 4 && (sizeof(eve::element_type_t<T>) < 8) )
     {
-      return values;
+      auto a = v0;
+      auto b = get<1>(values);
+      auto c = get<2>(values);
+      auto d = get<3>(values);
+
+      auto [ab0, ab1] = interleave(a, b);
+      auto [cd0, cd1] = interleave(c, d);
+
+      using up_e_t = upgrade_t<eve::element_type_t<T>>;
+      using up_t   = wide<up_e_t, eve::fixed<T::size() / 2>>;
+
+      auto [abcd00, abcd01] = interleave(bit_cast(ab0, as<up_t>()), bit_cast(cd0, as<up_t>()));
+      auto [abcd10, abcd11] = interleave(bit_cast(ab1, as<up_t>()), bit_cast(cd1, as<up_t>()));
+
+      return kumi::make_tuple (
+        bit_cast(abcd00, as(v0)),
+        bit_cast(abcd01, as(v0)),
+        bit_cast(abcd10, as(v0)),
+        bit_cast(abcd11, as(v0))
+      );
     }
     else
     {
-      constexpr auto nb   = 1 + sizeof...(Ts);
       constexpr auto card = T::size();
 
       return [&]<std::size_t... J>(std::index_sequence<J...>)

--- a/include/eve/detail/function/simd/common/interleave.hpp
+++ b/include/eve/detail/function/simd/common/interleave.hpp
@@ -22,8 +22,11 @@ namespace eve::detail
     auto const values = kumi::make_tuple(v0,vs...);
     constexpr auto nb   = 1 + sizeof...(Ts);
 
+    using ABI = abi_t<element_type_t<T>, eve::fixed<T::size()>>;
+    constexpr bool is_bit_logical = logical_simd_value<T> && !ABI::is_wide_logical;
+
          if constexpr (T::size() == 1) return values;
-    else if constexpr ( nb == 4 && (sizeof(eve::element_type_t<T>) < 8) )
+    else if constexpr ( nb == 4 && (sizeof(eve::element_type_t<T>) < 8) && !is_bit_logical )
     {
       auto a = v0;
       auto b = get<1>(values);

--- a/include/eve/detail/function/simd/x86/interleave.hpp
+++ b/include/eve/detail/function/simd/x86/interleave.hpp
@@ -144,7 +144,8 @@ namespace eve::detail
       type uh       = _mm256_permute2f128_si256(ul_lanes, uh_lanes, 0x31);
       return kumi::make_tuple(ul, uh);
     }
-    else if constexpr ( match(c, category::int8x32, category::uint8x32) )
+    else if constexpr ( match(c, category::int8x32 , category::uint8x32,
+                                 category::int16x16, category::uint16x16) )
     {
       auto [a0, a1] = v0.slice();
       auto [b0, b1] = v1.slice();
@@ -152,10 +153,11 @@ namespace eve::detail
       auto [ab10, ab11] = interleave(a1, b1);
       return kumi::make_tuple(type(ab00, ab01), type(ab10, ab11));
     }
-    else if constexpr ( match(c, category::int8x64, category::uint8x64) )
+    else if constexpr ( match(c, category::int8x64 , category::uint8x64,
+                                 category::int16x32, category::uint16x32) )
     {
-      type ul_lanes = _mm512_unpacklo_epi8(v0, v1);
-      type uh_lanes = _mm512_unpackhi_epi8(v0, v1);
+      type ul_lanes = sizeof(T) == 2 ? _mm512_unpacklo_epi16(v0, v1) : _mm512_unpacklo_epi8(v0, v1);
+      type uh_lanes = sizeof(T) == 2 ? _mm512_unpackhi_epi16(v0, v1) : _mm512_unpackhi_epi8(v0, v1);
 
       // Can't use shuffle_i32x4, only applies within lanes
       using idx_t = typename type::template rebind<std::uint64_t, fixed<8>>;

--- a/include/eve/detail/function/simd/x86/interleave.hpp
+++ b/include/eve/detail/function/simd/x86/interleave.hpp
@@ -124,6 +124,16 @@ namespace eve::detail
         }
       }
     }
+    else if constexpr( match(c,category::int8x16, category::uint8x16) )
+    {
+      if constexpr (N() == 16) return kumi::make_tuple(type(_mm_unpacklo_epi8(v0, v1)), type(_mm_unpackhi_epi8(v0, v1)));
+      else
+      {
+        type combined = _mm_unpacklo_epi8(v0, v1);
+        auto [lo, hi] = combined.slice();
+        return kumi::make_tuple(eve::bit_cast(lo, eve::as(v0)), eve::bit_cast(lo, eve::as(v1)));
+      }
+    }
     else
     {
       return interleave_(EVE_RETARGET(cpu_),v0,v1);

--- a/include/eve/detail/function/simd/x86/interleave.hpp
+++ b/include/eve/detail/function/simd/x86/interleave.hpp
@@ -134,6 +134,22 @@ namespace eve::detail
         return kumi::make_tuple(eve::bit_cast(lo, eve::as(v0)), eve::bit_cast(lo, eve::as(v1)));
       }
     }
+    else if constexpr ( match(c, category::int8x32, category::uint8x32) && current_api >= avx2 )
+    {
+      type ul_lanes = _mm256_unpacklo_epi8(v0, v1);
+      type uh_lanes = _mm256_unpackhi_epi8(v0, v1);
+      type ul       = _mm256_permute2f128_si256(ul_lanes, uh_lanes, 0x20);
+      type uh       = _mm256_permute2f128_si256(ul_lanes, uh_lanes, 0x31);
+      return kumi::make_tuple(ul, uh);
+    }
+    else if constexpr ( match(c, category::int8x32, category::uint8x32) )
+    {
+      auto [a0, a1] = v0.slice();
+      auto [b0, b1] = v1.slice();
+      auto [ab00, ab01] = interleave(a0, b0);
+      auto [ab10, ab11] = interleave(a1, b1);
+      return kumi::make_tuple(type(ab00, ab01), type(ab10, ab11));
+    }
     else
     {
       return interleave_(EVE_RETARGET(cpu_),v0,v1);

--- a/include/eve/detail/function/simd/x86/interleave.hpp
+++ b/include/eve/detail/function/simd/x86/interleave.hpp
@@ -134,10 +134,12 @@ namespace eve::detail
         return kumi::make_tuple(eve::bit_cast(lo, eve::as(v0)), eve::bit_cast(lo, eve::as(v1)));
       }
     }
-    else if constexpr ( match(c, category::int8x32, category::uint8x32) && current_api >= avx2 )
+    else if constexpr ( match(c,category::int8x32,  category::uint8x32,
+                                category::int16x16, category::uint16x16)
+                        && current_api >= avx2 )
     {
-      type ul_lanes = _mm256_unpacklo_epi8(v0, v1);
-      type uh_lanes = _mm256_unpackhi_epi8(v0, v1);
+      type ul_lanes = sizeof(T) == 2 ? _mm256_unpacklo_epi16(v0, v1) : _mm256_unpacklo_epi8(v0, v1);
+      type uh_lanes = sizeof(T) == 2 ? _mm256_unpackhi_epi16(v0, v1) : _mm256_unpackhi_epi8(v0, v1);
       type ul       = _mm256_permute2f128_si256(ul_lanes, uh_lanes, 0x20);
       type uh       = _mm256_permute2f128_si256(ul_lanes, uh_lanes, 0x31);
       return kumi::make_tuple(ul, uh);

--- a/test/unit/api/regular/interleave.cpp
+++ b/test/unit/api/regular/interleave.cpp
@@ -47,7 +47,10 @@ EVE_TEST_TYPES( "Check behavior of interleave on arithmetic data"
       auto reference    = loader(ref , card_t{}, rep_t{});
       auto interleaved  = kumi::apply( [](auto... m) { return eve::interleave(m...); }, inputs);
 
-      TTS_EXPECT( eve::all(interleaved == reference) );
+      TTS_EXPECT( eve::all(interleaved == reference) )
+        << "\ni: " << inputs
+        << "\ne: " << reference
+        << "\nr: " << interleaved;
     };
 
     ((rep( std::integral_constant<std::size_t,Rs>{} )),...);

--- a/test/unit/api/regular/interleave.cpp
+++ b/test/unit/api/regular/interleave.cpp
@@ -50,7 +50,8 @@ EVE_TEST_TYPES( "Check behavior of interleave on arithmetic data"
       TTS_EXPECT( eve::all(interleaved == reference) )
         << "\ni: " << inputs
         << "\ne: " << reference
-        << "\nr: " << interleaved;
+        << "\nr: " << interleaved
+        << '\n';
     };
 
     ((rep( std::integral_constant<std::size_t,Rs>{} )),...);


### PR DESCRIPTION
I don't feel like doing it proper until I do the perfect shuffles but the fixes for bytes and words should unblock the interleave image use-case.