### PR TITLE
Remove dependency to bit_cast in tests

### DIFF
--- a/test/tts/tts.hpp
+++ b/test/tts/tts.hpp
@@ -904,10 +904,24 @@ namespace tts
 #include <cstdint>
 #include <type_traits>
 #include <utility>
+#if !defined(__cpp_lib_bit_cast)
+# include <cstring>
+#endif
 namespace tts::detail
 {
-  inline auto as_int(float a)   noexcept  { return std::bit_cast<std::int32_t>(a); }
-  inline auto as_int(double a)  noexcept  { return std::bit_cast<std::int64_t>(a); }
+#if !defined(__cpp_lib_bit_cast)
+  template <class To, class From>
+  To bit_cast(const From& src) noexcept requires(sizeof(To) == sizeof(From))
+  {
+    To dst;
+    std::memcpy(&dst, &src, sizeof(To));
+    return dst;
+  }
+#else
+  using std::bit_cast;
+#endif
+  inline auto as_int(float a)   noexcept  { return bit_cast<std::int32_t>(a); }
+  inline auto as_int(double a)  noexcept  { return bit_cast<std::int64_t>(a); }
   template<typename T> inline auto bitinteger(T a) noexcept
   {
     auto ia = as_int(a);


### PR DESCRIPTION
As per discussion #1251 and in order to simplify on-going porting efforts, we try to not depend on anything further than libstdc++.10.3

TTS was using bit_cast willy-nilly and has been fixed