### PR TITLE
Fix MSVC image

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,8 @@ build_script:
 - cd build
 - cmake -G "Visual Studio 17 2022" -A x64 ..
 - cmake --build . --target unit.arch.exe --verbose --config Release
+- cmake --build . --target unit.meta.exe --verbose --config Release
 
 test_script:
-- ctest -C Release   -VV -R ^unit.arch.*.exe
+- ctest -C Release -VV -R ^unit.arch.*.exe
+- ctest -C Release -VV -R ^unit.meta.*.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 version: 1.0.{build}
-os: Visual Studio 2022
+os: Previous Visual Studio 2022
 
 environment:
   matrix:


### PR DESCRIPTION
Appveyor changes MSVC version in a non-trivial way, leading to failing PRs for no reason.
Let's fix the actual version fo MSVC for now.