### PR TITLE
Fix #1415 - Better sign implementation for integers

### DIFF
--- a/include/eve/module/core/regular/impl/simd/x86/sign.hpp
+++ b/include/eve/module/core/regular/impl/simd/x86/sign.hpp
@@ -20,17 +20,30 @@ template<integral_scalar_value T, typename N>
 EVE_FORCEINLINE wide<T, N>
                 sign_(EVE_SUPPORTS(ssse3_), wide<T, N> a) noexcept requires x86_abi<abi_t<T, N>>
 {
-  constexpr auto c = categorize<wide<T, N>>();
+  using enum category;
+  constexpr auto c    = categorize<wide<T, N>>();
+  constexpr auto tgt  = eve::as(a);
 
-  if constexpr( current_api >= avx2 && c == category::int32x8 )
-    return _mm256_sign_epi32(one(eve::as(a)), a);
-  else if constexpr( current_api >= avx2 && c == category::int16x16 )
-    return _mm256_sign_epi16(one(eve::as(a)), a);
-  else if constexpr( current_api >= avx2 && c == category::int8x32 )
-    return _mm256_sign_epi8(one(eve::as(a)), a);
-  else if constexpr( c == category::int32x4 ) return _mm_sign_epi32(one(eve::as(a)), a);
-  else if constexpr( c == category::int16x8 ) return _mm_sign_epi16(one(eve::as(a)), a);
-  else if constexpr( c == category::int8x16 ) return _mm_sign_epi8(one(eve::as(a)), a);
+  if constexpr(   current_api >= avx512
+              ||  unsigned_value<T> || sizeof(T) == 8
+              )                                             return sign_(EVE_RETARGET(cpu_), a);
+  else if constexpr( current_api >= avx2 && c == int32x8 )  return _mm256_sign_epi32(one(tgt), a);
+  else if constexpr( current_api >= avx2 && c == int32x8 )  return _mm256_sign_epi32(one(tgt), a);
+  else if constexpr( current_api >= avx2 && c == int16x16)  return _mm256_sign_epi16(one(tgt), a);
+  else if constexpr( current_api >= avx2 && c == int8x32 )  return _mm256_sign_epi8 (one(tgt), a);
+  else if constexpr( current_api >= avx && N::value > 1)
+  {
+    auto[l,h] = a.slice();
+    return wide<T,N>(sign(l),sign(h));
+  }
+  else if constexpr( current_api >= ssse3 && c == int32x4 ) return _mm_sign_epi32(one(tgt), a);
+  else if constexpr( current_api >= ssse3 && c == int16x8 ) return _mm_sign_epi16(one(tgt), a);
+  else if constexpr( current_api >= ssse3 && c == int8x16 ) return _mm_sign_epi8(one(tgt), a);
+  else if constexpr( current_api >= sse2 )
+  {
+    constexpr auto shft = sizeof(T) * 8;
+    return (a >> shft) - (a > 0).mask();
+  }
   else return sign_(EVE_RETARGET(cpu_), a);
 }
 }

--- a/include/eve/module/core/regular/negate.hpp
+++ b/include/eve/module/core/regular/negate.hpp
@@ -53,11 +53,11 @@ namespace eve
 //!   * Masked Call
 //!
 //!     The call `eve::negate[mask](x, ...)` provides a masked
-//!     version of `negate` which is
-//!     equivalent to `if_else(mask, negate(x, ...), x)`
-//!      **Example**
+//!     version of `negate` which is equivalent to `if_else(mask, negate(x, ...), x)`
 //!
-//!        @godbolt{doc/core/raw/negate.cpp}
+//!   **Example**
+//!
+//!    @godbolt{doc/core/raw/negate.cpp}
 //! @}
 //================================================================================================
 EVE_MAKE_CALLABLE(negate_, negate);

--- a/include/eve/module/core/regular/sign.hpp
+++ b/include/eve/module/core/regular/sign.hpp
@@ -37,20 +37,15 @@ namespace eve
 //!
 //!     * `x` :  [argument](@ref eve::value).
 //!
-//!    **Return value**
+//!   **Return value**
 //!
-//!      * Computes  [elementwise](@ref glossary_elementwise) the sign of `x`.
+//!   The [elementwise](@ref glossary_elementwise) sign of `x` computed as:
+//!     - `+1` , if `x` is greater than 0
+//!     - `-1` , if `x` is less than 0
+//!     -  `0` , if `x` is equal to 0
+//!     - `-0.`, if `x` is equal -0
 //!
-//!      * For [real](@ref eve::value) `x`,  the call is semantically equivalent to:
-//!        * If x is greater than 0, 1 is returned.
-//!        * If x is less than 0,  -1 is returned.
-//!        * If x is zero, x is returned.
-//!
-//!      *  Moreover for  [floating real value](@ref eve::floating_value)
-//!         if x is `Nan`, the result is `Nan`
-//!
-//!    value containing the [elementwise](@ref glossary_elementwise)
-//!    sign of `x` if it is representable in this type.
+//!   If called on `Nan`, the result is the actual sign of `Nan`.
 //!
 //!  @groupheader{Example}
 //!

--- a/test/unit/module/core/negate.cpp
+++ b/test/unit/module/core/negate.cpp
@@ -43,14 +43,6 @@ TTS_CASE_TPL("Check return types of negate", eve::test::simd::all_types)
                 eve::inf(eve::as<T>()));
       TTS_EQUAL(eve::negate(eve::minf(eve::as<T>()), eve::minf(eve::as<T>())),
                 eve::inf(eve::as<T>()));
-
-      TTS_IEEE_EQUAL(eve::negate(eve::nan(eve::as<T>()), eve::nan(eve::as<T>())),
-                     eve::nan(eve::as<T>()));
-      TTS_IEEE_EQUAL(eve::negate(eve::nan(eve::as<T>()), T(0)), eve::nan(eve::as<T>()));
-      TTS_IEEE_EQUAL(eve::negate(T(0), eve::nan(eve::as<T>())), eve::nan(eve::as<T>()));
-      TTS_IEEE_EQUAL(eve::negate(eve::nan(eve::as<T>()), T(0)), eve::nan(eve::as<T>()));
-      TTS_IEEE_EQUAL(eve::negate(T(1), eve::nan(eve::as<T>())), eve::nan(eve::as<T>()));
-      TTS_IEEE_EQUAL(eve::negate(eve::nan(eve::as<T>()), T(1)), eve::nan(eve::as<T>()));
     }
 
     TTS_EQUAL(eve::negate(T(-1), T(-1)), T(1));
@@ -83,7 +75,6 @@ TTS_CASE_WITH("Check behavior of negate(wide)",
   TTS_ULP_EQUAL(
       negate(a0, a1), map([](auto e, auto f) -> v_t { return e * eve::sign(f); }, a0, a1), 2);
 };
-
 
 //==================================================================================================
 // Tests for masked negate

--- a/test/unit/module/core/sign.cpp
+++ b/test/unit/module/core/sign.cpp
@@ -41,7 +41,16 @@ TTS_CASE_WITH("Check behavior of eve::sign(eve::wide)",
 <typename T, typename M>(T const& a0, M const& mask)
 {
   using eve::detail::map;
+  using eve::all;
+  using eve::is_positive;
+  using eve::is_negative;
   using v_t = eve::element_type_t<T>;
+
+  if constexpr(eve::floating_value<T>)
+  {
+    TTS_EXPECT( all(is_positive(eve::sign(eve::zero (eve::as(a0))))) );
+    TTS_EXPECT( all(is_negative(eve::sign(eve::mzero(eve::as(a0))))) );
+  }
 
   TTS_EQUAL(eve::sign(a0), map([](auto e) -> v_t { return e > 0 ? 1 : (e ? -1 : 0); }, a0));
   TTS_EQUAL(eve::sign[mask](a0), eve::if_else(mask, eve::sign(a0), a0));


### PR DESCRIPTION
# Content
We now:
 - Use the min/max tricks whenever possible
 - Have a bettrr SSE2/AVX specific path
 - Clarify that `sign(-0)  == -0` and test for it

Code for float use the old code path with slight clarification.

# Codegen

X86 SSE2
```c++
  movdqa  xmm1, xmm0
  psrad   xmm0, 32
  pxor    xmm2, xmm2
  pcmpgtd xmm1, xmm2
  psubd   xmm0, xmm1
  ret
```

X86 SSE4
```c++
  movdqa  xmm1, xmm0
  movdqa  xmm0, XMMWORD PTR .LC2[rip]
  psignd  xmm0, xmm1
  ret
```

X86 AVX
```c++
  vmovdqa xmm1, XMMWORD PTR .LC2[rip]
  vmovdqa xmm2, xmm0
  vextractf128    xmm0, ymm0, 0x1
  vpsignd xmm0, xmm1, xmm0
  vpsignd xmm1, xmm1, xmm2
  vinsertf128     ymm0, ymm1, xmm0, 0x1
  ret
```

X86 AVX2
```c++
  vmovdqa ymm1, ymm0
  vmovdqa ymm0, YMMWORD PTR .LC2[rip]
  vpsignd ymm0, ymm0, ymm1
  ret
```

X86 AVX512
```c++
  vmovdqa64       zmm1, zmm0
  vpbroadcastd    zmm0, DWORD PTR .LC5[rip]
  vpminsd zmm0, zmm0, zmm1
  vpternlogd      zmm1, zmm1, zmm1, 0xFF
  vpmaxsd zmm0, zmm0, zmm1
  ret
```

PPC:
```c++
  vspltisw 1,1
  vspltisw 0,-1
  vminsw 2,2,1
  vmaxsw 2,2,0
  stxvw4x 34,0,3
  blr
```

AARCH64
```c++
  movi    v2.4s, 0x1
  mvni    v1.4s, 0
  smin    v0.4s, v0.4s, v2.4s
  smax    v0.4s, v0.4s, v1.4s
  ret
```

ARM
```c++
  vmov.i32        q9, #1  @ v4si
  vmov.i32        q8, #4294967295  @ v4si
  vmin.s32        q0, q0, q9
  vmax.s32        q0, q0, q8
  bx      lr
```