### PR TITLE
FIX-1194: zip with iota should align

### DIFF
--- a/include/eve/algo/for_each_iteration.hpp
+++ b/include/eve/algo/for_each_iteration.hpp
@@ -190,10 +190,9 @@ namespace eve::algo
     auto operator()(Traits traits, I f, S l) const
     {
       EVE_ASSERT(f != l, "for_each_iteration requires a non-empty range");
-           if constexpr (!Traits::contains(no_aligning))          return detail::for_each_iteration_aligning{traits, f, l};
-      else if constexpr (Traits::contains(divisible_by_cardinal)) return detail::for_each_iteration_precise_f_l{traits, f, l};
-      else                                                        return detail::for_each_iteration_precise_f{traits, f, l};
+           if constexpr (!Traits::contains(no_aligning) && !partially_aligned_iterator<I> ) return detail::for_each_iteration_aligning{traits, f, l};
+      else if constexpr (Traits::contains(divisible_by_cardinal)                          ) return detail::for_each_iteration_precise_f_l{traits, f, l};
+      else                                                                                  return detail::for_each_iteration_precise_f{traits, f, l};
     }
-
   } inline constexpr for_each_iteration;
 }

--- a/include/eve/algo/preprocess_range.hpp
+++ b/include/eve/algo/preprocess_range.hpp
@@ -85,15 +85,11 @@ namespace eve::algo
 
     auto deduced = []
     {
-      if constexpr( !partially_aligned_iterator<I> )
-        return traits {};
-      else
-      {
-        if constexpr( std::same_as<I, S> && !always_aligned_iterator<I> )
-          return algo::traits(no_aligning, divisible_by_cardinal);
-        else
-          return algo::traits(no_aligning);
-      }
+      if constexpr( partially_aligned_iterator<I> &&
+                    std::same_as<I, S> &&
+                    !always_aligned_iterator<I> )
+          return algo::traits(divisible_by_cardinal);
+      else return algo::traits();
     }();
 
     return preprocess_range_result { default_to(traits_, deduced), f, l};

--- a/test/unit/algo/for_each_iteration.cpp
+++ b/test/unit/algo/for_each_iteration.cpp
@@ -48,6 +48,7 @@ TTS_CASE("eve.algo for_each_iteration, selection")
 
   auto f = fix.unaligned_begin() + 3;
   auto l = f + 40;
+  auto a_f = fix.aligned_begin();
 
   using u_it = decltype(f);
   using a_it = decltype(fix.aligned_begin());
@@ -85,6 +86,18 @@ TTS_CASE("eve.algo for_each_iteration, selection")
 
     TTS_EQUAL(sel.base, f);
     TTS_TYPE_IS(decltype(sel.base), u_it);
+  }
+
+  // aligned f
+  {
+    auto tr  = eve::algo::traits();
+    auto sel = eve::algo::for_each_iteration(tr, a_f, l);
+
+    TTS_TYPE_IS(decltype(sel),
+                (eve::algo::detail::for_each_iteration_precise_f<decltype(tr), a_it, u_it>));
+
+    TTS_EQUAL(sel.base, a_f);
+    TTS_TYPE_IS(decltype(sel.base), a_it);
   }
 };
 

--- a/test/unit/algo/preprocess_range.cpp
+++ b/test/unit/algo/preprocess_range.cpp
@@ -66,7 +66,7 @@ TTS_CASE_TPL("Check preprocess_range for contiguous iterators", algo_test::selec
       eve::algo::ptr_iterator<ap, N>{},
       u_it{}
     );
-    TTS_CONSTEXPR_EXPECT(decltype(processed.traits())::contains(eve::algo::no_aligning));
+    TTS_CONSTEXPR_EXPECT(eve::algo::partially_aligned_iterator<decltype(processed.begin())>);
   }
 
   // const aligned_pointer
@@ -78,7 +78,7 @@ TTS_CASE_TPL("Check preprocess_range for contiguous iterators", algo_test::selec
       eve::algo::ptr_iterator<ap, N>{},
       uc_it{}
     );
-    TTS_CONSTEXPR_EXPECT(decltype(processed.traits())::contains(eve::algo::no_aligning));
+    TTS_CONSTEXPR_EXPECT(eve::algo::partially_aligned_iterator<decltype(processed.begin())>);
   }
 
   // two aligned_pointers
@@ -90,7 +90,7 @@ TTS_CASE_TPL("Check preprocess_range for contiguous iterators", algo_test::selec
       eve::algo::ptr_iterator<ap, N>{},
       eve::algo::ptr_iterator<ap, N>{}
     );
-    TTS_CONSTEXPR_EXPECT(decltype(processed.traits())::contains(eve::algo::no_aligning));
+    TTS_CONSTEXPR_EXPECT(eve::algo::partially_aligned_iterator<decltype(processed.begin())>);
     TTS_CONSTEXPR_EXPECT(decltype(processed.traits())::contains(eve::algo::divisible_by_cardinal));
   }
 
@@ -103,7 +103,7 @@ TTS_CASE_TPL("Check preprocess_range for contiguous iterators", algo_test::selec
       eve::algo::ptr_iterator<ap, N>{},
       eve::algo::ptr_iterator<ap, N>{}
     );
-    TTS_CONSTEXPR_EXPECT(decltype(processed.traits())::contains(eve::algo::no_aligning));
+    TTS_CONSTEXPR_EXPECT(eve::algo::partially_aligned_iterator<decltype(processed.begin())>);
     TTS_CONSTEXPR_EXPECT(decltype(processed.traits())::contains(eve::algo::divisible_by_cardinal));
   }
 
@@ -195,14 +195,13 @@ TTS_CASE_TPL("Check preprocess_range for eve ptr iterators", algo_test::selected
     run_one_test(u_f, a_l, eve::algo::traits(eve::algo::unroll<2>));
     if constexpr ( N{}() >= expected_N{}())
     {
-      run_one_test(a_f, a_l, eve::algo::traits(eve::algo::unroll<2>, eve::algo::no_aligning, eve::algo::divisible_by_cardinal));
-      run_one_test(a_f, u_l, eve::algo::traits(eve::algo::unroll<2>, eve::algo::no_aligning));
+      run_one_test(a_f, a_l, eve::algo::traits(eve::algo::unroll<2>, eve::algo::divisible_by_cardinal));
     }
     else
     {
       run_one_test(a_f, a_l, eve::algo::traits(eve::algo::unroll<2>));
-      run_one_test(a_f, u_l, eve::algo::traits(eve::algo::unroll<2>));
     }
+    run_one_test(a_f, u_l, eve::algo::traits(eve::algo::unroll<2>));
   };
 
   run_test(arr.begin(), arr.end());

--- a/test/unit/views/convert.cpp
+++ b/test/unit/views/convert.cpp
@@ -54,6 +54,9 @@ TTS_CASE("eve::views::convert, preprocess test")
     TTS_TYPE_IS(decltype(processed.begin()), I);
     TTS_TYPE_IS(decltype(processed.end()), S);
 
+    TTS_CONSTEXPR_EQUAL(eve::algo::partially_aligned_iterator<decltype(processed.begin())>,
+                        eve::algo::partially_aligned_iterator<ExpectedRawF>);
+
     // Two converting iterators is mostly the same thing, except for when the range has more info
     auto cf = eve::views::convert(r.begin(), tgt);
     auto cl = eve::views::convert(r.end(), tgt);
@@ -97,7 +100,7 @@ TTS_CASE("eve::views::convert, preprocess test")
 
     common_test(eve::algo::as_range(f, l),
                 eve::as<To>{}, eve::algo::traits{}, a_it{}, u_it{},
-                eve::algo::traits{eve::algo::no_aligning});
+                eve::algo::traits{});
   }
 };
 

--- a/test/unit/views/preprocess_zip_range.cpp
+++ b/test/unit/views/preprocess_zip_range.cpp
@@ -130,9 +130,7 @@ TTS_CASE("preprocess zip range, traits")
     auto zipped = eve::views::zip(c, i);
     auto processed = eve::algo::preprocess_range(eve::algo::traits{}, zipped);
 
-    eve::algo::traits expected_traits{ };
-
-    TTS_TYPE_IS(decltype(processed.traits()), decltype(expected_traits));
+    TTS_TYPE_IS(decltype(processed.traits()), decltype(eve::algo::traits{}));
     TTS_TYPE_IS(decltype(processed.begin()), zip_uc_it_ui_it);
     TTS_TYPE_IS(decltype(processed.end()), zip_uc_it_ui_it);
   }
@@ -144,9 +142,8 @@ TTS_CASE("preprocess zip range, traits")
     auto zipped = eve::views::zip(af_ul(c), i);
     auto processed = eve::algo::preprocess_range(eve::algo::traits{}, zipped);
 
-    eve::algo::traits expected_traits{ eve::algo::no_aligning };
-
-    TTS_TYPE_IS(decltype(processed.traits()), decltype(expected_traits));
+    TTS_CONSTEXPR_EXPECT(eve::algo::partially_aligned_iterator<zip_ac_it_ui_it>);
+    TTS_TYPE_IS(decltype(processed.traits()), decltype(eve::algo::traits{}));
     TTS_TYPE_IS(decltype(processed.begin()), zip_ac_it_ui_it);
     TTS_TYPE_IS(decltype(processed.end()), zip_uc_it_ui_it);
   }
@@ -158,9 +155,9 @@ TTS_CASE("preprocess zip range, traits")
     auto zipped = eve::views::zip(c, af_ul(i));
     auto processed = eve::algo::preprocess_range(eve::algo::traits{}, zipped);
 
-    eve::algo::traits expected_traits{ eve::algo::no_aligning };
+    TTS_CONSTEXPR_EXPECT(eve::algo::partially_aligned_iterator<zip_uc_it_ai_it>);
 
-    TTS_TYPE_IS(decltype(processed.traits()), decltype(expected_traits));
+    TTS_TYPE_IS(decltype(processed.traits()), decltype(eve::algo::traits{}));
     TTS_TYPE_IS(decltype(processed.begin()), zip_uc_it_ai_it);
     TTS_TYPE_IS(decltype(processed.end()), zip_uc_it_ui_it);
   }
@@ -172,8 +169,9 @@ TTS_CASE("preprocess zip range, traits")
     auto zipped = eve::views::zip(af_al(c), i);
     auto processed = eve::algo::preprocess_range(eve::algo::traits{}, zipped);
 
-    eve::algo::traits expected_traits{ eve::algo::no_aligning, eve::algo::divisible_by_cardinal };
+    eve::algo::traits expected_traits{ eve::algo::divisible_by_cardinal };
 
+    TTS_CONSTEXPR_EXPECT(eve::algo::partially_aligned_iterator<zip_ac_it_ui_it>);
     TTS_TYPE_IS(decltype(processed.traits()), decltype(expected_traits));
     TTS_TYPE_IS(decltype(processed.begin()), zip_ac_it_ui_it);
     TTS_TYPE_IS(decltype(processed.end()), zip_ac_it_ui_it);

--- a/test/unit/views/zip.cpp
+++ b/test/unit/views/zip.cpp
@@ -9,6 +9,7 @@
 #include "unit/algo/algo_test.hpp"
 
 #include <eve/views/convert.hpp>
+#include <eve/views/iota.hpp>
 #include <eve/views/zip.hpp>
 
 #include <vector>
@@ -120,4 +121,14 @@ TTS_CASE("zip force_type")
     auto zipped = eve::views::zip(v, c)[eve::algo::force_type<std::int8_t>];
     TTS_TYPE_IS(decltype(zipped), decltype(expected));
   }
+};
+
+TTS_CASE("zip_with_iota, should align")
+{
+  std::array<std::uint32_t, 64> i;
+  auto zipped = eve::views::zip(i , eve::views::iota(0));
+  auto processed = eve::algo::preprocess_range(eve::algo::traits{}, zipped);
+  TTS_CONSTEXPR_EXPECT_NOT(decltype(processed.traits())::contains(eve::algo::no_aligning));
+  TTS_CONSTEXPR_EXPECT(eve::algo::unaligned_iterator<decltype(processed.begin())>);
+  TTS_CONSTEXPR_EXPECT_NOT(eve::algo::always_aligned_iterator<decltype(processed.begin())>);
 };


### PR DESCRIPTION
Decided to give up on deducing no aligning - it brought too much difficulties.
instead now for_each will just decide to not align for already aligned iterators.

This fixes the fact that we were not aligning zip with `iota_iterator` because that deduced `no_aligning` (preprocess range said iota is already aligned - so no need to align it and then zip kept that).