### PR TITLE
Fix 1358 - category API cleanup

### DIFF
--- a/include/eve/detail/category.hpp
+++ b/include/eve/detail/category.hpp
@@ -103,11 +103,6 @@ namespace eve::detail
     return static_cast<category>(to_int(a) | to_int(b));
   }
 
-  inline std::ostream& operator<<(std::ostream& os, category a) noexcept
-  {
-    return os << static_cast<std::uint32_t>(a);
-  }
-
   template<typename... Cat>
   EVE_FORCEINLINE constexpr bool match(category a, Cat... tst) noexcept
   {

--- a/include/eve/detail/category.hpp
+++ b/include/eve/detail/category.hpp
@@ -18,17 +18,17 @@ namespace eve::detail
   enum class category : std::uint32_t
   {
     // Building blocks
-    int_      = 0x01000000,
-    uint_     = 0x02000000,
-    float_    = 0x04000000,
-    unsigned_ = 0x02000000,
-    integer_  = int_ | uint_,
-    signed_   = int_ | float_,
-    size64_   = 0x00080000,
-    size32_   = 0x00040000,
-    size16_   = 0x00020000,
-    size8_    = 0x00010000,
-    invalid   = 0x00000000,
+    invalid   = 0x000000000,
+    signed_   = 0x010000000,
+    unsigned_ = 0x020000000,
+    integer_  = 0x001000000,
+    float_    = 0x002000000 | signed_,
+    int_      = integer_    | signed_,
+    uint_     = integer_    | unsigned_,
+    size8_    = 0x000100000,
+    size16_   = 0x000200000,
+    size32_   = 0x000400000,
+    size64_   = 0x000800000,
 
     // All known native float64
     float64     = float_  | size64_,
@@ -108,6 +108,11 @@ namespace eve::detail
     return (to_int(a) & to_int(b)) != 0;
   }
 
+  inline std::ostream& operator<<(std::ostream& os, category a) noexcept
+  {
+    return os << static_cast<std::uint32_t>(a);
+  }
+
   template<typename... Cat>
   EVE_FORCEINLINE constexpr bool match(category a, Cat... tst) noexcept
   {
@@ -129,7 +134,7 @@ namespace eve::detail
 
       // Base type size & Cardinal
       constexpr auto card = static_cast<category>(sizeof(storage_t) / sizeof(type));
-      constexpr auto sz   = static_cast<category>(sizeof(type) << 16);
+      constexpr auto sz   = static_cast<category>(sizeof(type) << 20);
 
       return value | sz | card;
     }

--- a/include/eve/detail/category.hpp
+++ b/include/eve/detail/category.hpp
@@ -103,11 +103,6 @@ namespace eve::detail
     return static_cast<category>(to_int(a) | to_int(b));
   }
 
-  EVE_FORCEINLINE constexpr bool operator&&(category a, category b) noexcept
-  {
-    return (to_int(a) & to_int(b)) != 0;
-  }
-
   inline std::ostream& operator<<(std::ostream& os, category a) noexcept
   {
     return os << static_cast<std::uint32_t>(a);

--- a/include/eve/detail/function/simd/x86/bit_compounds.hpp
+++ b/include/eve/detail/function/simd/x86/bit_compounds.hpp
@@ -216,7 +216,7 @@ namespace eve::detail
     {
       const     auto bits = bit_cast(other, as<type> {});
       constexpr auto c    = categorize<type>();
-      constexpr bool i    = c && category::integer_;
+      constexpr bool i    = match(c, category::integer_);
 
             if constexpr( c == category::float64x8        ) self = _mm512_and_pd(self, bits);
       else  if constexpr( c == category::float64x4        ) self = _mm256_and_pd(self, bits);
@@ -258,7 +258,7 @@ namespace eve::detail
     {
       auto bits = detail::bit_cast_(EVE_RETARGET(cpu_), other, as<type> {});
       constexpr auto c = categorize<type>();
-      constexpr bool i = c && category::integer_;
+      constexpr bool i = match(c, category::integer_);
 
             if constexpr  ( c == category::float64x8        ) self = _mm512_or_pd(self, bits);
       else  if constexpr  ( c == category::float64x4        ) self = _mm256_or_pd(self, bits);
@@ -300,7 +300,7 @@ namespace eve::detail
     {
       auto bits = detail::bit_cast_(EVE_RETARGET(cpu_), other, as<type> {});
       constexpr auto c = categorize<type>();
-      constexpr bool i = c && category::integer_;
+      constexpr bool i = match(c, category::integer_);
 
             if constexpr  ( c == category::float64x8        ) self = _mm512_xor_pd(self, bits);
       else  if constexpr  ( c == category::float64x4        ) self = _mm256_xor_pd(self, bits);

--- a/include/eve/module/core/regular/impl/simd/arm/neon/abs.hpp
+++ b/include/eve/module/core/regular/impl/simd/arm/neon/abs.hpp
@@ -19,8 +19,8 @@ abs_(EVE_SUPPORTS(neon128_), wide<T, N> const& v) noexcept requires arm_abi<abi_
 {
   constexpr auto cat = categorize<wide<T, N>>();
 
-  if constexpr( cat && category::unsigned_ ) return v;
-  else if constexpr( cat && category::size64_ ) return map(eve::abs, v);
+  if constexpr( match(cat, category::unsigned_) ) return v;
+  else if constexpr( match(cat, category::size64_) ) return map(eve::abs, v);
   else if constexpr( cat == category::float32x4 ) return vabsq_f32(v);
   else if constexpr( cat == category::int32x4 ) return vabsq_s32(v);
   else if constexpr( cat == category::int16x8 ) return vabsq_s16(v);

--- a/include/eve/module/core/regular/impl/simd/arm/neon/convert.hpp
+++ b/include/eve/module/core/regular/impl/simd/arm/neon/convert.hpp
@@ -63,8 +63,8 @@ EVE_FORCEINLINE wide<U, N>
     else if constexpr( c_o == int32x2 ) return vcvt_s32_f32(v);
     else if constexpr( c_o == uint32x2 ) return vcvt_u32_f32(v);
     else if constexpr( sizeof(U) == 8 ) return map(convert, v, tgt);
-    else if constexpr( c_o && signed_ ) return convert(convert(v, t_i32), tgt);
-    else if constexpr( c_o && unsigned_ ) return convert(convert(v, t_u32), tgt);
+    else if constexpr( match(c_o, signed_   ) ) return convert(convert(v, t_i32), tgt);
+    else if constexpr( match(c_o, unsigned_ ) ) return convert(convert(v, t_u32), tgt);
   }
   else if constexpr( N {} == 4 )
   {

--- a/include/eve/module/core/regular/impl/simd/arm/neon/minus.hpp
+++ b/include/eve/module/core/regular/impl/simd/arm/neon/minus.hpp
@@ -20,8 +20,8 @@ minus_(EVE_SUPPORTS(neon128_), wide<T, N> const& v) noexcept requires arm_abi<ab
 {
   constexpr auto cat = categorize<wide<T, N>>();
 
-  if constexpr( cat && category::unsigned_ ) return zero(eve::as(v)) - v;
-  else if constexpr( cat && category::size64_ ) return zero(eve::as(v)) - v;
+  if constexpr( match(cat, category::unsigned_) ) return zero(eve::as(v)) - v;
+  else if constexpr( match(cat, category::size64_) ) return zero(eve::as(v)) - v;
   else if constexpr( cat == category::float32x4 ) return vnegq_f32(v);
   else if constexpr( cat == category::int32x4 ) return vnegq_s32(v);
   else if constexpr( cat == category::int16x8 ) return vnegq_s16(v);

--- a/include/eve/module/core/regular/impl/simd/ppc/abs.hpp
+++ b/include/eve/module/core/regular/impl/simd/ppc/abs.hpp
@@ -17,12 +17,13 @@ namespace eve::detail
 {
 template<real_scalar_value T, typename N>
 EVE_FORCEINLINE wide<T, N>
-                abs_(EVE_SUPPORTS(vmx_), wide<T, N> const                &v) noexcept requires ppc_abi<abi_t<T, N>>
+                abs_(EVE_SUPPORTS(vmx_), wide<T, N> const& v) noexcept
+requires ppc_abi<abi_t<T, N>>
 {
   constexpr auto cat = categorize<wide<T, N>>();
 
-  if constexpr( cat && category::unsigned_ ) return v;
-  else if constexpr( cat && category::size64_ ) return map(eve::abs, v);
+  if constexpr( match(cat, category::unsigned_) ) return v;
+  else if constexpr( match(cat, category::size64_) ) return map(eve::abs, v);
   else return vec_abs(v.storage());
 }
 }

--- a/include/eve/module/core/regular/impl/simd/x86/abs.hpp
+++ b/include/eve/module/core/regular/impl/simd/x86/abs.hpp
@@ -24,12 +24,12 @@ abs_(EVE_SUPPORTS(sse2_), wide<T, N> const& v) noexcept requires x86_abi<abi_t<T
 {
   constexpr auto c = categorize<wide<T, N>>();
 
-  if constexpr( c && category::unsigned_ ) return v;
+  if constexpr( match(c, category::unsigned_) ) return v;
   else if constexpr( c == category::float32x16 ) return _mm512_abs_ps(v);
   else if constexpr( c == category::float64x8 ) return _mm512_abs_pd(v);
-  else if constexpr( c && category::float_ ) return bit_notand(mzero(as(v)), v);
+  else if constexpr( match(c, category::float_) ) return bit_notand(mzero(as(v)), v);
   else if constexpr( c == category::int64x8 ) return _mm512_abs_epi64(v);
-  else if constexpr( c && category::size64_ ) return map(eve::abs, v);
+  else if constexpr( match(c, category::size64_) ) return map(eve::abs, v);
   else if constexpr( c == category::int32x16 ) return _mm512_abs_epi32(v);
   else if constexpr( c == category::int32x8 )
   {
@@ -86,10 +86,10 @@ abs_(EVE_SUPPORTS(sse2_), C const& cx, wide<T, N> const& v) noexcept requires x8
     auto src = alternative(cx, v, as<wide<T, N>> {});
     auto m   = expand_mask(cx, as<wide<T, N>> {}).storage().value;
 
-    if constexpr( c && category::unsigned_ ) return if_else(cx, eve::abs(v), src);
+    if constexpr( match(c, category::unsigned_) ) return if_else(cx, eve::abs(v), src);
     else if constexpr( c == category::float32x16 ) return _mm512_mask_abs_ps(src, m, v);
     else if constexpr( c == category::float64x8 ) return _mm512_mask_abs_pd(src, m, v);
-    else if constexpr( c && category::float_ ) return if_else(cx, eve::abs(v), src);
+    else if constexpr( match(c, category::float_) ) return if_else(cx, eve::abs(v), src);
     else if constexpr( c == category::int64x8 ) return _mm512_mask_abs_epi64(src, m, v);
     else if constexpr( c == category::int64x4 ) return _mm256_mask_abs_epi64(src, m, v);
     else if constexpr( c == category::int64x2 ) return _mm_mask_abs_epi64(src, m, v);

--- a/include/eve/module/core/regular/impl/simd/x86/average.hpp
+++ b/include/eve/module/core/regular/impl/simd/x86/average.hpp
@@ -60,15 +60,15 @@ EVE_FORCEINLINE wide<T, N>
     auto src = alternative(cx, v, as<wide<T, N>> {});
     auto m   = expand_mask(cx, as<wide<T, N>> {}).storage().value;
 
-    if constexpr( c && category::float_ ) return if_else(cx, eve::average(v, w), src);
-    else if constexpr( c && category::int_ ) return if_else(cx, eve::average(v, w), src);
+    if constexpr( match(c, category::float_) ) return if_else(cx, eve::average(v, w), src);
+    else if constexpr( match(c, category::int_) ) return if_else(cx, eve::average(v, w), src);
     else if constexpr( c == category::uint16x32 ) return _mm512_mask_avg_epu16(src, m, v, w);
     else if constexpr( c == category::uint16x16 ) return _mm256_mask_avg_epu16(src, m, v, w);
     else if constexpr( c == category::uint16x8 ) return _mm_mask_avg_epu16(src, m, v, w);
     else if constexpr( c == category::uint8x64 ) return _mm512_mask_avg_epu8(src, m, v, w);
     else if constexpr( c == category::uint8x32 ) return _mm256_mask_avg_epu8(src, m, v, w);
     else if constexpr( c == category::uint8x16 ) return _mm_mask_avg_epu8(src, m, v, w);
-    else if constexpr( c && category::uint_ ) return if_else(cx, eve::average(v, w), src);
+    else if constexpr( match(c, category::uint_) ) return if_else(cx, eve::average(v, w), src);
   }
 }
 

--- a/include/eve/module/core/regular/impl/simd/x86/bit_and.hpp
+++ b/include/eve/module/core/regular/impl/simd/x86/bit_and.hpp
@@ -39,21 +39,21 @@ EVE_FORCEINLINE wide<T, N>
 
     if constexpr( c == category::float32x16 ) return _mm512_mask_and_ps(src, m, v0, v1);
     else if constexpr( c == category::float64x8 ) return _mm512_mask_and_pd(src, m, v0, v1);
-    else if constexpr( c && category::float_ ) return if_else(cx, eve::bit_and(v0, v1), src);
+    else if constexpr( match(c, category::float_) ) return if_else(cx, eve::bit_and(v0, v1), src);
     else if constexpr( c == category::int64x8 ) return _mm512_mask_and_epi64(src, m, v0, v1);
     else if constexpr( c == category::int64x4 ) return _mm256_mask_and_epi64(src, m, v0, v1);
     else if constexpr( c == category::int64x2 ) return _mm_mask_and_epi64(src, m, v0, v1);
     else if constexpr( c == category::int32x16 ) return _mm512_mask_and_epi32(src, m, v0, v1);
     else if constexpr( c == category::int32x8 ) return _mm256_mask_and_epi32(src, m, v0, v1);
     else if constexpr( c == category::int32x4 ) return _mm_mask_and_epi32(src, m, v0, v1);
-    else if constexpr( c && category::int_ ) return if_else(cx, eve::bit_and(v0, v1), src);
+    else if constexpr( match(c, category::int_) ) return if_else(cx, eve::bit_and(v0, v1), src);
     else if constexpr( c == category::uint64x8 ) return _mm512_mask_and_epi64(src, m, v0, v1);
     else if constexpr( c == category::uint64x4 ) return _mm256_mask_and_epi64(src, m, v0, v1);
     else if constexpr( c == category::uint64x2 ) return _mm_mask_and_epi64(src, m, v0, v1);
     else if constexpr( c == category::uint32x16 ) return _mm512_mask_and_epi32(src, m, v0, v1);
     else if constexpr( c == category::uint32x8 ) return _mm256_mask_and_epi32(src, m, v0, v1);
     else if constexpr( c == category::uint32x4 ) return _mm_mask_and_epi32(src, m, v0, v1);
-    else if constexpr( c && category::uint_ ) return if_else(cx, eve::bit_and(v0, v1), src);
+    else if constexpr( match(c, category::uint_) ) return if_else(cx, eve::bit_and(v0, v1), src);
   }
 }
 }

--- a/include/eve/module/core/regular/impl/simd/x86/bit_andnot.hpp
+++ b/include/eve/module/core/regular/impl/simd/x86/bit_andnot.hpp
@@ -27,7 +27,7 @@ EVE_FORCEINLINE wide<T, N>
                             wide<T, N> const                &v1) noexcept requires x86_abi<abi_t<T, N>>
 {
   constexpr auto c = categorize<wide<T, N>>();
-  constexpr bool i = c && category::integer_;
+  constexpr bool i = match(c, category::integer_);
 
   if constexpr( c == category::float64x8 ) return _mm512_andnot_pd(v1, v0);
   else if constexpr( c == category::float64x4 ) return _mm256_andnot_pd(v1, v0);
@@ -68,21 +68,21 @@ EVE_FORCEINLINE wide<T, N>
 
     if constexpr( c == category::float32x16 ) return _mm512_mask_andnot_ps(src, m, v1, v0);
     else if constexpr( c == category::float64x8 ) return _mm512_mask_andnot_pd(src, m, v1, v0);
-    else if constexpr( c && category::float_ ) return if_else(cx, eve::bit_andnot(v0, v1), src);
+    else if constexpr( match(c, category::float_) ) return if_else(cx, eve::bit_andnot(v0, v1), src);
     else if constexpr( c == category::int64x8 ) return _mm512_mask_andnot_epi64(src, m, v1, v0);
     else if constexpr( c == category::int64x4 ) return _mm256_mask_andnot_epi64(src, m, v1, v0);
     else if constexpr( c == category::int64x2 ) return _mm_mask_andnot_epi64(src, m, v1, v0);
     else if constexpr( c == category::int32x16 ) return _mm512_mask_andnot_epi32(src, m, v1, v0);
     else if constexpr( c == category::int32x8 ) return _mm256_mask_andnot_epi32(src, m, v1, v0);
     else if constexpr( c == category::int32x4 ) return _mm_mask_andnot_epi32(src, m, v1, v0);
-    else if constexpr( c && category::int_ ) return if_else(cx, eve::bit_andnot(v0, v1), src);
+    else if constexpr( match(c, category::int_) ) return if_else(cx, eve::bit_andnot(v0, v1), src);
     else if constexpr( c == category::uint64x8 ) return _mm512_mask_andnot_epi64(src, m, v1, v0);
     else if constexpr( c == category::uint64x4 ) return _mm256_mask_andnot_epi64(src, m, v1, v0);
     else if constexpr( c == category::uint64x2 ) return _mm_mask_andnot_epi64(src, m, v1, v0);
     else if constexpr( c == category::uint32x16 ) return _mm512_mask_andnot_epi32(src, m, v1, v0);
     else if constexpr( c == category::uint32x8 ) return _mm256_mask_andnot_epi32(src, m, v1, v0);
     else if constexpr( c == category::uint32x4 ) return _mm_mask_andnot_epi32(src, m, v1, v0);
-    else if constexpr( c && category::uint_ ) return if_else(cx, eve::bit_andnot(v0, v1), src);
+    else if constexpr( match(c, category::uint_) ) return if_else(cx, eve::bit_andnot(v0, v1), src);
   }
 }
 }

--- a/include/eve/module/core/regular/impl/simd/x86/bit_notand.hpp
+++ b/include/eve/module/core/regular/impl/simd/x86/bit_notand.hpp
@@ -86,21 +86,21 @@ EVE_FORCEINLINE wide<T, N>
 
     if constexpr( c == category::float32x16 ) return _mm512_mask_andnot_ps(src, m, v0, v1);
     else if constexpr( c == category::float64x8 ) return _mm512_mask_andnot_pd(src, m, v0, v1);
-    else if constexpr( c && category::float_ ) return if_else(cx, eve::bit_notand(v0, v1), src);
+    else if constexpr( match(c, category::float_) ) return if_else(cx, eve::bit_notand(v0, v1), src);
     else if constexpr( c == category::int64x8 ) return _mm512_mask_andnot_epi64(src, m, v0, v1);
     else if constexpr( c == category::int64x4 ) return _mm256_mask_andnot_epi64(src, m, v0, v1);
     else if constexpr( c == category::int64x2 ) return _mm_mask_andnot_epi64(src, m, v0, v1);
     else if constexpr( c == category::int32x16 ) return _mm512_mask_andnot_epi32(src, m, v0, v1);
     else if constexpr( c == category::int32x8 ) return _mm256_mask_andnot_epi32(src, m, v0, v1);
     else if constexpr( c == category::int32x4 ) return _mm_mask_andnot_epi32(src, m, v0, v1);
-    else if constexpr( c && category::int_ ) return if_else(cx, eve::bit_notand(v0, v1), src);
+    else if constexpr( match(c, category::int_) ) return if_else(cx, eve::bit_notand(v0, v1), src);
     else if constexpr( c == category::uint64x8 ) return _mm512_mask_andnot_epi64(src, m, v0, v1);
     else if constexpr( c == category::uint64x4 ) return _mm256_mask_andnot_epi64(src, m, v0, v1);
     else if constexpr( c == category::uint64x2 ) return _mm_mask_andnot_epi64(src, m, v0, v1);
     else if constexpr( c == category::uint32x16 ) return _mm512_mask_andnot_epi32(src, m, v0, v1);
     else if constexpr( c == category::uint32x8 ) return _mm256_mask_andnot_epi32(src, m, v0, v1);
     else if constexpr( c == category::uint32x4 ) return _mm_mask_andnot_epi32(src, m, v0, v1);
-    else if constexpr( c && category::uint_ ) return if_else(cx, eve::bit_notand(v0, v1), src);
+    else if constexpr( match(c, category::uint_) ) return if_else(cx, eve::bit_notand(v0, v1), src);
   }
 }
 }

--- a/include/eve/module/core/regular/impl/simd/x86/bit_or.hpp
+++ b/include/eve/module/core/regular/impl/simd/x86/bit_or.hpp
@@ -38,21 +38,21 @@ EVE_FORCEINLINE wide<T, N>
     auto m   = expand_mask(cx, as<wide<T, N>> {}).storage().value;
     if constexpr( c == category::float32x16 ) return _mm512_mask_or_ps(src, m, v0, v1);
     else if constexpr( c == category::float64x8 ) return _mm512_mask_or_pd(src, m, v0, v1);
-    else if constexpr( c && category::float_ ) return if_else(cx, eve::bit_or(v0, v1), src);
+    else if constexpr( match(c, category::float_) ) return if_else(cx, eve::bit_or(v0, v1), src);
     else if constexpr( c == category::int64x8 ) return _mm512_mask_or_epi64(src, m, v0, v1);
     else if constexpr( c == category::int64x4 ) return _mm256_mask_or_epi64(src, m, v0, v1);
     else if constexpr( c == category::int64x2 ) return _mm_mask_or_epi64(src, m, v0, v1);
     else if constexpr( c == category::int32x16 ) return _mm512_mask_or_epi32(src, m, v0, v1);
     else if constexpr( c == category::int32x8 ) return _mm256_mask_or_epi32(src, m, v0, v1);
     else if constexpr( c == category::int32x4 ) return _mm_mask_or_epi32(src, m, v0, v1);
-    else if constexpr( c && category::int_ ) return if_else(cx, eve::bit_or(v0, v1), src);
+    else if constexpr( match(c, category::int_) ) return if_else(cx, eve::bit_or(v0, v1), src);
     else if constexpr( c == category::uint64x8 ) return _mm512_mask_or_epi64(src, m, v0, v1);
     else if constexpr( c == category::uint64x4 ) return _mm256_mask_or_epi64(src, m, v0, v1);
     else if constexpr( c == category::uint64x2 ) return _mm_mask_or_epi64(src, m, v0, v1);
     else if constexpr( c == category::uint32x16 ) return _mm512_mask_or_epi32(src, m, v0, v1);
     else if constexpr( c == category::uint32x8 ) return _mm256_mask_or_epi32(src, m, v0, v1);
     else if constexpr( c == category::uint32x4 ) return _mm_mask_or_epi32(src, m, v0, v1);
-    else if constexpr( c && category::uint_ ) return if_else(cx, eve::bit_or(v0, v1), src);
+    else if constexpr( match(c, category::uint_) ) return if_else(cx, eve::bit_or(v0, v1), src);
   }
 }
 }

--- a/include/eve/module/core/regular/impl/simd/x86/bit_xor.hpp
+++ b/include/eve/module/core/regular/impl/simd/x86/bit_xor.hpp
@@ -38,21 +38,21 @@ EVE_FORCEINLINE wide<T, N>
     auto m   = expand_mask(cx, as<wide<T, N>> {}).storage().value;
     if constexpr( c == category::float32x16 ) return _mm512_mask_xor_ps(src, m, v0, v1);
     else if constexpr( c == category::float64x8 ) return _mm512_mask_xor_pd(src, m, v0, v1);
-    else if constexpr( c && category::float_ ) return if_else(cx, eve::bit_xor(v0, v1), src);
+    else if constexpr( match(c, category::float_) ) return if_else(cx, eve::bit_xor(v0, v1), src);
     else if constexpr( c == category::int64x8 ) return _mm512_mask_xor_epi64(src, m, v0, v1);
     else if constexpr( c == category::int64x4 ) return _mm256_mask_xor_epi64(src, m, v0, v1);
     else if constexpr( c == category::int64x2 ) return _mm_mask_xor_epi64(src, m, v0, v1);
     else if constexpr( c == category::int32x16 ) return _mm512_mask_xor_epi32(src, m, v0, v1);
     else if constexpr( c == category::int32x8 ) return _mm256_mask_xor_epi32(src, m, v0, v1);
     else if constexpr( c == category::int32x4 ) return _mm_mask_xor_epi32(src, m, v0, v1);
-    else if constexpr( c && category::int_ ) return if_else(cx, eve::bit_xor(v0, v1), src);
+    else if constexpr( match(c, category::int_) ) return if_else(cx, eve::bit_xor(v0, v1), src);
     else if constexpr( c == category::uint64x8 ) return _mm512_mask_xor_epi64(src, m, v0, v1);
     else if constexpr( c == category::uint64x4 ) return _mm256_mask_xor_epi64(src, m, v0, v1);
     else if constexpr( c == category::uint64x2 ) return _mm_mask_xor_epi64(src, m, v0, v1);
     else if constexpr( c == category::uint32x16 ) return _mm512_mask_xor_epi32(src, m, v0, v1);
     else if constexpr( c == category::uint32x8 ) return _mm256_mask_xor_epi32(src, m, v0, v1);
     else if constexpr( c == category::uint32x4 ) return _mm_mask_xor_epi32(src, m, v0, v1);
-    else if constexpr( c && category::uint_ ) return if_else(cx, eve::bit_xor(v0, v1), src);
+    else if constexpr( match(c, category::uint_) ) return if_else(cx, eve::bit_xor(v0, v1), src);
   }
 }
 }

--- a/include/eve/module/core/regular/impl/simd/x86/ceil.hpp
+++ b/include/eve/module/core/regular/impl/simd/x86/ceil.hpp
@@ -50,10 +50,10 @@ ceil_(EVE_SUPPORTS(sse2_), C const& cx, wide<T, N> const& v) noexcept requires x
     auto src = alternative(cx, v, as<wide<T, N>> {});
     auto m   = expand_mask(cx, as<wide<T, N>> {}).storage().value;
 
-    if constexpr( c && category::integer_ ) return if_else(cx, v, src);
+    if constexpr( match(c, category::integer_) ) return if_else(cx, v, src);
     else if constexpr( c == category::float32x16 ) return _mm512_mask_ceil_ps(src, m, v);
     else if constexpr( c == category::float64x8 ) return _mm512_mask_ceil_pd(src, m, v);
-    else if constexpr( c && category::float_ ) return if_else(cx, eve::ceil(v), src);
+    else if constexpr( match(c, category::float_) ) return if_else(cx, eve::ceil(v), src);
   }
 }
 }

--- a/include/eve/module/core/regular/impl/simd/x86/floor.hpp
+++ b/include/eve/module/core/regular/impl/simd/x86/floor.hpp
@@ -50,10 +50,10 @@ floor_(EVE_SUPPORTS(sse2_), C const& cx, wide<T, N> const& v) noexcept requires 
     auto src = alternative(cx, v, as<wide<T, N>> {});
     auto m   = expand_mask(cx, as<wide<T, N>> {}).storage().value;
 
-    if constexpr( c && category::integer_ ) return if_else(cx, v, src);
+    if constexpr( match(c, category::integer_) ) return if_else(cx, v, src);
     else if constexpr( c == category::float32x16 ) return _mm512_mask_floor_ps(src, m, v);
     else if constexpr( c == category::float64x8 ) return _mm512_mask_floor_pd(src, m, v);
-    else if constexpr( c && category::float_ ) return if_else(cx, eve::floor(v), src);
+    else if constexpr( match(c, category::float_) ) return if_else(cx, eve::floor(v), src);
   }
 }
 }

--- a/include/eve/module/core/regular/impl/simd/x86/is_ordered.hpp
+++ b/include/eve/module/core/regular/impl/simd/x86/is_ordered.hpp
@@ -24,7 +24,7 @@ EVE_FORCEINLINE logical<wide<T, N>>
   constexpr auto c = categorize<wide<T, N>>();
   constexpr auto m = _CMP_ORD_Q;
 
-  if constexpr( c && category::integer_ ) return true_(eve::as<l_t>());
+  if constexpr( match(c, category::integer_) ) return true_(eve::as<l_t>());
   else if constexpr( current_api >= eve::avx512 )
   {
     using s_t = typename l_t::storage_type;

--- a/include/eve/module/core/regular/impl/simd/x86/is_unordered.hpp
+++ b/include/eve/module/core/regular/impl/simd/x86/is_unordered.hpp
@@ -26,7 +26,7 @@ EVE_FORCEINLINE logical<wide<T, N>>
   constexpr auto c = categorize<wide<T, N>>();
   constexpr auto m = _CMP_UNORD_Q;
 
-  if constexpr( c && category::integer_ ) return false_(eve::as<l_t>());
+  if constexpr( match(c, category::integer_) ) return false_(eve::as<l_t>());
   else if constexpr( current_api >= eve::avx512 )
   {
     using s_t = typename l_t::storage_type;

--- a/test/tts/tts.hpp
+++ b/test/tts/tts.hpp
@@ -996,6 +996,12 @@ namespace tts
     {
       return to_string(e);
     }
+    else if constexpr( std::is_enum_v<T> )
+    {
+      std::ostringstream os;
+      os << typename_<T> << "(" << static_cast<std::underlying_type_t<T>>(e) << ")";
+      return os.str();
+    }
     else if constexpr( sequence<T> )
     {
       std::string that = "{ ";

--- a/test/unit/internals/CMakeLists.txt
+++ b/test/unit/internals/CMakeLists.txt
@@ -14,6 +14,7 @@ add_custom_target(unit.internals.exe )
 ##==================================================================================================
 make_unit( "unit.internals" aggregation.cpp                     )
 make_unit( "unit.internals" byte_16_runtime_shuffle.cpp         )
+make_unit( "unit.internals" category.cpp                        )
 make_unit( "unit.internals" compress/compress_mask_num.cpp      )
 make_unit( "unit.internals" dispatch.cpp                        )
 make_unit( "unit.internals" horn.cpp                            )

--- a/test/unit/internals/category.cpp
+++ b/test/unit/internals/category.cpp
@@ -6,177 +6,225 @@
 */
 //==================================================================================================
 #include "test.hpp"
+
 #include <eve/detail/category.hpp>
 
-template<typename T, typename Cardinals>
-struct natives_impl;
+template<typename T, typename Cardinals> struct natives_impl;
 
-template<typename T, std::size_t... N>
-struct natives_impl<T, std::index_sequence<N...>>
+template<typename T, std::size_t... N> struct natives_impl<T, std::index_sequence<N...>>
 {
-  using types_list = tts::types< eve::wide<T, eve::fixed<(1<<N)>>...>;
+  using types_list = tts::types<eve::wide<T, eve::fixed<(1 << N)>>...>;
 };
 
-template<typename T> struct natives
-: natives_impl< T
-              , std::make_index_sequence<std::bit_width(std::size_t(eve::fundamental_cardinal_v<T>))>
-              >
+template<typename T>
+struct natives
+    : natives_impl<
+          T,
+          std::make_index_sequence<std::bit_width(std::size_t(eve::fundamental_cardinal_v<T>))>>
 {};
 
-TTS_CASE_TPL("Test category matching for double", natives<double> )
-<typename T>( tts::type<T> )
+TTS_CASE_TPL("Test category matching for double", natives<double>)
+<typename T>(tts::type<T>)
 {
-  // All types below fundamental cardinal categorize with the same # of lanes
-  using enum eve::detail::category;
-  constexpr auto lanes  = static_cast<eve::detail::category>(eve::fundamental_cardinal_v<double>);
+  if constexpr( eve::has_native_abi_v<T> )
+  {
+    // All types below fundamental cardinal categorize with the same # of lanes
+    using enum eve::detail::category;
+    constexpr auto lanes = static_cast<eve::detail::category>(eve::fundamental_cardinal_v<double>);
 
-  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), float_  ));
-  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), signed_ ));
-  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), size64_ ));
-  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), float64 ));
-  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), lanes   ));
-  TTS_CONSTEXPR_EQUAL( eve::detail::categorize<T>(), float64 | lanes);
+    TTS_CONSTEXPR_EXPECT(match(eve::detail::categorize<T>(), float_));
+    TTS_CONSTEXPR_EXPECT(match(eve::detail::categorize<T>(), signed_));
+    TTS_CONSTEXPR_EXPECT(match(eve::detail::categorize<T>(), size64_));
+    TTS_CONSTEXPR_EXPECT(match(eve::detail::categorize<T>(), float64));
+    TTS_CONSTEXPR_EXPECT(match(eve::detail::categorize<T>(), lanes));
+    TTS_CONSTEXPR_EQUAL(eve::detail::categorize<T>(), float64 | lanes);
+  }
+  else { TTS_PASS("wide<double,N> is not native and therefore can't be categorized."); }
 };
 
-TTS_CASE_TPL("Test category matching for std::int64", natives<std::int64_t> )
-<typename T>( tts::type<T> )
+TTS_CASE_TPL("Test category matching for std::int64", natives<std::int64_t>)
+<typename T>(tts::type<T>)
 {
-  // All types below fundamental cardinal categorize with the same # of lanes
-  using enum eve::detail::category;
-  constexpr auto lanes  = static_cast<eve::detail::category>(eve::fundamental_cardinal_v<std::int64_t>);
+  if constexpr( eve::has_native_abi_v<T> )
+  {
+    // All types below fundamental cardinal categorize with the same # of lanes
+    using enum eve::detail::category;
+    constexpr auto lanes =
+        static_cast<eve::detail::category>(eve::fundamental_cardinal_v<std::int64_t>);
 
-  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), integer_  ));
-  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), signed_   ));
-  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), size64_   ));
-  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), int_      ));
-  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), int64     ));
-  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), lanes     ));
-  TTS_CONSTEXPR_EQUAL( eve::detail::categorize<T>(), int64 | lanes    );
+    TTS_CONSTEXPR_EXPECT(match(eve::detail::categorize<T>(), integer_));
+    TTS_CONSTEXPR_EXPECT(match(eve::detail::categorize<T>(), signed_));
+    TTS_CONSTEXPR_EXPECT(match(eve::detail::categorize<T>(), size64_));
+    TTS_CONSTEXPR_EXPECT(match(eve::detail::categorize<T>(), int_));
+    TTS_CONSTEXPR_EXPECT(match(eve::detail::categorize<T>(), int64));
+    TTS_CONSTEXPR_EXPECT(match(eve::detail::categorize<T>(), lanes));
+    TTS_CONSTEXPR_EQUAL(eve::detail::categorize<T>(), int64 | lanes);
+  }
+  else { TTS_PASS("wide<int64,N> is not native and therefore can't be categorized."); }
 };
 
-TTS_CASE_TPL("Test category matching for std::uint64", natives<std::uint64_t> )
-<typename T>( tts::type<T> )
+TTS_CASE_TPL("Test category matching for std::uint64", natives<std::uint64_t>)
+<typename T>(tts::type<T>)
 {
-  // All types below fundamental cardinal categorize with the same # of lanes
-  using enum eve::detail::category;
-  constexpr auto lanes  = static_cast<eve::detail::category>(eve::fundamental_cardinal_v<std::uint64_t>);
+  if constexpr( eve::has_native_abi_v<T> )
+  {
+    // All types below fundamental cardinal categorize with the same # of lanes
+    using enum eve::detail::category;
+    constexpr auto lanes =
+        static_cast<eve::detail::category>(eve::fundamental_cardinal_v<std::uint64_t>);
 
-  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), integer_  ));
-  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), unsigned_ ));
-  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), size64_   ));
-  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), uint_     ));
-  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), uint64    ));
-  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), lanes     ));
-  TTS_CONSTEXPR_EQUAL( eve::detail::categorize<T>(), uint64 | lanes   );
+    TTS_CONSTEXPR_EXPECT(match(eve::detail::categorize<T>(), integer_));
+    TTS_CONSTEXPR_EXPECT(match(eve::detail::categorize<T>(), unsigned_));
+    TTS_CONSTEXPR_EXPECT(match(eve::detail::categorize<T>(), size64_));
+    TTS_CONSTEXPR_EXPECT(match(eve::detail::categorize<T>(), uint_));
+    TTS_CONSTEXPR_EXPECT(match(eve::detail::categorize<T>(), uint64));
+    TTS_CONSTEXPR_EXPECT(match(eve::detail::categorize<T>(), lanes));
+    TTS_CONSTEXPR_EQUAL(eve::detail::categorize<T>(), uint64 | lanes);
+  }
+  else { TTS_PASS("wide<uint64_t,N> is not native and therefore can't be categorized."); }
 };
 
-TTS_CASE_TPL("Test category matching for float", natives<float> )
-<typename T>( tts::type<T> )
+TTS_CASE_TPL("Test category matching for float", natives<float>)
+<typename T>(tts::type<T>)
 {
-  // All types below fundamental cardinal categorize with the same # of lanes
-  using enum eve::detail::category;
-  constexpr auto lanes  = static_cast<eve::detail::category>(eve::fundamental_cardinal_v<float>);
+  if constexpr( eve::has_native_abi_v<T> )
+  {
+    // All types below fundamental cardinal categorize with the same # of lanes
+    using enum eve::detail::category;
+    constexpr auto lanes = static_cast<eve::detail::category>(eve::fundamental_cardinal_v<float>);
 
-  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), float_  ));
-  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), signed_ ));
-  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), size32_ ));
-  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), float32 ));
-  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), lanes   ));
-  TTS_CONSTEXPR_EQUAL( eve::detail::categorize<T>(), float32 | lanes);
+    TTS_CONSTEXPR_EXPECT(match(eve::detail::categorize<T>(), float_));
+    TTS_CONSTEXPR_EXPECT(match(eve::detail::categorize<T>(), signed_));
+    TTS_CONSTEXPR_EXPECT(match(eve::detail::categorize<T>(), size32_));
+    TTS_CONSTEXPR_EXPECT(match(eve::detail::categorize<T>(), float32));
+    TTS_CONSTEXPR_EXPECT(match(eve::detail::categorize<T>(), lanes));
+    TTS_CONSTEXPR_EQUAL(eve::detail::categorize<T>(), float32 | lanes);
+  }
+  else { TTS_PASS("wide<float,N> is not native and therefore can't be categorized."); }
 };
 
-TTS_CASE_TPL("Test category matching for std::int32", natives<std::int32_t> )
-<typename T>( tts::type<T> )
+TTS_CASE_TPL("Test category matching for std::int32", natives<std::int32_t>)
+<typename T>(tts::type<T>)
 {
-  // All types below fundamental cardinal categorize with the same # of lanes
-  using enum eve::detail::category;
-  constexpr auto lanes  = static_cast<eve::detail::category>(eve::fundamental_cardinal_v<std::int32_t>);
+  if constexpr( eve::has_native_abi_v<T> )
+  {
+    // All types below fundamental cardinal categorize with the same # of lanes
+    using enum eve::detail::category;
+    constexpr auto lanes =
+        static_cast<eve::detail::category>(eve::fundamental_cardinal_v<std::int32_t>);
 
-  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), integer_));
-  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), signed_ ));
-  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), size32_ ));
-  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), int_    ));
-  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), int32   ));
-  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), lanes   ));
-  TTS_CONSTEXPR_EQUAL( eve::detail::categorize<T>(), int32 | lanes  );
+    TTS_CONSTEXPR_EXPECT(match(eve::detail::categorize<T>(), integer_));
+    TTS_CONSTEXPR_EXPECT(match(eve::detail::categorize<T>(), signed_));
+    TTS_CONSTEXPR_EXPECT(match(eve::detail::categorize<T>(), size32_));
+    TTS_CONSTEXPR_EXPECT(match(eve::detail::categorize<T>(), int_));
+    TTS_CONSTEXPR_EXPECT(match(eve::detail::categorize<T>(), int32));
+    TTS_CONSTEXPR_EXPECT(match(eve::detail::categorize<T>(), lanes));
+    TTS_CONSTEXPR_EQUAL(eve::detail::categorize<T>(), int32 | lanes);
+  }
+  else { TTS_PASS("wide<int32,N> is not native and therefore can't be categorized."); }
 };
 
-TTS_CASE_TPL("Test category matching for std::uint32", natives<std::uint32_t> )
-<typename T>( tts::type<T> )
+TTS_CASE_TPL("Test category matching for std::uint32", natives<std::uint32_t>)
+<typename T>(tts::type<T>)
 {
-  // All types below fundamental cardinal categorize with the same # of lanes
-  using enum eve::detail::category;
-  constexpr auto lanes  = static_cast<eve::detail::category>(eve::fundamental_cardinal_v<std::uint32_t>);
+  if constexpr( eve::has_native_abi_v<T> )
+  {
+    // All types below fundamental cardinal categorize with the same # of lanes
+    using enum eve::detail::category;
+    constexpr auto lanes =
+        static_cast<eve::detail::category>(eve::fundamental_cardinal_v<std::uint32_t>);
 
-  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), integer_  ));
-  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), unsigned_ ));
-  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), size32_   ));
-  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), uint_     ));
-  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), uint32    ));
-  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), lanes     ));
-  TTS_CONSTEXPR_EQUAL( eve::detail::categorize<T>(), uint32 | lanes   );
+    TTS_CONSTEXPR_EXPECT(match(eve::detail::categorize<T>(), integer_));
+    TTS_CONSTEXPR_EXPECT(match(eve::detail::categorize<T>(), unsigned_));
+    TTS_CONSTEXPR_EXPECT(match(eve::detail::categorize<T>(), size32_));
+    TTS_CONSTEXPR_EXPECT(match(eve::detail::categorize<T>(), uint_));
+    TTS_CONSTEXPR_EXPECT(match(eve::detail::categorize<T>(), uint32));
+    TTS_CONSTEXPR_EXPECT(match(eve::detail::categorize<T>(), lanes));
+    TTS_CONSTEXPR_EQUAL(eve::detail::categorize<T>(), uint32 | lanes);
+  }
+  else { TTS_PASS("wide<uint32,N> is not native and therefore can't be categorized."); }
 };
 
-TTS_CASE_TPL("Test category matching for std::int16", natives<std::int16_t> )
-<typename T>( tts::type<T> )
+TTS_CASE_TPL("Test category matching for std::int16", natives<std::int16_t>)
+<typename T>(tts::type<T>)
 {
-  // All types below fundamental cardinal categorize with the same # of lanes
-  using enum eve::detail::category;
-  constexpr auto lanes  = static_cast<eve::detail::category>(eve::fundamental_cardinal_v<std::int16_t>);
+  if constexpr( eve::has_native_abi_v<T> )
+  {
+    // All types below fundamental cardinal categorize with the same # of lanes
+    using enum eve::detail::category;
+    constexpr auto lanes =
+        static_cast<eve::detail::category>(eve::fundamental_cardinal_v<std::int16_t>);
 
-  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), integer_));
-  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), signed_ ));
-  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), size16_ ));
-  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), int_    ));
-  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), int16   ));
-  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), lanes   ));
-  TTS_CONSTEXPR_EQUAL( eve::detail::categorize<T>(), int16 | lanes  );
+    TTS_CONSTEXPR_EXPECT(match(eve::detail::categorize<T>(), integer_));
+    TTS_CONSTEXPR_EXPECT(match(eve::detail::categorize<T>(), signed_));
+    TTS_CONSTEXPR_EXPECT(match(eve::detail::categorize<T>(), size16_));
+    TTS_CONSTEXPR_EXPECT(match(eve::detail::categorize<T>(), int_));
+    TTS_CONSTEXPR_EXPECT(match(eve::detail::categorize<T>(), int16));
+    TTS_CONSTEXPR_EXPECT(match(eve::detail::categorize<T>(), lanes));
+    TTS_CONSTEXPR_EQUAL(eve::detail::categorize<T>(), int16 | lanes);
+  }
+  else { TTS_PASS("wide<int16,N> is not native and therefore can't be categorized."); }
 };
 
-TTS_CASE_TPL("Test category matching for std::uint16", natives<std::uint16_t> )
-<typename T>( tts::type<T> )
+TTS_CASE_TPL("Test category matching for std::uint16", natives<std::uint16_t>)
+<typename T>(tts::type<T>)
 {
-  // All types below fundamental cardinal categorize with the same # of lanes
-  using enum eve::detail::category;
-  constexpr auto lanes  = static_cast<eve::detail::category>(eve::fundamental_cardinal_v<std::uint16_t>);
+  if constexpr( eve::has_native_abi_v<T> )
+  {
+    // All types below fundamental cardinal categorize with the same # of lanes
+    using enum eve::detail::category;
+    constexpr auto lanes =
+        static_cast<eve::detail::category>(eve::fundamental_cardinal_v<std::uint16_t>);
 
-  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), integer_  ));
-  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), unsigned_ ));
-  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), size16_   ));
-  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), uint_     ));
-  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), uint16    ));
-  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), lanes     ));
-  TTS_CONSTEXPR_EQUAL( eve::detail::categorize<T>(), uint16 | lanes   );
+    TTS_CONSTEXPR_EXPECT(match(eve::detail::categorize<T>(), integer_));
+    TTS_CONSTEXPR_EXPECT(match(eve::detail::categorize<T>(), unsigned_));
+    TTS_CONSTEXPR_EXPECT(match(eve::detail::categorize<T>(), size16_));
+    TTS_CONSTEXPR_EXPECT(match(eve::detail::categorize<T>(), uint_));
+    TTS_CONSTEXPR_EXPECT(match(eve::detail::categorize<T>(), uint16));
+    TTS_CONSTEXPR_EXPECT(match(eve::detail::categorize<T>(), lanes));
+    TTS_CONSTEXPR_EQUAL(eve::detail::categorize<T>(), uint16 | lanes);
+  }
+  else { TTS_PASS("wide<uint16,N> is not native and therefore can't be categorized."); }
 };
 
-TTS_CASE_TPL("Test category matching for std::int8", natives<std::int8_t> )
-<typename T>( tts::type<T> )
+TTS_CASE_TPL("Test category matching for std::int8", natives<std::int8_t>)
+<typename T>(tts::type<T>)
 {
-  // All types below fundamental cardinal categorize with the same # of lanes
-  using enum eve::detail::category;
-  constexpr auto lanes  = static_cast<eve::detail::category>(eve::fundamental_cardinal_v<std::int8_t>);
+  if constexpr( eve::has_native_abi_v<T> )
+  {
+    // All types below fundamental cardinal categorize with the same # of lanes
+    using enum eve::detail::category;
+    constexpr auto lanes =
+        static_cast<eve::detail::category>(eve::fundamental_cardinal_v<std::int8_t>);
 
-  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), integer_));
-  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), signed_ ));
-  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), size8_  ));
-  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), int_    ));
-  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), int8    ));
-  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), lanes   ));
-  TTS_CONSTEXPR_EQUAL( eve::detail::categorize<T>(), int8 | lanes   );
+    TTS_CONSTEXPR_EXPECT(match(eve::detail::categorize<T>(), integer_));
+    TTS_CONSTEXPR_EXPECT(match(eve::detail::categorize<T>(), signed_));
+    TTS_CONSTEXPR_EXPECT(match(eve::detail::categorize<T>(), size8_));
+    TTS_CONSTEXPR_EXPECT(match(eve::detail::categorize<T>(), int_));
+    TTS_CONSTEXPR_EXPECT(match(eve::detail::categorize<T>(), int8));
+    TTS_CONSTEXPR_EXPECT(match(eve::detail::categorize<T>(), lanes));
+    TTS_CONSTEXPR_EQUAL(eve::detail::categorize<T>(), int8 | lanes);
+  }
+  else { TTS_PASS("wide<int8,N> is not native and therefore can't be categorized."); }
 };
 
-TTS_CASE_TPL("Test category matching for std::uint8", natives<std::uint8_t> )
-<typename T>( tts::type<T> )
+TTS_CASE_TPL("Test category matching for std::uint8", natives<std::uint8_t>)
+<typename T>(tts::type<T>)
 {
-  // All types below fundamental cardinal categorize with the same # of lanes
-  using enum eve::detail::category;
-  constexpr auto lanes  = static_cast<eve::detail::category>(eve::fundamental_cardinal_v<std::uint8_t>);
+  if constexpr( eve::has_native_abi_v<T> )
+  {
+    // All types below fundamental cardinal categorize with the same # of lanes
+    using enum eve::detail::category;
+    constexpr auto lanes =
+        static_cast<eve::detail::category>(eve::fundamental_cardinal_v<std::uint8_t>);
 
-  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), integer_  ));
-  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), unsigned_ ));
-  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), size8_    ));
-  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), uint_     ));
-  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), uint8     ));
-  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), lanes     ));
-  TTS_CONSTEXPR_EQUAL( eve::detail::categorize<T>(), uint8 | lanes    );
+    TTS_CONSTEXPR_EXPECT(match(eve::detail::categorize<T>(), integer_));
+    TTS_CONSTEXPR_EXPECT(match(eve::detail::categorize<T>(), unsigned_));
+    TTS_CONSTEXPR_EXPECT(match(eve::detail::categorize<T>(), size8_));
+    TTS_CONSTEXPR_EXPECT(match(eve::detail::categorize<T>(), uint_));
+    TTS_CONSTEXPR_EXPECT(match(eve::detail::categorize<T>(), uint8));
+    TTS_CONSTEXPR_EXPECT(match(eve::detail::categorize<T>(), lanes));
+    TTS_CONSTEXPR_EQUAL(eve::detail::categorize<T>(), uint8 | lanes);
+  }
+  else { TTS_PASS("wide<uint8,N> is not native and therefore can't be categorized."); }
 };

--- a/test/unit/internals/category.cpp
+++ b/test/unit/internals/category.cpp
@@ -1,0 +1,182 @@
+//==================================================================================================
+/*
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+*/
+//==================================================================================================
+#include "test.hpp"
+#include <eve/detail/category.hpp>
+
+template<typename T, typename Cardinals>
+struct natives_impl;
+
+template<typename T, std::size_t... N>
+struct natives_impl<T, std::index_sequence<N...>>
+{
+  using types_list = tts::types< eve::wide<T, eve::fixed<(1<<N)>>...>;
+};
+
+template<typename T> struct natives
+: natives_impl< T
+              , std::make_index_sequence<std::bit_width(std::size_t(eve::fundamental_cardinal_v<T>))>
+              >
+{};
+
+TTS_CASE_TPL("Test category matching for double", natives<double> )
+<typename T>( tts::type<T> )
+{
+  // All types below fundamental cardinal categorize with the same # of lanes
+  using enum eve::detail::category;
+  constexpr auto lanes  = static_cast<eve::detail::category>(eve::fundamental_cardinal_v<double>);
+
+  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), float_  ));
+  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), signed_ ));
+  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), size64_ ));
+  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), float64 ));
+  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), lanes   ));
+  TTS_CONSTEXPR_EQUAL( eve::detail::categorize<T>(), float64 | lanes);
+};
+
+TTS_CASE_TPL("Test category matching for std::int64", natives<std::int64_t> )
+<typename T>( tts::type<T> )
+{
+  // All types below fundamental cardinal categorize with the same # of lanes
+  using enum eve::detail::category;
+  constexpr auto lanes  = static_cast<eve::detail::category>(eve::fundamental_cardinal_v<std::int64_t>);
+
+  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), integer_  ));
+  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), signed_   ));
+  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), size64_   ));
+  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), int_      ));
+  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), int64     ));
+  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), lanes     ));
+  TTS_CONSTEXPR_EQUAL( eve::detail::categorize<T>(), int64 | lanes    );
+};
+
+TTS_CASE_TPL("Test category matching for std::uint64", natives<std::uint64_t> )
+<typename T>( tts::type<T> )
+{
+  // All types below fundamental cardinal categorize with the same # of lanes
+  using enum eve::detail::category;
+  constexpr auto lanes  = static_cast<eve::detail::category>(eve::fundamental_cardinal_v<std::uint64_t>);
+
+  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), integer_  ));
+  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), unsigned_ ));
+  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), size64_   ));
+  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), uint_     ));
+  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), uint64    ));
+  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), lanes     ));
+  TTS_CONSTEXPR_EQUAL( eve::detail::categorize<T>(), uint64 | lanes   );
+};
+
+TTS_CASE_TPL("Test category matching for float", natives<float> )
+<typename T>( tts::type<T> )
+{
+  // All types below fundamental cardinal categorize with the same # of lanes
+  using enum eve::detail::category;
+  constexpr auto lanes  = static_cast<eve::detail::category>(eve::fundamental_cardinal_v<float>);
+
+  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), float_  ));
+  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), signed_ ));
+  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), size32_ ));
+  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), float32 ));
+  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), lanes   ));
+  TTS_CONSTEXPR_EQUAL( eve::detail::categorize<T>(), float32 | lanes);
+};
+
+TTS_CASE_TPL("Test category matching for std::int32", natives<std::int32_t> )
+<typename T>( tts::type<T> )
+{
+  // All types below fundamental cardinal categorize with the same # of lanes
+  using enum eve::detail::category;
+  constexpr auto lanes  = static_cast<eve::detail::category>(eve::fundamental_cardinal_v<std::int32_t>);
+
+  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), integer_));
+  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), signed_ ));
+  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), size32_ ));
+  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), int_    ));
+  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), int32   ));
+  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), lanes   ));
+  TTS_CONSTEXPR_EQUAL( eve::detail::categorize<T>(), int32 | lanes  );
+};
+
+TTS_CASE_TPL("Test category matching for std::uint32", natives<std::uint32_t> )
+<typename T>( tts::type<T> )
+{
+  // All types below fundamental cardinal categorize with the same # of lanes
+  using enum eve::detail::category;
+  constexpr auto lanes  = static_cast<eve::detail::category>(eve::fundamental_cardinal_v<std::uint32_t>);
+
+  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), integer_  ));
+  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), unsigned_ ));
+  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), size32_   ));
+  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), uint_     ));
+  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), uint32    ));
+  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), lanes     ));
+  TTS_CONSTEXPR_EQUAL( eve::detail::categorize<T>(), uint32 | lanes   );
+};
+
+TTS_CASE_TPL("Test category matching for std::int16", natives<std::int16_t> )
+<typename T>( tts::type<T> )
+{
+  // All types below fundamental cardinal categorize with the same # of lanes
+  using enum eve::detail::category;
+  constexpr auto lanes  = static_cast<eve::detail::category>(eve::fundamental_cardinal_v<std::int16_t>);
+
+  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), integer_));
+  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), signed_ ));
+  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), size16_ ));
+  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), int_    ));
+  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), int16   ));
+  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), lanes   ));
+  TTS_CONSTEXPR_EQUAL( eve::detail::categorize<T>(), int16 | lanes  );
+};
+
+TTS_CASE_TPL("Test category matching for std::uint16", natives<std::uint16_t> )
+<typename T>( tts::type<T> )
+{
+  // All types below fundamental cardinal categorize with the same # of lanes
+  using enum eve::detail::category;
+  constexpr auto lanes  = static_cast<eve::detail::category>(eve::fundamental_cardinal_v<std::uint16_t>);
+
+  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), integer_  ));
+  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), unsigned_ ));
+  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), size16_   ));
+  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), uint_     ));
+  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), uint16    ));
+  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), lanes     ));
+  TTS_CONSTEXPR_EQUAL( eve::detail::categorize<T>(), uint16 | lanes   );
+};
+
+TTS_CASE_TPL("Test category matching for std::int8", natives<std::int8_t> )
+<typename T>( tts::type<T> )
+{
+  // All types below fundamental cardinal categorize with the same # of lanes
+  using enum eve::detail::category;
+  constexpr auto lanes  = static_cast<eve::detail::category>(eve::fundamental_cardinal_v<std::int8_t>);
+
+  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), integer_));
+  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), signed_ ));
+  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), size8_  ));
+  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), int_    ));
+  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), int8    ));
+  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), lanes   ));
+  TTS_CONSTEXPR_EQUAL( eve::detail::categorize<T>(), int8 | lanes   );
+};
+
+TTS_CASE_TPL("Test category matching for std::uint8", natives<std::uint8_t> )
+<typename T>( tts::type<T> )
+{
+  // All types below fundamental cardinal categorize with the same # of lanes
+  using enum eve::detail::category;
+  constexpr auto lanes  = static_cast<eve::detail::category>(eve::fundamental_cardinal_v<std::uint8_t>);
+
+  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), integer_  ));
+  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), unsigned_ ));
+  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), size8_    ));
+  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), uint_     ));
+  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), uint8     ));
+  TTS_CONSTEXPR_EXPECT( match(eve::detail::categorize<T>(), lanes     ));
+  TTS_CONSTEXPR_EQUAL( eve::detail::categorize<T>(), uint8 | lanes    );
+};


### PR DESCRIPTION
Clarify bit values for category to ensure match works all the time and operator&& can be removed.