### PR TITLE
#include <array> is missing

### DIFF
--- a/include/eve/detail/function/simd/common/slice.hpp
+++ b/include/eve/detail/function/simd/common/slice.hpp
@@ -14,6 +14,7 @@
 #include <eve/traits/as_wide.hpp>
 #include <eve/as.hpp>
 
+#include <array>
 #include <cstddef>
 #include <type_traits>
 


### PR DESCRIPTION
Compilation error https://godbolt.org/z/PYn3x5v4s

Maybe we should be using as_register header or smth but I think just including array is fine too.