### PR TITLE
FIX-1206: improve deinterleave codegen

### DIFF
--- a/include/eve/module/core/regular/impl/generic/deinterleave_groups_shuffle.hpp
+++ b/include/eve/module/core/regular/impl/generic/deinterleave_groups_shuffle.hpp
@@ -88,7 +88,6 @@ namespace eve::detail
     using res_t = wide<T, typename N::combined_type>;
 
          if constexpr ( G       >= N()                    ) return eve::combine(v0, v1);
-    else if constexpr ( N() * 2 <= expected_cardinal_v<T> ) return deinterleave_groups_shuffle( eve::combine(v0, v1), lane<G> );
     else if constexpr ( is_bundle_v<abi_t<T, N>>          )
     {
       return res_t(kumi::map([](auto _v0, auto _v1) { return deinterleave_groups_shuffle(_v0, _v1, lane<G>); }


### PR DESCRIPTION
Not perfect but let's maybe hae another crack with `perfect shuffle`.

Disassembly:

```
using bytes = eve::wide<std::uint8_t, eve::fixed<16>>;

auto call_deinterleave_real(bytes r, bytes g, bytes b, bytes a)
{
  return eve::deinterleave_groups(eve::lane<1>, r, g, b, a);
}
```

ARM-V8:
```
	uzp1	v6.16b, v0.16b, v1.16b
	sub	sp, sp, #640
	.cfi_def_cfa_offset 640
	uzp2	v4.16b, v0.16b, v1.16b
	uzp1	v16.16b, v2.16b, v3.16b
	add	sp, sp, 640
	.cfi_def_cfa_offset 0
	uzp2	v3.16b, v2.16b, v3.16b
	uzp1	v18.16b, v6.16b, v16.16b
	uzp1	v20.16b, v4.16b, v3.16b
	uzp2	v2.16b, v6.16b, v16.16b
	uzp2	v3.16b, v4.16b, v3.16b
	mov	v0.16b, v18.16b
	mov	v1.16b, v20.16b
```

x86:

```
vmovdqa	xmm4, xmmword ptr [rip + .LCPI0_0] # xmm4 = [0,2,4,6,8,10,12,14,1,3,5,7,9,11,13,15]
	vpshufb	xmm0, xmm0, xmm4
	vpshufb	xmm1, xmm1, xmm4
	vpshufb	xmm2, xmm2, xmm4
	vpshufb	xmm3, xmm3, xmm4
	vpunpcklbw	xmm4, xmm0, xmm1        # xmm4 = xmm0[0],xmm1[0],xmm0[1],xmm1[1],xmm0[2],xmm1[2],xmm0[3],xmm1[3],xmm0[4],xmm1[4],xmm0[5],xmm1[5],xmm0[6],xmm1[6],xmm0[7],xmm1[7]
	vmovdqa	xmm5, xmmword ptr [rip + .LCPI0_1] # xmm5 = [0,4,8,12,1,5,9,13,2,6,10,14,3,7,11,15]
	vpshufb	xmm4, xmm4, xmm5
	vpunpcklbw	xmm6, xmm2, xmm3        # xmm6 = xmm2[0],xmm3[0],xmm2[1],xmm3[1],xmm2[2],xmm3[2],xmm2[3],xmm3[3],xmm2[4],xmm3[4],xmm2[5],xmm3[5],xmm2[6],xmm3[6],xmm2[7],xmm3[7]
	vpshufb	xmm6, xmm6, xmm5
	vpunpcklqdq	xmm7, xmm4, xmm6        # xmm7 = xmm4[0],xmm6[0]
	vpunpckhqdq	xmm4, xmm4, xmm6        # xmm4 = xmm4[1],xmm6[1]
	vpunpckhbw	xmm0, xmm0, xmm1        # xmm0 = xmm0[8],xmm1[8],xmm0[9],xmm1[9],xmm0[10],xmm1[10],xmm0[11],xmm1[11],xmm0[12],xmm1[12],xmm0[13],xmm1[13],xmm0[14],xmm1[14],xmm0[15],xmm1[15]
	vpshufb	xmm0, xmm0, xmm5
	vpunpckhbw	xmm1, xmm2, xmm3        # xmm1 = xmm2[8],xmm3[8],xmm2[9],xmm3[9],xmm2[10],xmm3[10],xmm2[11],xmm3[11],xmm2[12],xmm3[12],xmm2[13],xmm3[13],xmm2[14],xmm3[14],xmm2[15],xmm3[15]
	vpshufb	xmm1, xmm1, xmm5
	vpunpcklqdq	xmm2, xmm0, xmm1        # xmm2 = xmm0[0],xmm1[0]
	vpunpckhqdq	xmm0, xmm0, xmm1        # xmm0 = xmm0[1],xmm1[1]
	vinserti128	ymm1, ymm7, xmm2, 1
	vmovdqu	ymmword ptr [rdi], ymm1
	vmovdqa	xmmword ptr [rdi + 32], xmm4
	vmovdqa	xmmword ptr [rdi + 48], xmm0
	vzeroupper
```

For interleave:

ARM:

```
	zip2	v4.16b, v0.16b, v1.16b
	sub	sp, sp, #320
	.cfi_def_cfa_offset 320
	zip1	v5.16b, v0.16b, v1.16b
	zip1	v1.16b, v2.16b, v3.16b
	add	sp, sp, 320
	.cfi_def_cfa_offset 0
	zip2	v3.16b, v2.16b, v3.16b
	zip1	v0.8h, v5.8h, v1.8h
	zip1	v2.8h, v4.8h, v3.8h
	zip2	v1.8h, v5.8h, v1.8h
	zip2	v3.8h, v4.8h, v3.8h
	ret
```

x86:

```
	mov	rax, rdi
	vpunpcklbw	xmm4, xmm0, xmm1        # xmm4 = xmm0[0],xmm1[0],xmm0[1],xmm1[1],xmm0[2],xmm1[2],xmm0[3],xmm1[3],xmm0[4],xmm1[4],xmm0[5],xmm1[5],xmm0[6],xmm1[6],xmm0[7],xmm1[7]
	vpunpckhbw	xmm0, xmm0, xmm1        # xmm0 = xmm0[8],xmm1[8],xmm0[9],xmm1[9],xmm0[10],xmm1[10],xmm0[11],xmm1[11],xmm0[12],xmm1[12],xmm0[13],xmm1[13],xmm0[14],xmm1[14],xmm0[15],xmm1[15]
	vpunpcklbw	xmm1, xmm2, xmm3        # xmm1 = xmm2[0],xmm3[0],xmm2[1],xmm3[1],xmm2[2],xmm3[2],xmm2[3],xmm3[3],xmm2[4],xmm3[4],xmm2[5],xmm3[5],xmm2[6],xmm3[6],xmm2[7],xmm3[7]
	vpunpckhbw	xmm2, xmm2, xmm3        # xmm2 = xmm2[8],xmm3[8],xmm2[9],xmm3[9],xmm2[10],xmm3[10],xmm2[11],xmm3[11],xmm2[12],xmm3[12],xmm2[13],xmm3[13],xmm2[14],xmm3[14],xmm2[15],xmm3[15]
	vpunpcklwd	xmm3, xmm4, xmm1        # xmm3 = xmm4[0],xmm1[0],xmm4[1],xmm1[1],xmm4[2],xmm1[2],xmm4[3],xmm1[3]
	vpunpckhwd	xmm1, xmm4, xmm1        # xmm1 = xmm4[4],xmm1[4],xmm4[5],xmm1[5],xmm4[6],xmm1[6],xmm4[7],xmm1[7]
	vpunpcklwd	xmm4, xmm0, xmm2        # xmm4 = xmm0[0],xmm2[0],xmm0[1],xmm2[1],xmm0[2],xmm2[2],xmm0[3],xmm2[3]
	vpunpckhwd	xmm0, xmm0, xmm2        # xmm0 = xmm0[4],xmm2[4],xmm0[5],xmm2[5],xmm0[6],xmm2[6],xmm0[7],xmm2[7]
	vmovdqa	xmmword ptr [rdi], xmm3
	vmovdqa	xmmword ptr [rdi + 16], xmm1
	vmovdqa	xmmword ptr [rdi + 32], xmm4
	vmovdqa	xmmword ptr [rdi + 48], xmm0
	ret
```