### PR TITLE
Complete #1144 fixes

### DIFF
--- a/examples/algorithms/writing_new/collect_indexes__complicated_real_example.cpp
+++ b/examples/algorithms/writing_new/collect_indexes__complicated_real_example.cpp
@@ -93,7 +93,7 @@ void collect_indexes(R&& r, P p, std::vector<IdxType, Alloc>& res)
         auto test = p(elems);
 
         // We don't know what was the result of applying a predicate to garbage, we need to mask it.
-        test = eve::replace_ignored(test, ignore, false);
+        test = eve::replace_ignored(test, ignore, eve::false_);
 
         // unsafe(compress_store) - write elements marked as true to the output.
         // the elements are packed together to the left.

--- a/include/eve/arch/cpu/logical_wide.hpp
+++ b/include/eve/arch/cpu/logical_wide.hpp
@@ -128,6 +128,10 @@ namespace eve
     EVE_FORCEINLINE explicit logical(S v) noexcept
                   : storage_base(detail::make(eve::as<logical>{}, v)) {}
 
+    //! Construct from a `bool`
+    EVE_FORCEINLINE explicit logical(bool v) noexcept
+                  : storage_base(detail::make(eve::as<logical>{}, v)) {}
+
     //! Constructs a eve::logical from a sequence of scalar values of proper size
     template<typename T0, typename T1, typename... Ts>
     EVE_FORCEINLINE logical(T0 const &v0, T1 const &v1, Ts const &... vs) noexcept
@@ -319,7 +323,7 @@ namespace eve
     //! @{
     //==============================================================================================
     //! Set the value of a given lane
-    EVE_FORCEINLINE void set(std::size_t i, scalar_value auto v) noexcept
+    EVE_FORCEINLINE void set(std::size_t i, std::convertible_to<bool> auto v) noexcept
     {
       detail::insert(*this, i, v);
     }

--- a/include/eve/arch/cpu/wide.hpp
+++ b/include/eve/arch/cpu/wide.hpp
@@ -146,13 +146,16 @@ namespace eve
     {}
 
     //! Constructs a eve::wide from a sequence of scalar values of proper size
-    template<typename S0, typename S1, typename... Ss>
+    template<scalar_value S0, scalar_value S1, scalar_value... Ss>
     EVE_FORCEINLINE wide(S0 v0, S1 v1, Ss... vs) noexcept
         requires( (Cardinal::value == 2 + sizeof...(vs))
-                  && std::constructible_from<Type,S0>
-                  && (std::constructible_from<Type,S1> && ... && std::constructible_from<Type,Ss>)
+                  && std::is_convertible_v<S0,Type>
+                  && (std::is_convertible_v<S1, Type> && ... && std::is_convertible_v<Ss, Type>)
                 )
-        : storage_base(detail::make(eve::as<wide>{},Type(v0),Type(v1),Type(vs)...))
+        : storage_base(detail::make(eve::as<wide> {},
+                                    static_cast<Type>(v0),
+                                    static_cast<Type>(v1),
+                                    static_cast<Type>(vs)...))
     {}
 
     //! Constructs a eve::wide from a sequence of values

--- a/include/eve/arch/cpu/wide.hpp
+++ b/include/eve/arch/cpu/wide.hpp
@@ -139,7 +139,7 @@ namespace eve
     {}
 
     //! Constructs a eve::wide by splatting a scalar value in all lanes
-    template<scalar_value S>
+    template<std::convertible_to<Type> S>
     requires requires(S v) { static_cast<Type>(v); }
     EVE_FORCEINLINE explicit wide(S const& v) noexcept
         : storage_base(detail::make(eve::as<wide> {}, static_cast<Type>(v)))

--- a/include/eve/arch/cpu/wide.hpp
+++ b/include/eve/arch/cpu/wide.hpp
@@ -139,23 +139,20 @@ namespace eve
     {}
 
     //! Constructs a eve::wide by splatting a scalar value in all lanes
-    template<std::convertible_to<Type> S>
-    requires requires(S v) { static_cast<Type>(v); }
+    template<typename S>
+    requires std::constructible_from<Type,S>
     EVE_FORCEINLINE explicit wide(S const& v) noexcept
-        : storage_base(detail::make(eve::as<wide> {}, static_cast<Type>(v)))
+        : storage_base(detail::make(eve::as<wide>{}, Type(v)))
     {}
 
     //! Constructs a eve::wide from a sequence of scalar values of proper size
-    template<scalar_value S0, scalar_value S1, scalar_value... Ss>
+    template<typename S0, typename S1, typename... Ss>
     EVE_FORCEINLINE wide(S0 v0, S1 v1, Ss... vs) noexcept
         requires( (Cardinal::value == 2 + sizeof...(vs))
-                  && std::is_convertible_v<S0,Type>
-                  && (std::is_convertible_v<S1, Type> && ... && std::is_convertible_v<Ss, Type>)
+                  && std::constructible_from<Type,S0>
+                  && (std::constructible_from<Type,S1> && ... && std::constructible_from<Type,Ss>)
                 )
-        : storage_base(detail::make(eve::as<wide> {},
-                                    static_cast<Type>(v0),
-                                    static_cast<Type>(v1),
-                                    static_cast<Type>(vs)...))
+        : storage_base(detail::make(eve::as<wide>{},Type(v0),Type(v1),Type(vs)...))
     {}
 
     //! Constructs a eve::wide from a sequence of values

--- a/include/eve/concept/scalar.hpp
+++ b/include/eve/concept/scalar.hpp
@@ -18,17 +18,15 @@
 namespace eve
 {
 template<typename T>
-concept plain_scalar_value = detail::one_of<T,
-                                            float,
-                                            double,
-                                            std::int8_t,
-                                            std::int16_t,
-                                            std::int32_t,
-                                            std::int64_t,
-                                            std::uint8_t,
-                                            std::uint16_t,
-                                            std::uint32_t,
-                                            std::uint64_t>;
+concept   plain_scalar_value
+        = detail::one_of<T
+                        , float, double
+                        , std::int8_t   , std::int16_t , std::int32_t , std::int64_t
+                        , std::uint8_t  , std::uint16_t, std::uint32_t, std::uint64_t
+                        , decltype(0ULL), decltype(0UL), decltype(0U)
+                        , decltype(0LL) , decltype(0L) , decltype(0)
+                        , std::ptrdiff_t, std::size_t
+                        >;
 
 namespace detail
 {

--- a/include/eve/concept/scalar.hpp
+++ b/include/eve/concept/scalar.hpp
@@ -19,14 +19,8 @@ namespace eve
 {
 template<typename T>
 concept   plain_scalar_value
-        = detail::one_of<T
-                        , float, double
-                        , std::int8_t   , std::int16_t , std::int32_t , std::int64_t
-                        , std::uint8_t  , std::uint16_t, std::uint32_t, std::uint64_t
-                        , decltype(0ULL), decltype(0UL), decltype(0U)
-                        , decltype(0LL) , decltype(0L) , decltype(0)
-                        , std::ptrdiff_t, std::size_t
-                        >;
+        =  !(std::is_same_v<T, bool> || std::is_same_v<T, long double>)
+        &&  (std::is_floating_point_v<T> || std::is_integral_v<T>);
 
 namespace detail
 {

--- a/include/eve/concept/vectorizable.hpp
+++ b/include/eve/concept/vectorizable.hpp
@@ -7,52 +7,9 @@
 //==================================================================================================
 #pragma once
 
-#include <eve/detail/kumi.hpp>
-#include <eve/detail/wide_forward.hpp>
-#include <eve/traits/element_type.hpp>
-#include <eve/traits/is_logical.hpp>
 #include <eve/concept/logical.hpp>
-
+#include <eve/concept/scalar.hpp>
 #include <concepts>
-#include <type_traits>
-#include <utility>
-
-namespace eve::detail
-{
-  //================================================================================================
-  // Check if something is a scalar_value
-  //================================================================================================
-
-  //================================================================================================
-  // Case #1 - it is arithmetic
-  //================================================================================================
-  template<typename T> struct is_scalar_value : std::is_arithmetic<T>
-  {};
-
-  //================================================================================================
-  // Case #2 - it is a product_type of arithmetic
-  //================================================================================================
-  template<typename T>
-  static constexpr bool check_tuple()
-  {
-    return []<std::size_t... I>( std::index_sequence<I...> )
-    {
-      return ( is_scalar_value<kumi::element_t<I,T>>::value && ... && true );
-    }(std::make_index_sequence<kumi::size<T>::value>{});
-  }
-
-  template<typename T>
-  requires( kumi::product_type<T> )
-  struct  is_scalar_value<T> : std::bool_constant< check_tuple<T>() >
-  {};
-
-  //================================================================================================
-  // Case #3 - it is a logical
-  //================================================================================================
-  template<typename T>
-  struct is_scalar_value<eve::logical<T>> : std::is_arithmetic<T>
-  {};
-}
 
 namespace eve
 {
@@ -60,15 +17,16 @@ namespace eve
   //! @concept scalar_value
   //! @brief Specify that a type represents a scalar value
   //!
-  //! The concept `scalar_value<T>` is satisfied if and only if it is arithmetic or a product type
-  //! which types satisfies scalar_value themselves.
+  //! The concept `scalar_value<T>` is satisfied if and only if it satisfies either
+  //! arithmetic_scalar_value or logical_scalar_value.
   //!
   //! @groupheader{Examples}
   //! - `float`
-  //! - `std::int32_t`
+  //! - `logical<std::int32_t>`
+  //! - `kumi::tuple<double,std::int32_t>`
   //================================================================================================
   template<typename T>
-  concept scalar_value = detail::is_scalar_value<T>::value;
+  concept scalar_value = arithmetic_scalar_value<T> || logical_scalar_value<T>;
 
   //================================================================================================
   //! @concept integral_scalar_value
@@ -106,18 +64,21 @@ namespace eve
   //! @groupheader{Examples}
   //! - `std::uint32_t`
   //================================================================================================
-  template<typename T> concept unsigned_scalar_value          = scalar_value<T> && std::unsigned_integral<T>;
+  template<typename T>
+  concept unsigned_scalar_value = scalar_value<T> && std::unsigned_integral<T>;
 
   //================================================================================================
   //! @concept signed_integral_scalar_value
   //! @brief Specify that a type represents a scalar value
   //!
-  //! The concept `unsigned_integral_scalar_value<T>` is satisfied if and only if T is signed,  integral and scalar_value
+  //! The concept `unsigned_integral_scalar_value<T>` is satisfied if and only if T is signed,
+  //! integral and scalar_value
   //!
   //! @groupheader{Examples}
   //! - `std::int32_t`
   //================================================================================================
-  template<typename T> concept signed_integral_scalar_value   = scalar_value<T> && std::signed_integral<T>;
+  template<typename T>
+  concept signed_integral_scalar_value   = scalar_value<T> && std::signed_integral<T>;
 
   //================================================================================================
   //! @concept floating_scalar_value
@@ -129,5 +90,6 @@ namespace eve
   //! - `float`
   //! - `double`
   //================================================================================================
-  template<typename T> concept floating_scalar_value          = scalar_value<T> && std::floating_point<T>;
+  template<typename T>
+  concept floating_scalar_value = scalar_value<T> && std::floating_point<T>;
 }

--- a/include/eve/concept/vectorizable.hpp
+++ b/include/eve/concept/vectorizable.hpp
@@ -33,63 +33,65 @@ namespace eve
   //! @brief Specify that a type represents an integral scalar value
   //!
   //! The concept `integral_scalar_value<T>` is satisfied if and only if T satisfies
-  //! `eve::scalar_value<T>` and `std::integral<T>`.
+  //! `eve::arithmetic_scalar_value<T>` and `std::integral<T>`.
   //!
   //! @groupheader{Examples}
   //! - `std::int32_t`
   //================================================================================================
   template<typename T>
-  concept integral_scalar_value  = scalar_value<T> && std::integral<T>;
+  concept integral_scalar_value  = arithmetic_scalar_value<T> && std::integral<T>;
 
   //================================================================================================
   //! @concept signed_scalar_value
   //! @brief Specify that a type represents a signed scalar value
   //!
-  //! The concept `signed_scalar_value<T>` is satisfied if and only if T  satisfies
-  //! `eve::scalar_value<T>` and `std::integral<T>`.
+  //! The concept `signed_scalar_value<T>` is satisfied if and only if T satisfies
+  //! `eve::arithmetic_scalar_value<T>` and `std::integral<T>`.
   //!
   //! @groupheader{Examples}
   //! - `std::int32_t`
   //! - `float`
   //================================================================================================
   template<typename T>
-  concept signed_scalar_value  = scalar_value<T> && std::is_signed_v<T>;
+  concept signed_scalar_value  = arithmetic_scalar_value<T> && std::is_signed_v<T>;
 
   //================================================================================================
   //! @concept unsigned_scalar_value
   //! @brief Specify that a type represents a scalar value
   //!
-  //! The concept `unsigned_scalar_value<T>` is satisfied if and only if T is unsigned and scalar_value
+  //! The concept `unsigned_scalar_value<T>` is satisfied if and only if T satisfies
+  //! `eve::arithmetic_scalar_value<T>` and `std::unsigned_integral<T>`.
   //!
   //! @groupheader{Examples}
   //! - `std::uint32_t`
   //================================================================================================
   template<typename T>
-  concept unsigned_scalar_value = scalar_value<T> && std::unsigned_integral<T>;
+  concept unsigned_scalar_value = arithmetic_scalar_value<T> && std::unsigned_integral<T>;
 
   //================================================================================================
   //! @concept signed_integral_scalar_value
   //! @brief Specify that a type represents a scalar value
   //!
-  //! The concept `signed_integral_scalar_value<T>` is satisfied if and only if T is signed,
-  //! integral and scalar_value
+  //! The concept `unsigned_scalar_value<T>` is satisfied if and only if T satisfies
+  //! `eve::arithmetic_scalar_value<T>` and `std::signed_integral<T>`.
   //!
   //! @groupheader{Examples}
   //! - `std::int32_t`
   //================================================================================================
   template<typename T>
-  concept signed_integral_scalar_value   = scalar_value<T> && std::signed_integral<T>;
+  concept signed_integral_scalar_value = arithmetic_scalar_value<T> && std::signed_integral<T>;
 
   //================================================================================================
   //! @concept floating_scalar_value
   //! @brief Specify that a type represents a scalar value
   //!
-  //! The concept `floating_scalar_value<T>` is satisfied if and only if T is floating_point and scalar_value
+  //! The concept `unsigned_scalar_value<T>` is satisfied if and only if T satisfies
+  //! `eve::arithmetic_scalar_value<T>` and `std::floating_point<T>`.
   //!
   //! @groupheader{Examples}
   //! - `float`
   //! - `double`
   //================================================================================================
   template<typename T>
-  concept floating_scalar_value = scalar_value<T> && std::floating_point<T>;
+  concept floating_scalar_value = arithmetic_scalar_value<T> && std::floating_point<T>;
 }

--- a/include/eve/concept/vectorizable.hpp
+++ b/include/eve/concept/vectorizable.hpp
@@ -71,7 +71,7 @@ namespace eve
   //! @concept signed_integral_scalar_value
   //! @brief Specify that a type represents a scalar value
   //!
-  //! The concept `unsigned_integral_scalar_value<T>` is satisfied if and only if T is signed,
+  //! The concept `signed_integral_scalar_value<T>` is satisfied if and only if T is signed,
   //! integral and scalar_value
   //!
   //! @groupheader{Examples}

--- a/include/eve/concept/vectorized.hpp
+++ b/include/eve/concept/vectorized.hpp
@@ -30,7 +30,7 @@ namespace eve
   // !   - `eve::wide<int, eve::fixed<1>>`
   //================================================================================================
   template<typename T>
-  concept simd_value = !std::same_as<eve::cardinal_t<T>, scalar_cardinal>;
+  concept simd_value = arithmetic_simd_value<T> || logical_simd_value<T>;
 
   //================================================================================================
   //!   @concept integral_simd_value
@@ -44,15 +44,12 @@ namespace eve
   //!    - `eve::wide<int, eve::fixed<1>>`
   //================================================================================================
   template<typename T>
-  concept integral_simd_value        = simd_value<T> && std::integral<element_type_t<T>>;
+  concept integral_simd_value = simd_value<T> && std::integral<element_type_t<T>>;
 
   template<typename T> concept signed_simd_value          = simd_value<T> && std::is_signed_v<element_type_t<T>>;
   template<typename T> concept unsigned_simd_value        = simd_value<T> && std::unsigned_integral<element_type_t<T>>;
   template<typename T> concept signed_integral_simd_value = simd_value<T> && std::signed_integral<element_type_t<T>>;
   template<typename T> concept floating_simd_value        = simd_value<T> && std::floating_point<element_type_t<T>>;
-  template<typename T> concept real_simd_value            = simd_value<T> && std::is_arithmetic_v<element_type_t<T>>;
-  template<typename T> concept floating_real_simd_value   = real_simd_value<T> && std::floating_point<element_type_t<T>>;
-  template<typename T> concept integral_real_simd_value   = real_simd_value<T> && std::integral<element_type_t<T>>;
 
   template<typename T> struct is_simd_value : std::bool_constant<simd_value<T>> {};
 }

--- a/include/eve/concept/vectorized.hpp
+++ b/include/eve/concept/vectorized.hpp
@@ -18,38 +18,91 @@
 namespace eve
 {
   //================================================================================================
-  //!   @concept simd_value
-  //!   @brief    Specifies that a type a SIMD type
+  //! @concept simd_value
+  //! @brief   Specifies that a type a SIMD type
   //!
-  //!    The concept `simd_value<T>` is satisfied if and only if T verifies that
-  //!    `std::is_same_v<cardinal_t<T>,scalar_cardinal> == false`.
+  //! The concept `simd_value<T>` is satisfied if and only if T satisfies either
+  //! `eve::arithmetic_simd_value` or `eve::logical_simd_value`.
   //!
-  //!    @groupheader{Examples}
-  //!    - `eve::logical<eve::wide<char>>`
-  //!    - `eve::wide<float>`
-  // !   - `eve::wide<int, eve::fixed<1>>`
+  //! @groupheader{Examples}
+  //!   - `eve::logical<eve::wide<short>>`
+  //!   - `eve::wide<float>`
+  //!   - `eve::wide<int, eve::fixed<1>>`
   //================================================================================================
   template<typename T>
   concept simd_value = arithmetic_simd_value<T> || logical_simd_value<T>;
 
   //================================================================================================
-  //!   @concept integral_simd_value
-  //!   @brief    Specifies that a type a SIMD type with integral elements
+  //! @concept integral_simd_value
+  //! @brief   Specifies that a type a SIMD type with integral elements
   //!
-  //!    The concept `integral_simd_value<T>` is satisfied if and only if T satisfies
-  //!    `eve::simd_value<T>` and `std::integral<` `eve::element_type<T>::``type>`.
+  //! The concept `integral_simd_value<T>` is satisfied if and only if T satisfies
+  //! `eve::arithmetic_simd_value<T>` and `eve::element_type<T>` satisfies `std::integral`.
   //!
-  //!    @groupheader{Examples}
-  //!    - `eve::logical<eve::wide<char>>`
-  //!    - `eve::wide<int, eve::fixed<1>>`
+  //! @groupheader{Examples}
+  //!  - `eve::logical<eve::wide<short>>`
+  //!  - `eve::wide<unsigned int, eve::fixed<1>>`
   //================================================================================================
   template<typename T>
-  concept integral_simd_value = simd_value<T> && std::integral<element_type_t<T>>;
+  concept integral_simd_value = arithmetic_simd_value<T> && std::integral<element_type_t<T>>;
 
-  template<typename T> concept signed_simd_value          = simd_value<T> && std::is_signed_v<element_type_t<T>>;
-  template<typename T> concept unsigned_simd_value        = simd_value<T> && std::unsigned_integral<element_type_t<T>>;
-  template<typename T> concept signed_integral_simd_value = simd_value<T> && std::signed_integral<element_type_t<T>>;
-  template<typename T> concept floating_simd_value        = simd_value<T> && std::floating_point<element_type_t<T>>;
+  //================================================================================================
+  //! @concept signed_simd_value
+  //! @brief   Specifies that a type a SIMD type with signed elements
+  //!
+  //! The concept `integral_simd_value<T>` is satisfied if and only if T satisfies
+  //! `eve::arithmetic_simd_value<T>` and `eve::element_type<T>` is signed.
+  //!
+  //! @groupheader{Examples}
+  //!  - `eve::logical<eve::wide<short>>`
+  //!  - `eve::wide<std::int64_t, eve::fixed<4>>`
+  //================================================================================================
+  template<typename T>
+  concept signed_simd_value = arithmetic_simd_value<T> && std::is_signed_v<element_type_t<T>>;
+
+  //================================================================================================
+  //! @concept unsigned_simd_value
+  //! @brief   Specifies that a type a SIMD type with unsigned elements
+  //!
+  //! The concept `unsigned_simd_value<T>` is satisfied if and only if T satisfies
+  //! `eve::arithmetic_simd_value<T>` and `eve::element_type<T>` satisfies `std::unsigned_integral`.
+  //!
+  //! @groupheader{Examples}
+  //!  - `eve::logical<eve::wide<unsigned int>>`
+  //!  - `eve::wide<std::uint8_t, eve::fixed<8>>`
+  //================================================================================================
+  template<typename T>
+  concept unsigned_simd_value =     arithmetic_simd_value<T>
+                                &&  std::unsigned_integral<element_type_t<T>>;
+
+  //================================================================================================
+  //! @concept signed_integral_simd_value
+  //! @brief   Specifies that a type a SIMD type with signed integral elements
+  //!
+  //! The concept `unsigned_simd_value<T>` is satisfied if and only if T satisfies
+  //! `eve::arithmetic_simd_value<T>` and `eve::element_type<T>` satisfies `std::signed_integral`.
+  //!
+  //! @groupheader{Examples}
+  //!  - `eve::logical<eve::wide<signed int>>`
+  //!  - `eve::wide<std::int16_t, eve::fixed<8>>`
+  //================================================================================================
+  template<typename T>
+  concept signed_integral_simd_value  =     arithmetic_simd_value<T>
+                                        &&  std::signed_integral<element_type_t<T>>;
+
+  //================================================================================================
+  //! @concept floating_simd_value
+  //! @brief   Specifies that a type a SIMD type with signed integral elements
+  //!
+  //! The concept `floating_simd_value<T>` is satisfied if and only if T satisfies
+  //! `eve::arithmetic_simd_value<T>` and `eve::element_type<T>` satisfies `std::floating_point`.
+  //!
+  //! @groupheader{Examples}
+  //!  - `eve::logical<eve::wide<signed int>>`
+  //!  - `eve::wide<std::int16_t, eve::fixed<8>>`
+  //================================================================================================
+  template<typename T>
+  concept floating_simd_value = arithmetic_simd_value<T> && std::floating_point<element_type_t<T>>;
 
   template<typename T> struct is_simd_value : std::bool_constant<simd_value<T>> {};
 }

--- a/include/eve/detail/function/simd/arm/neon/arithmetic_compounds.hpp
+++ b/include/eve/detail/function/simd/arm/neon/arithmetic_compounds.hpp
@@ -20,7 +20,7 @@ namespace eve::detail
   //================================================================================================
   // +=
   //================================================================================================
-  template<scalar_value T, value U, typename N>
+  template<plain_scalar_value T, value U, typename N>
   EVE_FORCEINLINE decltype(auto) self_add(wide<T, N> &self, U const &other) noexcept
       requires(scalar_value<U> || std::same_as<wide<T, N>, U>) && arm_abi<abi_t<T, N>>
   {
@@ -65,7 +65,7 @@ namespace eve::detail
   //================================================================================================
   // -=
   //================================================================================================
-  template<scalar_value T, value U, typename N>
+  template<plain_scalar_value T, value U, typename N>
   EVE_FORCEINLINE decltype(auto) self_sub(wide<T, N> &self, U const &other) noexcept
       requires(scalar_value<U> || std::same_as<wide<T, N>, U>) && arm_abi<abi_t<T, N>>
   {
@@ -110,7 +110,7 @@ namespace eve::detail
   //================================================================================================
   // *=
   //================================================================================================
-  template<scalar_value T, value U, typename N>
+  template<plain_scalar_value T, value U, typename N>
   EVE_FORCEINLINE decltype(auto) self_mul(wide<T, N> &self, U const &other) noexcept
       requires(scalar_value<U> || std::same_as<wide<T, N>, U>) && arm_abi<abi_t<T, N>>
   {
@@ -174,7 +174,7 @@ namespace eve::detail
   //================================================================================================
   // /=
   //================================================================================================
-  template<scalar_value T, value U, typename N>
+  template<plain_scalar_value T, value U, typename N>
   EVE_FORCEINLINE decltype(auto) self_div(wide<T, N> &self, U const &other) noexcept
       requires(scalar_value<U> || std::same_as<wide<T, N>, U>) && arm_abi<abi_t<T, N>>
   {

--- a/include/eve/detail/function/simd/arm/sve/arithmetic_compounds.hpp
+++ b/include/eve/detail/function/simd/arm/sve/arithmetic_compounds.hpp
@@ -13,7 +13,7 @@
 
 namespace eve::detail
 {
-template<scalar_value T, value U, typename N>
+template<plain_scalar_value T, value U, typename N>
 EVE_FORCEINLINE auto&
 self_add(wide<T, N>& self, U const& other) noexcept
 requires(scalar_value<U> || std::same_as<wide<T, N>, U>) && sve_abi<abi_t<T, N>>
@@ -22,7 +22,7 @@ requires(scalar_value<U> || std::same_as<wide<T, N>, U>) && sve_abi<abi_t<T, N>>
   return self;
 }
 
-template<scalar_value T, value U, typename N>
+template<plain_scalar_value T, value U, typename N>
 EVE_FORCEINLINE auto&
 self_sub(wide<T, N>& self, U const& other) noexcept
 requires(scalar_value<U> || std::same_as<wide<T, N>, U>) && sve_abi<abi_t<T, N>>
@@ -31,7 +31,7 @@ requires(scalar_value<U> || std::same_as<wide<T, N>, U>) && sve_abi<abi_t<T, N>>
   return self;
 }
 
-template<scalar_value T, value U, typename N>
+template<plain_scalar_value T, value U, typename N>
 EVE_FORCEINLINE auto&
 self_mul(wide<T, N>& self, U const& other) noexcept
 requires(scalar_value<U> || std::same_as<wide<T, N>, U>) && sve_abi<abi_t<T, N>>
@@ -40,7 +40,7 @@ requires(scalar_value<U> || std::same_as<wide<T, N>, U>) && sve_abi<abi_t<T, N>>
   return self;
 }
 
-template<scalar_value T, value U, typename N>
+template<plain_scalar_value T, value U, typename N>
 EVE_FORCEINLINE auto&
 self_div(wide<T, N>& self, U const& other) noexcept
 requires(scalar_value<U> || std::same_as<wide<T, N>, U>) && sve_abi<abi_t<T, N>>

--- a/include/eve/detail/function/simd/common/arithmetic_compounds.hpp
+++ b/include/eve/detail/function/simd/common/arithmetic_compounds.hpp
@@ -20,7 +20,7 @@ namespace eve::detail
   //================================================================================================
   // +=
   //================================================================================================
-  template<scalar_value T, value U, typename N>
+  template<plain_scalar_value T, value U, typename N>
   EVE_FORCEINLINE decltype(auto)
   self_add(wide<T, N> &self,
            U const &        other) requires(scalar_value<U> || std::same_as<wide<T, N>, U>)
@@ -49,7 +49,7 @@ namespace eve::detail
   //================================================================================================
   // -=
   //================================================================================================
-  template<scalar_value T, value U, typename N>
+  template<plain_scalar_value T, value U, typename N>
   EVE_FORCEINLINE decltype(auto)
   self_sub(wide<T, N> &self,
            U const &        other) requires(scalar_value<U> || std::same_as<wide<T, N>, U>)
@@ -76,7 +76,7 @@ namespace eve::detail
   //================================================================================================
   // *=
   //================================================================================================
-  template<scalar_value T, value U, typename N>
+  template<plain_scalar_value T, value U, typename N>
   EVE_FORCEINLINE decltype(auto)
   self_mul(wide<T, N> &self,
            U const &        other) requires(scalar_value<U> || std::same_as<wide<T, N>, U>)
@@ -103,7 +103,7 @@ namespace eve::detail
   //================================================================================================
   // /=
   //================================================================================================
-  template<scalar_value T, value U, typename N>
+  template<plain_scalar_value T, value U, typename N>
   EVE_FORCEINLINE decltype(auto)
   self_div(wide<T, N> &self,
            U const &        other) requires(scalar_value<U> || std::same_as<wide<T, N>, U>)

--- a/include/eve/detail/function/simd/common/to_logical.hpp
+++ b/include/eve/detail/function/simd/common/to_logical.hpp
@@ -51,7 +51,7 @@ template<scalar_value T>
 EVE_FORCEINLINE auto
 to_logical(T v) noexcept
 {
-  return logical<std::conditional_t<std::is_same_v<T, bool>, std::uint8_t, T>>(v);
+  return logical<T>(v);
 }
 
 template<relative_conditional_expr C, simd_value T>

--- a/include/eve/detail/function/simd/ppc/arithmetic_compounds.hpp
+++ b/include/eve/detail/function/simd/ppc/arithmetic_compounds.hpp
@@ -19,7 +19,7 @@ namespace eve::detail
   //================================================================================================
   // +=
   //================================================================================================
-  template<scalar_value T, value U, typename N>
+  template<plain_scalar_value T, value U, typename N>
   EVE_FORCEINLINE decltype(auto) self_add( wide<T, N>& self, U const& other )
   requires( scalar_value<U> || std::same_as<wide<T, N>, U> ) && ppc_abi<abi_t<T, N>>
   {
@@ -40,7 +40,7 @@ namespace eve::detail
   //================================================================================================
   // -=
   //================================================================================================
-  template<scalar_value T, value U, typename N>
+  template<plain_scalar_value T, value U, typename N>
   EVE_FORCEINLINE decltype(auto) self_sub( wide<T,N>& self, U const& other )
   requires( scalar_value<U> || std::same_as<wide<T, N>,U> ) && ppc_abi<abi_t<T, N>>
   {
@@ -61,7 +61,7 @@ namespace eve::detail
   //================================================================================================
   // *=
   //================================================================================================
-  template<scalar_value T, value U, typename N>
+  template<plain_scalar_value T, value U, typename N>
   EVE_FORCEINLINE decltype(auto) self_mul( wide<T,N>& self, U const& other )
   requires( scalar_value<U> || std::same_as<wide<T, N>,U> ) && ppc_abi<abi_t<T, N>>
   {
@@ -82,7 +82,7 @@ namespace eve::detail
   //================================================================================================
   // /=
   //================================================================================================
-  template<scalar_value T, value U, typename N>
+  template<plain_scalar_value T, value U, typename N>
   EVE_FORCEINLINE decltype(auto) self_div( wide<T, N>& self, U const& other )
   requires( scalar_value<U> || std::same_as<wide<T, N>,U> ) && ppc_abi<abi_t<T, N>>
   {

--- a/include/eve/detail/function/simd/x86/arithmetic_compounds.hpp
+++ b/include/eve/detail/function/simd/x86/arithmetic_compounds.hpp
@@ -18,7 +18,7 @@ namespace eve::detail
   //================================================================================================
   // +=
   //================================================================================================
-  template<scalar_value T, value U, typename N>
+  template<plain_scalar_value T, value U, typename N>
   EVE_FORCEINLINE decltype(auto) self_add(wide<T, N> &self, U const &other) noexcept
       requires(scalar_value<U> || std::same_as<wide<T, N>, U>) && x86_abi<abi_t<T, N>>
   {
@@ -81,7 +81,7 @@ namespace eve::detail
   //================================================================================================
   // -=
   //================================================================================================
-  template<scalar_value T, value U, typename N>
+  template<plain_scalar_value T, value U, typename N>
   EVE_FORCEINLINE decltype(auto) self_sub(wide<T, N> &self, U const &other) noexcept
       requires(scalar_value<U> || std::same_as<wide<T, N>, U>) && x86_abi<abi_t<T, N>>
   {
@@ -144,7 +144,7 @@ namespace eve::detail
   //================================================================================================
   // *=
   //================================================================================================
-  template<scalar_value T, value U, typename N>
+  template<plain_scalar_value T, value U, typename N>
   EVE_FORCEINLINE decltype(auto) self_mul(wide<T, N> &self, U const &other) noexcept
       requires(scalar_value<U> || std::same_as<wide<T, N>, U>) && x86_abi<abi_t<T, N>>
   {
@@ -228,7 +228,7 @@ namespace eve::detail
   //================================================================================================
   // /=
   //================================================================================================
-  template<scalar_value T, value U, typename N>
+  template<plain_scalar_value T, value U, typename N>
   EVE_FORCEINLINE decltype(auto) self_div(wide<T, N> &self, U const &other) noexcept
       requires(scalar_value<U> || std::same_as<wide<T, N>, U>) && x86_abi<abi_t<T, N>>
   {

--- a/include/eve/detail/overload.hpp
+++ b/include/eve/detail/overload.hpp
@@ -89,8 +89,16 @@ namespace tag { struct TAG {}; }                                                
         return callable_object_bind_recurse<callable_object, decltype(cond)>{cond};                \
       }                                                                                            \
                                                                                                    \
+      template<std::same_as<bool> T>                                                               \
+      EVE_FORCEINLINE constexpr auto operator[](T c) const noexcept                                \
+      requires( eve::supports_conditional<tag_type>::value )                                       \
+      {                                                                                            \
+        using type = std::conditional_t<std::same_as<bool,T>,std::uint8_t,T>;                      \
+        return (*this)[if_(logical<type>(c))];                                                     \
+      }                                                                                            \
+                                                                                                   \
       template<conditional_expr Condition>                                                         \
-      EVE_FORCEINLINE constexpr auto operator[](Condition c) const noexcept                 \
+      EVE_FORCEINLINE constexpr auto operator[](Condition c) const noexcept                        \
       requires( eve::supports_conditional<tag_type>::value )                                       \
       {                                                                                            \
         return callable_object_bind_recurse<callable_object, Condition>{c};                        \

--- a/include/eve/module/core/constant/as_value.hpp
+++ b/include/eve/module/core/constant/as_value.hpp
@@ -9,6 +9,7 @@
 
 #include <eve/as.hpp>
 #include <eve/concept/value.hpp>
+#include <eve/concept/invocable.hpp>
 #include <eve/detail/implementation.hpp>
 
 #include <concepts>
@@ -59,8 +60,8 @@ namespace detail
   template<typename From, value T>
   EVE_FORCEINLINE constexpr auto as_value_(EVE_SUPPORTS(cpu_), From from, as<T> const& t) noexcept
   {
-    if constexpr( !value<From> ) return from(t);
-    else if constexpr( std::integral<T> || std::floating_point<T> ) return (T)from;
+    if constexpr( instance_of<From,callable_object> ) return from(t);
+    else if constexpr( scalar_value<T> ) return static_cast<T>(from);
     else return T {from};
   }
 }

--- a/include/eve/module/core/regular/impl/if_else.hpp
+++ b/include/eve/module/core/regular/impl/if_else.hpp
@@ -96,6 +96,17 @@ if_else_(EVE_SUPPORTS(cpu_),
   }
 }
 
+// Supports bool as condition
+template<typename U, typename V>
+EVE_FORCEINLINE auto
+if_else_(EVE_SUPPORTS(cpu_),
+        bool cond,
+        U const& t,
+        V const& f) requires(compatible_values<U, V> || value<U> || value<V>)
+{
+  return if_else(logical<std::uint8_t>(cond),t,f);
+}
+
 //------------------------------------------------------------------------------------------------
 // Optimizes if_else(c,t,constant)
 template<value T, value U, generator<U> Constant>

--- a/include/eve/module/math/regular/impl/pow.hpp
+++ b/include/eve/module/math/regular/impl/pow.hpp
@@ -101,10 +101,10 @@ pow_(EVE_SUPPORTS(cpu_), T a0, U a1) noexcept
       T base = a0;
       U expo = a1;
 
-      T result(1);
+      auto result = one(as(a0));
       while( eve::any(to_logical(expo)) )
       {
-        result *= if_else(is_odd(expo), base, T(1));
+        result *= if_else(is_odd(expo), base, one(as(a0)));
         expo = (expo >> 1);
         base = sqr(base);
       }

--- a/include/eve/module/math/regular/impl/pow.hpp
+++ b/include/eve/module/math/regular/impl/pow.hpp
@@ -78,7 +78,7 @@ pow_(EVE_SUPPORTS(cpu_), T a0, U a1) noexcept
       T base = a0;
       U expo = a1;
 
-      T result(1);
+      auto result = one(as(a0));
       while( expo )
       {
         if( is_odd(expo) ) result *= base;

--- a/test/random/module/math/cotd.cpp
+++ b/test/random/module/math/cotd.cpp
@@ -14,7 +14,7 @@ TTS_CASE_TPL("Random check for eve::cotd", eve::test::simd::ieee_reals)
 <typename T>(tts::type<T>)
 {
   using e_t = eve::element_type_t<T>;
-  auto std_cotd = [](auto e) { return e_t(eve::rec(std::tan(1.7453292519943295769236907684886127134428718885417e-2l*(long double)e))); };
+  auto std_cotd = [](auto e) { return e_t(eve::rec(e_t(std::tan(1.7453292519943295769236907684886127134428718885417e-2l*(long double)e)))); };
   {
     auto vmin = e_t(-45.);
     auto vmax = e_t(45.);

--- a/test/unit/api/tuple/zip.cpp
+++ b/test/unit/api/tuple/zip.cpp
@@ -8,7 +8,6 @@
 #include "test.hpp"
 #include <eve/module/core.hpp>
 
-
 template<typename T>
 using tuple_t = kumi::tuple<std::int8_t,T,double>;
 
@@ -26,13 +25,14 @@ TTS_CASE_TPL( "Check eve::zip", eve::test::simd::all_types)
   using w1_t = std::tuple_element_t<1, s_t>;
   using w2_t = std::tuple_element_t<2, s_t>;
 
-  w0_t w8{'z'};
+  std::int8_t z = 'z';
+  w0_t w8{z};
   w1_t wt{e_t{45}};
   w2_t wd{13.37};
 
-  TTS_EQUAL(w_t(tuple_t<e_t>{ 'z', e_t{45}, 13.37 }), eve::zip(eve::as<tuple_t<e_t>>(), w8,wt,wd));
-  TTS_EQUAL(w_t(tuple_t<e_t>{ 'z', e_t{45}, 13.37 }), eve::zip(w8,wt,wd));
+  TTS_EQUAL(w_t(tuple_t<e_t>{ z, e_t{45}, 13.37 }), eve::zip(eve::as<tuple_t<e_t>>(), w8,wt,wd));
+  TTS_EQUAL(w_t(tuple_t<e_t>{ z, e_t{45}, 13.37 }), eve::zip(w8,wt,wd));
 
-  TTS_EQUAL((tuple_t<e_t>{ 'z', e_t{45}, 13.37 }), eve::zip(eve::as<tuple_t<e_t>>(), 'z', e_t{45}, 13.37));
-  TTS_EQUAL((tuple_t<e_t>{ 'z', e_t{45}, 13.37 }), eve::zip('z', e_t{45}, 13.37));
+  TTS_EQUAL((tuple_t<e_t>{ z, e_t{45}, 13.37 }), eve::zip(eve::as<tuple_t<e_t>>(), z, e_t{45}, 13.37));
+  TTS_EQUAL((tuple_t<e_t>{ z, e_t{45}, 13.37 }), eve::zip(z, e_t{45}, 13.37));
 };

--- a/test/unit/meta/concepts/value.cpp
+++ b/test/unit/meta/concepts/value.cpp
@@ -16,7 +16,6 @@ TTS_CASE("Check validation of the scalar_value concept" )
   using eve::wide;
 
   TTS_EXPECT( eve::scalar_value<int>   );
-  TTS_EXPECT( eve::scalar_value<char>  );
   TTS_EXPECT( eve::scalar_value<float> );
   TTS_EXPECT( eve::scalar_value<double>);
 
@@ -25,9 +24,10 @@ TTS_CASE("Check validation of the scalar_value concept" )
 
   TTS_EXPECT( (eve::scalar_value<kumi::tuple<int,float>>) );
 
-  TTS_EXPECT_NOT( (eve::scalar_value<wide<int>>           ) );
-  TTS_EXPECT_NOT( (eve::scalar_value<logical<wide<int>>>  ) );
-  TTS_EXPECT_NOT( (eve::scalar_value<wide<std::int8_t,fixed<16>>>) );
+  TTS_EXPECT_NOT( (eve::scalar_value<char>                        ) );
+  TTS_EXPECT_NOT( (eve::scalar_value<wide<int>>                   ) );
+  TTS_EXPECT_NOT( (eve::scalar_value<logical<wide<int>>>          ) );
+  TTS_EXPECT_NOT( (eve::scalar_value<wide<std::int8_t,fixed<16>>> ) );
   TTS_EXPECT_NOT( (eve::scalar_value<wide<kumi::tuple<int,float>>>) );
 };
 

--- a/test/unit/meta/concepts/value.cpp
+++ b/test/unit/meta/concepts/value.cpp
@@ -15,6 +15,7 @@ TTS_CASE("Check validation of the scalar_value concept" )
   using eve::fixed;
   using eve::wide;
 
+  TTS_EXPECT( eve::scalar_value<char>  );
   TTS_EXPECT( eve::scalar_value<int>   );
   TTS_EXPECT( eve::scalar_value<float> );
   TTS_EXPECT( eve::scalar_value<double>);
@@ -24,7 +25,6 @@ TTS_CASE("Check validation of the scalar_value concept" )
 
   TTS_EXPECT( (eve::scalar_value<kumi::tuple<int,float>>) );
 
-  TTS_EXPECT_NOT( (eve::scalar_value<char>                        ) );
   TTS_EXPECT_NOT( (eve::scalar_value<wide<int>>                   ) );
   TTS_EXPECT_NOT( (eve::scalar_value<logical<wide<int>>>          ) );
   TTS_EXPECT_NOT( (eve::scalar_value<wide<std::int8_t,fixed<16>>> ) );
@@ -37,8 +37,8 @@ TTS_CASE("Check validation of the simd_value" )
   using eve::fixed;
   using eve::wide;
 
-  TTS_EXPECT_NOT( eve::simd_value<int>   );
   TTS_EXPECT_NOT( eve::simd_value<char>  );
+  TTS_EXPECT_NOT( eve::simd_value<int>   );
   TTS_EXPECT_NOT( eve::simd_value<float> );
   TTS_EXPECT_NOT( eve::simd_value<double>);
 

--- a/test/unit/module/core/if_else.cpp
+++ b/test/unit/module/core/if_else.cpp
@@ -145,7 +145,7 @@ TTS_EQUAL(actual, expected);
   L expected = l;
   expected.set(0, false);
   TTS_EQUAL(actual, expected);
-  actual = eve::if_else[eve::ignore_first(1)](l, false);
+  actual = eve::if_else[eve::ignore_first(1)](l, L{false});
   TTS_EQUAL(actual, expected);
 }
 };


### PR DESCRIPTION
This PR rewrite `scalar_value`and `simd_value` to follow the plan from #1144.
Most fixes are rather straightforward with the concept changes.

However one controversial change is done: Extending plain_scalar_value support
    
A lot of internal code use non csdtint type and it would have been too complicated to change all of them. 
Also, the added types are commonly used by users they warrant to be taken into account.
