### PR TITLE
Make unit.core.exe compile with MSVC

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -111,12 +111,14 @@ jobs:
           cmake --build . --target unit.arch.exe      --config ${{ matrix.cfg.mode }} --parallel 2
           cmake --build . --target unit.meta.exe      --config ${{ matrix.cfg.mode }} --parallel 2
           cmake --build . --target unit.internals.exe --config ${{ matrix.cfg.mode }} --parallel 2
+          cmake --build . --target unit.core.exe      --config ${{ matrix.cfg.mode }} --parallel 2
       - name: Running Tests
         run: |
           cd build
           ctest -C ${{ matrix.cfg.mode }} --output-on-failure -R ^unit.arch.*.exe
           ctest -C ${{ matrix.cfg.mode }} --output-on-failure -R ^unit.meta.*.exe
           ctest -C ${{ matrix.cfg.mode }} --output-on-failure -R ^unit.internals.*.exe
+          ctest -C ${{ matrix.cfg.mode }} --output-on-failure -R ^unit.core.*.exe
 
   avx512:
     runs-on: [self-hosted, avx512]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,6 @@ endif()
 ## =================================================================================================
 if( EVE_BUILD_TEST )
   include(config/dependencies)
-  include(CTest)
   include(target/add_parent_target)
   include(config/compiler)
   include(config/types)

--- a/test/unit/module/core/constants.cpp
+++ b/test/unit/module/core/constants.cpp
@@ -8,6 +8,9 @@
 #include "test.hpp"
 
 #include <eve/module/core.hpp>
+#include <eve/module/math/regular/exp2.hpp>
+
+#include <limits>
 
 TTS_CASE_TPL("Check basic constants behavior", eve::test::simd::ieee_reals)
 <typename T>(tts::type<T>)
@@ -23,7 +26,7 @@ TTS_CASE_TPL("Check basic constants behavior", eve::test::simd::ieee_reals)
 
   if constexpr( eve::floating_value<T> )
   {
-    TTS_IEEE_EQUAL(eve::allbits(as<T>()), T(0.0 / 0.0));
+    TTS_IEEE_EQUAL(eve::allbits(as<T>()), T(std::numeric_limits<double>::quiet_NaN()));
     TTS_EQUAL(eve::mzero(as<T>()), T(-0));
     TTS_EQUAL(eve::half(as<T>()), T(0.5));
     TTS_EQUAL(eve::mhalf(as<T>()), T(-0.5));
@@ -40,7 +43,7 @@ TTS_CASE_TPL("Check ieee754 constants", eve::test::simd::ieee_reals)
   using ilt_t = eve::as_integer_t<elt_t>;
   using i_t   = eve::as_integer_t<T, signed>;
   TTS_EQUAL(eve::bitincrement(as<T>()), T(eve::bit_cast(eve::one(as<ilt_t>()), as<elt_t>())));
-  TTS_IEEE_EQUAL(eve::nan(as<T>()), T(0.0 / 0.0));
+  TTS_IEEE_EQUAL(eve::nan(as<T>()), T(std::numeric_limits<double>::quiet_NaN()));
   TTS_EQUAL(eve::signmask(as<T>()),
             T(eve::bit_cast(eve::one(as<ilt_t>()) << (sizeof(ilt_t) * 8 - 1), as<elt_t>())));
   TTS_EQUAL(eve::mindenormal(as<T>()), eve::bitincrement(as<T>()));

--- a/test/unit/module/core/frexp.cpp
+++ b/test/unit/module/core/frexp.cpp
@@ -8,6 +8,7 @@
 #include "test.hpp"
 
 #include <eve/module/core.hpp>
+#include <eve/module/math/constant/minlog2denormal.hpp>
 
 #include <cmath>
 #include <tuple>

--- a/test/unit/module/core/hi.cpp
+++ b/test/unit/module/core/hi.cpp
@@ -34,7 +34,7 @@ TTS_CASE_WITH("Check behavior of hi(wide) on unsigned integral ",
 {
   using v_t       = eve::element_type_t<T>;
   using d_t       = eve::detail::downgrade_t<v_t>;
-  constexpr int s = sizeof(v_t) * 4;
+  static constexpr int s = sizeof(v_t) * 4;
   if constexpr( s == 4 )
   {
     TTS_EQUAL(eve::hi(a0), map([&](auto e) -> v_t { return d_t(eve::shr(e, s)); }, a0));

--- a/test/unit/module/core/lo.cpp
+++ b/test/unit/module/core/lo.cpp
@@ -34,7 +34,7 @@ TTS_CASE_WITH("Check behavior of lo(wide) on unsigned integral ",
 {
   using v_t       = eve::element_type_t<T>;
   using d_t       = eve::detail::downgrade_t<v_t>;
-  constexpr int s = sizeof(v_t) * 4;
+  static constexpr int s = sizeof(v_t) * 4;
   if constexpr( s == 4 )
   {
     TTS_EQUAL(eve::lo(a0),

--- a/test/unit/module/core/scan.cpp
+++ b/test/unit/module/core/scan.cpp
@@ -10,7 +10,7 @@
 
 #include <eve/module/core.hpp>
 
-#include <algorithm>
+#include <numeric>
 #include <array>
 
 template<typename T, typename Op>


### PR DESCRIPTION
* I slightly altered the logic of `value_type_t` it now prefers nested `T::value_type` over range/iterator. Not sure whether this will have a negative effect on the other modules.
* I had to add includes for frexp and exp2 to two of the tests, not sure whether it is supposed to be like that.
* `include(CTest)` is not necessary to run tests with ctest, it just clutters the project with unnecessary targets.
* [std::inclusive_scan](https://en.cppreference.com/w/cpp/algorithm/inclusive_scan) is in fact in the header <numeric> and not <algorithm>

There is also an issue in https://github.com/jfalcou/tts/blob/main/include/tts/tts.hpp#L943 which can create a `std::uniform_int_distribution<uint64_t>` from -10 to +10 which become 18446744073709551606 to 10, which triggers an assertion in MSVC:

```
_STL_ASSERT(_Min0 <= _Max0, "invalid min and max arguments for uniform_int");
```

Resolves a part of https://github.com/jfalcou/eve/issues/1236