### PR TITLE
First batch of fixes for MSVC support

### DIFF
--- a/cmake/config/compiler.cmake
+++ b/cmake/config/compiler.cmake
@@ -9,8 +9,8 @@
 ##==================================================================================================
 add_library(eve_test INTERFACE)
 
-if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-  target_compile_options( eve_test INTERFACE /W3 /EHsc /std:c++latest)
+if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+  target_compile_options( eve_test INTERFACE /W3 /EHsc /std:c++20)
 else()
   target_compile_options( eve_test INTERFACE -std=c++20 -Werror -Wall -Wpedantic -Wextra)
 endif()
@@ -30,7 +30,7 @@ target_include_directories( eve_test SYSTEM INTERFACE
 ##==================================================================================================
 add_library(eve_bench INTERFACE)
 
-if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+if (CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
   target_compile_options( eve_bench INTERFACE /0x /W3 /EHsc /std:c++latest)
 else()
   target_compile_options( eve_bench INTERFACE -O3 -std=c++20 -Werror -Wall -Wpedantic -Wextra)

--- a/include/eve/conditional.hpp
+++ b/include/eve/conditional.hpp
@@ -293,7 +293,8 @@ namespace eve
       }
       else
       {
-        using i_t   = typename as_integer<typename type::mask_type>::type;
+        using m_t = typename type::mask_type;
+        using i_t = as_integer_t<m_t>;
         if constexpr(eve::use_complete_storage<type>)
         {
           return bit_cast(detail::linear_ramp(eve::as<i_t>()) < i_t(count_), as<type>());
@@ -428,7 +429,8 @@ namespace eve
       }
       else
       {
-        using i_t   = typename as_integer<typename type::mask_type>::type;
+        using m_t = typename type::mask_type;
+        using i_t = as_integer_t<m_t>;
         constexpr std::ptrdiff_t card = cardinal_v<T>;
         if constexpr(eve::use_complete_storage<type>)
         {
@@ -568,7 +570,8 @@ namespace eve
       }
       else
       {
-        using i_t   = typename as_integer<typename type::mask_type>::type;
+        using m_t = typename type::mask_type;
+        using i_t = as_integer_t<m_t>;
         if constexpr(eve::use_complete_storage<type>)
         {
           auto const i = detail::linear_ramp(eve::as<i_t>());

--- a/include/eve/conditional.hpp
+++ b/include/eve/conditional.hpp
@@ -14,7 +14,7 @@
 #include <eve/detail/function/iota.hpp>
 #include <eve/detail/bits.hpp>
 #include <eve/module/core/regular/bit_cast.hpp>
-#include <eve/traits/cardinal.hpp>
+#include <eve/traits.hpp>
 #include <type_traits>
 #include <ostream>
 #include <compare>
@@ -293,7 +293,7 @@ namespace eve
       }
       else
       {
-        using i_t   = as_integer_t<typename type::mask_type>;
+        using i_t   = typename as_integer<typename type::mask_type>::type;
         if constexpr(eve::use_complete_storage<type>)
         {
           return bit_cast(detail::linear_ramp(eve::as<i_t>()) < i_t(count_), as<type>());
@@ -428,7 +428,7 @@ namespace eve
       }
       else
       {
-        using i_t   = as_integer_t<typename type::mask_type>;
+        using i_t   = typename as_integer<typename type::mask_type>::type;
         constexpr std::ptrdiff_t card = cardinal_v<T>;
         if constexpr(eve::use_complete_storage<type>)
         {
@@ -568,8 +568,7 @@ namespace eve
       }
       else
       {
-        using i_t = as_integer_t<typename type::mask_type>;
-
+        using i_t   = typename as_integer<typename type::mask_type>::type;
         if constexpr(eve::use_complete_storage<type>)
         {
           auto const i = detail::linear_ramp(eve::as<i_t>());

--- a/include/eve/detail/abi.hpp
+++ b/include/eve/detail/abi.hpp
@@ -25,9 +25,7 @@
 
 // Force a lambda function to be inline
 #if !defined(EVE_LAMBDA_FORCEINLINE)
-#  if defined(_MSC_VER)
-#    define EVE_LAMBDA_FORCEINLINE __forceinline
-#  elif defined(__GNUC__) && __GNUC__ > 3
+#  if defined(__GNUC__) && __GNUC__ > 3
 #    define EVE_LAMBDA_FORCEINLINE __attribute__((__always_inline__))
 #  else
 #    define EVE_LAMBDA_FORCEINLINE

--- a/include/eve/detail/abi.hpp
+++ b/include/eve/detail/abi.hpp
@@ -23,15 +23,6 @@
 #  endif
 #endif
 
-// Force a lambda function to be inline
-#if !defined(EVE_LAMBDA_FORCEINLINE)
-#  if defined(__GNUC__) && __GNUC__ > 3
-#    define EVE_LAMBDA_FORCEINLINE __attribute__((__always_inline__))
-#  else
-#    define EVE_LAMBDA_FORCEINLINE
-#  endif
-#endif
-
 // Captures math related options and translate to proper setup
 #if defined(__FAST_MATH__) && !defined(EVE_FAST_MATH)
 #  define EVE_FAST_MATH

--- a/include/eve/detail/function/simd/x86/bitmask.hpp
+++ b/include/eve/detail/function/simd/x86/bitmask.hpp
@@ -112,9 +112,9 @@ namespace eve::detail
     {
             if constexpr(std::is_same_v<T, float >) return _mm_movemask_ps(p.storage());
       else  if constexpr(std::is_same_v<T, double>) return _mm_movemask_pd(p.storage());
-      else  if constexpr(sizeof(T) == 8)            return _mm_movemask_pd((__m128d)p.storage());
-      else  if constexpr(sizeof(T) == 4)            return _mm_movemask_ps((__m128)p.storage());
-      else  if constexpr(sizeof(T) == 2)
+      else  if constexpr( sizeof(T) == 8 )          return _mm_movemask_pd(_mm_castsi128_pd(p.storage()));
+      else  if constexpr( sizeof(T) == 4 )          return _mm_movemask_ps(_mm_castsi128_ps((p.storage())));
+      else  if constexpr( sizeof(T) == 2 )
       {
         return _mm_movemask_epi8(_mm_packs_epi16(p.storage(), _mm_setzero_si128()));
       }
@@ -124,8 +124,8 @@ namespace eve::detail
     {
             if constexpr(std::is_same_v<T, float >) return _mm256_movemask_ps(p.storage());
       else  if constexpr(std::is_same_v<T, double>) return _mm256_movemask_pd(p.storage());
-      else  if constexpr(sizeof(T) == 8)            return _mm256_movemask_pd((__m256d)p.storage());
-      else  if constexpr(sizeof(T) == 4)            return _mm256_movemask_ps((__m256)p.storage());
+      else  if constexpr(sizeof(T) == 8)            return _mm256_movemask_pd(_mm256_castsi256_pd(p.storage()));
+      else  if constexpr(sizeof(T) == 4)            return _mm256_movemask_ps(_mm256_castsi256_ps(p.storage()));
       else  if constexpr(sizeof(T) == 2)
       {
         auto [l, h] = p.slice();

--- a/include/eve/detail/function/simd/x86/movemask.hpp
+++ b/include/eve/detail/function/simd/x86/movemask.hpp
@@ -27,19 +27,18 @@ namespace eve::detail
     auto raw = [&] {
       if constexpr( std::same_as<abi_t<T, N>, x86_128_> )
       {
-             if constexpr( std::is_same_v<T, float > ) return (std::uint16_t)_mm_movemask_ps(v);
-        else if constexpr( std::is_same_v<T, double> ) return (std::uint16_t)_mm_movemask_pd(v);
-        else if constexpr( sizeof(T) == 8 )            return (std::uint16_t)_mm_movemask_pd((__m128d)v.storage());
-        else if constexpr( sizeof(T) == 4 )            return (std::uint16_t)_mm_movemask_ps((__m128)v.storage());
-        else                                           return (std::uint16_t)_mm_movemask_epi8(v);
+              if constexpr( std::is_same_v<T, float > ) return (std::uint16_t)_mm_movemask_ps(v);
+        else  if constexpr( std::is_same_v<T, double> ) return (std::uint16_t)_mm_movemask_pd(v);
+        else  if constexpr( sizeof(T) == 8 )            return (std::uint16_t)_mm_movemask_pd( _mm_castsi128_pd(v.storage()) );
+        else  if constexpr( sizeof(T) == 4 )            return (std::uint16_t)_mm_movemask_ps(_mm_castsi128_ps((v.storage())));
+        else                                            return (std::uint16_t)_mm_movemask_epi8(v);
       }
       else
       {
-        if constexpr( std::is_same_v<T, float > )  return (std::uint32_t)_mm256_movemask_ps(v);
-        else if constexpr( std::is_same_v<T, double> ) return (std::uint32_t)_mm256_movemask_pd(v);
-        else if constexpr( sizeof(T) == 8 )            return (std::uint32_t)_mm256_movemask_pd((__m256d)v.storage());
-        else if constexpr( sizeof(T) == 4 )            return (std::uint32_t)_mm256_movemask_ps((__m256)v.storage());
-        else if constexpr( current_api == avx2 )       return (std::uint32_t)_mm256_movemask_epi8(v);
+        if constexpr( std::is_same_v<T, float > )     return (std::uint32_t)_mm256_movemask_ps(v);
+        else if constexpr( std::is_same_v<T, double>) return (std::uint32_t)_mm256_movemask_pd(v);
+        else  if constexpr(sizeof(T) == 8)            return (std::uint32_t)_mm256_movemask_pd(_mm256_castsi256_pd(p.storage()));
+        else  if constexpr(sizeof(T) == 4)            return (std::uint32_t)_mm256_movemask_ps(_mm256_castsi256_ps(p.storage()));        else if constexpr( current_api == avx2 )       return (std::uint32_t)_mm256_movemask_epi8(v);
         else if constexpr( current_api == avx )
         {
           auto [l, h] = v.slice();

--- a/include/eve/detail/function/simd/x86/movemask.hpp
+++ b/include/eve/detail/function/simd/x86/movemask.hpp
@@ -37,8 +37,8 @@ namespace eve::detail
       {
         if constexpr( std::is_same_v<T, float > )     return (std::uint32_t)_mm256_movemask_ps(v);
         else if constexpr( std::is_same_v<T, double>) return (std::uint32_t)_mm256_movemask_pd(v);
-        else  if constexpr(sizeof(T) == 8)            return (std::uint32_t)_mm256_movemask_pd(_mm256_castsi256_pd(p.storage()));
-        else  if constexpr(sizeof(T) == 4)            return (std::uint32_t)_mm256_movemask_ps(_mm256_castsi256_ps(p.storage()));        else if constexpr( current_api == avx2 )       return (std::uint32_t)_mm256_movemask_epi8(v);
+        else  if constexpr(sizeof(T) == 8)            return (std::uint32_t)_mm256_movemask_pd(_mm256_castsi256_pd(v.storage()));
+        else  if constexpr(sizeof(T) == 4)            return (std::uint32_t)_mm256_movemask_ps(_mm256_castsi256_ps(v.storage()));        else if constexpr( current_api == avx2 )       return (std::uint32_t)_mm256_movemask_epi8(v);
         else if constexpr( current_api == avx )
         {
           auto [l, h] = v.slice();

--- a/include/eve/detail/overload.hpp
+++ b/include/eve/detail/overload.hpp
@@ -85,7 +85,7 @@ namespace tag { struct TAG {}; }                                                
       EVE_FORCEINLINE constexpr auto operator[](Condition const &c) const noexcept                 \
       requires( eve::supports_conditional<tag_type>::value )                                       \
       {                                                                                            \
-        return  [cond = if_(to_logical(c))](auto const&... args) EVE_LAMBDA_FORCEINLINE            \
+        return  [cond = if_(to_logical(c))](auto const&... args)                                   \
                 {                                                                                  \
                   return callable_object::call(cond, args...);                                     \
                 };                                                                                 \
@@ -95,7 +95,7 @@ namespace tag { struct TAG {}; }                                                
       EVE_FORCEINLINE constexpr auto operator[](Condition const &c) const noexcept                 \
       requires( eve::supports_conditional<tag_type>::value )                                       \
       {                                                                                            \
-        return  [c](auto const&... args) EVE_LAMBDA_FORCEINLINE                                    \
+        return  [c](auto const&... args)                                                           \
                 {                                                                                  \
                   return callable_object::call(c, args...);                                        \
                 };                                                                                 \

--- a/include/eve/detail/overload.hpp
+++ b/include/eve/detail/overload.hpp
@@ -152,6 +152,10 @@ namespace eve
   //================================================================================================
   struct decorator_ {};
   template<typename ID> concept decorator = std::derived_from<ID,decorator_>;
+  template<typename D, typename F> concept specific_decorator = requires(D d, F f)
+  {
+    { d(f) };
+  };
 
   template<typename Decoration> struct decorated;
   template<typename Decoration, typename... Args>
@@ -180,7 +184,7 @@ namespace eve
     template<typename Function>
     constexpr EVE_FORCEINLINE auto operator()(Function f) const noexcept
     {
-      if constexpr( requires{ Decoration{}(f); } )  return Decoration{}(f);
+      if constexpr( specific_decorator<Decoration,Function> )  return Decoration{}(f);
       else                                          return fwding_lamda<Function>{f};
     }
   };

--- a/include/eve/memory/aligned_allocator.hpp
+++ b/include/eve/memory/aligned_allocator.hpp
@@ -8,8 +8,13 @@
 #pragma once
 
 #include <eve/memory/align.hpp>
+#include <eve/detail/spy.hpp>
 #include <cstddef>
 #include <bit>
+
+#if defined(SPY_COMPILER_IS_MSVC)
+#include <malloc.h>
+#endif
 
 namespace eve
 {
@@ -63,7 +68,14 @@ namespace eve
     value_type *allocate(std::size_t n)
     {
       auto nbelem = align(n * sizeof(value_type), over{alignment()});
-      return static_cast<value_type *>( std::aligned_alloc(alignment(), nbelem) );
+
+      #if defined(SPY_COMPILER_IS_MSVC)
+      void *result = _aligned_malloc(nbelem,alignment());
+      #else
+      void *result = std::aligned_alloc(alignment(), nbelem);
+      #endif
+
+      return static_cast<value_type*>(result);
     }
 
     //! @brief Deallocates aligned storage

--- a/include/eve/memory/aligned_allocator.hpp
+++ b/include/eve/memory/aligned_allocator.hpp
@@ -81,7 +81,12 @@ namespace eve
     //! @brief Deallocates aligned storage
     void deallocate(value_type *p, std::size_t) noexcept
     {
+      #if defined(SPY_COMPILER_IS_MSVC)
+      _aligned_free((void *)p)
+      #else
       std::free((void *)p);
+      #endif
+
     }
   };
   //================================================================================================

--- a/include/eve/module/core/regular/impl/load.hpp
+++ b/include/eve/module/core/regular/impl/load.hpp
@@ -108,10 +108,10 @@ namespace eve::detail
     }
   }
 
-#if defined(SPY_COMPILER_IS_CLANG) or defined(SPY_COMPILER_IS_GCC)
-#define DISABLE_SANITIZERS __attribute__((no_sanitize_address)) __attribute__((no_sanitize_thread))
-#elif defined(SPY_COMPILER_IS_MSVC) and !defined(__clang__)
+#if defined(SPY_COMPILER_IS_MSVC)
 #define DISABLE_SANITIZERS __declspec(no_sanitize_address)
+#elif defined(SPY_COMPILER_IS_CLANG) or defined(SPY_COMPILER_IS_GCC)
+#define DISABLE_SANITIZERS __attribute__((no_sanitize_address)) __attribute__((no_sanitize_thread))
 #else
 #define DISABLE_SANITIZERS
 #endif

--- a/include/eve/module/core/regular/impl/load.hpp
+++ b/include/eve/module/core/regular/impl/load.hpp
@@ -110,7 +110,7 @@ namespace eve::detail
 
 #if defined(SPY_COMPILER_IS_CLANG) or defined(SPY_COMPILER_IS_GCC)
 #define DISABLE_SANITIZERS __attribute__((no_sanitize_address)) __attribute__((no_sanitize_thread))
-#elif defined(SPY_COMPILER_IS_MSVC)
+#elif defined(SPY_COMPILER_IS_MSVC) and !defined(__clang__)
 #define DISABLE_SANITIZERS __declspec(no_sanitize_address)
 #else
 #define DISABLE_SANITIZERS

--- a/include/eve/module/core/saturated/impl/convert.hpp
+++ b/include/eve/module/core/saturated/impl/convert.hpp
@@ -18,9 +18,9 @@ namespace eve::detail
   //////////////////////////////////////////////////////////////////////////////////////
   // saturated case
   //////////////////////////////////////////////////////////////////////////////////////
-  template<value IN, scalar_value OUT>
-  EVE_FORCEINLINE auto
-  convert_(EVE_SUPPORTS(cpu_), saturated_type const &, IN const &v0, as<OUT> const &tgt) noexcept
+  template<value T, scalar_value U>
+  EVE_FORCEINLINE
+  auto convert_(EVE_SUPPORTS(cpu_), saturated_type const &, T const &v0, as<U> const &tgt) noexcept
   {
     return convert(saturate(v0, tgt), tgt);
   }

--- a/include/eve/traits/common_compatible.hpp
+++ b/include/eve/traits/common_compatible.hpp
@@ -33,22 +33,17 @@ namespace eve::detail
     friend cmn<B,std::max(S1,S2),std::max(V1,V2)> operator%(cmn<A,S1,V1>, cmn<B,S2,V2>);
   };
 
-  // Use a layer of std::void_t to make common_compatible SFINAE-friendly
-  template<typename L, typename Enable = void>
-  struct  common_compatible_impl
-  {};
+  template<typename... Ts>
+  using cmn_t = decltype( (detail::cmn< Ts
+                                      , scalar_value<Ts>
+                                      , simd_value<Ts>
+                                      >{}
+                          % ... )
+                        );
 
   template<typename... Ts>
-  struct  common_compatible_impl< types<Ts...>
-                                , std::enable_if_t< decltype( (detail::cmn< Ts
-                                                                          , scalar_value<Ts>
-                                                                          , simd_value<Ts>
-                                                                          >{}
-                                                              % ... )
-                                                            )::is_valid
-                                                  >
-                                >
-        : decltype( (detail::cmn<Ts,scalar_value<Ts>,simd_value<Ts>>{} % ... ) )
+  requires( cmn_t<Ts...>::is_valid )
+  struct  common_compatible_impl : cmn_t<Ts...>
   {};
 }
 

--- a/test/tts/tts.hpp
+++ b/test/tts/tts.hpp
@@ -547,7 +547,7 @@ namespace tts::detail
   {
     static constexpr auto value() noexcept
     {
-  #if defined(_MSC_VER )
+  #if defined(_MSC_VER ) && !defined(__clang__)
       std::string_view data(__FUNCSIG__);
       auto i = data.find('<') + 1,
         j = data.find(">::value");

--- a/test/unit/api/regular/swizzle/broadcast_group.cpp
+++ b/test/unit/api/regular/swizzle/broadcast_group.cpp
@@ -33,18 +33,19 @@ EVE_TEST( "Check behavior of broadcast_groups swizzle"
   eve::detail::for_<0,1,ssz>
   ( [&]<typename Group>(Group g)
   {
-    constexpr auto grp = (T::size()/(1<<g));
     eve::detail::for_<0,1,(1<<Group::value)>
     ( [&]<typename Index>(Index)
     {
       T ref = [=](auto i, auto c)
               {
+                constexpr auto grp = (T::size()/(1<<g));
                 constexpr auto p = broadcast_group_n<grp,Index::value,T::size()>;
                 return simd.get(p(i,c));
               };
 
       L lref  = [=](auto i, auto c)
                 {
+                  constexpr auto grp = (T::size()/(1<<g));
                   constexpr auto p = broadcast_group_n<grp,Index::value,T::size()>;
                   return logicals.get(p(i,c));
                 };

--- a/test/unit/api/regular/swizzle/broadcast_group.cpp
+++ b/test/unit/api/regular/swizzle/broadcast_group.cpp
@@ -50,6 +50,7 @@ EVE_TEST( "Check behavior of broadcast_groups swizzle"
                   return logicals.get(p(i,c));
                 };
 
+      constexpr auto grp = (T::size()/(1<<g));
       TTS_EQUAL ( eve::broadcast_group( simd, eve::lane<grp>
                                       , eve::index<Index::value>, eve::lane<T::size()>
                                       )

--- a/test/unit/arch/top_bits.cpp
+++ b/test/unit/arch/top_bits.cpp
@@ -16,12 +16,12 @@ template <typename T, typename Test> void test_over_top_bits(Test test)
   using logical = eve::logical<T>;
   logical x(false);
 
-  for (int i = 0; i != logical::size(); ++i)
+  for (std::ptrdiff_t i = 0; i != logical::size(); ++i)
   {
     x.set(i, true);
     test(x);
 
-    for (int j = i + 1; j < logical::size(); ++j)
+    for (std::ptrdiff_t j = i + 1; j < logical::size(); ++j)
     {
       x.set(j, true);
       test(x);
@@ -170,11 +170,11 @@ EVE_TEST_TYPES("Check top_bits from ignore_*", eve::test::simd::all_types)
 
   // ignore_extrema / keep_between
   {
-    for (int i = 0; i < logical::size() + 1; ++i)
+    for (std::ptrdiff_t i = 0; i < logical::size() + 1; ++i)
     {
-      for (int j = logical::size() - i; j ; --j)
+      for (std::ptrdiff_t j = logical::size() - i; j ; --j)
       {
-        logical expected([&](int k, int) { return (k >= i) && (logical::size() - k) > j; });
+        logical expected([&](auto k, auto) { return (k >= i) && (logical::size() - k) > j; });
         eve::top_bits<logical> actual(eve::ignore_extrema(i, j));
         TTS_EQUAL(expected, eve::detail::to_logical(actual));
 
@@ -186,9 +186,9 @@ EVE_TEST_TYPES("Check top_bits from ignore_*", eve::test::simd::all_types)
 
   // ignore first / keep_last
   {
-    for (int i = 0; i < logical::size() + 1; ++i)
+    for (std::ptrdiff_t i = 0; i < logical::size() + 1; ++i)
     {
-      logical expected([&](int j, int) { return j >= i; });
+      logical expected([&](auto j, auto) { return j >= i; });
       eve::top_bits<logical> actual(eve::ignore_first{i});
       TTS_EQUAL(expected, eve::detail::to_logical(actual));
 
@@ -199,9 +199,9 @@ EVE_TEST_TYPES("Check top_bits from ignore_*", eve::test::simd::all_types)
 
   // ignore last / keep_first
   {
-    for (int i = 0; i < logical::size() + 1; ++i)
+    for (std::ptrdiff_t i = 0; i < logical::size() + 1; ++i)
     {
-      logical expected([&](int j, int) { return (logical::size() - j) > i; });
+      logical expected([&](auto j, auto) { return (logical::size() - j) > i; });
       eve::top_bits<logical> actual(eve::ignore_last{i});
       TTS_EQUAL(expected, eve::detail::to_logical(actual));
 
@@ -220,8 +220,8 @@ EVE_TEST_TYPES("Check top_bits bitwise operators", eve::test::simd::all_types)
   using logical = eve::logical<T>;
 
   logical test_inputs[] {
-    logical([](int i, int) { return i & 1; }),
-    logical([](int i, int) { return i & 2; }),
+    logical([](auto i, auto) { return i & 1; }),
+    logical([](auto i, auto) { return i & 2; }),
     logical(false),
     logical(true)
   };
@@ -271,7 +271,7 @@ EVE_TEST_TYPES("Check top_bits slicing", eve::test::simd::all_types)
     }
     else
     {
-      for( int i = 0; i != T::size() - 1; ++i )
+      for( std::ptrdiff_t i = 0; i != T::size() - 1; ++i )
       {
         logical v([=](auto e, auto) { return e > i; });
         auto [vl, vh] = v.slice();


### PR DESCRIPTION
- Make some constructs more explicit
- `IN` and `OUT` are not good names
- fixed warning for converting int <-> `ptrdiff_t` in some tests
- Other small scale fixes demanded by MSVC front-end