### PR TITLE
First step for  #1316

### DIFF
--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -13,7 +13,7 @@ CREATE_SUBDIRS         = NO
 ALLOW_UNICODE_NAMES    = NO
 
 BRIEF_MEMBER_DESC      = YES
-REPEAT_BRIEF           = YES
+REPEAT_BRIEF           = NO
 ABBREVIATE_BRIEF       = "The $name class" \
                          "The $name widget" \
                          "The $name file" \

--- a/include/eve/detail/raberu.hpp
+++ b/include/eve/detail/raberu.hpp
@@ -1,7 +1,7 @@
 //==================================================================================================
 /*
   RABERU - Fancy Parameters Library
-  Copyright : RABERU Contributors & Maintainers
+  Copyright : RABERU Project Contributors
   SPDX-License-Identifier: BSL-1.0
 */
 //==================================================================================================
@@ -9,6 +9,7 @@
 #define RABERU_HPP_INCLUDED
 
 #include <array>
+#include <compare>
 #include <cstring>
 #include <ostream>
 #include <string_view>
@@ -17,37 +18,135 @@
 
 #define RBR_FWD(...) static_cast<decltype(__VA_ARGS__) &&>(__VA_ARGS__)
 
+//==================================================================================================
+//! @namespace rbr
+//! @brief Main Raberu namespace
+//==================================================================================================
+
+//==================================================================================================
+//! @defgroup main Main RABERU components
+//!
+//! @ingroup  main
+//! @{
+//!   @defgroup kwds Keywords definitions and handling
+//!   @brief    Functions and types to handle RABERU keywords
+//! @}
+//==================================================================================================
+
+//==================================================================================================
+//!   @defgroup stng Settings definitions and handling
+//!   @brief    Functions and types to handle RABERU settings
+//! @}
+//==================================================================================================
+
+//==================================================================================================
+//! @defgroup utility   Helper types and function
+//! @brief    Tools for interacting with Raberu components
+//==================================================================================================
+
+//==================================================================================================
+//! @ingroup  utility
+//! @{
+//!   @defgroup udls   User-defined Literal operators
+//!   @brief    UDL operators
+//! @}
+//==================================================================================================
+
+// Fix for non-conformant libcpp
+namespace rbr::stdfix
+{
+  template<typename T, typename U >
+  concept is_same_impl = std::is_same_v<T, U>;
+
+  template<typename T, typename U >
+  concept same_as = is_same_impl<T, U> && is_same_impl<U, T>;
+}
+
+//==================================================================================================
+//! @namespace rbr::concepts
+//! @brief Raberu Concepts namespace
+//==================================================================================================
 namespace rbr::concepts
 {
-  // Keyword concept
+  //================================================================================================
+  //! @brief Keyword concept
+  //!
+  //! A Keyword type is able to be bound to a value as an [Option](@ref rbr::concepts::option)
+  //================================================================================================
   template<typename K> concept keyword = requires( K k )
   {
     typename K::tag_type;
-    { K::template accept<int>() } -> std::same_as<bool>;
+    { K::template accept<int>() } -> stdfix::same_as<bool>;
   };
 
-  // Option concept
+  //================================================================================================
+  //! @brief Option concept
+  //!
+  //! An Option type can be aggregated in a [Settings](@ref rbr::concepts::settings) and be
+  //! fetched later
+  //================================================================================================
   template<typename O> concept option = requires( O const& o )
   {
     { o(typename std::remove_cvref_t<O>::keyword_type{}) }
-    -> std::same_as<typename std::remove_cvref_t<O>::stored_value_type>;
+    -> stdfix::same_as<typename std::remove_cvref_t<O>::stored_value_type>;
   };
 
-  // Type checker concept
-  template<typename C> concept type_checker = requires( C const& )
+  //================================================================================================
+  //! @brief Settings concept
+  //!
+  //! A Settings is a group of [Options](@ref rbr::concepts::option)
+  //================================================================================================
+  template<typename S> concept settings = requires( S const& s )
   {
-    typename C::template apply<int>::type;
+    typename S::rbr_settings;
   };
 
-  // keyword parameter exact match
+  //================================================================================================
+  //! @brief Exact match concept helper
+  //!
+  //! rbr::concepts::exactly is to be used to constraint functions template parameter to be an
+  //! instantiation of a precise [Keyword](@ref rbr::concepts::keyword)
+  //================================================================================================
   template<typename Option, auto Keyword>
-  concept exactly = std::same_as< typename Option::keyword_type
-                                , std::remove_cvref_t<decltype(Keyword)>
-                                >;
+  concept exactly = stdfix::same_as < typename Option::keyword_type
+                                    , std::remove_cvref_t<decltype(Keyword)>
+                                    >;
 }
 
 namespace rbr::detail
 {
+  // Check for check()
+  template<typename K, typename T>
+  concept checks_for = requires(K)
+  {
+    { K::template check<T>() };
+  };
+
+  // Checks for identifier
+  template<typename T>
+  concept identifiable = requires(T t)
+  {
+    { t.identifier };
+  };
+
+  // Checks for identifier
+  template<typename T>
+  concept self_identifiable = requires(T t, std::ostream& os)
+  {
+    { os << t };
+  };
+
+  // Checks for display
+  template<typename T, typename V>
+  concept displayable = requires(T t, std::ostream& os, V v)
+  {
+    { t.display(os,v) };
+  };
+
+  // Concept to constraint size
+  template<std::size_t N, std::size_t M>
+  concept fits = (N <= M);
+
   // Lightweight container of value in alternatives
   template<concepts::keyword T, typename V> struct type_or_
   {
@@ -58,26 +157,44 @@ namespace rbr::detail
   };
 
   // Type -> String converter
-  template <typename T> constexpr auto type_name() noexcept
+  template <typename T> constexpr auto typer() noexcept
   {
-    std::string_view name, prefix, suffix;
-  #ifdef __clang__
-    name = __PRETTY_FUNCTION__;
-    prefix = "auto rbr::detail::type_name() [T = ";
-    suffix = "]";
-  #elif defined(__GNUC__)
-    name = __PRETTY_FUNCTION__;
-    prefix = "constexpr auto rbr::detail::type_name() [with T = ";
-    suffix = "]";
-  #elif defined(_MSC_VER)
-    name = __FUNCSIG__;
-    prefix = "auto __cdecl rbr::detail::type_name<";
-    suffix = ">(void)";
-  #endif
-    name.remove_prefix(prefix.size());
-    name.remove_suffix(suffix.size());
-    return name;
+#if defined(__clang__)
+    constexpr auto pfx = std::string_view("auto rbr::detail::typer() [T = ").size();
+    constexpr auto sfx = std::string_view("]").size();
+    constexpr auto raw = std::string_view(__PRETTY_FUNCTION__);
+#elif defined(__GNUC__)
+    constexpr auto pfx = std::string_view("constexpr auto rbr::detail::typer() [with " "T = ").size();
+    constexpr auto sfx = std::string_view("]").size();
+    constexpr auto raw = std::string_view(__PRETTY_FUNCTION__);
+#elif defined(_MSC_VER)
+    constexpr auto pfx = std::string_view("auto __cdecl rbr::detail::typer<").size();
+    constexpr auto sfx = std::string_view(">(void)").size();
+    constexpr auto raw = std::string_view(__FUNCSIG__);
+#endif
+    auto value = raw;
+    value.remove_prefix(pfx);
+    value.remove_suffix(sfx);
+
+    constexpr auto size = raw.size() - (pfx + sfx);
+    auto fn = [&]<std::size_t... Is>(std::index_sequence<Is...>)
+    {
+      return std::array<char const, sizeof...(Is) + 1>{value[Is]...};
+    };
+
+    return fn(std::make_index_sequence<size>{});
   }
+
+  template<typename T>  inline constexpr auto type_array  = typer<T>();
+
+  template<typename T, auto ID = type_array<T>>
+  struct type_t
+  {
+    static constexpr auto name() { return std::string_view(ID.data(), ID.size());}
+  };
+
+  template<typename T>
+  inline constexpr auto type  = type_t<T>{};
 
   // Helpers for working on list of keys as unique lists - needed by merge and some contains_*
   template<typename... Ks> struct keys {};
@@ -85,7 +202,7 @@ namespace rbr::detail
   template<typename K, typename Ks> struct contains;
 
   template<typename... Ks, typename K>
-  struct  contains<K, keys<Ks...>> : std::bool_constant<(std::same_as<K,Ks> || ...)>
+  struct  contains<K, keys<Ks...>> : std::bool_constant<(stdfix::same_as<K,Ks> || ...)>
   {};
 
   template<typename K, typename Ks, bool>  struct append_if_impl;
@@ -130,168 +247,322 @@ namespace rbr::detail
   {};
 }
 
+#if !defined(RBR_MAX_LITERAL_SIZE)
+#define RBR_MAX_LITERAL_SIZE 32
+#endif
+
 namespace rbr
 {
-  // ID user defined literals
+  //================================================================================================
+  //! @namespace rbr::literals
+  //! @brief Raberu literals namespace
+  //================================================================================================
   namespace literals
   {
-    template<std::size_t N> struct str_
+    //==============================================================================================
+    //! @ingroup utility
+    //! @brief Compile-time static string
+    //==============================================================================================
+    struct str
     {
-      std::array<char,N> data;
+      static constexpr std::size_t max_size = RBR_MAX_LITERAL_SIZE;
 
-      template <std::size_t... Is>
-      constexpr str_(const char (&str)[N], std::index_sequence<Is...>) :data{str[Is]...} {}
-      constexpr str_(const char (&str)[N]) : str_{str, std::make_index_sequence<N>{}} {}
+      char         data_[max_size+1];
+      std::uint8_t size_;
 
-      static constexpr  auto  size()  { return N; }
-      auto value() const { return std::string_view(&data[0],strlen(&data[0])); }
+      template<std::size_t N, std::size_t... Is>
+      requires detail::fits<N,max_size>
+      constexpr str(const char (&s)[N], std::index_sequence<Is...>) : data_{s[Is]...}, size_(N)
+      {}
+
+      template <std::size_t N>
+      requires detail::fits<N,max_size>
+      constexpr str(const char (&s)[N]) : str{s, std::make_index_sequence<N>{}}
+      {}
+
+      constexpr std::size_t       size()  const { return size_; }
+      constexpr std::string_view  value() const { return std::string_view(&data_[0],size_); }
+
+      friend std::ostream& operator<<(std::ostream& os, str const& s)
+      {
+        return os << '\'' << s.value() << '\'';
+      }
     };
-
-    template<std::size_t N> str_(const char (&str)[N]) -> str_<N>;
   }
 
-  template<literals::str_ ID> struct id_
+  //================================================================================================
+  //! @ingroup utility
+  //! @brief Compile-time text based ID
+  //! @tparam ID Compile-time string for the ID
+  //================================================================================================
+  template<literals::str ID> struct id_
   {
+    /// Inserts an rbr::id_ in an output stream
     friend std::ostream& operator<<(std::ostream& os, id_ const&)
     {
-      return os << '\'' << ID.value() << '\'';
+      return os << ID;
     }
   };
 
   namespace literals
   {
-    template<str_ ID> constexpr auto operator""_id() noexcept { return id_<ID>{}; }
+    //==============================================================================================
+    //! @ingroup udls
+    //! @brief Forms an ID constant literal
+    //! @return An instance of rbr::id_ for the specified string
+    //==============================================================================================
+    template<str ID> constexpr auto operator""_id() noexcept { return id_<ID>{}; }
   }
 
-  // Callable alternative wrapper
-  template<typename Func>
-  struct call
+  //================================================================================================
+  //! @ingroup kwds
+  //! @brief Callable object wrapper for functional default value
+  //! @tparam Func Callable object to keep
+  //================================================================================================
+  template<typename Func> struct call
   {
     constexpr call(Func f) : callable(f) {}
     constexpr auto perform() const { return callable(); }
     Func callable;
   };
 
-  // Option implementation
+  //================================================================================================
+  //! @ingroup stng
+  //! @brief Callable object wrapper for functional default value
+  //! @tparam Keyword Keyword for the option
+  //! @tparam Value   Value stored in the option
+  //================================================================================================
   template<concepts::keyword Keyword, typename Value> struct option
   {
-    using stored_value_type    = Value;
-    using keyword_type  = Keyword;
+    using stored_value_type = std::decay_t<Value>;
+    using keyword_type      = Keyword;
 
     constexpr stored_value_type operator()(keyword_type const&) const noexcept { return contents; }
-    Value contents;
+    stored_value_type contents;
   };
 
-// Base class for custom keyword
+  //================================================================================================
+  //! @ingroup kwds
+  //! @brief Base class for keyword definition
+  //!
+  //! rbr::as_keyword provides an CRTP base class for keyword-like types. It is internally used
+  //! to provide specific keyword constructors but can be used to define user-defined keyword.
+  //!
+  //! @tparam Keyword Keyword type being defined
+  //================================================================================================
   template<typename Keyword> struct as_keyword
   {
+    /// Derived keyword type
     using tag_type  = Keyword;
 
+    /// Keyword comparison
     inline constexpr auto operator<=>(as_keyword const&) const noexcept = default;
 
-    template<typename T> static constexpr bool accept()
+    //==============================================================================================
+    //! @brief Compile-time validation of value
+    //!
+    //! When a value is bound to a [Keyword](@ref rbr::concepts::keyword) to form an
+    //! [Option](@ref rbr::concepts::option), one can validate this binding by checking arbitrary
+    //! properties on the value type. This is done by the accept() member.
+    //!
+    //! If `Keyword` defines a `check` static template member function, it will be called to provide
+    //! the return value of accept(). Otherwise, true is returned, thus automatically validating any
+    //! value type.
+    //!
+    //! @tparam T Type to validate
+    //! @return `true` if T is accepted by current keyword, `false` otherwise.
+    //!
+    //! ## Example:
+    //! @snippet doc/accept.cpp Custom Accept
+    //==============================================================================================
+
+    template<typename T>
+    static constexpr bool accept()
     {
-      if constexpr( requires(Keyword) { Keyword::template check<T>(); } )
-        return Keyword::template check<T>();
-      else
-        return true;
+      if      constexpr(stdfix::same_as<std::remove_cvref_t<T>,as_keyword>)             return true;
+      else if constexpr(detail::checks_for<Keyword,T>)          return Keyword::template check<T>();
+      else                                                                              return true;
     }
 
+    //==============================================================================================
+    //! @brief Assignment of a value to a keyword
+    //!
+    //! Bind a value to current [Keyword](@ref rbr::concepts::keyword) and returns an instance of
+    //! an [Option](@ref rbr::concepts::option).
+    //!
+    //! @param v Bound value
+    //! @return An rbr::option binding the keyword to `v`.
+    //==============================================================================================
     template<typename Type>
     constexpr auto operator=(Type&& v) const noexcept requires( accept<Type>() )
     {
-      return option<Keyword,std::remove_cvref_t<Type>>{RBR_FWD(v)};
+      return option<Keyword,Type>{RBR_FWD(v)};
     }
 
+    //==============================================================================================
+    //! @brief Stream insertion function
+    //!
+    //! Display a textual description of current keyword and bound value over an output stream.
+    //!
+    //! If `Keyword` defines a `display` member variable, it will be used to perform this display.
+    //! Otherwise, its value will be displayed along with either a user-defined identifier or its
+    //! stringified typename.
+    //!
+    //! @param os Output stream
+    //! @param v  Value bound to current keyword
+    //! @return The up-to-date output stream
+    //!
+    //! ## Example:
+    //! @snippet doc/show.cpp Custom Show
+    //==============================================================================================
     template<typename V> std::ostream& show(std::ostream& os, V const& v) const
     {
-      if constexpr(  requires(Keyword t) { t.display(os,v); } ) return Keyword{}.display(os,v);
+      if constexpr(detail::displayable<Keyword,V>) return Keyword{}.display(os,v);
       else
       {
-        os << '[' << detail::type_name<Keyword>() << ']';
-        return os << " : " << v << " (" << detail::type_name<V>() << ')';
+        if constexpr(detail::identifiable<Keyword>) os << Keyword::identifier;
+        else                                        os << '[' << detail::type<Keyword>.name() << ']';
+
+        return os << " : " << v << " (" << detail::type<V>.name() << ')';
       }
     }
 
+    /// Specify a default value for the keyword
     template<typename Type>
     constexpr auto operator|(Type&& v) const noexcept requires( accept<Type>() )
     {
       return detail::type_or_<Keyword,std::remove_cvref_t<Type>>{RBR_FWD(v)};
     }
 
+    /// Specify a Callable object as a default value for the keyword
     template<typename Func> constexpr auto operator|(call<Func>&& v) const noexcept
     {
       return detail::type_or_<Keyword,call<Func>>{RBR_FWD(v)};
     }
 
+    //==============================================================================================
+    //! @brief Keyword fetching from options set
+    //!
+    //! @param o Set of options to inspect
+    //! @return f current keyword is present in `o...`, return its bound value. Otherwise,
+    //! returns an instance of rbr::unknown_key.
+    //!
+    //! ## Example:
+    //! @include doc/keyword_fetch.cpp
+    //==============================================================================================
     template<concepts::option... Os>
     constexpr decltype(auto) operator()(Os&&... o) const { return fetch(Keyword{}, RBR_FWD(o)...); }
   };
 
-  // checked_keyword implementation
-  template<typename Tag, typename Traits>
-  struct checked_keyword : as_keyword<checked_keyword<Tag, Traits>>
+  //================================================================================================
+  //! @ingroup kwds
+  //! @brief Checked keyword
+  //!
+  //! A Checked keyword is a keyword that verify if a value's type satisfies a predicates before
+  //! binding it
+  //!
+  //! @tparam ID        Unique identifier for the keyword
+  //! @tparam Checker   Unary template meta-function acting as predicate
+  //================================================================================================
+  template<typename ID, template<class> class Checker>
+  struct checked_keyword : as_keyword<checked_keyword<ID, Checker>>
   {
-    constexpr checked_keyword() {}
-    constexpr checked_keyword(Tag, Traits) {}
-
-    template<typename T> static constexpr bool check()
-    {
-      return Traits::template apply<std::remove_cvref_t<T>>::value;
-    }
+    using as_keyword<checked_keyword<ID, Checker>>::operator=;
+    template<typename T>  static constexpr bool check() { return Checker<T>::value; }
 
     template<typename V>
     std::ostream& display(std::ostream& os, V const& v) const
     {
-      if constexpr(  requires(Tag t) { os << Tag{}; } ) os << Tag{};
-      else os << '[' << detail::type_name<Tag>() << ']';
+      if constexpr(detail::self_identifiable<ID>) os << ID{};
+      else
+      {
+        if constexpr(detail::identifiable<ID>) os << ID::identifier;
+        else os << '[' << detail::type<ID>.name() << ']';
+      }
 
-      os << " ::: " << v << " (" << detail::type_name<V>() << ") checked by '";
-      return os << detail::type_name<Traits>() << '\'';
+      os << " ::: " << v << " (" << detail::type<V>.name() << ") checked by '";
+      return os << detail::type<Checker<V>>.name() << '\'';
     }
-
-    using as_keyword<checked_keyword<Tag, Traits>>::operator=;
   };
 
-  // Keyword accepting a precise type as input
-  template<typename Tag, typename Value>
-  struct typed_keyword  : as_keyword<typed_keyword<Tag, Value>>
+  //================================================================================================
+  //! @ingroup kwds
+  //! @brief Typed keyword
+  //!
+  //! A Typed keyword is a keyword that verify if a value's type is exactly matching a type.
+  //!
+  //! @tparam ID    Unique identifier for the keyword
+  //! @tparam Type  Type to accept
+  //================================================================================================
+  template<typename ID, typename Type>
+  struct typed_keyword  : as_keyword<typed_keyword<ID, Type>>
   {
-    template<typename T> static constexpr bool check() { return std::is_same_v<T,Value>; }
-
-    using as_keyword<typed_keyword<Tag, Value>>::operator=;
+    using as_keyword<typed_keyword<ID, Type>>::operator=;
+    template<typename T>
+    static constexpr bool check() { return std::is_same_v<std::remove_cvref_t<T>,Type>; }
 
     template<typename V>
     std::ostream& display(std::ostream& os, V const& v) const
     {
-      if constexpr(  requires(Tag t) { os << Tag{}; } ) os << Tag{};
-      else os << '[' << detail::type_name<Tag>() << ']';
+      if constexpr(detail::self_identifiable<ID>) os << ID{};
+      else
+      {
+        if constexpr(detail::identifiable<ID>) os << ID::identifier;
+        else os << '[' << detail::type<ID>.name() << ']';
+      }
 
-      return os << " : " << v << " [[" << detail::type_name<V>() << "]]";
+      return os << " : " << v << " of type '" << detail::type<V>.name() << '\'';
     }
   };
 
-  // Keyword accepting any type as input
-  template<typename Tag>
-  struct any_keyword   : as_keyword<any_keyword<Tag>>
+  //================================================================================================
+  //! @ingroup kwds
+  //! @brief Regular keyword
+  //!
+  //! A Regular keyword is a keyword that accepts any types.
+  //!
+  //! @tparam ID    Unique identifier for the keyword
+  //================================================================================================
+  template<typename ID>
+  struct any_keyword   : as_keyword<any_keyword<ID>>
   {
-    using as_keyword<any_keyword<Tag>>::operator=;
+    using as_keyword<any_keyword<ID>>::operator=;
+
+    /// ID type associated to the keyword
+    using id_type = ID;
 
     template<typename V>
     std::ostream& display(std::ostream& os, V const& v) const
     {
-      if constexpr(requires(Tag t) { os << Tag{}; })  os << Tag{};
-      else                                            os << '[' << detail::type_name<Tag>() << ']';
+      if constexpr(detail::self_identifiable<ID>) os << ID{};
+      else
+      {
+        if constexpr(detail::identifiable<ID>) os << ID::identifier;
+        else os << '[' << detail::type<ID>.name() << ']';
+      }
 
-      return os << " : " << v << " (" << detail::type_name<V>() << ')';
+      return os << " : " << v << " (" << detail::type<V>.name() << ')';
     }
   };
 
-  // Flags are keyword/options which value is given by its sole presence
-  template<typename Keyword> struct flag_keyword
+  //================================================================================================
+  //! @ingroup kwds
+  //! @brief Flag keyword
+  //!
+  //! A Flag keyword is a keyword which value is given by its mere presence. It accepts no binding
+  //! and return a value convertible to `bool` when set in a rbr::settings.
+  //!
+  //! By design, a flag is also its own rbr::option.
+  //!
+  //! @tparam ID    Unique identifier for the keyword
+  //================================================================================================
+  template<typename ID> struct flag_keyword
   {
     constexpr flag_keyword() {}
-    constexpr flag_keyword(Keyword const&) {}
+    constexpr flag_keyword(ID const&) {}
+
+    /// ID type associated to the keyword
+    using id_type = ID;
 
     template<typename T> static constexpr bool accept()
     {
@@ -300,18 +571,19 @@ namespace rbr
 
     std::ostream& show(std::ostream& os, bool) const
     {
-      return os << Keyword{} << " : set";
+      if constexpr(detail::identifiable<ID>) os << ID::identifier;
+      else if constexpr(detail::self_identifiable<ID>) os << ID{};
+      else os << '[' << detail::type<ID>.name() << ']';
+
+      return os << " : set";
     }
 
-    using tag_type          = Keyword;
+    using tag_type          = ID;
     using keyword_type      = flag_keyword;
     using stored_value_type = std::true_type;
 
     template<typename Type>
-    constexpr auto operator=(Type&&) const noexcept
-    {
-      return *this;
-    }
+    constexpr auto operator=(Type&&) const noexcept { return *this; }
 
     template<typename Type>
     constexpr auto operator|(Type&& v) const noexcept
@@ -329,34 +601,85 @@ namespace rbr
     template<typename O0, typename O1, typename... Os>
     constexpr decltype(auto) operator()(O0&&, O1&&, Os&&... ) const
     {
-      return    std::same_as<keyword_type , typename std::remove_cvref_t<O0>::keyword_type>
-            ||  std::same_as<keyword_type , typename std::remove_cvref_t<O1>::keyword_type>
-            || (std::same_as<keyword_type, typename std::remove_cvref_t<Os>::keyword_type> || ...);
+      return    stdfix::same_as<keyword_type, typename std::remove_cvref_t<O0>::keyword_type>
+            ||  stdfix::same_as<keyword_type, typename std::remove_cvref_t<O1>::keyword_type>
+            || (stdfix::same_as<keyword_type, typename std::remove_cvref_t<Os>::keyword_type> || ...);
     }
   };
 
-  // Keyword builder
-  template<typename Tag> constexpr flag_keyword<Tag>  flag(Tag) noexcept { return {}; }
-  template<typename Tag> constexpr any_keyword<Tag>   keyword(Tag) noexcept { return {}; }
+  //================================================================================================
+  //! @ingroup kwds
+  //! @related rbr::flag_keyword
+  //! @brief Create a flag keyword for reuse
+  //! @param  id  Unique rbr::id_ for the keyword being built
+  //! @return An instance of rbr::flag_keyword
+  //! ## Example:
+  //! @include doc/flag.cpp
+  //================================================================================================
+  template<typename Tag>
+  constexpr flag_keyword<Tag>  flag([[maybe_unused]] Tag id) noexcept { return {}; }
 
-  template<concepts::type_checker Checker, typename Tag>
-  constexpr checked_keyword<Tag,Checker> keyword(Tag) noexcept { return {}; }
+  //================================================================================================
+  //! @ingroup kwds
+  //! @related rbr::any_keyword
+  //! @brief Create a regular keyword for reuse
+  //! @param  id  Unique rbr::id_ for the keyword being built
+  //! @return An instance of rbr::any_keyword
+  //! ## Example:
+  //! @include doc/regular.cpp
+  //================================================================================================
+  template<typename ID>
+  constexpr any_keyword<ID> keyword([[maybe_unused]] ID id) noexcept { return {}; }
 
-  template<typename Type, typename Tag>
-  constexpr typed_keyword<Tag, Type> keyword(Tag) noexcept { return {}; }
+  //================================================================================================
+  //! @ingroup kwds
+  //! @related rbr::checked_keyword
+  //! @brief Create a checked keyword for reuse
+  //! @tparam Checker Unary template meta-function to use for validation
+  //! @param  id  Unique rbr::id_ for the keyword being built
+  //! @return An instance of rbr::checked_keyword
+  //! ## Example:
+  //! @include doc/checked.cpp
+  //================================================================================================
+  template<template<class> class Checker, typename ID>
+  constexpr checked_keyword<ID,Checker> keyword([[maybe_unused]] ID id) noexcept { return {}; }
 
-  // Keyword/Flag-type user defined literals
+  //================================================================================================
+  //! @ingroup kwds
+  //! @related rbr::typed_keyword
+  //! @brief Create a typed Keyword for reuse
+  //! @tparam Type Type accepted by the keyword
+  //! @param  id  Unique rbr::id_ for the keyword being built
+  //! @return An instance of rbr::checked_keyword
+  //! ## Example:
+  //! @include doc/checked.cpp
+  //================================================================================================
+  template<typename Type, typename ID>
+  constexpr typed_keyword<ID, Type> keyword([[maybe_unused]] ID id) noexcept { return {}; }
+
   namespace literals
   {
-    template<str_ ID>
+    //==============================================================================================
+    //! @ingroup udls
+    //! @related rbr::any_keyword
+    //! @brief Forms an instance of rbr::any_keyword from a literal string
+    //! @return An instance of rbr::any_keyword using the specified string as ID
+    //==============================================================================================
+    template<str ID>
     constexpr auto operator""_kw() noexcept { return any_keyword<id_<ID>>{}; }
 
-    template<str_ ID>
+    //==============================================================================================
+    //! @ingroup udls
+    //! @related rbr::flag_keyword
+    //! @brief Forms an instance of rbr::flag_keyword from a literal string
+    //! @return An instance of rbr::flag_keyword using the specified string as ID
+    //==============================================================================================
+    template<str ID>
     constexpr auto operator""_fl() noexcept { return flag_keyword<id_<ID>>{}; }
   }
 
-  // Tag for when something is not found in an aggregator
-  struct unknown_key {};
+  /// Type indicating that a [Keyword](@ref rbr::concepts::keyword) is not available
+  struct unknown_key { using type = unknown_key; };
 
   // Option calls aggregator
   template<concepts::option... Ts> struct aggregator : Ts...
@@ -370,26 +693,63 @@ namespace rbr
     }
   };
 
-  // Settings is a group of options
+  //================================================================================================
+  //! @ingroup stng
+  //! @brief Defines a group of options for processing
+  //!
+  //! rbr::settings acts as an aggregation of [Options](@ref rbr::concepts::option) (ie pair of
+  //! [Keyword](@ref rbr::concepts::keyword)/value) that provides an user-interface for accessing
+  //! or managing said [Options](@ref rbr::concepts::option) and to gather informations.
+  //!
+  //! @tparam Opts  List of [options](@ref rbr::concepts::option) aggregated
+  //================================================================================================
   template<concepts::option... Opts> struct settings
   {
+    using rbr_settings = void;
     using base = aggregator<Opts...>;
+
+    /// Constructor from a variadic pack of rbr::concepts::option
     constexpr settings(Opts const&... opts) : content_(opts...) {}
 
+    /// Number of options in current rbr::settings
     static constexpr std::ptrdiff_t size() noexcept { return sizeof...(Opts); }
 
+    //==============================================================================================
+    //! @brief Checks if a given rbr::keyword is stored inside rbr::settings
+    //! @param kw Keyword to check
+    //! @return An instance of `std::true_type` if current setting contains an option based on `kw`.
+    //!         Otherwise, return an instance of `std::false_type`.
+    //! ## Example:
+    //! @include doc/contains.cpp
+    //==============================================================================================
     template<concepts::keyword Key>
-    static constexpr auto contains(Key const &) noexcept
+    static constexpr auto contains([[maybe_unused]] Key const& kw) noexcept
     {
       using found = decltype((std::declval<base>())(Key{}));
-      return std::bool_constant<!std::same_as<found, unknown_key> >{};
+      return std::bool_constant<!stdfix::same_as<found, unknown_key> >{};
     }
 
+    //==============================================================================================
+    //! @brief Checks if rbr::settings contains at least one of maybe keyword
+    //! @param ks Keywords to check
+    //! @return An instance of `std::true_type` if current setting contains at least one option
+    //!         based on any of the `ks`. Otherwise, return an instance of `std::false_type`.
+    //! ## Example:
+    //! @include doc/contains_any.cpp
+    //==============================================================================================
     template<concepts::keyword... Keys>
     static constexpr auto contains_any(Keys... ks) noexcept { return (contains(ks) || ...); }
 
+    //==============================================================================================
+    //! @brief Checks if rbr::settings contains options based only on selected keywords
+    //! @param ks Keywords to check
+    //! @return An instance of `std::true_type` if current setting contains only options
+    //!         based on any of the `ks`. Otherwise, return an instance of `std::false_type`.
+    //! ## Example:
+    //! @include doc/contains_only.cpp
+    //==============================================================================================
     template<concepts::keyword... Keys>
-    static constexpr auto contains_only(Keys const&...) noexcept
+    static constexpr auto contains_only([[maybe_unused]] Keys const&... ks) noexcept
     {
       using current_keys    = detail::keys<typename Opts::keyword_type...>;
       using acceptable_keys = detail::keys<Keys...>;
@@ -397,20 +757,42 @@ namespace rbr
       return  detail::is_equivalent<unique_set, acceptable_keys>::value;
     }
 
+    //==============================================================================================
+    //! @brief Checks if rbr::settings contains no options based on any of the selected keywords
+    //! @param ks Keywords to check
+    //! @return An instance of `std::true_type` if current setting contains no options
+    //!         based on any of the `ks`. Otherwise, return an instance of `std::false_type`.
+    //! ## Example:
+    //! @include doc/contains_none.cpp
+    //==============================================================================================
     template<concepts::keyword... Keys>
     static constexpr auto contains_none(Keys... ks) noexcept { return !contains_any(ks...); }
 
+    //==============================================================================================
+    //! @brief Retrieved a value via a keyword
+    //!
+    //! Retrieve the value bound to a given keyword `k` inside current rbr::settings instance.
+    //! If such a keyword is not present, either an instance of rbr::unknown_key is returned or
+    //! a default value or function call will be returned.
+    //!
+    //! @param k Keywords to check
+    //! @return If any, the value bound to `k`.
+    //! ## Example:
+    //! @include doc/subscript.cpp
+    //==============================================================================================
     template<concepts::keyword Key> constexpr auto operator[](Key const& k) const noexcept
     {
       return content_(k);
     }
 
+    //! @overload
     template<typename Keyword>
     constexpr auto operator[](flag_keyword<Keyword> const&) const noexcept
     {
       return contains(flag_keyword<Keyword>{});
     }
 
+    //! @overload
     template<concepts::keyword Key, typename Value>
     constexpr auto operator[](detail::type_or_<Key, Value> const & tgt) const
     {
@@ -419,6 +801,8 @@ namespace rbr
       else                                                      return tgt.value;
     }
 
+    //! @related rbr::settings
+    //! @brief Output stream insertion
     friend std::ostream& operator<<(std::ostream& os, settings const& s)
     {
       auto show = [&]<typename T, typename V>(T t, V const& v) -> std::ostream&
@@ -434,10 +818,25 @@ namespace rbr
     base content_;
   };
 
+  /// rbr::settings deduction guide
   template<concepts::option... Opts>
-  settings(Opts&&... opts) -> settings<std::remove_cvref_t<Opts>...>;
+  settings(Opts const&... opts) -> settings<Opts...>;
 
-  // Merge settings
+  //================================================================================================
+  //! @ingroup stng
+  //! @related rbr::settings
+  //! @brief Merge two instances of rbr::settings
+  //!
+  //! Merge all options of `opts` and `defs`. If an options is present in both arguments, the one
+  //! from `opts` is used.
+  //!
+  //! @param opts rbr::settings to merge
+  //! @param defs rbr::settings acting as default value
+  //! @return An instance of rbr::settings containing all options from `opts` and any options
+  //!         from `defs` not present in `opts`.
+  //! ## Example:
+  //! @include doc/merge.cpp
+  //================================================================================================
   template<concepts::option... K1s, concepts::option... K2s>
   constexpr auto merge(settings<K1s...> const& opts, settings<K2s...> const& defs) noexcept
   {
@@ -458,7 +857,6 @@ namespace rbr
                                           >::type{},opts,defs);
   }
 
-  // Drop keyword from settings
   namespace detail
   {
     template<typename K, concepts::keyword... Kept>
@@ -469,7 +867,7 @@ namespace rbr
       template<typename T> constexpr auto operator+(keys<T> const&) const
       {
         using kw_t = typename T::keyword_type;
-        if constexpr(!std::same_as<K, typename kw_t::tag_type>)  return filter<K, Kept..., kw_t>{};
+        if constexpr(!stdfix::same_as<K, typename kw_t::tag_type>)  return filter<K, Kept..., kw_t>{};
         else                                            return *this;
       }
     };
@@ -483,39 +881,87 @@ namespace rbr
     };
   }
 
-  template<concepts::keyword K, concepts::option... Os>
-  constexpr auto drop(K const&, settings<Os...> const& os)
+  //================================================================================================
+  //! @ingroup stng
+  //! @related rbr::settings
+  //! @brief Remove an option from a rbr::settings
+  //!
+  //! Build a rbr::settings containing all options from s except for any option bound to the `k`
+  //! rbr::keyword.
+  //!
+  //! @param k Keyword to remove
+  //! @param s Original rbr::settings
+  //! @return An instance of rbr::settings containing all options of `s` except those bound to `k`.
+  //!
+  //! ## Example:
+  //! @include doc/drop.cpp
+  //================================================================================================
+  template<concepts::keyword K, concepts::option... O>
+  [[nodiscard]] constexpr auto drop([[maybe_unused]] K const& k, settings<O...> const& s)
   {
-    using selected_keys_t = typename detail::select_keys<K,settings<Os...>>::type;
+    using selected_keys_t = typename detail::select_keys<K,settings<O...>>::type;
 
     return [&]<typename ... Ks>( detail::keys<Ks...> )
     {
       // Rebuild a new settings by going over the keys that we keep
-      return rbr::settings{ (Ks{} = os[Ks{}] )...};
+      return rbr::settings{ (Ks{} = s[Ks{}] )...};
     }(selected_keys_t{});
   }
 
-  // Standalone fetch one keyword inside N
+  //================================================================================================
+  //! @ingroup stng
+  //! @brief Retrieved a value via a keyword
+  //!
+  //! Retrieve the value bound to a given keyword `k` inside a variadic list of rbr::options.
+  //! If such a keyword is not present, either an instance of rbr::unknown_key is returned or
+  //! a default value or function call will be returned.
+  //!
+  //! @param k Keywords to check
+  //! @param os Options to inspect
+  //! @return If any, the value bound to `k`.
+  //!
+  //! ## Helper Types
+  //! @code
+  //! namespace rbr::result
+  //! {
+  //!   template<auto Keyword, typename... Sources> struct fetch
+  //!
+  //!   template<auto Keyword, typename... Sources>
+  //!   using fetch_t = typename fetch<Keyword,Sources...>::type;
+  //! }
+  //! @endcode
+  //!
+  //! Return the type of a call to rbr::fetch.
+  //!
+  //! ## Example:
+  //! @include doc/fetch.cpp
+  //================================================================================================
   template<concepts::keyword K, concepts::option... Os>
-  constexpr decltype(auto) fetch(K const& kw, Os const&... os)
+  constexpr decltype(auto) fetch(K const& k, Os const&... os)
   {
     auto const opts = settings(os...);
-    return opts[kw];
+    return opts[k];
   }
 
+  //! @overload
   template<concepts::keyword K, typename V, concepts::option... Os>
-  constexpr decltype(auto) fetch(detail::type_or_<K, V> const& kw, Os const&... os)
+  constexpr decltype(auto) fetch(detail::type_or_<K, V> const& k, Os const&... os)
   {
     auto const opts = settings(os...);
-    return opts[kw];
+    return opts[k];
   }
 
-  template<typename K, typename Settings>
-  constexpr decltype(auto) fetch(K const& kw, Settings const& opts)
+  //! @overload
+  template<typename K, concepts::settings Settings>
+  constexpr decltype(auto) fetch(K const& k, Settings const& opts)
   {
-    return opts[kw];
+    return opts[k];
   }
 
+  //================================================================================================
+  //! @namespace rbr::result
+  //! @brief Raberu helper traits namespace
+  //================================================================================================
   namespace result
   {
     template<auto Keyword, typename... Sources> struct fetch;
@@ -523,10 +969,10 @@ namespace rbr
     template<auto Keyword, concepts::option... Os>
     struct fetch<Keyword, Os...>
     {
-      using type = decltype( rbr::fetch(Keyword, Os{}...) );
+      using type = decltype( rbr::fetch(Keyword, std::declval<Os>()...) );
     };
 
-    template<auto Keyword, typename Settings>
+    template<auto Keyword, concepts::settings Settings>
     struct fetch<Keyword, Settings>
     {
       using type = decltype( rbr::fetch(Keyword, std::declval<Settings>()) );
@@ -536,7 +982,10 @@ namespace rbr
     using fetch_t = typename fetch<Keyword,Sources...>::type;
   }
 
-  // Global keyword/value_type types extractors
+  //================================================================================================
+  //! @ingroup utility
+  //! @brief Lightweight variadic type list
+  //================================================================================================
   template<typename... T> struct types {};
 
   namespace result
@@ -563,17 +1012,103 @@ namespace rbr
     using values_t = typename values<Settings,List>::type;
   }
 
+  //================================================================================================
+  //! @ingroup stng
+  //! @brief Retrieved the list of all keywords in a settings
+  //!
+  //! @tparam List  A n-ary template type to hold the result values
+  //! @param s      Settings to inspect
+  //! @return An instance of rbr::type containing all the keyword from a rbr::settings.
+  //!
+  //! ## Helper Types
+  //! @code
+  //! namespace rbr::result
+  //! {
+  //!   template<template<typename...> class List, typename Settings> struct keywords;
+  //!
+  //!   template<template<typename...> class List, typename Settings>
+  //!   using keywords_t = typename keywords<List,Settings>::type;
+  //! }
+  //! @endcode
+  //!
+  //! Return the type of a call to rbr::keywords.
+  //!
+  //! ## Example:
+  //! @include doc/keywords.cpp
+  //================================================================================================
   template<template<typename...> class List, typename... Opts>
-  auto keywords(rbr::settings<Opts...> const&)
+  auto keywords([[maybe_unused]]rbr::settings<Opts...> const& s)
   {
     return result::keywords_t<rbr::settings<Opts...>,List>{typename Opts::keyword_type{}...};
   }
 
+  //================================================================================================
+  //! @ingroup stng
+  //! @brief Retrieved the list of all value stored in a settings
+  //!
+  //! @tparam List  A n-ary template type to hold the result
+  //! @param s      Settings to inspect
+  //! @return an instance of rbr::type containing all the values from a rbr::settings.
+  //!
+  //! ## Helper Types
+  //! @code
+  //! namespace rbr::result
+  //! {
+  //!   template<template<typename...> class List, typename Settings> struct values;
+  //!
+  //!   template<template<typename...> class List, typename Settings>
+  //!   using values_t = typename values<List,Settings>::type;
+  //! }
+  //! @endcode
+  //!
+  //! Return the type of a call to rbr::values.
+  //!
+  //! ## Example:
+  //! @include doc/values.cpp
+  //================================================================================================
   template<template<typename...> class List, typename... Opts>
-  auto values(rbr::settings<Opts...> const& o)
+  auto values(rbr::settings<Opts...> const& s)
   {
-    return result::values_t<rbr::settings<Opts...>,List>{ o[typename Opts::keyword_type{}]... };
+    return result::values_t<rbr::settings<Opts...>,List>{ s[typename Opts::keyword_type{}]... };
   }
+
+  //================================================================================================
+  //! @ingroup stng
+  //! @brief Checks the equivalence of two rbr::settings
+  //!
+  //! Two rbr::settings are equivalent if they contain the same exact set of keywords irregardless
+  //! of their values or value types.
+  //!
+  //! @tparam S1 rbr::settings to compare
+  //! @tparam S2 rbr::settings to compare
+  //!
+  //! ## Helper Value
+  //! @code
+  //! namespace rbr
+  //! {
+  //!   template<concepts::settings S1, concepts::settings S2>
+  //!   inline constexpr bool is_equivalent_v = is_equivalent<S1,S2>::value;
+  //! }
+  //! @endcode
+  //!
+  //! Contains the result of a call to rbr::is_equivalent.
+  //!
+  //! ## Example:
+  //! @include doc/is_equivalent.cpp
+  //================================================================================================
+  template<concepts::settings S1, concepts::settings S2>
+  struct  is_equivalent
+        : std::bool_constant<   detail::is_equivalent < result::keywords_t<S1,detail::keys>
+                                                      , result::keywords_t<S2,detail::keys>
+                                                      >::value
+                            &&  detail::is_equivalent < result::keywords_t<S2,detail::keys>
+                                                      , result::keywords_t<S1,detail::keys>
+                                                      >::value
+                            >
+  {};
+
+  template<concepts::settings S1, concepts::settings S2>
+  inline constexpr bool is_equivalent_v = is_equivalent<S1,S2>::value;
 }
 
 #undef RBR_FWD

--- a/include/eve/detail/raberu.hpp
+++ b/include/eve/detail/raberu.hpp
@@ -190,7 +190,8 @@ namespace rbr::detail
   template<typename T, auto ID = type_array<T>>
   struct type_t
   {
-    static constexpr auto name() { return std::string_view(ID.data(), ID.size());}
+    static constexpr auto len(auto p, auto r) noexcept { while(*p) { r++; p++; } return r; }
+    static constexpr auto name() { return std::string_view(ID.data(), len(ID.data(),0));}
   };
 
   template<typename T>

--- a/include/eve/traits/invoke.hpp
+++ b/include/eve/traits/invoke.hpp
@@ -1,0 +1,12 @@
+//====================================================================================================
+/*
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+*/
+//====================================================================================================
+#pragma once
+
+#include <eve/traits/invoke/tag_invoke.hpp>
+#include <eve/traits/invoke/protocol.hpp>
+#include <eve/traits/invoke/decorator.hpp>

--- a/include/eve/traits/invoke/decorator.hpp
+++ b/include/eve/traits/invoke/decorator.hpp
@@ -1,0 +1,174 @@
+//====================================================================================================
+/*
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+*/
+//====================================================================================================
+#pragma once
+
+#include <eve/arch/spec.hpp>
+#include <eve/conditional.hpp>
+#include <eve/detail/raberu.hpp>
+#include <eve/traits/is_logical.hpp>
+#include <eve/traits/invoke/protocol.hpp>
+
+#include <ostream>
+
+namespace eve::detail
+{
+  struct mask_ : rbr::as_keyword<mask_>
+  {
+    using rbr::as_keyword<mask_>::operator=;
+    template<typename T> static constexpr bool check()
+    {
+      return conditional_expr<std::remove_cvref_t<T>>;
+    }
+
+    std::ostream& show(std::ostream& os, auto v) const
+    {
+      return os << "Mask: " << std::boolalpha << v << std::noboolalpha;
+    }
+  };
+
+  // This is an internal option to carry around the mask from options
+  inline constexpr mask_ mask;
+}
+
+namespace eve
+{
+  //================================================================================================
+  //! @addtogroup invoke
+  //! @{
+  //================================================================================================
+
+  //================================================================================================
+  //! @struct decorators
+  //! @brief Overloading error reporting helper
+  //!
+  //! eve::decorators gathers decorators and masks that user could apply on a eve::callable to modify
+  //! its semantic.
+  //!
+  //! @tparam Settings Internal settings type
+  //================================================================================================
+  template <rbr::concepts::settings Settings>
+  struct decorators : Settings
+  {
+    template <rbr::concepts::option... Options>
+    constexpr explicit decorators(Options && ... options) : Settings(EVE_FWD(options) ...) {}
+
+    constexpr decorators(Settings const& options) : Settings(options) {}
+  };
+
+  /// Deduction guide for eve::decorators
+  template <rbr::concepts::option ... Options>
+  decorators(Options&& ... options) -> decorators<decltype(rbr::settings(EVE_FWD(options) ...))>;
+
+  //================================================================================================
+  //! @struct support_options
+  //! @brief  Make an eve::callable responsive to decorators and masks
+  //!
+  //! eve::callable can inherits from eve::support_options to gain the ability to supports
+  //! user-provided decorators and masks to modify its semantic.
+  //!
+  //! Decorators and masks are gathered via the overloaded `operator[]` that eve::support_options
+  //! provides. Decorators and masks can then be chained via multiple application of said operator.
+  //!
+  //! The handling of those decorators and masks are left to the implementation of the callable
+  //! itself.
+  //!
+  //! @tparam Tag eve::callable using eve::support_options
+  //================================================================================================
+  template<typename Tag> struct support_options
+  {
+    template<typename Settings> struct fn
+    {
+      using callable_tag_type = void;
+
+      template<typename Options>
+      EVE_FORCEINLINE auto operator[](Options&& o) const
+      {
+        auto new_opts = rbr::merge(rbr::settings{o}, opts);
+        return fn<decltype(new_opts)>{new_opts};
+      }
+
+      EVE_FORCEINLINE auto operator[](conditional_expr auto m) const
+      {
+        return (*this)[detail::mask = m];
+      }
+
+      template<std::same_as<bool> T>
+      EVE_FORCEINLINE constexpr auto operator[](T c) const noexcept
+      {
+        using type = std::conditional_t<std::same_as<bool,T>,std::uint8_t,T>;
+        return (*this)[detail::mask = if_(logical<type>(c))];
+      }
+
+      template<typename... Args>
+      EVE_FORCEINLINE auto operator()(Args&&... x) const
+      -> tag_invoke_result<Tag, current_api_type, decorators<Settings>, Args&&...>
+      {
+        return tag_invoke(Tag{}, current_api, decorators{opts}, EVE_FWD(x)...);
+      }
+
+#if !defined(EVE_ALLOW_VERBOSE_CALLABLE_ERRORS)
+      template<typename... T>
+      unsupported_call<Tag, Settings, T...> operator()(T&&...x) const noexcept
+      requires(!requires(decorators<Settings> const& s)
+                { tag_invoke(Tag{}, current_api, s, EVE_FWD(x)...); }
+              ) = delete;
+#endif
+
+      Settings opts;
+    };
+
+    //! @brief Modify the semantic of current eve::callable via a bundle of decorators or masks
+    template<rbr::concepts::settings Settings>
+    EVE_FORCEINLINE auto operator[](Settings const& s) const
+    {
+      return fn<decorators<Settings>>{decorators{s}};
+    }
+
+    //! @brief Modify the semantic of current eve::callable by a decorator
+    template<rbr::concepts::option Options>
+    EVE_FORCEINLINE auto operator[](Options const& o) const
+    {
+      return (*this)[decorators{o}];
+    }
+
+    //! @brief Modify the semantic of current eve::callable by a mask
+    EVE_FORCEINLINE auto operator[](conditional_expr auto m) const
+    {
+      return (*this)[detail::mask = m];
+    }
+
+    //! @brief Modify the semantic of current eve::callable by a boolean mask
+    template<std::same_as<bool> T>
+    EVE_FORCEINLINE constexpr auto operator[](T c) const noexcept
+    {
+      using type = std::conditional_t<std::same_as<bool,T>,std::uint8_t,T>;
+      return (*this)[detail::mask = if_(logical<type>(c))];
+    }
+  };
+
+  //================================================================================================
+  //! @}
+  //================================================================================================
+}
+
+//==================================================================================================
+// Basic hook for tag_invoke that just forward to the proper deferred call if possible when dealing
+// callable being decorated.
+// This specialization lives in eve::tags to be found by ADL as tag themselves will be defines
+// in eve::tags.
+//==================================================================================================
+namespace eve::tags
+{
+  template<typename S>
+  constexpr auto tag_invoke(deferred_callable auto tag, auto arch, decorators<S> opts, auto... x)
+  noexcept(noexcept(tag.deferred_call(arch, opts, x...)))
+          ->  decltype(tag.deferred_call(arch, opts, x...))
+  {
+    return tag.deferred_call(arch, opts, x...);
+  }
+}

--- a/include/eve/traits/invoke/decorator.hpp
+++ b/include/eve/traits/invoke/decorator.hpp
@@ -106,18 +106,16 @@ namespace eve
 
       template<typename... Args>
       EVE_FORCEINLINE auto operator()(Args&&... x) const
-      -> tag_invoke_result<Tag, current_api_type, decorators<Settings>, Args&&...>
+      -> tag_invoke_result<Tag, decorators<Settings>, Args&&...>
       {
-        return tag_invoke(Tag{}, current_api, decorators{opts}, EVE_FWD(x)...);
+        return eve::tag_invoke(Tag{}, decorators{opts}, EVE_FWD(x)...);
       }
 
-#if !defined(EVE_ALLOW_VERBOSE_CALLABLE_ERRORS)
       template<typename... T>
-      unsupported_call<Tag, Settings, T...> operator()(T&&...x) const noexcept
+      unsupported_call<Tag(Settings, T...)> operator()(T&&...x) const noexcept
       requires(!requires(decorators<Settings> const& s)
-                { tag_invoke(Tag{}, current_api, s, EVE_FWD(x)...); }
+                { eve::tag_invoke(Tag{}, s, EVE_FWD(x)...); }
               ) = delete;
-#endif
 
       Settings opts;
     };

--- a/include/eve/traits/invoke/protocol.hpp
+++ b/include/eve/traits/invoke/protocol.hpp
@@ -1,0 +1,268 @@
+//====================================================================================================
+/*
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+*/
+//====================================================================================================
+#pragma once
+
+#include <eve/arch/spec.hpp>
+#include <eve/traits/invoke/tag_invoke.hpp>
+
+namespace eve
+{
+//==================================================================================================
+//! @addtogroup invoke
+//! @{
+//==================================================================================================
+
+//==================================================================================================
+//! @struct unsupported_call
+//! @brief Overloading error reporting helper
+//!
+//! eve::unsupported_call is used as a return type when an **EVE** @callable is called with some
+//! incorrect parameter types or quantity. Its template parameters embed the tag of the @callable
+//! along with the parameter types that caused the error.
+//!
+//! @tparam Tag   Tag type of the incorrectly called @callable.
+//! @tparam Args  Arguments used in the incorrect call.
+//==================================================================================================
+template<typename Tag, typename... Args> struct unsupported_call
+{};
+
+//! @brief Tag type for elementwise @callable properties
+struct elementwise
+{
+  using elementwise_tag = void;
+};
+
+//! @brief Tag type for reduction @callable properties
+struct reduction
+{
+  using reduction_tag = void;
+};
+
+//! @brief Tag type for constant @callable properties
+struct constant
+{
+  using constant_tag = void;
+};
+
+//==================================================================================================
+//! @concept callable
+//! @brief **EVE** callable
+//!
+//! A type `T` satisfies eve::callable if and only if it is tagged as such either
+//! manually or by inheriting from a T properties.
+//!
+//! @tparam T  T type for the @callable to check
+//==================================================================================================
+template<typename T>
+concept callable = requires(T) { typename T::callable_tag_type; };
+
+//==================================================================================================
+//! @concept deferred_callable
+//! @brief **EVE** deferred callable
+//!
+//! A type `T` satisfies eve::deferred_callable_tag if and only if it is a eve::callable and
+//! provides the required static function `deferred_call`.
+//!
+//! @tparam T  T type for the @callable to check
+//==================================================================================================
+template<typename T>
+concept deferred_callable = requires(T) { typename T::deferred_callable_tag; };
+
+//==================================================================================================
+//! @concept named_callable
+//! @brief **EVE** callable with a text description
+//!
+//! A type `T` satisfies eve::callable if and only if it is an eve::callable and provides a
+//! `callable_tag_name` static member that can be streamed.
+//!
+//! @tparam T Tag type for the @callable to check
+//==================================================================================================
+template<typename T>
+concept named_callable = callable<T> && requires(T, std::ostream& os) { os << T::callable_id; };
+
+//==================================================================================================
+//! @concept elementwise_callable
+//! @brief **EVE** callable with elementwise semantic
+//!
+//! A type `T` satisfies eve::elementwise_callable if and only if it is an eve::callable that
+//! inherits from eve::elementwise.
+//!
+//! @tparam T  T type for the @callable to check
+//==================================================================================================
+template<typename T>
+concept elementwise_callable = callable<T> && requires(T) { typename T::elementwise_tag; };
+
+//==================================================================================================
+//! @concept reduction_callable
+//! @brief **EVE** callable with reduction semantic
+//!
+//! A type `T` satisfies eve::reduction_callable if and only if it is an eve::callable that
+//! inherits from eve::reduction.
+//!
+//! @tparam T  T type for the @callable to check
+//==================================================================================================
+template<typename T>
+concept reduction_callable = callable<T> && requires(T) { typename T::reduction_tag; };
+
+//==================================================================================================
+//! @concept constant_callable
+//! @brief **EVE** callable with constant semantic
+//!
+//! A type `T` satisfies eve::constant_callable if and only if it is an eve::callable that
+//! inherits from eve::constant.
+//!
+//! @tparam T  T type for the @callable to check
+//==================================================================================================
+template<typename T>
+concept constant_callable = callable<T> && requires(T) { typename T::constant_tag; };
+}
+
+//==================================================================================================
+// Basic hook for tag_invoke that just forward to the proper deferred call if possible.
+// This binds all existing implementation of <func>_ back to tag_invoke.
+// This specialization lives in eve::tags to be found by ADL as tag themselves will be defines
+// in eve::tags.
+//==================================================================================================
+namespace eve::tags
+{
+  constexpr   auto tag_invoke(deferred_callable auto tag, auto arch, auto... x)
+  noexcept(noexcept(tag.deferred_call(arch, x...)))
+          ->  decltype(tag.deferred_call(arch, x...))
+  {
+    return tag.deferred_call(arch, x...);
+  }
+}
+
+//==================================================================================================
+//! @}
+//==================================================================================================
+
+//==================================================================================================
+//  Helpers macros
+//  NOTE: Those macros are here for convenience but are no way mandatory to use in either EVE, any
+//        EVE-dependent library or any user-facing code. The required interface for EVE callable is
+//        short enough to be written manually if the need arise.
+//==================================================================================================
+
+//==================================================================================================
+//  Short-cut macro for defining the basic interface to satisfy callable and named_callable.
+//  Also defined a hidden friend stream insertion operator
+//==================================================================================================
+#define EVE_DEFINES_CALLABLE(TYPE, ID)                                                            \
+inline friend std::ostream& operator<<(std::ostream& os, TYPE const&)                             \
+{                                                                                                 \
+  return os << ID;                                                                                \
+}                                                                                                 \
+using callable_tag_type                       = TYPE;                                             \
+static constexpr std::string_view callable_id = ID                                                \
+/**/
+
+//==================================================================================================
+//  Short-cut macro for defining the callable local poison pill that uses =delete to stop error
+//  message propagation and contains the informations required to locate the incorrect call.
+//  NOTE: This is the preferred way to have SFINAE-Friendly callable and get short error messages.
+//        If you want to do something else, you're free to do so.
+//  NOTE: THis behavior can be deactivated via the EVE_ALLOW_VERBOSE_CALLABLE_ERRORS macro
+//==================================================================================================
+#if !defined(EVE_ALLOW_VERBOSE_CALLABLE_ERRORS)
+#define EVE_EXCLUDE_INCORRECT_CALLABLE(TYPE)                                                      \
+template<typename... T>                                                                           \
+eve::unsupported_call<TYPE, T...> operator()(T const&...x) const noexcept                         \
+requires(!requires { tag_invoke(*this, eve::current_api, x...); }) = delete                       \
+/**/
+#else
+#define EVE_EXCLUDE_INCORRECT_CALLABLE(TYPE) using verbose_callable_tag = void \
+/**/
+#endif
+
+//==================================================================================================
+// When using external deferred call to shorten the overload set of any given function, EVE expects
+// the use of an ADL delay type that lives in the namespace where the deferred functions live.
+// In EVE, this namespace is eve::detail but in other library, it may be desirable to change this.
+// This macro generate the required type and object in the namespace of your choice so that the
+// whole deferred call system works.
+//==================================================================================================
+#define EVE_DEFERRED_NAMESPACE()                                                                  \
+struct adl_delay_t {};                                                                            \
+inline constexpr auto adl_delay = adl_delay_t {}                                                  \
+/**/
+
+// Register eve::detail as the deferred namespace
+namespace eve::detail
+{
+  EVE_DEFERRED_NAMESPACE();
+}
+
+// Flag a function to support delayed calls on given architecture
+#define EVE_EXPECTS(ARCH) adl_delay_t const &, ARCH const &
+
+//==================================================================================================
+//  Defines the static deferred call interface. This static function in tag_invoke callable let
+//  external types specify their implementation by asking the callable to forward the call to an
+//  externally defined function with a specific name. This reduces the amount of overloads to look
+//  at by not looking at all the non NAME related calls.
+//==================================================================================================
+//  General macro taking the deferred namespace NS and the function NAME
+//==================================================================================================
+#define EVE_DEFERS_CALLABLE_FROM(NS,NAME)                                                         \
+static auto deferred_call(auto arch, auto&&...args) noexcept                                      \
+    -> decltype(NAME(NS::adl_delay, arch, EVE_FWD(args)...))                                      \
+{                                                                                                 \
+  return NAME(NS::adl_delay, arch, EVE_FWD(args)...);                                             \
+}                                                                                                 \
+using deferred_callable_tag = void                                                                \
+/**/
+
+//==================================================================================================
+//  EVE-specific macro that use eve::detail as the deferred namespace
+//==================================================================================================
+#define EVE_DEFERS_CALLABLE(NAME) EVE_DEFERS_CALLABLE_FROM(eve::detail,NAME)
+
+//==================================================================================================
+//  Defines the extended tag_invoke with deferred call support and named_callable interface
+//==================================================================================================
+//  General macro taking the deferred namespace NS and the function NAME
+//  NOTE: Don't hesitate to wrap this macro if you need it in your EVE-dependent library.
+//==================================================================================================
+#define EVE_IMPLEMENTS_CALLABLE_FROM(NS, TYPE, NAME, ID)                                          \
+EVE_DEFERS_CALLABLE_FROM(NS,NAME);                                                                \
+EVE_DEFINES_CALLABLE(TYPE, ID)                                                                    \
+/**/
+
+//==================================================================================================
+//  EVE-specific macro that use eve::detail as the deferred namespace
+//==================================================================================================
+#define EVE_IMPLEMENTS_CALLABLE(TYPE,NAME,ID) EVE_IMPLEMENTS_CALLABLE_FROM(eve::detail,TYPE,NAME,ID)
+
+//==================================================================================================
+//  General macro generating a tag_invoke interface. Use this if nothing special needs to be done
+//  at the callable level.
+//==================================================================================================
+#define EVE_CALLABLE_INTERFACE(TYPE)                                                              \
+template<typename... T>                                                                           \
+auto operator()(T const&... x) const noexcept                                                     \
+-> decltype(tag_invoke(*this, eve::current_api, x...))                                            \
+{                                                                                                 \
+  return tag_invoke(*this, eve::current_api, x...);                                               \
+}                                                                                                 \
+EVE_EXCLUDE_INCORRECT_CALLABLE(TYPE)
+
+//==================================================================================================
+//  Defines the complete extended tag_invoke with deferred call support and named_callable interface
+//==================================================================================================
+//  Generic macro for complete callable interface setup
+//==================================================================================================
+#define EVE_CALLABLE_FROM(NS, TYPE, NAME, ID)                                                     \
+EVE_IMPLEMENTS_CALLABLE_FROM(NS,TYPE,NAME,ID);                                                    \
+EVE_CALLABLE_INTERFACE(TYPE)                                                                      \
+/**/
+
+//==================================================================================================
+//  EVE-specific macro for complete callable interface setup
+//==================================================================================================
+#define EVE_CALLABLE(TYPE,NAME,ID) EVE_CALLABLE_FROM(eve::detail,TYPE,NAME,ID)

--- a/include/eve/traits/invoke/tag_invoke.hpp
+++ b/include/eve/traits/invoke/tag_invoke.hpp
@@ -7,6 +7,7 @@
 //====================================================================================================
 #pragma once
 
+#include <eve/arch/spec.hpp>
 #include <eve/detail/abi.hpp>
 
 #include <ostream>
@@ -23,12 +24,12 @@ namespace eve::func_ns
 struct invoker
 {
   template<typename Tag, typename... Args>
-  requires requires(Tag tag, Args&&...args) { tag_invoke(tag, EVE_FWD(args)...); }
+  requires requires(Tag tag, Args&&...args) { tag_invoke(tag, current_api, EVE_FWD(args)...); }
   EVE_FORCEINLINE constexpr auto operator()(Tag tag, Args&&...args) const
-      noexcept(noexcept(tag_invoke(tag, EVE_FWD(args)...)))
-          -> decltype(tag_invoke(tag, EVE_FWD(args)...))
+  noexcept(noexcept(tag_invoke(tag, current_api, EVE_FWD(args)...)))
+      -> decltype(tag_invoke(tag, current_api, EVE_FWD(args)...))
   {
-    return tag_invoke(tag, EVE_FWD(args)...);
+    return tag_invoke(tag, current_api, EVE_FWD(args)...);
   }
 };
 }

--- a/include/eve/traits/invoke/tag_invoke.hpp
+++ b/include/eve/traits/invoke/tag_invoke.hpp
@@ -1,0 +1,81 @@
+//====================================================================================================
+/*
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+*/
+//====================================================================================================
+#pragma once
+
+#include <eve/detail/abi.hpp>
+
+#include <ostream>
+#include <utility>
+#include <type_traits>
+
+//====================================================================================================
+//  This part is a indirect implementation of P1895R0
+//  See https://www.open-std.org/jtc1/sc22/WG21/docs/papers/2019/p1895r0.pdf for details and
+//  rationale.
+//====================================================================================================
+namespace eve::func_ns
+{
+struct invoker
+{
+  template<typename Tag, typename... Args>
+  requires requires(Tag tag, Args&&...args) { tag_invoke(tag, EVE_FWD(args)...); }
+  EVE_FORCEINLINE constexpr auto operator()(Tag tag, Args&&...args) const
+      noexcept(noexcept(tag_invoke(tag, EVE_FWD(args)...)))
+          -> decltype(tag_invoke(tag, EVE_FWD(args)...))
+  {
+    return tag_invoke(tag, EVE_FWD(args)...);
+  }
+};
+}
+
+namespace eve
+{
+//==================================================================================================
+//! @addtogroup traits
+//! @{
+//! @defgroup invoke Generalized Tag Invoke Protocol
+//! @brief This module defines all the **EVE** generalized tag_invoke protocol infrastructure.
+//! @}
+//==================================================================================================
+
+inline namespace callable_ns
+{
+  inline constexpr func_ns::invoker tag_invoke = {};
+}
+
+//==================================================================================================
+//! @addtogroup invoke
+//! @{
+//==================================================================================================
+
+//==================================================================================================
+//! @concept tag_invocable
+//! @brief Type supporting the tag_invoke protocol
+//!
+//! A type `Tag` satisfies eve::tag_invocable<Args...> if and only if it can be used in a call to
+//! eve::tag_invoke.
+//!
+//! @tparam Tag  Tag type for the @callable to check
+//! @tparam Args Arguments used in the call.
+//==================================================================================================
+template<typename Tag, typename... Args>
+concept tag_invocable =
+    requires(Tag&& tag, Args&&...args) { eve::tag_invoke(EVE_FWD(tag), EVE_FWD(args)...); };
+
+//! @brief Compute the return type of a eve::tag_invoke call.
+template<typename Tag, typename... Args>
+using tag_invoke_result = std::invoke_result_t<decltype(eve::tag_invoke), Tag, Args...>;
+
+//! @brief Compute the type of an instance of an **EVE** @callable.
+template<auto& Func> using tag_of = std::decay_t<decltype(Func)>;
+
+//==================================================================================================
+//! @}
+//==================================================================================================
+
+}

--- a/test/unit/meta/tag_invoke.cpp
+++ b/test/unit/meta/tag_invoke.cpp
@@ -1,0 +1,172 @@
+//==================================================================================================
+/**
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+**/
+//==================================================================================================
+#include "eve/detail/raberu.hpp"
+#include "eve/traits/invoke/decorator.hpp"
+#include "test.hpp"
+
+#include <eve/traits/invoke.hpp>
+#include <eve/module/core.hpp>
+#include <string>
+#include <sstream>
+
+// Defines some callable for test purpose
+namespace eve::tags
+{
+  struct func1 : elementwise  { EVE_CALLABLE(func1, func1_, "eve::func1");  };
+  struct func2 : reduction    { EVE_CALLABLE(func2, func2_, "func2");       };
+
+  struct func3 : constant
+  {
+    EVE_DEFINES_CALLABLE(func3, "the func III");
+    EVE_CALLABLE_INTERFACE(func3);
+  };
+
+  struct func4 : support_options<func4> { EVE_CALLABLE(func4, func4_, "eve::func4"); };
+}
+
+namespace eve
+{
+  // Callable objects
+  inline constexpr tags::func1 func1 = {};
+  inline constexpr tags::func2 func2 = {};
+  inline constexpr tags::func3 func3 = {};
+  inline constexpr tags::func4 func4 = {};
+
+  // Some specific flags
+  struct lazy_t {};
+  struct scale_t {};
+  struct other_t {};
+  inline constexpr auto lazy  = rbr::flag(lazy_t{});
+  inline constexpr auto scale = rbr::keyword(scale_t{});
+  inline constexpr auto other = rbr::keyword(other_t{});
+}
+
+// Fake type providing a hidden friend tag_invoke
+namespace eve
+{
+  template<typename T> struct sort_of
+  {
+    sort_of(T v) : value(v) {}
+
+    // The way we expect to use tag_invoke on most types
+    friend std::string tag_invoke(eve::tag_of<func1> const&, auto, sort_of x)
+    {
+      return "Sort of " + std::to_string(x.value);
+    }
+
+    T value;
+  };
+}
+
+// Actual external tag_invoke setup - must lives in eve::tags
+namespace eve::tags
+{
+  constexpr auto tag_invoke(func3, auto, eve::integral_value auto v)
+  {
+    return 1.5f * eve::convert(v,eve::as(1.5f));
+  }
+
+  // Regular func4
+  constexpr auto tag_invoke(func4, auto, auto x) noexcept { return 10*x; }
+}
+
+// Deferred call implementation - must lives in eve::detail
+namespace eve::detail
+{
+  constexpr auto func2_(EVE_EXPECTS(cpu_), scalar_value auto x) noexcept { return -x; }
+
+  // Decorated func4 - function can mix tag_invoke and deferred call if needed
+  template<typename S>
+  constexpr auto func4_(EVE_EXPECTS(cpu_), decorators<S> opts, auto x) noexcept
+  {
+    if constexpr(S::contains(detail::mask))
+    {
+      return  opts[detail::mask].mask(as(x)) ? -x : 16. * x;
+    }
+    else
+    {
+      return opts[lazy] ? opts[scale | 100.] * x : opts[scale | -2.] * x;
+    }
+  }
+}
+
+TTS_CASE("Check callable concepts")
+{
+  // func1/2/3 are callable but a random type is not
+  TTS_CONSTEXPR_EXPECT    ( eve::callable<eve::tag_of<eve::func1>> );
+  TTS_CONSTEXPR_EXPECT    ( eve::callable<eve::tag_of<eve::func2>> );
+  TTS_CONSTEXPR_EXPECT    ( eve::callable<eve::tag_of<eve::func3>> );
+  TTS_CONSTEXPR_EXPECT_NOT( eve::callable<std::plus<>> );
+
+  // only func1/2 use a deferred call
+  TTS_CONSTEXPR_EXPECT    ( eve::deferred_callable<eve::tag_of<eve::func1>> );
+  TTS_CONSTEXPR_EXPECT    ( eve::deferred_callable<eve::tag_of<eve::func2>> );
+  TTS_CONSTEXPR_EXPECT_NOT( eve::deferred_callable<eve::tag_of<eve::func3>> );
+
+  // checks callable sub-category
+  TTS_CONSTEXPR_EXPECT( eve::elementwise_callable<eve::tag_of<eve::func1>>);
+  TTS_CONSTEXPR_EXPECT( eve::reduction_callable<eve::tag_of<eve::func2>>  );
+  TTS_CONSTEXPR_EXPECT( eve::constant_callable<eve::tag_of<eve::func3>>   );
+};
+
+TTS_CASE("Check callable streaming")
+{
+  std::ostringstream out1,out2,out3;
+  out1 << eve::func1;
+  out2 << eve::func2;
+  out3 << eve::func3;
+
+  TTS_EQUAL(out1.str(), "eve::func1"  );
+  TTS_EQUAL(out2.str(), "func2"       );
+  TTS_EQUAL(out3.str(), "the func III");
+};
+
+TTS_CASE("Check tag_invoke call stack")
+{
+  TTS_EQUAL( eve::func1(eve::sort_of{9})  , "Sort of 9"             );
+  TTS_EQUAL( eve::func2(4)                , -4                      );
+  TTS_EQUAL( eve::func3(eve::wide<int>{7}), eve::wide<float>{10.5f} );
+  TTS_EQUAL( eve::func4(8.25)             , 82.5                    );
+};
+
+TTS_CASE("Check tag_invoke with options")
+{
+  bool b{};
+
+  eve::func2("lol");
+
+  // No option if no support_option
+  TTS_EXPECT_NOT_COMPILES(b, { eve::func1[b]; });
+  TTS_EXPECT_NOT_COMPILES(b, { eve::func2[b]; });
+  TTS_EXPECT_NOT_COMPILES(b, { eve::func3[b]; });
+
+  // Options are supported but duplicates are not allowed
+  TTS_EXPECT_COMPILES     (b, { eve::func4[b]; }   );
+  TTS_EXPECT_NOT_COMPILES (b, { eve::func4[b][b]; });
+
+  // Check mask/decorators processing
+  TTS_EQUAL( eve::func4[true](8.25)                             , -  8.25 );
+  TTS_EQUAL( eve::func4[false](8.25)                            ,  132.   );
+  TTS_EQUAL( eve::func4[eve::lazy](8.25)                        ,  825    );
+  TTS_EQUAL( eve::func4[eve::scale = 4](8.25)                   ,   33    );
+  TTS_EQUAL( eve::func4[eve::other = '1'](8.25)                 , - 16.5  );
+  TTS_EQUAL( eve::func4[eve::scale = 4][eve::lazy](8.25)        ,   33    );
+  TTS_EQUAL( eve::func4[eve::scale = 4][eve::other = '1'](8.25) ,   33    );
+};
+
+TTS_CASE("Check tag_invoke error checks")
+{
+  int x{};
+  auto y = "some text";
+  double z{};
+
+  TTS_EXPECT_NOT_COMPILES(x,  { eve::func1(x); } );
+  TTS_EXPECT_NOT_COMPILES(y,  { eve::func2(y); } );
+  TTS_EXPECT_NOT_COMPILES(z,  { eve::func3(z); } );
+};
+


### PR DESCRIPTION
This PR lays out the basic fiels for impleemnting a `std::tag_invoke` inspired protocol in EVE.
It is design to: 
 - rely on less macros
 - make the overload process homogeneous
 - let have a better control on per function pre/post condition checks
 - let have better error message
 - add a layer of abstraction by allowing functions to be grouped by familly of behavior
 - make use of Raberu options instead of decorators, thus making all functions working like the algo ones

This PR don't adapt ANY existing functions yet. It is an autonomous set of files implemententing the protocol and a test ofr said protocol.

Next step will be to adapt a simple set of functions (like constant) to see if everything is OK.