### PR TITLE
Optimize is_ltz for g++ x86

### DIFF
--- a/include/eve/module/core/regular/impl/is_ltz.hpp
+++ b/include/eve/module/core/regular/impl/is_ltz.hpp
@@ -18,8 +18,7 @@
 namespace eve::detail
 {
   template<real_value T>
-  EVE_FORCEINLINE constexpr as_logical_t<T> is_ltz_(EVE_SUPPORTS(cpu_)
-                                                   , T const &a) noexcept
+  EVE_FORCEINLINE constexpr as_logical_t<T> is_ltz_(EVE_SUPPORTS(cpu_), T const &a) noexcept
   {
     if constexpr(has_native_abi_v<T>)
     {

--- a/include/eve/module/core/regular/impl/simd/x86/is_ltz.hpp
+++ b/include/eve/module/core/regular/impl/simd/x86/is_ltz.hpp
@@ -1,0 +1,26 @@
+//==================================================================================================
+/*
+  EVE - Expressive Vector Engine
+  Copyright : EVE Contributors & Maintainers
+  SPDX-License-Identifier: MIT
+*/
+//==================================================================================================
+#pragma once
+
+#include <eve/detail/implementation.hpp>
+#include <eve/module/core/regular/bit_cast.hpp>
+#include <eve/traits/as_logical.hpp>
+#include "eve/detail/overload.hpp"
+
+namespace eve::detail
+{
+  // Generate better code on x86 than just comparing to 0
+  template<signed_integral_value T, typename N>
+  EVE_FORCEINLINE constexpr auto is_ltz_(EVE_SUPPORTS(sse2_), wide<T,N> const& v) noexcept
+  requires x86_abi<abi_t<T, N>>
+  {
+    using l_t = as_logical_t<wide<T,N>>;
+    if constexpr( abi_t<T, N>::is_wide_logical )  return bit_cast(v >> 31, as<l_t>{});
+    else                                          return  is_ltz_(EVE_RETARGET(cpu_), v);
+  }
+}

--- a/include/eve/module/core/regular/impl/simd/x86/is_ltz.hpp
+++ b/include/eve/module/core/regular/impl/simd/x86/is_ltz.hpp
@@ -10,7 +10,6 @@
 #include <eve/detail/implementation.hpp>
 #include <eve/module/core/regular/bit_cast.hpp>
 #include <eve/traits/as_logical.hpp>
-#include "eve/detail/overload.hpp"
 
 namespace eve::detail
 {

--- a/include/eve/module/core/regular/impl/simd/x86/is_ltz.hpp
+++ b/include/eve/module/core/regular/impl/simd/x86/is_ltz.hpp
@@ -17,10 +17,10 @@ namespace eve::detail
   // Generate better code on x86 than just comparing to 0
   template<signed_integral_value T, typename N>
   EVE_FORCEINLINE constexpr auto is_ltz_(EVE_SUPPORTS(sse2_), wide<T,N> const& v) noexcept
-  requires x86_abi<abi_t<T, N>>
+  requires(sizeof(T) < 8 && x86_abi<abi_t<T, N>> && abi_t<T, N>::is_wide_logical)
   {
     using l_t = as_logical_t<wide<T,N>>;
-    if constexpr( abi_t<T, N>::is_wide_logical )  return bit_cast(v >> 31, as<l_t>{});
-    else                                          return  is_ltz_(EVE_RETARGET(cpu_), v);
+    constexpr auto shift = 8*sizeof(T) - 1;
+    return bit_cast(v >> shift, as<l_t>{});
   }
 }

--- a/include/eve/module/core/regular/is_ltz.hpp
+++ b/include/eve/module/core/regular/is_ltz.hpp
@@ -77,3 +77,4 @@ namespace eve
 }
 
 #include <eve/module/core/regular/impl/is_ltz.hpp>
+#include <eve/module/core/regular/impl/simd/x86/is_ltz.hpp>


### PR DESCRIPTION
Ensure that g++ and clang generate this:

```c++
psrad   xmm0, 31
```
instead of that:

```c++
movdqa  xmm1, xmm0
pxor    xmm0, xmm0
pcmpgtd xmm0, xmm1
```