### PR TITLE
FIX-1147: nofs things

### DIFF
--- a/doc/tutorial/frequency-scaling.hpp
+++ b/doc/tutorial/frequency-scaling.hpp
@@ -1,0 +1,31 @@
+#error This file is for documentation only - DO NOT INCLUDE
+/**
+
+@page Frequency Scaling.
+
+In SIMD programming there is a known issue of processor frequency scaling:
+when working with wider registers, in order to avoid overheating, some processors
+limit their CPU frequency. There are a lot of situations where this can happen
+but it is a noticeable problem mostly for 64 byte registers on intel avx512 cpus.
+
+This is why, for example, if you look at libc, it at most uses 32 byte registers:
+sure you might speed up the strlen somewhat but then all the code after will be
+slower.
+
+For big datasets the price of lower frequency is often outweighted by processing
+more numbers in open operation and seed ups of 15% are not unheard of.
+
+This lead to a dilemma in the API design for us: if the user is on the AVX512 system,
+most likely they expect the register to be 64 bytes. But we suspect this is not what
+they actually want. So we decided that `eve::wide` on avx512 is by default 64 bytes
+but algorithms by default use 32 bytes. If you want to get an algorithm to use 64 byte
+you can pass `eve::algo::allow_frequency_scaling` trait.
+There are also a typedefs `nofs_wide`, `nofs_logical` where `nofs` stands for
+"no frequency scaling".
+
+@note: other than on avx512 on intel we always use the maximum width of the register,
+since we expect the compiler to do it anyways and it is usally accepted.
+If you want to set a specific cardianl for an algorithm, you can always use
+`eve::algo::force_cardinal`.
+
+**/

--- a/doc/tutorial/introduction-02.hpp
+++ b/doc/tutorial/introduction-02.hpp
@@ -50,18 +50,19 @@ In SIMD algorithms we by default assume that the provided operation is simple (a
 since this is the common case. This means we use aligned reads and do unrolling, which is an
 important optimisation. However, for a complex case, like here, it is beneficial to opt out.
 
-__EVE__ provides various traits to customize algorithms behavior. The two main traits we're
+__EVE__ provides various traits to customize algorithms behavior. The traits we're
 interested in are:
+  - eve::algo::expensive_callable - let's **EVE** know that the passed callable is fairly large.
+    By default **EVE** will assume that the passed callables are cheap and it will align loads/stores,
+    and unroll the loop body. There are also individual `eve::algo::no_aligning`, `eve::algo::unrolling`
 
-  - eve::algo::no_aligning that stops **EVE** from using aligned loads/stores in case where it leads
-    to more code.
-
-  - eve::algo::unroll that specify how many times the function will be unrolled inside the
-    algorithm. Unrolling is most efficient with small functions as it will maximize the use
-    of SIMD registers. Unrolling can be turned off by using eve::algo::unroll<1>.
+  - eve::algo::allow_frequency_scaling - tells **EVE** to use the maximum avaliable register size even
+    if it can substentially temporary reduce processor's frequency. This only makes sense for really big
+    arrays or if you spend most of your time doing simd operations.
+    (At the moment this is only relevant for avx512). More details in frequency-scaling tutorial.
 
 Algorithms in **EVE** being callable object, you can apply traits using their `[]` operators.
-For example, the following code disable aligning and force unroll to be 1.
+For example, the following code let's **EVE** know that the loop body is heavy.
 
 @snippet tutorial/intro-02.cpp simd-transform-traits
 

--- a/doc/tutorial/introduction-03.hpp
+++ b/doc/tutorial/introduction-03.hpp
@@ -55,6 +55,9 @@ SIMD algorithm call to use eve::views::zip for both the input and output ranges.
 
 @snippet tutorial/intro-03.cpp  simd-transform_zip
 
+@note: In this example we passed `eve::algo::allow_frequency_scaling` to simplify the example.
+We talk more about it in frequency scaling tutorial.
+
 # Conclusion
 In this tutorial, we managed to:
   - handle tuple in SIMD context using eve::wide and [**kumi::tuple**](https://jfalcou.github.io/kumi/)

--- a/doc/tutorial/introduction-04.hpp
+++ b/doc/tutorial/introduction-04.hpp
@@ -80,7 +80,9 @@ Let's see how eve::soa_vector can be used as a proper output parameter for out `
 @snippet tutorial/intro-04.cpp simd-soa_vector_out
 
 Now, as a final example, let's a do a `cartesian_coords` SIMD user-defined type and write
-`to_cartesian`.
+`to_cartesian`. We will also make `to_cartesian` to work for both scalar and wide cases,
+so you don't have to reimplement it. Since we made it so generic we also don't need to
+allow frequency scaling.
 
 @snippet tutorial/intro-04.cpp simd-soa_vector_in
 
@@ -90,5 +92,4 @@ In this tutorial, we managed to:
   - create new UDTs compatible with eve::wide by constrcution
   - use eve::soa_vector, the SIMD-aware storage in place of standard containers
   - process SIMD-aware storage with **EVE** algorithms
-
 **/

--- a/examples/algorithms/using_existing/case_insensitive_equals.cpp
+++ b/examples/algorithms/using_existing/case_insensitive_equals.cpp
@@ -25,7 +25,7 @@ namespace ascii
   {
     // Making this work for scalar is a bit tricky because scalar code tends to convert to ints alot.
     // So we are only doing wides.
-    EVE_FORCEINLINE auto operator()(eve::wide<std::uint8_t> c) const
+    EVE_FORCEINLINE auto operator()(eve::like<std::uint8_t> auto c) const
     {
       // eve::sub[condition](a, b) is an equivalent to `eve::if_else(condition, a - b, a)`
       // but it will also use masked instructions when those are avaliable.
@@ -52,13 +52,10 @@ namespace ascii
     auto *l1 = reinterpret_cast<std::uint8_t const *>(a.end());
     auto *f2 = reinterpret_cast<std::uint8_t const *>(b.begin());
 
-    return eve::algo::equal(eve::algo::as_range(f1, l1),
-                            f2,
-                            [](eve::wide<std::uint8_t> a, eve::wide<std::uint8_t> b)
-                            {
-                              // convert both to uppercase and then check if they're equal
-                              return to_upper(a) == to_upper(b);
-                            });
+    // convert both to uppercase and then check if they're equal
+    return eve::algo::equal(
+      eve::views::map(eve::algo::as_range(f1, l1), to_upper),
+      eve::views::map(f2, to_upper));
   }
 }
 

--- a/examples/algorithms/using_existing/inclusive_scan_zip__using_zip_with_algorithms.cpp
+++ b/examples/algorithms/using_existing/inclusive_scan_zip__using_zip_with_algorithms.cpp
@@ -44,21 +44,25 @@ void inclusive_scan_complex(std::vector<float>& re, std::vector<float>& im, cmpl
     return x;
   };
 
-  eve::algo::inclusive_scan_inplace(  // in eve we have two versions of inclusive_scan
-                                      // _inplace and _to. The _to one is like std.
-                                      // the _inplace is the same as passing first as the output
-                                      // and is slightly more efficient
-                                      // ---
-    zipped,                           // we iterate over both vectors as one range
-                                      // ---
-    std::pair{plus, eve::zero},       // In eve we need not only the operation but also
-                                      // an identity element for that operation, so we accept a pair.
-                                      // eve::zero is an equivalent to cmplx_tuple{0.0, 0.0}
-                                      // but we use the knowledge that it's zero to generate better
-                                      // code for some platforms.
-                                      // ---
-    init                              // init value.
-                                      // Passing eve::zero here is not supported properly at the moment: FIX-955.
+  eve::algo::inclusive_scan_inplace     // in eve we have two versions of inclusive_scan
+                                        // _inplace and _to. The _to one is like std.
+                                        // the _inplace is the same as passing first as the output
+                                        // and is slightly more efficient
+                                        // ---
+  [eve::algo::allow_frequency_scaling]( // When using maximum width registers some CPUs (intel avx512)
+                                        // will very noticeably reduce frequecny. In this example we assume
+                                        // the input arrays to be very large and this being acceptable.
+                                        // ---
+    zipped,                             // we iterate over both vectors as one range
+                                        // ---
+    std::pair{plus, eve::zero},         // In eve we need not only the operation but also
+                                        // an identity element for that operation, so we accept a pair.
+                                        // eve::zero is an equivalent to cmplx_tuple{0.0, 0.0}
+                                        // but we use the knowledge that it's zero to generate better
+                                        // code for some platforms.
+                                        // ---
+    init                                // init value.
+                                        // Passing eve::zero here is not supported properly at the moment: FIX-955.
   );
 }
 

--- a/examples/tutorial/intro-02.cpp
+++ b/examples/tutorial/intro-02.cpp
@@ -102,7 +102,7 @@ namespace simd::unrolled
   {
     std::vector<float> out(xs.size());
 
-    eve::algo::transform_to[eve::algo::no_aligning][eve::algo::unroll<1>]
+    eve::algo::transform_to[ eve::algo::expensive_callable ]
                             ( eve::views::zip(xs, ys), out
                             , [](auto xy)
                               {

--- a/examples/tutorial/intro-03.cpp
+++ b/examples/tutorial/intro-03.cpp
@@ -59,7 +59,8 @@ namespace simd
     auto ins  = eve::views::zip(xs, ys);
     auto outs = eve::views::zip(rho, theta);
 
-    eve::algo::transform_to ( ins, outs
+    eve::algo::transform_to[eve::algo::allow_frequency_scaling]
+                           ( ins, outs
                             , [](auto in) { return to_polar( get<0>(in), get<1>(in)); }
                             );
 

--- a/include/eve/arch/nofs.hpp
+++ b/include/eve/arch/nofs.hpp
@@ -1,0 +1,71 @@
+//==================================================================================================
+/*
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+*/
+//==================================================================================================
+#pragma once
+
+#include <eve/wide.hpp>
+
+namespace eve
+{
+  //================================================================================================
+  //! @addtogroup arch
+  //! @{
+  //!   @var nofs_cardinal_v
+  //!   @brief nofs stands for "no frequency scaling".
+  //!
+  //!   This refers to extreme frequency scaling one encounters when working with 64 byte
+  //!   registers on intel. The processor scales frequency drammatically for a substantial
+  //!   period of time. So even if the algorithm itself will run faster the overall perf
+  //!   will go down. Generally speaking, 64 byte registers on intel make sense only
+  //!   for really big data sets. `nofs_cardinal` will produce 32 byte registers on avx512
+  //!   intel.
+  //!
+  //!   @note: frquency scaling exists for avx2 as well but is generally considered
+  //!   acceptable. For example popular implementations of libc use avx2, so you are very
+  //!   likely already have it. You can always set the width manually if needed.
+  //!
+  //!   @note: `eve::algo` by default will use `nofs_cardinal`. See `allow_frequency_scaling`
+  //!   trait.
+  //!
+  //!   @tparam Type  Type of value to assess
+  //!   @tparam ABI   SIMD ABI to use as reference. Must models eve::regular_abi. defaults to current.
+  //!
+  //!    <br/>
+  //!    #### Helpers
+  //!
+  //!    @code{.cpp}
+  //!    template <scalar_value T, regular_abi ABI = eve::current_abi_type>
+  //!    using nofs_cardinal_t = fixed<nofs_cardinal_v<T>>;
+  //!
+  //!    template <scalar_value T>
+  //!    using nofs_wide = wide<T, nofs_cardinal_t<T>>;
+  //!
+  //!    template <plain_scalar_value T>
+  //!    using nofs_logical = logical<nofs_wide<T>>;
+  //!
+  //!    @endcode
+  //!
+  //! @}
+  //================================================================================================
+
+  template <scalar_value T, regular_abi ABI = eve::current_abi_type>
+  constexpr std::ptrdiff_t nofs_cardinal_v =
+    (std::same_as<ABI, x86_512_> /*TODO: spy FIX-29 && !spy::amd64_*/)
+     ? expected_cardinal_v<T, x86_256_> : expected_cardinal_v<T, ABI>;
+
+  template <scalar_value T, regular_abi ABI = eve::current_abi_type>
+  using nofs_cardinal_t = fixed<nofs_cardinal_v<T>>;
+
+  template <scalar_value T>
+  using nofs_wide = wide<T, nofs_cardinal_t<T>>;
+
+  template <plain_scalar_value T>
+  using nofs_logical = logical<nofs_wide<T>>;
+
+  template <typename T>
+  using nofs_aligned_ptr = aligned_ptr<T, nofs_cardinal_t<T>>;
+}

--- a/include/eve/concept/scalar.hpp
+++ b/include/eve/concept/scalar.hpp
@@ -108,4 +108,19 @@ concept product_scalar_value = detail::scalar_tuple<T>();
 //==================================================================================================
 template<typename T>
 concept arithmetic_scalar_value = plain_scalar_value<T> || product_scalar_value<T>;
+
+//================================================================================================
+//! @concept scalar_value
+//! @brief Specify that a type represents a scalar value
+//!
+//! The concept `scalar_value<T>` is satisfied if and only if it satisfies either
+//! arithmetic_scalar_value or logical_scalar_value.
+//!
+//! @groupheader{Examples}
+//! - `float`
+//! - `logical<std::int32_t>`
+//! - `kumi::tuple<double,std::int32_t>`
+//================================================================================================
+template<typename T>
+concept scalar_value = arithmetic_scalar_value<T> || logical_scalar_value<T>;
 }

--- a/include/eve/concept/vectorizable.hpp
+++ b/include/eve/concept/vectorizable.hpp
@@ -13,21 +13,6 @@
 namespace eve
 {
   //================================================================================================
-  //! @concept scalar_value
-  //! @brief Specify that a type represents a scalar value
-  //!
-  //! The concept `scalar_value<T>` is satisfied if and only if it satisfies either
-  //! arithmetic_scalar_value or logical_scalar_value.
-  //!
-  //! @groupheader{Examples}
-  //! - `float`
-  //! - `logical<std::int32_t>`
-  //! - `kumi::tuple<double,std::int32_t>`
-  //================================================================================================
-  template<typename T>
-  concept scalar_value = arithmetic_scalar_value<T> || logical_scalar_value<T>;
-
-  //================================================================================================
   //! @concept integral_scalar_value
   //! @brief Specify that a type represents an integral scalar value
   //!

--- a/include/eve/module/algo/algo/container/detail/soa_storage.hpp
+++ b/include/eve/module/algo/algo/container/detail/soa_storage.hpp
@@ -9,7 +9,6 @@
 
 #include <eve/module/algo/algo/copy.hpp>
 #include <eve/module/algo/algo/views/zip.hpp>
-#include <eve/arch/expected_cardinal.hpp>
 #include <eve/concept/simd_allocator.hpp>
 #include <eve/detail/kumi.hpp>
 #include <eve/memory/aligned_allocator.hpp>

--- a/include/eve/module/algo/algo/preprocess_range.hpp
+++ b/include/eve/module/algo/algo/preprocess_range.hpp
@@ -31,7 +31,7 @@ namespace eve::algo
     template <typename T>
     EVE_FORCEINLINE auto ptr_to_iterator(T* ptr)
     {
-      using N          = eve::fixed<eve::expected_cardinal_v<std::remove_const_t<T>>>;
+      using N          = eve::fixed<eve::nofs_cardinal_v<std::remove_const_t<T>>>;
       return ptr_iterator<T*, N>{ptr};
     }
 

--- a/include/eve/module/algo/algo/views/iota.hpp
+++ b/include/eve/module/algo/algo/views/iota.hpp
@@ -146,7 +146,7 @@ namespace eve::algo::views
     template <typename T>
     EVE_FORCEINLINE auto operator()(T base, T step) const
     {
-      using N = eve::fixed<eve::expected_cardinal_v<T>>;
+      using N = eve::fixed<eve::nofs_cardinal_v<T>>;
       return iota_with_step_iterator<T, N>{base, step, 0};
     }
 

--- a/include/eve/module/core.hpp
+++ b/include/eve/module/core.hpp
@@ -100,3 +100,4 @@
 #include <eve/module/core/pedantic/core.hpp>
 #include <eve/module/core/saturated/core.hpp>
 #include <eve/wide.hpp>
+#include <eve/arch/nofs.hpp>

--- a/test/unit/arch/nofs.cpp
+++ b/test/unit/arch/nofs.cpp
@@ -1,0 +1,29 @@
+//==================================================================================================
+/**
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+**/
+//==================================================================================================
+#include "test.hpp"
+
+#include <eve/wide.hpp>
+
+TTS_CASE("Check for nofs cardinal")
+{
+  //if (!spy::amd64_) {
+    TTS_EQUAL((eve::nofs_cardinal_v<double, eve::x86_512_>),
+              (eve::expected_cardinal_v<double, eve::x86_256_>));
+  //}
+  TTS_EQUAL((eve::nofs_cardinal_v<double, eve::x86_256_>),
+            (eve::expected_cardinal_v<double, eve::x86_256_>));
+  TTS_EQUAL((eve::nofs_cardinal_v<double, eve::arm_128_>),
+            (eve::expected_cardinal_v<double, eve::arm_128_>));
+};
+
+TTS_CASE("Check for nofs_wide")
+{
+  eve::nofs_wide<int> a{0}, b{1};
+  eve::nofs_logical<int> test = a != b;
+  TTS_EXPECT(eve::all(test));
+};

--- a/test/unit/module/algo/algo_test.hpp
+++ b/test/unit/module/algo/algo_test.hpp
@@ -18,23 +18,23 @@ namespace algo_test
 {
   using selected_types = tts::types<
       eve::wide<std::int8_t, eve::fixed<1>>
-    , eve::wide<std::uint8_t>
+    , eve::nofs_wide<std::uint8_t>
     , eve::wide<std::int16_t>
     , eve::wide<std::uint16_t, eve::fixed<4>>
     , eve::wide<int>
-    , eve::wide<float>
+    , eve::nofs_wide<float>
     , eve::wide<double>
     , eve::wide<std::uint64_t>
     , eve::wide < std::uint32_t
-                , eve::fixed<eve::expected_cardinal_v<std::uint32_t> * 2>
+                , eve::fixed<eve::nofs_cardinal_v<std::uint32_t> * 2>
                 >
   >;
 
   using selected_pairs_types = tts::types<
       eve::wide<kumi::tuple<std::int8_t, std::int16_t>, eve::fixed<1>>
-    , eve::wide<kumi::tuple<std::uint8_t, std::uint8_t>>
+    , eve::nofs_wide<kumi::tuple<std::uint8_t, std::uint8_t>>
     , eve::wide<kumi::tuple<std::int32_t, std::int32_t>>
-    , eve::wide<kumi::tuple<std::int32_t, std::uint16_t>>
+    , eve::nofs_wide<kumi::tuple<std::int32_t, std::uint16_t>>
     , eve::wide<kumi::tuple<float, double>, eve::fixed<2>>
     , eve::wide<kumi::tuple<float, double>>
     , eve::wide<kumi::tuple<std::uint32_t, std::int64_t>,

--- a/test/unit/module/algo/algorithm/find_generic_test.hpp
+++ b/test/unit/module/algo/algorithm/find_generic_test.hpp
@@ -63,7 +63,7 @@ namespace algo_test
   template <typename T, typename Algo, typename Check>
   void find_generic_test(eve::as<T> as_t, Algo alg, Check check)
   {
-    find_generic_test_page_ends(eve::as<eve::wide<typename T::value_type>>{}, alg, check);
+    find_generic_test_page_ends(eve::as<eve::nofs_wide<typename T::value_type>>{}, alg, check);
 
     find_generic_test_page_ends(as_t, alg[eve::algo::force_cardinal<T::size()>][eve::algo::unroll<1>], check);
     find_generic_test_page_ends(as_t, alg[eve::algo::force_cardinal<T::size()>][eve::algo::unroll<2>], check);

--- a/test/unit/module/algo/algorithm/find_last_generic_test.hpp
+++ b/test/unit/module/algo/algorithm/find_last_generic_test.hpp
@@ -69,7 +69,7 @@ template<typename T, typename Algo, typename Check>
 void
 find_generic_backward_test(eve::as<T> as_t, Algo alg, Check check)
 {
-  find_generic_backward_test_page_ends(eve::as<eve::wide<typename T::value_type>> {}, alg, check);
+  find_generic_backward_test_page_ends(eve::as<eve::nofs_wide<typename T::value_type>> {}, alg, check);
 
   find_generic_backward_test_page_ends(
       as_t, alg[eve::algo::force_cardinal<T::size()>][eve::algo::unroll<1>], check);

--- a/test/unit/module/algo/algorithm/find_like_special_cases.cpp
+++ b/test/unit/module/algo/algorithm/find_like_special_cases.cpp
@@ -66,7 +66,7 @@ TTS_CASE("eve.algo.find point")
     eve::algo::views::zip(x, y), eve::as<udt::point2D>{});
 
   auto found = eve::algo::find_if(as_points,
-    [](eve::wide<udt::point2D> points) { return get_y(points) != 0; });
+    [](eve::nofs_wide<udt::point2D> points) { return get_y(points) != 0; });
 
   TTS_EQUAL(eve::read(found), (udt::point2D{3, 1}));
 };
@@ -118,7 +118,7 @@ TTS_CASE("eve.algo.mismatch example, first point not within a radius")
   auto x_y = eve::algo::views::zip[eve::algo::common_with_types<double>](x, y);
 
   auto found = eve::algo::mismatch(x_y, within,
-    [](eve::wide<kumi::tuple<double, double>> x_y, eve::wide<double> r) {
+    [](eve::nofs_wide<kumi::tuple<double, double>> x_y, eve::nofs_wide<double> r) {
       auto [x, y] = x_y;
       return x * x + y * y <= r * r;
     }

--- a/test/unit/module/algo/algorithm/minmax_generic_test.hpp
+++ b/test/unit/module/algo/algorithm/minmax_generic_test.hpp
@@ -92,7 +92,7 @@ void
 minmax_generic_test(eve::as<T> as_t, Algo alg, Check check)
 {
   minmax_generic_test_page_ends<biggest, right>(
-      eve::as<eve::wide<typename T::value_type>> {}, alg, check);
+      eve::as<eve::nofs_wide<typename T::value_type>> {}, alg, check);
 
   minmax_generic_test_page_ends<biggest, right>(
       as_t, alg[eve::algo::force_cardinal<T::size()>][eve::algo::unroll<1>], check);

--- a/test/unit/module/algo/algorithm/mismatch_generic_test.hpp
+++ b/test/unit/module/algo/algorithm/mismatch_generic_test.hpp
@@ -70,7 +70,7 @@ namespace algo_test
   {
     std::mt19937 gen;
 
-    mismatch_one_algo_test(eve::as<eve::wide<typename T::value_type>>{}, alg, check, gen);
+    mismatch_one_algo_test(eve::as<eve::nofs_wide<typename T::value_type>>{}, alg, check, gen);
 
     mismatch_one_algo_test(tgt, alg[eve::algo::force_cardinal<T::size()>][eve::algo::unroll<2>], check, gen);
     mismatch_one_algo_test(tgt, alg[eve::algo::force_cardinal<T::size()>][eve::algo::unroll<3>], check, gen);

--- a/test/unit/module/algo/algorithm/sums_special_cases.cpp
+++ b/test/unit/module/algo/algorithm/sums_special_cases.cpp
@@ -98,17 +98,17 @@ TTS_CASE("eve.algo.transform_reduce_types")
 
   {
     auto r = eve::algo::transform_reduce(
-        v, [](eve::wide<std::int8_t> x) { return x + x; }, std::int8_t {0});
+        v, [](eve::nofs_wide<std::int8_t> x) { return x + x; }, std::int8_t {0});
     TTS_TYPE_IS(decltype(r), std::int8_t);
   }
   {
-    using N = eve::fixed<eve::expected_cardinal_v<std::int16_t>>;
+    using N = eve::nofs_cardinal_t<std::int16_t>;
     auto r  = eve::algo::transform_reduce(
         v, [](eve::wide<std::int8_t, N> x) { return x + x; }, std::int16_t {0});
     TTS_TYPE_IS(decltype(r), std::int16_t);
   }
   {
-    using N = eve::fixed<eve::expected_cardinal_v<std::int16_t>>;
+    using N = eve::nofs_cardinal_t<std::int16_t>;
     // return type of map does not matter
     auto r = eve::algo::transform_reduce(
         v,

--- a/test/unit/module/algo/algorithm/swap_ranges_generic.cpp
+++ b/test/unit/module/algo/algorithm/swap_ranges_generic.cpp
@@ -66,7 +66,7 @@ TTS_CASE_TPL("Check swap ranges", algo_test::selected_pairs_types)
 <typename T>(tts::type<T>)
 {
   using e_t = eve::element_type_t<T>;
-  auto native_tgt = eve::as<eve::wide<e_t>>{};
+  auto native_tgt = eve::as<eve::nofs_wide<e_t>>{};
 
   swap_ranges_test_page_ends(native_tgt, eve::algo::swap_ranges);
 

--- a/test/unit/module/algo/algorithm/transform_inplace_generic_test.hpp
+++ b/test/unit/module/algo/algorithm/transform_inplace_generic_test.hpp
@@ -68,7 +68,7 @@ namespace algo_test
   void transform_inplace_generic_test(eve::as<T> tgt, Algo alg, Control control, Args... args)
   {
     using e_t = eve::element_type_t<T>;
-    auto native_tgt = eve::as<eve::wide<e_t>>{};
+    auto native_tgt = eve::as<eve::nofs_wide<e_t>>{};
 
     transform_inplace_generic_test_page_ends(native_tgt, alg, control, args...);
     transform_inplace_generic_test_page_ends(tgt, alg[eve::algo::unroll<1>][eve::algo::force_cardinal<T::size()>],

--- a/test/unit/module/algo/algorithm/transform_to_generic_test.hpp
+++ b/test/unit/module/algo/algorithm/transform_to_generic_test.hpp
@@ -77,7 +77,7 @@ namespace algo_test {
   void transform_to_generic_test(eve::as<T> tgt, Algo alg, Control control, Args... args)
   {
     using e_t = eve::element_type_t<T>;
-    auto native_tgt = eve::as<eve::wide<e_t>>{};
+    auto native_tgt = eve::as<eve::nofs_wide<e_t>>{};
 
     transform_to_generic_test_page_ends(native_tgt, alg, control, args...);
     transform_to_generic_test_page_ends(tgt, alg[eve::algo::unroll<1>][eve::algo::force_cardinal<T::size()>],

--- a/test/unit/module/algo/concepts.cpp
+++ b/test/unit/module/algo/concepts.cpp
@@ -15,10 +15,10 @@
 TTS_CASE("concepts, relaxed")
 {
   TTS_CONSTEXPR_EXPECT(eve::algo::relaxed_iterator<int*>);
-  TTS_CONSTEXPR_EXPECT(eve::algo::relaxed_iterator<eve::aligned_ptr<int>>);
+  TTS_CONSTEXPR_EXPECT(eve::algo::relaxed_iterator<eve::nofs_aligned_ptr<int>>);
   TTS_CONSTEXPR_EXPECT(eve::algo::relaxed_iterator<int const*>);
-  TTS_CONSTEXPR_EXPECT(eve::algo::relaxed_iterator<eve::aligned_ptr<int const>>);
-  TTS_CONSTEXPR_EXPECT(eve::algo::relaxed_iterator<eve::aligned_ptr<int const> const&>);
+  TTS_CONSTEXPR_EXPECT(eve::algo::relaxed_iterator<eve::nofs_aligned_ptr<int const>>);
+  TTS_CONSTEXPR_EXPECT(eve::algo::relaxed_iterator<eve::nofs_aligned_ptr<int const> const&>);
 
   TTS_CONSTEXPR_EXPECT_NOT(eve::algo::relaxed_range<int*>);
   TTS_CONSTEXPR_EXPECT(eve::algo::relaxed_range<std::vector<int>>);

--- a/test/unit/module/algo/container/erase_remove.cpp
+++ b/test/unit/module/algo/container/erase_remove.cpp
@@ -28,7 +28,7 @@ TTS_CASE("erase/remove idiom in eve")
   udt::point2D bad_start{0, 1};
 
   lines.erase(
-    eve::algo::remove_if(lines, [&](eve::wide<udt::line2D> l) {
+    eve::algo::remove_if(lines, [&](eve::nofs_wide<udt::line2D> l) {
       return get_start(l) == bad_start;
     }),
     lines.end()
@@ -50,7 +50,7 @@ TTS_CASE("erase/remove idiom in eve")
   };
 
   points.erase(
-    eve::algo::remove_if(points, [&](eve::wide<udt::point2D> p) {
+    eve::algo::remove_if(points, [&](eve::nofs_wide<udt::point2D> p) {
       return p == bad;
     }),
     points.end()

--- a/test/unit/module/algo/preprocess_range.cpp
+++ b/test/unit/module/algo/preprocess_range.cpp
@@ -18,12 +18,12 @@ TTS_CASE_TPL("Check preprocess_range for contiguous iterators", algo_test::selec
 <typename T>(tts::type<T>)
 {
   using e_t = eve::element_type_t<T>;
-  using N = eve::fixed<eve::expected_cardinal_v<e_t>>;
+  using N = eve::fixed<eve::nofs_cardinal_v<e_t>>;
 
   using u_it  = eve::algo::ptr_iterator<e_t*, N>;
   using uc_it = eve::algo::ptr_iterator<e_t const*, N>;
 
-  alignas(sizeof(eve::wide<e_t, N>) * 2) std::array<e_t, N{}()> arr{};
+  alignas(sizeof(eve::wide<e_t, N>) * 4) std::array<e_t, N{}()> arr{};
 
   std::vector<e_t> vec(100u, 0);
 
@@ -137,7 +137,7 @@ TTS_CASE_TPL("Check preprocess_range for contiguous iterators", algo_test::selec
   // over aligned
   {
     common_test(
-      eve::aligned_ptr<e_t, eve::fixed<N{}() * 2>>{arr.begin()}, eve::aligned_ptr<e_t>{arr.end()},
+      eve::aligned_ptr<e_t, eve::fixed<N{}() * 2>>{arr.begin()}, eve::aligned_ptr<e_t, N>{arr.end()},
       eve::algo::ptr_iterator<eve::aligned_ptr<e_t, N>, N>{},
       eve::algo::ptr_iterator<eve::aligned_ptr<e_t, N>, N>{}
     );
@@ -159,7 +159,7 @@ TTS_CASE_TPL("Check preprocess_range for eve ptr iterators", algo_test::selected
 {
   using e_t = eve::element_type_t<T>;
   using N = eve::fixed<T::size()>;
-  using expected_N = eve::fixed<eve::expected_cardinal_v<e_t>>;
+  using expected_N = eve::fixed<eve::nofs_cardinal_v<e_t>>;
 
   alignas(sizeof(T)) std::array<e_t, T::size()> arr;
 
@@ -208,7 +208,7 @@ TTS_CASE_TPL("contiguous ranges", algo_test::selected_types)
 <typename T>(tts::type<T>)
 {
   using e_t = eve::element_type_t<T>;
-  using N = eve::fixed<eve::expected_cardinal_v<e_t>>;
+  using N = eve::fixed<eve::nofs_cardinal_v<e_t>>;
 
   // empty vector
   {
@@ -298,7 +298,7 @@ TTS_CASE_TPL("cardinal/type manipulation", algo_test::selected_types)
 
     using I = decltype(processed.begin());
     TTS_TYPE_IS(typename I::value_type, double);
-    TTS_TYPE_IS(eve::wide_value_type_t<I>, eve::wide<double>);
+    TTS_TYPE_IS(eve::wide_value_type_t<I>, eve::nofs_wide<double>);
   }
 
   {
@@ -317,7 +317,7 @@ TTS_CASE_TPL("cardinal/type manipulation", algo_test::selected_types)
 
     using I = decltype(processed.begin());
     TTS_TYPE_IS(eve::wide_value_type_t<I>,
-                (eve::wide<e_t, eve::fixed<eve::expected_cardinal_v<double>>>));
+                (eve::wide<e_t, eve::fixed<eve::nofs_cardinal_v<double>>>));
   }
 
   {
@@ -326,7 +326,23 @@ TTS_CASE_TPL("cardinal/type manipulation", algo_test::selected_types)
 
     using I = decltype(processed.begin());
     TTS_TYPE_IS(eve::wide_value_type_t<I>,
-                (eve::wide<e_t, eve::fixed<eve::expected_cardinal_v<double>>>));
+                (eve::wide<e_t, eve::fixed<eve::nofs_cardinal_v<double>>>));
+  }
+};
+
+TTS_CASE_TPL("support for equivlanets", algo_test::selected_types)
+<typename T>(tts::type<T>)
+{
+  using e_t = eve::element_type_t<T>;
+
+  std::vector<e_t> v;
+  {
+    auto processed = eve::algo::preprocess_range(
+    eve::algo::traits(eve::algo::expensive_callable), v);
+
+    TTS_TYPE_IS(decltype(processed.traits()),
+               (decltype(eve::algo::traits{eve::algo::no_aligning,
+                         eve::algo::unroll<1>})));
   }
 };
 

--- a/test/unit/module/algo/traits.cpp
+++ b/test/unit/module/algo/traits.cpp
@@ -93,15 +93,21 @@ TTS_CASE("eve.algo.traits, type and cardinal")
 {
   {
     eve::algo::traits tr;
-    TTS_TYPE_IS((eve::algo::iteration_cardinal_t<decltype(tr), int*>), eve::fixed<eve::expected_cardinal_v<int>>);
+    TTS_TYPE_IS((eve::algo::iteration_cardinal_t<decltype(tr), int*>), eve::fixed<eve::nofs_cardinal_v<int>>);
+    eve::algo::traits tr1{eve::algo::allow_frequency_scaling};
+    TTS_TYPE_IS((eve::algo::iteration_cardinal_t<decltype(tr1), int*>), eve::fixed<eve::expected_cardinal_v<int>>);
   }
   {
     eve::algo::traits tr{eve::algo::force_cardinal<2>};
     TTS_TYPE_IS((eve::algo::iteration_cardinal_t<decltype(tr), int*>), eve::fixed<2>);
+    eve::algo::traits tr1{eve::algo::force_cardinal<2>, eve::algo::allow_frequency_scaling};
+    TTS_TYPE_IS((eve::algo::iteration_cardinal_t<decltype(tr1), int*>), eve::fixed<2>);
   }
   {
     eve::algo::traits tr{eve::algo::consider_types<double>};
-    TTS_TYPE_IS((eve::algo::iteration_cardinal_t<decltype(tr), int*>), eve::fixed<eve::expected_cardinal_v<double>>);
+    TTS_TYPE_IS((eve::algo::iteration_cardinal_t<decltype(tr), int*>), eve::fixed<eve::nofs_cardinal_v<double>>);
+    eve::algo::traits tr1{eve::algo::consider_types<double>, eve::algo::allow_frequency_scaling};
+    TTS_TYPE_IS((eve::algo::iteration_cardinal_t<decltype(tr1), int*>), eve::fixed<eve::expected_cardinal_v<double>>);
   }
   {
     eve::algo::traits tr;

--- a/test/unit/module/algo/views/backward.cpp
+++ b/test/unit/module/algo/views/backward.cpp
@@ -34,7 +34,7 @@ TTS_CASE("eve::views::backward, backward of backward")
 {
   // pointer
   {
-    using ap = eve::aligned_ptr<std::int8_t>;
+    using ap = eve::nofs_aligned_ptr<std::int8_t>;
     ap                                   in{};
     eve::views::backward_iterator<ap>    rev  = eve::views::backward(in);
     ap                                   back = eve::views::backward(rev);
@@ -66,10 +66,10 @@ TTS_CASE("eve::views::backward, backward of backward")
 
 TTS_CASE("eve::views::backward, preprocess_range")
 {
-  using ap = eve::aligned_ptr<int>;
+  using ap = eve::nofs_aligned_ptr<int>;
   using up = int*;
-  using a_it = eve::algo::ptr_iterator<ap, eve::fixed<eve::expected_cardinal_v<int>>>;
-  using u_it = eve::algo::ptr_iterator<up, eve::fixed<eve::expected_cardinal_v<int>>>;
+  using a_it = eve::algo::ptr_iterator<ap, eve::fixed<eve::nofs_cardinal_v<int>>>;
+  using u_it = eve::algo::ptr_iterator<up, eve::fixed<eve::nofs_cardinal_v<int>>>;
 
   {
     auto processed = eve::algo::preprocess_range(eve::algo::traits{}, eve::views::backward(eve::algo::as_range(ap{}, up{})));
@@ -90,15 +90,15 @@ TTS_CASE("eve::views::backward, preprocess_range")
 
 TTS_CASE("eve::views::reverse, basic_load_store")
 {
-  std::array<int, eve::expected_cardinal_v<int>> a;
+  std::array<int, eve::nofs_cardinal_v<int>> a;
   a.fill(0);
 
-  eve::wide<int> iota  = [](int i, int) { return i; };
+  eve::nofs_wide<int> iota  = [](int i, int) { return i; };
 
   auto processed = eve::algo::preprocess_range(eve::algo::traits{}, eve::views::backward(a));
 
   eve::store(iota, processed.begin());
 
-  TTS_EQUAL(iota,  eve::wide<int>{a.data()});
+  TTS_EQUAL(iota,  eve::nofs_wide<int>{a.data()});
   TTS_EQUAL(iota,  eve::load(processed.begin()));
 };

--- a/test/unit/module/algo/views/convert.cpp
+++ b/test/unit/module/algo/views/convert.cpp
@@ -36,7 +36,7 @@ TTS_CASE("eve::views::convert, preprocess test")
   using From      = float;
   using To        = int;
   using SmallerTo = short;
-  using N         = eve::fixed<eve::expected_cardinal_v<To>>;
+  using N         = eve::nofs_cardinal_t<To>;
 
   auto common_test = []<typename R, typename T,
                         typename ExpectedRawF,
@@ -141,8 +141,8 @@ TTS_CASE("views.convert to/from")
 
 TTS_CASE("eve.algo.views.convert_iterator const/non-const")
 {
-  using ap             = eve::aligned_ptr<std::int8_t>;
-  using acp            = eve::aligned_ptr<std::int8_t const>;
+  using ap             = eve::nofs_aligned_ptr<std::int8_t>;
+  using acp            = eve::nofs_aligned_ptr<std::int8_t const>;
   using converting_it  = eve::views::converting_iterator<ap,  int>;
   using converting_cit = eve::views::converting_iterator<acp, int>;
 

--- a/test/unit/module/algo/views/iota.cpp
+++ b/test/unit/module/algo/views/iota.cpp
@@ -36,7 +36,7 @@ TTS_CASE_TPL("Check iota_with_step_iterator, conversions", eve::test::scalar::al
   auto f = eve::views::iota_with_step(T(0), T(1));
 
   auto actual_bytes   = eve::views::convert(f, eve::as<std::int8_t>{});
-  auto expected_bytes = eve::views::iota_with_step(std::int8_t{0}, std::int8_t{1}).cardinal_cast(eve::lane<eve::expected_cardinal_v<T>>);
+  auto expected_bytes = eve::views::iota_with_step(std::int8_t{0}, std::int8_t{1}).cardinal_cast(eve::lane<eve::nofs_cardinal_v<T>>);
   TTS_EQUAL(expected_bytes, actual_bytes);
 
   auto actual_back = eve::views::convert(actual_bytes, eve::as<T>{});

--- a/test/unit/module/algo/views/map.cpp
+++ b/test/unit/module/algo/views/map.cpp
@@ -57,10 +57,10 @@ TTS_CASE("eve::views::map, preprocess")
   std::vector<int> v;
 
   using up = int*;
-  using ap = eve::aligned_ptr<int>;
+  using ap = eve::nofs_aligned_ptr<int>;
 
   // double because the map operation returns double
-  using N      = eve::fixed<eve::expected_cardinal_v<double>>;
+  using N      = eve::fixed<eve::nofs_cardinal_v<double>>;
   using ui     = eve::algo::ptr_iterator<int*, N>;
   using ai     = eve::algo::ptr_iterator<eve::aligned_ptr<int, N>, N>;
   using map_ui = eve::views::map_iterator<ui, load_op, store_op>;
@@ -78,5 +78,5 @@ TTS_CASE("eve::views::map, preprocess")
 
   TTS_TYPE_IS(decltype(processed.begin()), map_ai);
   TTS_TYPE_IS(decltype(processed.end()), map_ui);
-  TTS_TYPE_IS(decltype(eve::load(processed.begin())), eve::wide<double>);
+  TTS_TYPE_IS(decltype(eve::load(processed.begin())), eve::nofs_wide<double>);
 };

--- a/test/unit/module/algo/views/preprocess_zip_range.cpp
+++ b/test/unit/module/algo/views/preprocess_zip_range.cpp
@@ -21,7 +21,7 @@ TTS_CASE("zip_iterator, preprocess range, scalar end")
   using v_i = std::vector<int>::iterator;
   using zip_vi = eve::views::zip_iterator<v_i, v_i>;
 
-  using N = eve::fixed<eve::expected_cardinal_v<int>>;
+  using N = eve::fixed<eve::nofs_cardinal_v<int>>;
   using ui_it = eve::algo::ptr_iterator<int*, N>;
   using zip_ui = eve::views::zip_iterator<ui_it, ui_it>;
 
@@ -38,11 +38,11 @@ TTS_CASE("zip_iterator, preprocess range, scalar end")
 TTS_CASE("zip_iterator, preprocess range, zip end")
 {
   using u      = int const*;
-  using a      = eve::aligned_ptr<int const>;
+  using a      = eve::nofs_aligned_ptr<int const>;
   using zip_au = eve::views::zip_iterator<a, u>;
   using zip_uu = eve::views::zip_iterator<u, u>;
 
-  using N = eve::fixed<eve::expected_cardinal_v<int>>;
+  using N = eve::fixed<eve::nofs_cardinal_v<int>>;
   using a_it = eve::algo::ptr_iterator<a, N>;
   using u_it = eve::algo::ptr_iterator<u, N>;
   using zip_au_it = eve::views::zip_iterator<a_it, u_it>;
@@ -95,11 +95,11 @@ TTS_CASE("zip_iterator, preprocess range, zip end")
 
 TTS_CASE("preprocess zip range, traits")
 {
-  using N = eve::fixed<eve::expected_cardinal_v<std::uint32_t>>;
+  using N = eve::fixed<eve::nofs_cardinal_v<std::uint32_t>>;
   using uc = std::int8_t*;
   using ac = eve::aligned_ptr<std::int8_t, N>;
   using ui = std::uint32_t*;
-  using ai = eve::aligned_ptr<std::uint32_t>;
+  using ai = eve::nofs_aligned_ptr<std::uint32_t>;
 
   using uc_it = eve::algo::ptr_iterator<uc, N>;
   using ui_it = eve::algo::ptr_iterator<ui, N>;
@@ -201,7 +201,7 @@ TTS_CASE("preprocess zip range, common_type")
   std::array<std::uint32_t, 64> i;
 
   {
-    using N           = eve::fixed<eve::expected_cardinal_v<std::uint32_t>>;
+    using N           = eve::fixed<eve::nofs_cardinal_v<std::uint32_t>>;
     using uc_it       = eve::algo::ptr_iterator<std::int8_t*, N>;
     using ui_it       = eve::algo::ptr_iterator<std::uint32_t*, N>;
     using conv_uc_it  = eve::views::converting_iterator<uc_it, std::uint32_t>;

--- a/test/unit/module/algo/views/reverse.cpp
+++ b/test/unit/module/algo/views/reverse.cpp
@@ -37,7 +37,7 @@ TTS_CASE("eve::views::reverse, reverse of reverse")
 {
   // pointer
   {
-    using ap = eve::aligned_ptr<std::int8_t>;
+    using ap = eve::nofs_aligned_ptr<std::int8_t>;
     ap                                  in{};
     eve::views::reverse_iterator<ap>    rev  = eve::views::reverse(in);
     ap                                  back = eve::views::reverse(rev);
@@ -69,10 +69,10 @@ TTS_CASE("eve::views::reverse, reverse of reverse")
 
 TTS_CASE("eve::views::reverse, preprocess_range")
 {
-  using ap = eve::aligned_ptr<int>;
+  using ap = eve::nofs_aligned_ptr<int>;
   using up = int*;
-  using a_it = eve::algo::ptr_iterator<ap, eve::fixed<eve::expected_cardinal_v<int>>>;
-  using u_it = eve::algo::ptr_iterator<up, eve::fixed<eve::expected_cardinal_v<int>>>;
+  using a_it = eve::algo::ptr_iterator<ap, eve::fixed<eve::nofs_cardinal_v<int>>>;
+  using u_it = eve::algo::ptr_iterator<up, eve::fixed<eve::nofs_cardinal_v<int>>>;
 
   {
     auto processed = eve::algo::preprocess_range(eve::algo::traits{}, eve::views::reverse(eve::algo::as_range(ap{}, up{})));
@@ -93,16 +93,16 @@ TTS_CASE("eve::views::reverse, preprocess_range")
 
 TTS_CASE("eve::views::reverse, basic_load_store")
 {
-  std::array<int, eve::expected_cardinal_v<int>> a;
+  std::array<int, eve::nofs_cardinal_v<int>> a;
   a.fill(0);
 
-  eve::wide<int> iota  = [](int i, int) { return i; };
-  eve::wide<int> riota = [](int i, int size) { return size - i - 1; };
+  eve::nofs_wide<int> iota  = [](int i, int) { return i; };
+  eve::nofs_wide<int> riota = [](int i, int size) { return size - i - 1; };
 
   auto processed = eve::algo::preprocess_range(eve::algo::traits{}, eve::views::reverse(a));
 
   eve::store(iota, processed.begin());
 
-  TTS_EQUAL(riota, eve::wide<int>{a.data()});
+  TTS_EQUAL(riota, eve::nofs_wide<int>{a.data()});
   TTS_EQUAL(iota,  eve::load(processed.begin()));
 };

--- a/test/unit/module/algo/views/zip_iterator.cpp
+++ b/test/unit/module/algo/views/zip_iterator.cpp
@@ -56,7 +56,7 @@ TTS_CASE("zip_iterator for not eve iterators")
 
 TTS_CASE("zip_iterator for not eve iterators, unaligned")
 {
-  using a_p = eve::aligned_ptr<int>;
+  using a_p = eve::nofs_aligned_ptr<int>;
   using u_p = int*;
 
   using expected = eve::views::zip_iterator<u_p, u_p>;


### PR DESCRIPTION
Make algorithms by default use 32 byte registers on avx512, otherwise we might make people's code slower.

Intorduce `nofs_wide`, `nofs_logical`, `allow_frequency_scaling`