### PR TITLE
FIX-#1013: compress as algo 3

### DIFF
--- a/include/eve/detail/compress/simd/common/compress_using_masks.hpp
+++ b/include/eve/detail/compress/simd/common/compress_using_masks.hpp
@@ -112,13 +112,23 @@ namespace eve::detail
   constexpr auto pattern_8_elements_bytes_v alignas(sizeof(T) * 8) =
     pattern_8_elements(idxs_bytes<T>);
 
+  struct compress_using_masks_shuffle_recurse
+  {
+    std::ptrdiff_t num;
+
+    EVE_FORCEINLINE auto operator()(auto v) const
+    {
+      return compress_using_masks_shuffle(v, num);
+    }
+  };
+
   template <typename T, typename N>
   EVE_FORCEINLINE
   auto compress_using_masks_shuffle_(EVE_SUPPORTS(cpu_), wide<T, N> v, std::ptrdiff_t num) noexcept
   {
     if constexpr ( kumi::product_type<T> )
     {
-      return wide<T, N>{ kumi::map([num](auto v_) { return compress_using_masks_shuffle(v_, num); }, v) };
+      return wide<T, N>{ kumi::map(compress_using_masks_shuffle_recurse{num}, v) };
     }
     else
     {

--- a/include/eve/module/core/detail/generic/basic_shuffle.hpp
+++ b/include/eve/module/core/detail/generic/basic_shuffle.hpp
@@ -40,6 +40,15 @@ namespace eve::detail
     return bit_cast( shuffle(v.mask(),p), as<logical<wide<T,fixed<sz>>>>() );
   }
 
+  template<typename T, typename N, std::ptrdiff_t... I>
+  EVE_FORCEINLINE auto basic_shuffle_emulated(wide<T,N> const& v, pattern_t<I...>)
+  {
+    constexpr auto sz = pattern_t<I...>::size();
+    using that_t      = as_wide_t<wide<T,N>,fixed<sz>>;
+
+    return that_t{ (I == na_ ? T{0} : v.get(I))... };
+  }
+
   //================================================================================================
   // Emulation
   //================================================================================================
@@ -51,11 +60,6 @@ namespace eve::detail
     using that_t      = as_wide_t<wide<T,N>,fixed<sz>>;
 
     constexpr Pattern q = {};
-
-    [[maybe_unused]] auto do_shuffle = [=]<std::ptrdiff_t... I>(pattern_t<I...> const&)
-    {
-      return that_t{ (I == na_ ? T{0} : v.get(I))... };
-    };
 
     // We're swizzling so much we aggregate the output
     if constexpr( has_bundle_abi_v<that_t> )
@@ -101,12 +105,12 @@ namespace eve::detail
       }
       else
       {
-        return do_shuffle(q);
+        return basic_shuffle_emulated(v, q);
       }
     }
     else
     {
-      return do_shuffle(q);
+      return basic_shuffle_emulated(v, q);
     }
   }
 }


### PR DESCRIPTION
zip does not specialise compress store anymore.
I'm going to say done.

reverse iterator/backward iterator do not support compress store, even though ideally, given that it's an algo, they should. But since it's not efficient anyways, w/e.