### PR TITLE
Add a local doxygen generation target

### DIFF
--- a/cmake/config/doxygen.cmake
+++ b/cmake/config/doxygen.cmake
@@ -21,9 +21,16 @@ endif (DOXYGEN_FOUND)
 if (DOXYGEN_FOUND)
   set(DOXYGEN_CONFIG ${PROJECT_SOURCE_DIR}/doc/Doxyfile)
   add_custom_target ( doxygen
-                      COMMAND ${DOXYGEN_EXECUTABLE} ${DOXYGEN_CONFIG}
+                      COMMAND EVE_DOXYGEN_OUPUT=../docs ${DOXYGEN_EXECUTABLE} ${DOXYGEN_CONFIG}
                       WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/doc
                       COMMENT "[eve] Generating API documentation with Doxygen"
+                      VERBATIM
+                    )
+
+  add_custom_target ( doxygen-local
+                      COMMAND EVE_DOXYGEN_OUPUT=${PROJECT_BINARY_DIR}/docs ${DOXYGEN_EXECUTABLE} ${DOXYGEN_CONFIG}
+                      WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/doc
+                      COMMENT "[eve] Generating API documentation with Doxygen - Local version"
                       VERBATIM
                     )
 endif (DOXYGEN_FOUND)

--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -8,7 +8,7 @@ PROJECT_NUMBER         =
 PROJECT_BRIEF          = v2022.03.00
 PROJECT_LOGO           = logo.png
 
-OUTPUT_DIRECTORY       = ../docs
+OUTPUT_DIRECTORY       = $(EVE_DOXYGEN_OUPUT)
 CREATE_SUBDIRS         = NO
 ALLOW_UNICODE_NAMES    = NO
 

--- a/doc/page01_info.md
+++ b/doc/page01_info.md
@@ -145,7 +145,16 @@ using the `doxygen` target:
 cmake --build build --target doxygen
 @endcode
 
-The resulting HTML files will be available in the `doc` folder.
+The resulting HTML files will be available in the `docs` folder.
+
+You can also build **EVE** documentation in your build folder by using the  `doxygen-local` target:
+<br/>
+
+@code
+cmake --build build --target doxygen-local
+@endcode
+
+The resulting HTML files will be available in the `docs` folder inside your build folder.
 
 # Using the library
 


### PR DESCRIPTION
When debugging documentation, it helps if we don't pollute the actual docs/ folder. The new doxygen-local target generates the documentation in the build folder instead.