### PR TITLE
Fix issue with dynamic SIMD extension detection

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -181,6 +181,6 @@ jobs:
           mkdir build && cd build
           cmake .. -DEVE_OPTIONS="${{ matrix.cfg.opts }}" -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchain/${{ matrix.cfg.comp }}.${{ matrix.cfg.arch }}.cmake
       - name: Compiling Unit Tests
-        run:  cd build && VERBOSE=1 make unit -j 4
+        run:  cd build && VERBOSE=1 make unit -j 3
       - name: Running Unit Tests
-        run: cd build && ctest --output-on-failure -j 4
+        run: cd build && ctest --output-on-failure -j 3

--- a/include/eve/arch/arm/detection.hpp
+++ b/include/eve/arch/arm/detection.hpp
@@ -22,7 +22,7 @@ namespace eve
   //================================================================================================
   // Runtime detection of CPU support
   //================================================================================================
-  inline bool is_supported(spy::arm_simd_info<spy::detail::simd_version::neon_ > const &) noexcept
+  inline bool is_supported(neon128_ const &) noexcept
   {
     #if defined( SPY_SIMD_IS_ARM )
     auto hwcaps = getauxval(AT_HWCAP);
@@ -32,7 +32,7 @@ namespace eve
     #endif
   }
 
-  inline bool is_supported(spy::arm_simd_info<spy::detail::simd_version::asimd_ > const &) noexcept
+  inline bool is_supported(asimd_ const &) noexcept
   {
     #if defined( SPY_SIMD_IS_ARM_ASIMD )
     auto hwcaps = getauxval(AT_HWCAP);
@@ -41,4 +41,5 @@ namespace eve
       return false;
     #endif
   }
+
 }

--- a/include/eve/arch/arm/neon/tags.hpp
+++ b/include/eve/arch/arm/neon/tags.hpp
@@ -38,8 +38,8 @@ namespace eve
   //================================================================================================
   // Dispatching tag for ARM SIMD implementation
   //================================================================================================
-  struct neon128_ : simd_api<simd_   , spy::neon_>      {};
-  struct asimd_   : simd_api<neon128_, spy::asimd_>     {};
+  struct neon128_ : simd_api<simd_   , spy::neon_>  { using is_arm = void; };
+  struct asimd_   : simd_api<neon128_, spy::asimd_> { using is_arm = void; };
 
   //================================================================================================
   // NEON extensions tag objects
@@ -51,4 +51,5 @@ namespace eve
   // ARM ABI concept
   //================================================================================================
   template<typename T> concept arm_abi = detail::is_one_of<T> ( detail::types<arm_64_,arm_128_> {});
+  template<typename T> concept arm_tag = requires(T) { typename T::is_arm; };
 }

--- a/include/eve/arch/arm/sve/tags.hpp
+++ b/include/eve/arch/arm/sve/tags.hpp
@@ -39,11 +39,11 @@ namespace eve
   //================================================================================================
   // Dispatching tag for ARM SIMD implementation
   //================================================================================================
-  struct sve_     : simd_api<simd_   , spy::sve_> {};
-  struct sve_vls_ : simd_api<sve_    , spy::fixed_sve_> {};
-  struct sve128_  : simd_api<sve_vls_, spy::fixed_sve_> {};
-  struct sve256_  : simd_api<sve_vls_, spy::fixed_sve_> {};
-  struct sve512_  : simd_api<sve_vls_, spy::fixed_sve_> {};
+  struct sve_     : simd_api<simd_   , spy::sve_>       {  using is_sve = void;  };
+  struct sve_vls_ : simd_api<sve_    , spy::fixed_sve_> {  using is_sve = void;  };
+  struct sve128_  : simd_api<sve_vls_, spy::fixed_sve_> {  using is_sve = void;  };
+  struct sve256_  : simd_api<sve_vls_, spy::fixed_sve_> {  using is_sve = void;  };
+  struct sve512_  : simd_api<sve_vls_, spy::fixed_sve_> {  using is_sve = void;  };
 
   //================================================================================================
   // SVE extensions tag objects
@@ -62,4 +62,5 @@ namespace eve
                                                                               , arm_sve_512_
                                                                               > {}
                                                               );
+  template<typename T> concept sve_tag = requires(T) { typename T::is_sve; };
 }

--- a/include/eve/arch/cpu/tags.hpp
+++ b/include/eve/arch/cpu/tags.hpp
@@ -20,6 +20,7 @@ namespace eve
   // SPY SIMD API wrapper
   template<typename Base, auto API> struct simd_api : Base
   {
+    static constexpr auto version = API;
     using api_type = std::decay_t<decltype(API)>;
 
     constexpr api_type const& value() const noexcept { return API; }

--- a/include/eve/arch/ppc/detection.hpp
+++ b/include/eve/arch/ppc/detection.hpp
@@ -14,15 +14,15 @@ namespace eve
   //================================================================================================
   // Runtime detection of CPU support
   //================================================================================================
-  template<auto Version> inline bool is_supported(spy::ppc_simd_info<Version> const &) noexcept
+  template<ppc_tag API> bool is_supported(API const& ) noexcept
   {
     #if defined( SPY_SIMD_IS_PPC )
-    if constexpr( Version >= spy::vsx_.version )
+    if constexpr( API::version >= spy::vsx_ )
     {
       static const bool detected = (__builtin_cpu_supports( "vsx" ) != 0);
       return detected;
     }
-    else if constexpr( Version >= spy::vmx_.version )
+    else if constexpr( API::version >= spy::vmx_ )
     {
       static const bool detected = (__builtin_cpu_supports( "altivec" ) != 0);
       return detected;

--- a/include/eve/arch/ppc/tags.hpp
+++ b/include/eve/arch/ppc/tags.hpp
@@ -36,10 +36,10 @@ namespace eve
   //================================================================================================
   // Dispatching tag for V*X SIMD implementation
   //================================================================================================
-  using vmx_  = simd_api<simd_    , spy::vmx_ >;
-  using vsx_  = simd_api<vmx_ , spy::vsx_>;
+  struct vmx_    : simd_api<simd_, spy::vmx_> { using is_ppc = void; };
+  struct vsx_    : simd_api<vmx_ , spy::vsx_> { using is_ppc = void; };
 
-  //================================================================================================
+//================================================================================================
   //  V*X extension tag objects
   //================================================================================================
   inline constexpr vmx_ vmx = {};
@@ -50,4 +50,5 @@ namespace eve
   // PPC ABI concept
   //================================================================================================
   template<typename T> concept ppc_abi = detail::is_one_of<T>(detail::types<ppc_> {});
+  template<typename T> concept ppc_tag = requires(T) { typename T::is_ppc; };
 }

--- a/include/eve/arch/x86/detection.hpp
+++ b/include/eve/arch/x86/detection.hpp
@@ -16,19 +16,20 @@ namespace eve
   //================================================================================================
   // Runtime detection of CPU support
   //================================================================================================
-  template<auto Version> inline bool is_supported(spy::x86_simd_info<Version> const &) noexcept
+  template<x86_tag API>
+  bool is_supported(API const& ) noexcept
   {
     using namespace detail;
 
-          if constexpr( Version == sse2.value().version   ) return cpuid_states.supports_sse2();
-    else  if constexpr( Version == sse3.value().version   ) return cpuid_states.supports_sse3();
-    else  if constexpr( Version == ssse3.value().version  ) return cpuid_states.supports_ssse3();
-    else  if constexpr( Version == sse4_1.value().version ) return cpuid_states.supports_sse4_1();
-    else  if constexpr( Version == sse4_2.value().version ) return cpuid_states.supports_sse4_2();
-    else  if constexpr( Version == avx.value().version    ) return cpuid_states.supports_avx();
-    else  if constexpr( Version == avx2.value().version   ) return cpuid_states.supports_avx2();
-    else  if constexpr( Version == avx512.value().version ) return cpuid_states.supports_avx512F();
-    else                                                    return false;
+          if constexpr( API::version == sse2.value()   ) return cpuid_states.supports_sse2();
+    else  if constexpr( API::version == sse3.value()   ) return cpuid_states.supports_sse3();
+    else  if constexpr( API::version == ssse3.value()  ) return cpuid_states.supports_ssse3();
+    else  if constexpr( API::version == sse4_1.value() ) return cpuid_states.supports_sse4_1();
+    else  if constexpr( API::version == sse4_2.value() ) return cpuid_states.supports_sse4_2();
+    else  if constexpr( API::version == avx.value()    ) return cpuid_states.supports_avx();
+    else  if constexpr( API::version == avx2.value()   ) return cpuid_states.supports_avx2();
+    else  if constexpr( API::version == avx512.value() ) return cpuid_states.supports_avx512F();
+    else                                                        return false;
   }
 
   inline bool is_supported(fma3_ const &) noexcept  { return detail::cpuid_states.supports_fma3();}

--- a/include/eve/arch/x86/tags.hpp
+++ b/include/eve/arch/x86/tags.hpp
@@ -46,14 +46,14 @@ namespace eve
   //================================================================================================
   // Dispatching tag for SSE* SIMD implementation
   //================================================================================================
-  struct sse2_    : simd_api<simd_   , spy::sse2_>    {};
-  struct sse3_    : simd_api<sse2_   , spy::sse3_>    {};
-  struct ssse3_   : simd_api<sse3_   , spy::ssse3_>   {};
-  struct sse4_1_  : simd_api<ssse3_  , spy::sse41_>   {};
-  struct sse4_2_  : simd_api<sse4_1_ , spy::sse42_>   {};
-  struct avx_     : simd_api<sse4_2_ , spy::avx_>     {};
-  struct avx2_    : simd_api<avx_    , spy::avx2_>    {};
-  struct avx512_  : simd_api<avx2_   , spy::avx512_>  {};
+  struct sse2_    : simd_api<simd_   , spy::sse2_>    { using is_x86 = void; };
+  struct sse3_    : simd_api<sse2_   , spy::sse3_>    { using is_x86 = void; };
+  struct ssse3_   : simd_api<sse3_   , spy::ssse3_>   { using is_x86 = void; };
+  struct sse4_1_  : simd_api<ssse3_  , spy::sse41_>   { using is_x86 = void; };
+  struct sse4_2_  : simd_api<sse4_1_ , spy::sse42_>   { using is_x86 = void; };
+  struct avx_     : simd_api<sse4_2_ , spy::avx_>     { using is_x86 = void; };
+  struct avx2_    : simd_api<avx_    , spy::avx2_>    { using is_x86 = void; };
+  struct avx512_  : simd_api<avx2_   , spy::avx512_>  { using is_x86 = void; };
 
   //================================================================================================
   // SSE* extension tag objects - Forwarded from SPY
@@ -78,4 +78,7 @@ namespace eve
   //================================================================================================
   template<typename T>
   concept x86_abi = detail::is_one_of<T>(detail::types<x86_128_, x86_256_, x86_512_> {});
+
+  template<typename T>
+  concept x86_tag = requires(T) { typename T::is_x86; };
 }


### PR DESCRIPTION
When we changed the types to statically detect SIMD ISA, we broke the runtime one.
Added a tag concept to select the proper one without too much hassle