### PR TITLE
missing algorithm in expected_cardinal.hpp

### DIFF
--- a/include/eve/arch/expected_cardinal.hpp
+++ b/include/eve/arch/expected_cardinal.hpp
@@ -15,6 +15,8 @@
 #include <type_traits>
 #include <limits>
 #include <utility>
+#include <algorithm>
+
 
 namespace eve
 {


### PR DESCRIPTION
just a one-liner include in expected cardinal to properly have std::min