### PR TITLE
Provides eve::construct as an extension point for non-trivial UDT ctor

### DIFF
--- a/include/eve/arch/cpu/wide.hpp
+++ b/include/eve/arch/cpu/wide.hpp
@@ -19,6 +19,7 @@
 #include <eve/detail/abi.hpp>
 #include <eve/detail/function/combine.hpp>
 #include <eve/detail/function/compounds.hpp>
+#include <eve/detail/function/construct.hpp>
 #include <eve/detail/function/fill.hpp>
 #include <eve/detail/function/friends.hpp>
 #include <eve/detail/function/load.hpp>
@@ -162,17 +163,8 @@ namespace eve
     template<typename S0, typename... Ss>
     explicit EVE_FORCEINLINE wide(S0 const& v0, Ss const&...vs) noexcept
     requires(kumi::sized_product_type_or_more<Type,1+sizeof...(Ss)>)
-    {
-      storage_base::storage() = [&]<std::size_t... I>(std::index_sequence<I...>)
-        {
-          constexpr auto K = sizeof...(Ss);
-          return kumi::map([]<typename W>(auto const& n, W const&) { return W{n}; },
-                                 kumi::make_tuple(v0, vs..., kumi::element_t<K+I,Type>{}...),
-                                 *this
-                                );
-        }(std::make_index_sequence<kumi::size_v<Type> - (1+sizeof...(Ss))>{});
-    }
-
+            : storage_base( construct(as<wide>{},v0,vs...) )
+    {}
 
     //==============================================================================================
     //! @brief Constructs a eve::wide from a @callable.

--- a/include/eve/detail/function/construct.hpp
+++ b/include/eve/detail/function/construct.hpp
@@ -1,0 +1,18 @@
+//==================================================================================================
+/*
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+*/
+//==================================================================================================
+#pragma once
+
+#include <eve/arch.hpp>
+#include <eve/detail/overload.hpp>
+
+namespace eve
+{
+  EVE_MAKE_CALLABLE(construct_, construct);
+}
+
+#include <eve/detail/function/simd/common/construct.hpp>

--- a/include/eve/detail/function/simd/common/construct.hpp
+++ b/include/eve/detail/function/simd/common/construct.hpp
@@ -1,0 +1,32 @@
+//==================================================================================================
+/*
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+*/
+//==================================================================================================
+#pragma once
+
+#include <eve/as.hpp>
+#include <eve/concept/value.hpp>
+#include <eve/detail/abi.hpp>
+#include <eve/detail/kumi.hpp>
+
+namespace eve::detail
+{
+  template<simd_value Pack, typename... Args>
+  EVE_FORCEINLINE auto construct_(EVE_SUPPORTS(cpu_), as<Pack> const&, Args const&... args) noexcept
+  {
+    using v_t = typename Pack::value_type;
+    Pack that ( [&]<std::size_t... I>(std::index_sequence<I...>)
+                {
+                  constexpr auto K = sizeof...(Args);
+                  return kumi::map( [&]<typename W>(auto const& n, W const&) { return W(n); }
+                                  , kumi::make_tuple(args..., kumi::element_t<K+I,v_t>{}...)
+                                  , Pack{} // used for types only
+                                  );
+                }(std::make_index_sequence<kumi::size_v<v_t> - sizeof...(Args)>{})
+              );
+    return that;
+  }
+}

--- a/test/unit/api/udt/wide.cpp
+++ b/test/unit/api/udt/wide.cpp
@@ -125,6 +125,19 @@ TTS_CASE( "Check eve::wide<udt> enumerating constructor" )
 };
 
 //==================================================================================================
+// Construct by calling a non-trivial UDT ctor
+//==================================================================================================
+TTS_CASE( "Check eve::wide<udt> non-trivial constructor" )
+{
+  constexpr auto sz = eve::wide<udt::label_position>::size();
+
+  eve::wide<udt::label_position> vp( [](int i, int) { return 1.f/(i+1.f);} );
+
+  TTS_EQUAL(get<0>(vp), (eve::wide<float>([](int i, int) { return 1.f/(i+1.f);})) );
+  TTS_EQUAL(get<1>(vp), (eve::wide<std::uint8_t,eve::fixed<sz>>([](int i, int) { return 'A' + 1.f/(i+1.f);})) );
+};
+
+//==================================================================================================
 // Construct from raw storage
 //==================================================================================================
 TTS_CASE( "Check eve::wide<udt> constructor from raw storage")


### PR DESCRIPTION
Some UDT (like the double double @jtlap is working on) has non trivial constructor that don't fit the classic product-type, member per member constructor stragtegy we use. We can't rely on the scalar constructor as calling it N times may be suboptimal in many cases.

This PR introduce construct, a dispatchable function that can take care of non-trivial UDT constructor. The default implementation is usign the same product-type startegy from before and we added a test checking for an arbitrary non trivial ctor on `udt::label_posiiton`.