### PR TITLE
Fix #766 - Implement predicated min/max

### DIFF
--- a/include/eve/module/core/regular/impl/max.hpp
+++ b/include/eve/module/core/regular/impl/max.hpp
@@ -75,7 +75,7 @@ EVE_FORCEINLINE auto
 max_(EVE_SUPPORTS(cpu_), Callable f)
 {
   if constexpr( std::same_as<Callable, callable_is_less_> ) return eve::max;
-  else return [f](auto x, auto y) { return if_else(f(x, y), y, x); };
+  else return [f](auto x, auto y) { return if_else(f(y, x), x, y); };
 }
 
 }

--- a/include/eve/module/core/regular/impl/max.hpp
+++ b/include/eve/module/core/regular/impl/max.hpp
@@ -14,6 +14,7 @@
 #include <eve/module/core/regular/all.hpp>
 #include <eve/module/core/regular/if_else.hpp>
 #include <eve/module/core/regular/is_less.hpp>
+#include <eve/module/core/regular/is_greater.hpp>
 #include <eve/traits/common_compatible.hpp>
 
 namespace eve::detail
@@ -75,6 +76,7 @@ EVE_FORCEINLINE auto
 max_(EVE_SUPPORTS(cpu_), Callable f)
 {
   if constexpr( std::same_as<Callable, callable_is_less_> ) return eve::max;
+  else if constexpr( std::same_as<Callable, callable_is_greater_> ) return eve::min;
   else return [f](auto x, auto y) { return if_else(f(y, x), x, y); };
 }
 

--- a/include/eve/module/core/regular/impl/max.hpp
+++ b/include/eve/module/core/regular/impl/max.hpp
@@ -7,63 +7,75 @@
 //==================================================================================================
 #pragma once
 
-#include <eve/module/core/regular/if_else.hpp>
-#include <eve/module/core/regular/all.hpp>
-#include <eve/detail/implementation.hpp>
-#include <eve/module/core/regular/is_less.hpp>
-#include <eve/concept/value.hpp>
 #include <eve/concept/compatible.hpp>
+#include <eve/concept/value.hpp>
 #include <eve/detail/apply_over.hpp>
+#include <eve/detail/implementation.hpp>
+#include <eve/module/core/regular/all.hpp>
+#include <eve/module/core/regular/if_else.hpp>
+#include <eve/module/core/regular/is_less.hpp>
 #include <eve/traits/common_compatible.hpp>
 
 namespace eve::detail
 {
-  // -----------------------------------------------------------------------------------------------
-  // Regular
-  template<real_value T, real_value U>
-  EVE_FORCEINLINE  auto max_(EVE_SUPPORTS(cpu_)
-                            , T const &a
-                            , U const &b) noexcept
-  requires compatible_values<T, U>
-  {
-    return arithmetic_call(max, a, b);
-  }
+// -----------------------------------------------------------------------------------------------
+// Regular
+template<real_value T, real_value U>
+EVE_FORCEINLINE auto
+max_(EVE_SUPPORTS(cpu_), T const& a, U const& b) noexcept requires compatible_values<T, U>
+{
+  return arithmetic_call(max, a, b);
+}
 
-  template<real_scalar_value T>
-  EVE_FORCEINLINE  auto max_(EVE_SUPPORTS(cpu_)
-                            , T const &a
-                            , T const &b) noexcept
-  {
-    return if_else(a < b, b, a);
-  }
+template<real_scalar_value T>
+EVE_FORCEINLINE auto
+max_(EVE_SUPPORTS(cpu_), T const& a, T const& b) noexcept
+{
+  return b < a ? a : b;
+}
 
-  template<real_simd_value T>
-  EVE_FORCEINLINE  auto max_(EVE_SUPPORTS(cpu_)
-                            , T const &a
-                            , T const &b) noexcept
-  {
-    return apply_over(max, a, b);
-  }
+template<real_simd_value T>
+EVE_FORCEINLINE auto
+max_(EVE_SUPPORTS(cpu_), T const& a, T const& b) noexcept
+{
+  return apply_over(max, a, b);
+}
 
-  //================================================================================================
-  // Masked case
-  //================================================================================================
-  template<conditional_expr C, real_value U, real_value V>
-  EVE_FORCEINLINE auto max_(EVE_SUPPORTS(cpu_), C const &cond, U const &t, V const &f) noexcept
-      requires compatible_values<U, V>
-  {
-    return mask_op(  cond, eve::max, t, f);
-  }
+//================================================================================================
+// Masked case
+//================================================================================================
+template<conditional_expr C, real_value U, real_value V>
+EVE_FORCEINLINE auto
+max_(EVE_SUPPORTS(cpu_),
+     C const& cond,
+     U const& t,
+     V const& f) noexcept requires compatible_values<U, V>
+{
+  return mask_op(cond, eve::max, t, f);
+}
 
-  //================================================================================================
-  //N parameters
-  //================================================================================================
-  template<real_value T0, real_value T1, real_value ...Ts>
-  auto max_(EVE_SUPPORTS(cpu_), T0 a0, T1 a1, Ts... args)
-  {
-    using r_t = common_compatible_t<T0,T1,Ts...>;
-    r_t that(max(r_t(a0),r_t(a1)));
-    ((that = max(that,r_t(args))),...);
-    return that;
-  }
+//================================================================================================
+// N parameters
+//================================================================================================
+template<real_value T0, real_value T1, real_value... Ts>
+auto
+max_(EVE_SUPPORTS(cpu_), T0 a0, T1 a1, Ts... args)
+{
+  using r_t = common_compatible_t<T0, T1, Ts...>;
+  r_t that(max(r_t(a0), r_t(a1)));
+  ((that = max(that, r_t(args))), ...);
+  return that;
+}
+
+//================================================================================================
+// Predicate case
+//================================================================================================
+template<typename Callable>
+EVE_FORCEINLINE auto
+max_(EVE_SUPPORTS(cpu_), Callable f)
+{
+  if constexpr( std::same_as<Callable, callable_is_less_> ) return eve::max;
+  else return [f](auto x, auto y) { return if_else(f(x, y), y, x); };
+}
+
 }

--- a/include/eve/module/core/regular/impl/min.hpp
+++ b/include/eve/module/core/regular/impl/min.hpp
@@ -13,6 +13,7 @@
 #include <eve/detail/implementation.hpp>
 #include <eve/module/core/regular/all.hpp>
 #include <eve/module/core/regular/if_else.hpp>
+#include <eve/module/core/regular/is_less.hpp>
 #include <eve/traits/common_compatible.hpp>
 
 namespace eve::detail
@@ -30,7 +31,7 @@ template<real_scalar_value T>
 EVE_FORCEINLINE auto
 min_(EVE_SUPPORTS(cpu_), T const& a, T const& b) noexcept
 {
-  return if_else(b < a, b, a);
+  return b < a ? b : a;
 }
 
 template<real_simd_value T>
@@ -65,4 +66,16 @@ min_(EVE_SUPPORTS(cpu_), T0 a0, T1 a1, Ts... args)
   ((that = min(that, r_t(args))), ...);
   return that;
 }
+
+//================================================================================================
+// Predicate case
+//================================================================================================
+template<typename Callable>
+EVE_FORCEINLINE auto
+min_(EVE_SUPPORTS(cpu_), Callable f)
+{
+  if constexpr( std::same_as<Callable, callable_is_less_> ) return eve::min;
+  else return [f](auto x, auto y) { return if_else(f(y, x), y, x); };
+}
+
 }

--- a/include/eve/module/core/regular/impl/min.hpp
+++ b/include/eve/module/core/regular/impl/min.hpp
@@ -12,8 +12,10 @@
 #include <eve/detail/apply_over.hpp>
 #include <eve/detail/implementation.hpp>
 #include <eve/module/core/regular/all.hpp>
+#include <eve/module/core/regular/max.hpp>
 #include <eve/module/core/regular/if_else.hpp>
 #include <eve/module/core/regular/is_less.hpp>
+#include <eve/module/core/regular/is_greater.hpp>
 #include <eve/traits/common_compatible.hpp>
 
 namespace eve::detail
@@ -75,6 +77,7 @@ EVE_FORCEINLINE auto
 min_(EVE_SUPPORTS(cpu_), Callable f)
 {
   if constexpr( std::same_as<Callable, callable_is_less_> ) return eve::min;
+  else if constexpr( std::same_as<Callable, callable_is_greater_> ) return eve::max;
   else return [f](auto x, auto y) { return if_else(f(y, x), y, x); };
 }
 

--- a/test/unit/module/core/max.cpp
+++ b/test/unit/module/core/max.cpp
@@ -97,4 +97,21 @@ TTS_CASE_WITH("Check predicate version of max",
 
   auto pred = [](auto a, auto b) { return eve::abs(a) < eve::abs(b);};
   TTS_EQUAL(eve::max(pred)(a0, a1), eve::if_else(pred(a0,a1),a1,a0));
+
+  // Check for stability a la Stepanov
+  using e_t = eve::element_type_t<T>;
+  using w_t = eve::wide<kumi::tuple<e_t,e_t>, eve::cardinal_t<T>>;
+
+  w_t a { [](auto i, auto) { return i%2 ? i+1 : 0; }
+        , [](auto i, auto) { return i+1; }
+        };
+
+  w_t b { [](auto i, auto) { return i%2 ? i : 0; }
+        , [](auto i, auto) { return -(i+1); }
+        };
+
+  w_t ref { [=](auto i, auto) { return i%2 ? a.get(i) : b.get(i); } };
+
+  auto less_1st = [](auto a, auto b) { return get<0>(a) < get<0>(b); };
+  TTS_EQUAL( eve::max(less_1st)(a,b), ref );
 };

--- a/test/unit/module/core/max.cpp
+++ b/test/unit/module/core/max.cpp
@@ -95,6 +95,9 @@ TTS_CASE_WITH("Check predicate version of max",
   TTS_EXPR_IS(eve::max(eve::is_less), eve::callable_max_);
   TTS_EQUAL(eve::max(eve::is_less)(a0, a1), eve::max(a0, a1));
 
+  TTS_EXPR_IS(eve::max(eve::is_greater), eve::callable_min_);
+  TTS_EQUAL(eve::max(eve::is_greater)(a0, a1), eve::min(a0, a1));
+
   auto pred = [](auto a, auto b) { return eve::abs(a) < eve::abs(b);};
   TTS_EQUAL(eve::max(pred)(a0, a1), eve::if_else(pred(a0,a1),a1,a0));
 
@@ -102,11 +105,11 @@ TTS_CASE_WITH("Check predicate version of max",
   using e_t = eve::element_type_t<T>;
   using w_t = eve::wide<kumi::tuple<e_t,e_t>, eve::cardinal_t<T>>;
 
-  w_t a { [](auto i, auto) { return i%2 ? i+1 : 0; }
+  w_t a { [](auto i, auto) { return i%2 ? i/2+1 : 0; }
         , [](auto i, auto) { return i+1; }
         };
 
-  w_t b { [](auto i, auto) { return i%2 ? i : 0; }
+  w_t b { [](auto i, auto) { return i%2 ? i/2 : 0; }
         , [](auto i, auto) { return -(i+1); }
         };
 

--- a/test/unit/module/core/max.cpp
+++ b/test/unit/module/core/max.cpp
@@ -5,33 +5,33 @@
 **/
 //==================================================================================================
 #include "test.hpp"
-#include <algorithm>
+
 #include <eve/module/core.hpp>
+
+#include <algorithm>
 
 //==================================================================================================
 // Types tests
 //==================================================================================================
-TTS_CASE_TPL( "Check return types of max"
-              , eve::test::simd::all_types
-              )
+TTS_CASE_TPL("Check return types of max", eve::test::simd::all_types)
 <typename T>(tts::type<T>)
 {
   using v_t = eve::element_type_t<T>;
 
-  TTS_EXPR_IS( eve::max(T(), T(), T()  )  , T);
-  TTS_EXPR_IS( eve::max(T(), v_t(), T())  , T);
-  TTS_EXPR_IS( eve::max(v_t(), T(), T())  , T);
-  TTS_EXPR_IS( eve::max(T(), T(), v_t() ) , T);
-  TTS_EXPR_IS( eve::max(v_t(), v_t(), T()) , T);
-  TTS_EXPR_IS( eve::max(v_t(), T(), v_t()) , T);
-  TTS_EXPR_IS( eve::max(v_t(), v_t(), v_t()) , v_t);
-  TTS_EXPR_IS(eve::max(  T(),   T(),   T()), T  );
-  TTS_EXPR_IS(eve::max(  T(),   T(), v_t()), T  );
-  TTS_EXPR_IS(eve::max(  T(), v_t(),   T()), T  );
-  TTS_EXPR_IS(eve::max(  T(), v_t(), v_t()), T  );
-  TTS_EXPR_IS(eve::max(v_t(),   T(),   T()), T  );
-  TTS_EXPR_IS(eve::max(v_t(),   T(), v_t()), T  );
-  TTS_EXPR_IS(eve::max(v_t(), v_t(),   T()), T  );
+  TTS_EXPR_IS(eve::max(T(), T(), T()), T);
+  TTS_EXPR_IS(eve::max(T(), v_t(), T()), T);
+  TTS_EXPR_IS(eve::max(v_t(), T(), T()), T);
+  TTS_EXPR_IS(eve::max(T(), T(), v_t()), T);
+  TTS_EXPR_IS(eve::max(v_t(), v_t(), T()), T);
+  TTS_EXPR_IS(eve::max(v_t(), T(), v_t()), T);
+  TTS_EXPR_IS(eve::max(v_t(), v_t(), v_t()), v_t);
+  TTS_EXPR_IS(eve::max(T(), T(), T()), T);
+  TTS_EXPR_IS(eve::max(T(), T(), v_t()), T);
+  TTS_EXPR_IS(eve::max(T(), v_t(), T()), T);
+  TTS_EXPR_IS(eve::max(T(), v_t(), v_t()), T);
+  TTS_EXPR_IS(eve::max(v_t(), T(), T()), T);
+  TTS_EXPR_IS(eve::max(v_t(), T(), v_t()), T);
+  TTS_EXPR_IS(eve::max(v_t(), v_t(), T()), T);
   TTS_EXPR_IS(eve::max(v_t(), v_t(), v_t()), v_t);
 };
 
@@ -39,55 +39,62 @@ TTS_CASE_TPL( "Check return types of max"
 // max tests
 //==================================================================================================
 
-TTS_CASE_WITH( "Check behavior of max on all types full range"
-        , eve::test::simd::all_types
-        , tts::generate (  tts::randoms(eve::valmin, eve::valmax)
-                              ,  tts::randoms(eve::valmin, eve::valmax)
-                              ,  tts::randoms(eve::valmin, eve::valmax)
-                              ,  tts::logicals(0, 3)
-                             )
-        )
-<typename T, typename M>(  T const& a0, T const& a1, T const& a2, M const & t)
+TTS_CASE_WITH("Check behavior of max on all types full range",
+              eve::test::simd::all_types,
+              tts::generate(tts::randoms(eve::valmin, eve::valmax),
+                            tts::randoms(eve::valmin, eve::valmax),
+                            tts::randoms(eve::valmin, eve::valmax),
+                            tts::logicals(0, 3)))
+<typename T, typename M>(T const& a0, T const& a1, T const& a2, M const& t)
 {
+  using eve::abs;
   using eve::max;
   using eve::detail::map;
-  using eve::abs;
   using v_t = eve::element_type_t<T>;
-  auto m = [](auto a, auto b, auto c)-> v_t {return std::max(std::max(a, b), c); };
+  auto m    = [](auto a, auto b, auto c) -> v_t { return std::max(std::max(a, b), c); };
   TTS_ULP_EQUAL(max((a0), (a1), (a2)), map(m, a0, a1, a2), 2);
   TTS_ULP_EQUAL(eve::pedantic(max)((a0), (a1), (a2)), map(m, a0, a1, a2), 2);
-  TTS_ULP_EQUAL(eve::numeric (max)((a0), (a1), (a2)), map(m, a0, a1, a2), 2);
-
-
+  TTS_ULP_EQUAL(eve::numeric(max)((a0), (a1), (a2)), map(m, a0, a1, a2), 2);
 
   TTS_IEEE_EQUAL(max[t](a0, a1), eve::if_else(t, max(a0, a1), a0));
 };
 
-TTS_CASE_TPL( "Check values of max"
-              , eve::test::simd::ieee_reals
-              )
+TTS_CASE_TPL("Check values of max", eve::test::simd::ieee_reals)
 <typename T>(tts::type<T>)
 {
   using v_t = eve::element_type_t<T>;
-    TTS_IEEE_EQUAL(eve::pedantic(eve::max)(eve::nan(eve::as<T>())   , T(1)  ) , eve::nan(eve::as<T>()) );
-    TTS_IEEE_EQUAL(eve::pedantic(eve::max)(eve::nan(eve::as<v_t>()) , T(1)  ) , eve::nan(eve::as<T>()) );
-    TTS_IEEE_EQUAL(eve::pedantic(eve::max)(eve::nan(eve::as<T>())   , v_t(1)) , eve::nan(eve::as<T>()) );
+  TTS_IEEE_EQUAL(eve::pedantic(eve::max)(eve::nan(eve::as<T>()), T(1)), eve::nan(eve::as<T>()));
+  TTS_IEEE_EQUAL(eve::pedantic(eve::max)(eve::nan(eve::as<v_t>()), T(1)), eve::nan(eve::as<T>()));
+  TTS_IEEE_EQUAL(eve::pedantic(eve::max)(eve::nan(eve::as<T>()), v_t(1)), eve::nan(eve::as<T>()));
 
-    TTS_IEEE_EQUAL(eve::pedantic(eve::max)(T(1)  , eve::nan(eve::as<T>())   ), T(1) );
-    TTS_IEEE_EQUAL(eve::pedantic(eve::max)(v_t(1), eve::nan(eve::as<T>())   ), T(1) );
-    TTS_IEEE_EQUAL(eve::pedantic(eve::max)(T(1)  , eve::nan(eve::as<v_t>()) ), T(1) );
+  TTS_IEEE_EQUAL(eve::pedantic(eve::max)(T(1), eve::nan(eve::as<T>())), T(1));
+  TTS_IEEE_EQUAL(eve::pedantic(eve::max)(v_t(1), eve::nan(eve::as<T>())), T(1));
+  TTS_IEEE_EQUAL(eve::pedantic(eve::max)(T(1), eve::nan(eve::as<v_t>())), T(1));
 
-    TTS_EXPECT(eve::all(eve::is_positive(eve::pedantic(eve::max)(T(-0.), T( 0 )))));
-    TTS_EXPECT(eve::all(eve::is_positive(eve::pedantic(eve::max)(T( 0 ), T(-0.)))));
+  TTS_EXPECT(eve::all(eve::is_positive(eve::pedantic(eve::max)(T(-0.), T(0)))));
+  TTS_EXPECT(eve::all(eve::is_positive(eve::pedantic(eve::max)(T(0), T(-0.)))));
 
-    TTS_IEEE_EQUAL(eve::numeric(eve::max)((eve::nan(eve::as<T>()) ) , T(1))  , T(1) );
-    TTS_IEEE_EQUAL(eve::numeric(eve::max)((eve::nan(eve::as<v_t>())), T(1))  , T(1) );
-    TTS_IEEE_EQUAL(eve::numeric(eve::max)((eve::nan(eve::as<T>()) ) , v_t(1)) , T(1) );
+  TTS_IEEE_EQUAL(eve::numeric(eve::max)((eve::nan(eve::as<T>())), T(1)), T(1));
+  TTS_IEEE_EQUAL(eve::numeric(eve::max)((eve::nan(eve::as<v_t>())), T(1)), T(1));
+  TTS_IEEE_EQUAL(eve::numeric(eve::max)((eve::nan(eve::as<T>())), v_t(1)), T(1));
 
-    TTS_IEEE_EQUAL(eve::numeric(eve::max)(T(1)   , eve::nan(eve::as<T>())   ), T(1) );
-    TTS_IEEE_EQUAL(eve::numeric(eve::max)(v_t(1) , eve::nan(eve::as<T>())   ), T(1) );
-    TTS_IEEE_EQUAL(eve::numeric(eve::max)(T(1)   , eve::nan(eve::as<v_t>()) ), T(1) );
+  TTS_IEEE_EQUAL(eve::numeric(eve::max)(T(1), eve::nan(eve::as<T>())), T(1));
+  TTS_IEEE_EQUAL(eve::numeric(eve::max)(v_t(1), eve::nan(eve::as<T>())), T(1));
+  TTS_IEEE_EQUAL(eve::numeric(eve::max)(T(1), eve::nan(eve::as<v_t>())), T(1));
 
-    TTS_EXPECT(eve::all(eve::is_positive(eve::numeric(eve::max)(T(-0.), T( 0 )))));
-    TTS_EXPECT(eve::all(eve::is_positive(eve::numeric(eve::max)(T( 0 ), T(-0.)))));
+  TTS_EXPECT(eve::all(eve::is_positive(eve::numeric(eve::max)(T(-0.), T(0)))));
+  TTS_EXPECT(eve::all(eve::is_positive(eve::numeric(eve::max)(T(0), T(-0.)))));
+};
+
+TTS_CASE_WITH("Check predicate version of max",
+              eve::test::simd::all_types,
+              tts::generate(tts::randoms(eve::valmin, eve::valmin),
+                            tts::randoms(eve::valmin, eve::valmin)))
+<typename T>(T const& a0, T const& a1)
+{
+  TTS_EXPR_IS(eve::max(eve::is_less), eve::callable_max_);
+  TTS_EQUAL(eve::max(eve::is_less)(a0, a1), eve::max(a0, a1));
+
+  auto pred = [](auto a, auto b) { return eve::abs(a) < eve::abs(b);};
+  TTS_EQUAL(eve::max(pred)(a0, a1), eve::if_else(pred(a0,a1),a1,a0));
 };

--- a/test/unit/module/core/min.cpp
+++ b/test/unit/module/core/min.cpp
@@ -94,6 +94,9 @@ TTS_CASE_WITH("Check predicate version of min",
   TTS_EXPR_IS(eve::min(eve::is_less), eve::callable_min_);
   TTS_EQUAL(eve::min(eve::is_less)(a0, a1), eve::min(a0, a1));
 
+  TTS_EXPR_IS(eve::min(eve::is_greater), eve::callable_max_);
+  TTS_EQUAL(eve::min(eve::is_greater)(a0, a1), eve::max(a0, a1));
+
   auto pred = [](auto a, auto b) { return eve::abs(a) < eve::abs(b);};
   TTS_EQUAL(eve::min(pred)(a0, a1), eve::if_else(pred(a1,a0),a1,a0));
 
@@ -101,11 +104,11 @@ TTS_CASE_WITH("Check predicate version of min",
   using e_t = eve::element_type_t<T>;
   using w_t = eve::wide<kumi::tuple<e_t,e_t>, eve::cardinal_t<T>>;
 
-  w_t a { [](auto i, auto) { return i%2 ? i+1 : 0; }
+  w_t a { [](auto i, auto) { return i%2 ? i/2+1 : 0; }
         , [](auto i, auto) { return i+1; }
         };
 
-  w_t b { [](auto i, auto) { return i%2 ? i : 0; }
+  w_t b { [](auto i, auto) { return i%2 ? i/2 : 0; }
         , [](auto i, auto) { return -(i+1); }
         };
 

--- a/test/unit/module/core/min.cpp
+++ b/test/unit/module/core/min.cpp
@@ -5,89 +5,95 @@
 **/
 //==================================================================================================
 #include "test.hpp"
-#include <algorithm>
+
 #include <eve/module/core.hpp>
+
+#include <algorithm>
 
 //==================================================================================================
 // Types tests
 //==================================================================================================
-TTS_CASE_TPL( "Check return types of min"
-              , eve::test::simd::all_types
-              )
+TTS_CASE_TPL("Check return types of min", eve::test::simd::all_types)
 <typename T>(tts::type<T>)
 {
   using v_t = eve::element_type_t<T>;
 
-  TTS_EXPR_IS( eve::min(T(), T(), T()  )  , T);
-  TTS_EXPR_IS( eve::min(T(), v_t(), T())  , T);
-  TTS_EXPR_IS( eve::min(v_t(), T(), T())  , T);
-  TTS_EXPR_IS( eve::min(T(), T(), v_t() ) , T);
-  TTS_EXPR_IS( eve::min(v_t(), v_t(), T()) , T);
-  TTS_EXPR_IS( eve::min(v_t(), T(), v_t()) , T);
-  TTS_EXPR_IS( eve::min(v_t(), v_t(), v_t()) , v_t);
-  TTS_EXPR_IS(eve::min(  T(),   T(),   T()), T  );
-  TTS_EXPR_IS(eve::min(  T(),   T(), v_t()), T  );
-  TTS_EXPR_IS(eve::min(  T(), v_t(),   T()), T  );
-  TTS_EXPR_IS(eve::min(  T(), v_t(), v_t()), T  );
-  TTS_EXPR_IS(eve::min(v_t(),   T(),   T()), T  );
-  TTS_EXPR_IS(eve::min(v_t(),   T(), v_t()), T  );
-  TTS_EXPR_IS(eve::min(v_t(), v_t(),   T()), T  );
+  TTS_EXPR_IS(eve::min(T(), T(), T()), T);
+  TTS_EXPR_IS(eve::min(T(), v_t(), T()), T);
+  TTS_EXPR_IS(eve::min(v_t(), T(), T()), T);
+  TTS_EXPR_IS(eve::min(T(), T(), v_t()), T);
+  TTS_EXPR_IS(eve::min(v_t(), v_t(), T()), T);
+  TTS_EXPR_IS(eve::min(v_t(), T(), v_t()), T);
+  TTS_EXPR_IS(eve::min(v_t(), v_t(), v_t()), v_t);
+  TTS_EXPR_IS(eve::min(T(), T(), T()), T);
+  TTS_EXPR_IS(eve::min(T(), T(), v_t()), T);
+  TTS_EXPR_IS(eve::min(T(), v_t(), T()), T);
+  TTS_EXPR_IS(eve::min(T(), v_t(), v_t()), T);
+  TTS_EXPR_IS(eve::min(v_t(), T(), T()), T);
+  TTS_EXPR_IS(eve::min(v_t(), T(), v_t()), T);
+  TTS_EXPR_IS(eve::min(v_t(), v_t(), T()), T);
   TTS_EXPR_IS(eve::min(v_t(), v_t(), v_t()), v_t);
 };
 
 //==================================================================================================
 // min tests
 //==================================================================================================
-
-TTS_CASE_WITH( "Check behavior of min on all types full range"
-        , eve::test::simd::all_types
-        , tts::generate (  tts::randoms(eve::valmin, eve::valmin)
-                              ,  tts::randoms(eve::valmin, eve::valmin)
-                              ,  tts::randoms(eve::valmin, eve::valmin)
-                              ,  tts::logicals(0, 3)
-                              )
-        )
-<typename T, typename M>(  T const& a0, T const& a1, T const& a2, M const & t)
+TTS_CASE_WITH("Check behavior of min on all types full range",
+              eve::test::simd::all_types,
+              tts::generate(tts::randoms(eve::valmin, eve::valmin),
+                            tts::randoms(eve::valmin, eve::valmin),
+                            tts::randoms(eve::valmin, eve::valmin),
+                            tts::logicals(0, 3)))
+<typename T, typename M>(T const& a0, T const& a1, T const& a2, M const& t)
 {
+  using eve::abs;
   using eve::min;
   using eve::detail::map;
-  using eve::abs;
   using v_t = eve::element_type_t<T>;
-  auto m = [](auto a, auto b, auto c)-> v_t {return std::min(std::min(a, b), c); };
+  auto m    = [](auto a, auto b, auto c) -> v_t { return std::min(std::min(a, b), c); };
   TTS_ULP_EQUAL(min((a0), (a1), (a2)), map(m, a0, a1, a2), 2);
   TTS_ULP_EQUAL(eve::pedantic(min)((a0), (a1), (a2)), map(m, a0, a1, a2), 2);
-  TTS_ULP_EQUAL(eve::numeric (min)((a0), (a1), (a2)), map(m, a0, a1, a2), 2);
-  
-  
-  
+  TTS_ULP_EQUAL(eve::numeric(min)((a0), (a1), (a2)), map(m, a0, a1, a2), 2);
+
   TTS_IEEE_EQUAL(min[t](a0, a1), eve::if_else(t, min(a0, a1), a0));
 };
 
-TTS_CASE_TPL( "Check values of min"
-              , eve::test::simd::ieee_reals
-              )
+TTS_CASE_TPL("Check values of min", eve::test::simd::ieee_reals)
 <typename T>(tts::type<T>)
 {
   using v_t = eve::element_type_t<T>;
-    TTS_IEEE_EQUAL(eve::pedantic(eve::min)(eve::nan(eve::as<T>())   , T(1)  ) , eve::nan(eve::as<T>()) );
-    TTS_IEEE_EQUAL(eve::pedantic(eve::min)(eve::nan(eve::as<v_t>()) , T(1)  ) , eve::nan(eve::as<T>()) );
-    TTS_IEEE_EQUAL(eve::pedantic(eve::min)(eve::nan(eve::as<T>())   , v_t(1)) , eve::nan(eve::as<T>()) );
+  TTS_IEEE_EQUAL(eve::pedantic(eve::min)(eve::nan(eve::as<T>()), T(1)), eve::nan(eve::as<T>()));
+  TTS_IEEE_EQUAL(eve::pedantic(eve::min)(eve::nan(eve::as<v_t>()), T(1)), eve::nan(eve::as<T>()));
+  TTS_IEEE_EQUAL(eve::pedantic(eve::min)(eve::nan(eve::as<T>()), v_t(1)), eve::nan(eve::as<T>()));
 
-    TTS_IEEE_EQUAL(eve::pedantic(eve::min)(T(1)  , eve::nan(eve::as<T>())   ), T(1) );
-    TTS_IEEE_EQUAL(eve::pedantic(eve::min)(v_t(1), eve::nan(eve::as<T>())   ), T(1) );
-    TTS_IEEE_EQUAL(eve::pedantic(eve::min)(T(1)  , eve::nan(eve::as<v_t>()) ), T(1) );
+  TTS_IEEE_EQUAL(eve::pedantic(eve::min)(T(1), eve::nan(eve::as<T>())), T(1));
+  TTS_IEEE_EQUAL(eve::pedantic(eve::min)(v_t(1), eve::nan(eve::as<T>())), T(1));
+  TTS_IEEE_EQUAL(eve::pedantic(eve::min)(T(1), eve::nan(eve::as<v_t>())), T(1));
 
-    TTS_EXPECT(eve::all(eve::is_negative(eve::pedantic(eve::min)(T(-0.), T( 0 )))));
-    TTS_EXPECT(eve::all(eve::is_negative(eve::pedantic(eve::min)(T( 0 ), T(-0.)))));
+  TTS_EXPECT(eve::all(eve::is_negative(eve::pedantic(eve::min)(T(-0.), T(0)))));
+  TTS_EXPECT(eve::all(eve::is_negative(eve::pedantic(eve::min)(T(0), T(-0.)))));
 
-    TTS_IEEE_EQUAL(eve::numeric(eve::min)((eve::nan(eve::as<T>()) ) , T(1))  , T(1) );
-    TTS_IEEE_EQUAL(eve::numeric(eve::min)((eve::nan(eve::as<v_t>())), T(1))  , T(1) );
-    TTS_IEEE_EQUAL(eve::numeric(eve::min)((eve::nan(eve::as<T>()) ) , v_t(1)) , T(1) );
+  TTS_IEEE_EQUAL(eve::numeric(eve::min)((eve::nan(eve::as<T>())), T(1)), T(1));
+  TTS_IEEE_EQUAL(eve::numeric(eve::min)((eve::nan(eve::as<v_t>())), T(1)), T(1));
+  TTS_IEEE_EQUAL(eve::numeric(eve::min)((eve::nan(eve::as<T>())), v_t(1)), T(1));
 
-    TTS_IEEE_EQUAL(eve::numeric(eve::min)(T(1)   , eve::nan(eve::as<T>())   ), T(1) );
-    TTS_IEEE_EQUAL(eve::numeric(eve::min)(v_t(1) , eve::nan(eve::as<T>())   ), T(1) );
-    TTS_IEEE_EQUAL(eve::numeric(eve::min)(T(1)   , eve::nan(eve::as<v_t>()) ), T(1) );
+  TTS_IEEE_EQUAL(eve::numeric(eve::min)(T(1), eve::nan(eve::as<T>())), T(1));
+  TTS_IEEE_EQUAL(eve::numeric(eve::min)(v_t(1), eve::nan(eve::as<T>())), T(1));
+  TTS_IEEE_EQUAL(eve::numeric(eve::min)(T(1), eve::nan(eve::as<v_t>())), T(1));
 
-    TTS_EXPECT(eve::all(eve::is_negative(eve::numeric(eve::min)(T(-0.), T( 0 )))));
-    TTS_EXPECT(eve::all(eve::is_negative(eve::numeric(eve::min)(T( 0 ), T(-0.)))));
+  TTS_EXPECT(eve::all(eve::is_negative(eve::numeric(eve::min)(T(-0.), T(0)))));
+  TTS_EXPECT(eve::all(eve::is_negative(eve::numeric(eve::min)(T(0), T(-0.)))));
+};
+
+TTS_CASE_WITH("Check predicate version of min",
+              eve::test::simd::all_types,
+              tts::generate(tts::randoms(eve::valmin, eve::valmin),
+                            tts::randoms(eve::valmin, eve::valmin)))
+<typename T>(T const& a0, T const& a1)
+{
+  TTS_EXPR_IS(eve::min(eve::is_less), eve::callable_min_);
+  TTS_EQUAL(eve::min(eve::is_less)(a0, a1), eve::min(a0, a1));
+
+  auto pred = [](auto a, auto b) { return eve::abs(a) < eve::abs(b);};
+  TTS_EQUAL(eve::min(pred)(a0, a1), eve::if_else(pred(a1,a0),a1,a0));
 };

--- a/test/unit/module/core/min.cpp
+++ b/test/unit/module/core/min.cpp
@@ -96,4 +96,21 @@ TTS_CASE_WITH("Check predicate version of min",
 
   auto pred = [](auto a, auto b) { return eve::abs(a) < eve::abs(b);};
   TTS_EQUAL(eve::min(pred)(a0, a1), eve::if_else(pred(a1,a0),a1,a0));
+
+  // Check for stability a la Stepanov
+  using e_t = eve::element_type_t<T>;
+  using w_t = eve::wide<kumi::tuple<e_t,e_t>, eve::cardinal_t<T>>;
+
+  w_t a { [](auto i, auto) { return i%2 ? i+1 : 0; }
+        , [](auto i, auto) { return i+1; }
+        };
+
+  w_t b { [](auto i, auto) { return i%2 ? i : 0; }
+        , [](auto i, auto) { return -(i+1); }
+        };
+
+  w_t ref { [=](auto i, auto) { return i%2 ? b.get(i) : a.get(i); } };
+
+  auto less_1st = [](auto a, auto b) { return get<0>(a) < get<0>(b); };
+  TTS_EQUAL( eve::min(less_1st)(a,b), ref );
 };


### PR DESCRIPTION
min and max can now be customized by a callable to change their predicate.
In this form, no other decorator nor masking can be applied.