### PR TITLE
FIX-1602: one pass min

### DIFF
--- a/include/eve/module/algo/algo/common_forceinline_lambdas.hpp
+++ b/include/eve/module/algo/algo/common_forceinline_lambdas.hpp
@@ -67,6 +67,26 @@ namespace eve::algo
     }
   };
 
+  struct unroll_by_calling_single_step
+  {
+    template<typename I, std::size_t N, typename Delegate> struct impl
+    {
+      std::array<I, N> *arr;
+      Delegate         *delegate;
+
+      EVE_FORCEINLINE void operator()(auto i) const
+      {
+        delegate->step((*arr)[i()], eve::ignore_none, i);
+      }
+    };
+
+    template<typename I, std::size_t N, typename Delegate>
+    EVE_FORCEINLINE void operator()(std::array<I, N> arr, Delegate& delegate) const
+    {
+      eve::detail::for_<0, 1, N>(impl<I, N, Delegate> {&arr, &delegate});
+    }
+  };
+
   template <typename T>
   struct equal_to
   {

--- a/include/eve/module/algo/algo/min_element.hpp
+++ b/include/eve/module/algo/algo/min_element.hpp
@@ -9,7 +9,163 @@
 
 #include <eve/module/algo/algo/common_forceinline_lambdas.hpp>
 #include <eve/module/algo/algo/find.hpp>
+#include <eve/module/algo/algo/for_each_iteration_fixed_overflow.hpp>
 #include <eve/module/algo/algo/min_value.hpp>
+
+namespace eve::algo::detail
+{
+
+template<typename TraitsSupport> struct min_element_1_pass_ : TraitsSupport
+{
+  using traits_type = typename TraitsSupport::traits_type;
+
+  template<typename I, typename Less> struct delegate
+  {
+    using index_t  = get_index_type_t<traits_type, I>;
+    using wide_v   = eve::wide_value_type_t<I>;
+    using wide_i   = eve::wide<index_t, eve::iterator_cardinal_t<I>>;
+    using v_i      = kumi::tuple<value_type_t<I>, index_t>;
+    using wide_v_i = eve::wide<v_i, eve::iterator_cardinal_t<I>>;
+
+    // For now just have one loop_index.
+    // In preliminary experiments compiler unrolled it OK, can be improved later.
+    std::array<wide_v_i, get_unrolling<traits_type>()> best;
+    wide_i                                             loop_index;
+
+    I    base;
+    I    prev_best;
+    Less less;
+
+    struct
+    {
+      Less less;
+
+      EVE_FORCEINLINE wide_v_i operator()(wide_v_i x, wide_v_i y) const
+      {
+        wide_v_i r;
+        get<0>(r) = eve::min(less)(get<0>(x), get<0>(y));
+        get<1>(r) = eve::if_else(less(get<0>(y), get<0>(x)), get<1>(y), get<1>(x));
+        return r;
+      }
+
+    } combine {less};
+
+    void reset()
+    {
+      best.fill(wide_v_i {v_i {eve::read(prev_best), 0}});
+      loop_index = [](int i, int) { return i; };
+    }
+
+    delegate(I base, I f, Less less) : base(base), prev_best(f), less(less) { reset(); }
+
+    EVE_FORCEINLINE bool step(auto it, eve::relative_conditional_expr auto ignore, auto idx)
+    {
+      wide_v   cur_values = eve::load[ignore.else_(get<0>(best[idx()]))](it);
+      wide_v_i cur {cur_values, loop_index};
+
+      best[idx()] = combine(best[idx()], cur);
+
+      loop_index += loop_index.size();
+      return false;
+    }
+
+    EVE_FORCEINLINE bool unrolled_step(auto arr)
+    {
+      unroll_by_calling_single_step{}(arr, *this);
+      return false;
+    }
+
+    struct is_not_best_lambda
+    {
+      Less & less;
+      wide_v best_one;
+
+      EVE_FORCEINLINE wide_i operator()(wide_v_i x) const
+      {
+        auto is_not_best = less(best_one, get<0>(x));
+        return eve::if_else(is_not_best, std::numeric_limits<index_t>::max(), get<1>(x));
+      }
+    };
+
+    EVE_FORCEINLINE void update_res()
+    {
+      auto   values          = array_map(best, [](auto x) { return get<0>(x); });
+      wide_v lane_best_value = array_reduce(values, eve::min(less));
+      wide_v wide_prev_best(eve::read(prev_best));
+
+      if( !eve::any(less(lane_best_value, wide_prev_best)) ) return;
+
+      wide_v best_one = eve::splat(eve::reduce)(lane_best_value, eve::min(less));
+
+      auto best_indexes = array_map(best, is_not_best_lambda {less, best_one});
+
+      prev_best = base + eve::reduce(array_reduce(best_indexes, eve::min), eve::min);
+    }
+
+    EVE_FORCEINLINE void overflow(auto it)
+    {
+      update_res();
+      base = it;
+      reset();
+    }
+  };
+
+  template<relaxed_range Rng, typename Less>
+  EVE_FORCEINLINE auto operator()(Rng&& rng, Less less) const -> unaligned_iterator_t<Rng>
+  {
+    auto raw_processed = eve::algo::preprocess_range(TraitsSupport::get_traits(), rng);
+    if( raw_processed.begin() == raw_processed.end() ) return rng.begin();
+
+    using index_t  = get_index_type_t<traits_type, Rng>;
+    auto processed = preprocess_range(
+        default_to(TraitsSupport::get_traits(), algo::traits {consider_types<index_t>}), rng);
+
+    // No code is executed here, won't do a FORCEINLINE
+    auto iteration = [&]
+    {
+      if constexpr( sizeof(ptrdiff_t) <= sizeof(index_t) )
+      {
+        return for_each_iteration(processed.traits(), processed.begin(), processed.end());
+      }
+      else
+      {
+        eve::algo::traits overflow_traits {
+            overflow<(std::ptrdiff_t)std::numeric_limits<index_t>::max() + 1>};
+        return for_each_iteration_fixed_overflow(
+            default_to(processed.traits(), overflow_traits), processed.begin(), processed.end());
+      }
+    }();
+
+    using I = unaligned_t<decltype(processed.begin())>;
+    delegate<I, Less> d {iteration.base, processed.begin(), less};
+    iteration(d);
+    d.update_res();
+
+    return unalign(rng.begin()) + (d.prev_best - processed.begin());
+  }
+};
+
+inline constexpr auto min_element_1_pass = function_with_traits<min_element_1_pass_>;
+
+template<typename TraitsSupport> struct min_element_2_pass_ : TraitsSupport
+{
+  template<relaxed_range Rng, typename Less>
+  EVE_FORCEINLINE auto operator()(Rng&& rng, Less less) const -> unaligned_iterator_t<Rng>
+  {
+    if( rng.begin() == rng.end() ) return unalign(rng.begin());
+
+    auto v = *min_value[TraitsSupport::get_traits()](EVE_FWD(rng), less);
+    // We use user provided less to compare here (less(min, min) -> false
+    // but less(min, anything_else) - true). Maybe we should use bit wise equality instead,
+    // would also work if everything is well behaived.
+    return eve::algo::find_if_not[TraitsSupport::get_traits()](EVE_FWD(rng), bind_first {less, v});
+  }
+};
+
+inline constexpr auto min_element_2_pass =
+    function_with_traits<min_element_2_pass_>[default_simple_algo_traits];
+
+} // namespace eve::algo
 
 namespace eve::algo
 {
@@ -18,12 +174,12 @@ template<typename TraitsSupport> struct min_element_ : TraitsSupport
   template<relaxed_range Rng, typename Less>
   EVE_FORCEINLINE auto operator()(Rng&& rng, Less less) const -> unaligned_iterator_t<Rng>
   {
-    if( rng.begin() == rng.end() ) return unalign(rng.begin());
-
-    auto v = *min_value[TraitsSupport::get_traits()](EVE_FWD(rng), less);
-    // We use user provided less to compare here (less(min, min) -> false but less(min, anything_else) - true).
-    // Maybe we should use bit wise equality instead, would also work if everything is well behaived.
-    return eve::algo::find_if_not[TraitsSupport::get_traits()](EVE_FWD(rng), bind_first{less, v});
+    auto processed = preprocess_range(TraitsSupport::get_traits(), rng);
+    if constexpr( decltype(processed.traits())::contains(single_pass) )
+    {
+      return detail::min_element_1_pass[TraitsSupport::get_traits()](rng, less);
+    }
+    else { return detail::min_element_2_pass[TraitsSupport::get_traits()](rng, less); }
   }
 
   template<relaxed_range Rng>
@@ -42,7 +198,16 @@ template<typename TraitsSupport> struct min_element_ : TraitsSupport
 //!
 //!   @note if you just need a value and not position, use `eve::algo::min_value`.
 //!
+//!   Can be one of two algorithms: one pass and two pass (default).
+//!
+//!   Two pass finds a value and then does a linear search for the value.
+//!   This proves to be faster on smaller simpler arrays.
 //!   By default unrolls by 4 and aligned all memory accesses.
+//!
+//!   The one pass version keeps track of index and is better suited for complicated predicates.
+//!   You can opt in by using `single_pass` or `expensive_callable` traits.
+//!   The `single_pass` opt-in will be aligning all data accesses
+//~   (expensive_callable always disables this).
 //!
 //!   @note for equivalent elements we return the first amoung equal.
 //!   @note we assume that `eve::is_less` defined for your type is total order.
@@ -89,6 +254,5 @@ template<typename TraitsSupport> struct min_element_ : TraitsSupport
 //!
 //! @}
 //================================================================================================
-inline constexpr auto min_element = function_with_traits<min_element_>[default_simple_algo_traits];
-
+inline constexpr auto min_element = function_with_traits<min_element_>;
 }

--- a/test/doc/algo/min.cpp
+++ b/test/doc/algo/min.cpp
@@ -7,19 +7,25 @@ int main()
 {
   std::vector<int> v{ 2, -1, 4, -1, 0 };
 
-  std::cout << " -> v                                                       = "
+  std::cout << " -> v                                                                              = "
             << tts::as_string(v)
             << "\n";
 
-  std::cout << " -> eve::algo::min_value(v)                                 = "
+  std::cout << " -> eve::algo::min_value(v)                                                       = "
             << *eve::algo::min_value(v) << "\n";
 
-  std::cout << " -> eve::algo::min_element(v) - v.begin()                   = "
+  std::cout << " -> eve::algo::min_element(v) - v.begin()                                         = "
             << eve::algo::min_element(v) - v.begin() << "\n";
 
-  std::cout << " -> eve::algo::min_value(v, eve::is_greater)                = "
+  std::cout << " -> eve::algo::min_value(v, eve::is_greater)                                      = "
             << *eve::algo::min_value(v, eve::is_greater) << "\n";
 
-  std::cout << " -> eve::algo::min_value(v, eve::is_greater) - v.begin()    = "
+  std::cout << " -> eve::algo::min_value(v, eve::is_greater) - v.begin()                          = "
             << eve::algo::min_element(v, eve::is_greater) - v.begin() << "\n";
+
+
+  auto absolutes = eve::views::map(v, eve::abs);
+  std::cout << " -> eve::algo::min_element[eve::algo::single_pass](absolutes) - absolutes.begin() = "
+            << eve::algo::min_element[eve::algo::single_pass](absolutes) - absolutes.begin() << "\n";
+
 }

--- a/test/unit/module/algo/algorithm/min_element_generic_one_pass.cpp
+++ b/test/unit/module/algo/algorithm/min_element_generic_one_pass.cpp
@@ -10,13 +10,13 @@
 
 #include <eve/module/algo.hpp>
 
-#include <algorithm>
-
-TTS_CASE_TPL("Check min_element", algo_test::selected_types)
+TTS_CASE_TPL("Check min_element one_pass", algo_test::selected_types)
 <typename T>(tts::type<T>)
 {
   algo_test::minmax_generic_test</*biggest*/ false, /*right*/ false>(
       eve::as<T> {},
-      eve::algo::min_element,
-      [](auto, auto, auto expected, auto actual) { TTS_EQUAL(expected, actual); });
+      eve::algo::min_element[eve::algo::single_pass],
+      [](auto, auto, auto expected, auto actual) {
+         TTS_EQUAL(expected, actual);
+      });
 };

--- a/test/unit/module/algo/algorithm/min_element_generic_two_pass.cpp
+++ b/test/unit/module/algo/algorithm/min_element_generic_two_pass.cpp
@@ -1,0 +1,22 @@
+//==================================================================================================
+/**
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+**/
+//==================================================================================================
+
+#include "unit/module/algo/algorithm/minmax_generic_test.hpp"
+
+#include <eve/module/algo.hpp>
+
+TTS_CASE_TPL("Check min_element two pass", algo_test::selected_types)
+<typename T>(tts::type<T>)
+{
+  algo_test::minmax_generic_test</*biggest*/ false, /*right*/ false>(
+      eve::as<T> {},
+      eve::algo::min_element,
+      [](auto, auto, auto expected, auto actual) {
+         TTS_EQUAL(expected, actual);
+      });
+};

--- a/test/unit/module/algo/algorithm/min_element_special_cases.cpp
+++ b/test/unit/module/algo/algorithm/min_element_special_cases.cpp
@@ -1,0 +1,84 @@
+//==================================================================================================
+/**
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+**/
+//==================================================================================================
+#include "unit/module/algo/algo_test.hpp"
+
+#include <eve/module/algo.hpp>
+
+#include <span>
+
+TTS_CASE("Min element one pass, uint8 index")
+{
+  auto alg = eve::algo::min_element         //
+      [eve::algo::single_pass]              //
+      [eve::algo::index_type<std::uint8_t>] //
+      [eve::algo::unroll<2>];
+  {
+    std::vector v {1, 2, 3};
+    TTS_EQUAL(0, alg(v) - v.begin());
+  }
+  {
+    std::vector v {2, 1, 3};
+    TTS_EQUAL(1, alg(v) - v.begin());
+  }
+  {
+    std::vector v {3, 2, 1};
+    TTS_EQUAL(2, alg(v) - v.begin());
+  }
+  {
+    std::vector<std::int8_t> v(1000u, 1);
+    v.back() = 0;
+    TTS_EQUAL(999, alg(v) - v.begin());
+  }
+  {
+    std::vector<std::int8_t> v(std::numeric_limits<std::uint16_t>::max() + 1, 'b');
+    v.back() = 'a';
+    v[5]     = 'a';
+    TTS_EQUAL(5, alg(v) - v.begin());
+    v[5] = 'b';
+    TTS_EQUAL(std::ssize(v) - 1, alg(v) - v.begin());
+  }
+  {
+    std::vector<std::int8_t> v;
+    v.resize(48, 'b');
+    v[23] = 'a';
+    v[47] = 'a';
+    TTS_EQUAL(23, alg(v) - v.begin());
+  }
+  {
+    std::vector<std::int8_t> v;
+    v.resize(159, 'b');
+    v[2]     = 'a';
+    v.back() = 'a';
+    std::span<std::int8_t> s(v.begin() + 1, v.end());
+    TTS_EQUAL(1, alg(s) - s.begin());
+  }
+};
+
+TTS_CASE("Min element one pass, uint8 index, first one is the answer") {
+  auto alg = eve::algo::min_element         //
+      [eve::algo::single_pass]              //
+      [eve::algo::index_type<std::uint8_t>] //
+      [eve::algo::unroll<2>];
+
+  std::vector<std::int8_t> v;
+  v.resize(300);
+
+  for (int i = 0; i != 16; ++i) {
+    for (int j = 0; j != 16; ++j) {
+      eve::algo::fill(v, 0);
+      std::span<std::int8_t> sub(v.begin() + i, v.end() - j);
+      eve::algo::fill(sub, -1);
+
+      for (std::int8_t& x: sub) {
+        std::int8_t* found = std::to_address(alg(sub));
+        TTS_EQUAL(found, &x);
+        x = 0;
+      }
+    }
+  }
+};

--- a/test/unit/module/algo/preprocess_range.cpp
+++ b/test/unit/module/algo/preprocess_range.cpp
@@ -341,23 +341,7 @@ TTS_CASE_TPL("support for equivlanets", algo_test::selected_types)
     eve::algo::traits(eve::algo::expensive_callable), v);
 
     TTS_TYPE_IS(decltype(processed.traits()),
-               (decltype(eve::algo::traits{eve::algo::no_aligning,
-                         eve::algo::unroll<1>})));
-  }
-};
-
-TTS_CASE_TPL("support for equivlanets", algo_test::selected_types)
-<typename T>(tts::type<T>)
-{
-  using e_t = eve::element_type_t<T>;
-
-  std::vector<e_t> v;
-  {
-    auto processed = eve::algo::preprocess_range(
-    eve::algo::traits(eve::algo::expensive_callable), v);
-
-    TTS_TYPE_IS(decltype(processed.traits()),
-               (decltype(eve::algo::traits{eve::algo::no_aligning,
-                         eve::algo::unroll<1>})));
+                (decltype(eve::algo::traits {
+                    eve::algo::no_aligning, eve::algo::unroll<1>, eve::algo::single_pass})));
   }
 };

--- a/test/unit/module/algo/traits.cpp
+++ b/test/unit/module/algo/traits.cpp
@@ -124,10 +124,41 @@ TTS_CASE("eve.algo.traits, no_unrolling") {
 };
 
 TTS_CASE("eve.algo.traits, expensive_callable") {
-  eve::algo::traits expected{eve::algo::no_aligning, eve::algo::unroll<1>};
+  eve::algo::traits expected{eve::algo::no_aligning, eve::algo::unroll<1>, eve::algo::single_pass};
   eve::algo::traits actual  {eve::algo::expensive_callable};
 
   TTS_TYPE_IS( decltype(expected), decltype(process_equivalents(actual)) );
+};
+
+TTS_CASE("eve.algo.traits, index_type") {
+  // default
+  {
+    eve::algo::traits tr;
+    TTS_TYPE_IS( (eve::algo::get_index_type_t<decltype(tr), std::int8_t*>), (std::uint16_t));
+    TTS_TYPE_IS( (eve::algo::get_index_type_t<decltype(tr), short*>), (std::uint16_t));
+    TTS_TYPE_IS( (eve::algo::get_index_type_t<decltype(tr), std::int32_t*>), (std::uint32_t));
+    TTS_TYPE_IS( (eve::algo::get_index_type_t<decltype(tr), std::int64_t*>), (std::uint64_t));
+
+    TTS_TYPE_IS( (eve::algo::get_index_type_t<decltype(tr), kumi::tuple<std::int8_t, std::int32_t>*>), (std::uint32_t));
+  }
+
+  // overriden
+  {
+    eve::algo::traits tr {eve::algo::index_type<std::uint8_t>};
+    TTS_TYPE_IS( (eve::algo::get_index_type_t<decltype(tr), std::int8_t*>),  (std::uint8_t));
+    TTS_TYPE_IS( (eve::algo::get_index_type_t<decltype(tr), short*>),        (std::uint8_t));
+    TTS_TYPE_IS( (eve::algo::get_index_type_t<decltype(tr), std::int32_t*>), (std::uint8_t));
+    TTS_TYPE_IS( (eve::algo::get_index_type_t<decltype(tr), std::int64_t*>), (std::uint8_t));
+  }
+};
+
+TTS_CASE("eve.algo.traits, oveflow")
+{
+    using before_max_idx_t =
+        std::conditional_t<sizeof(ptrdiff_t) == 4, std::uint16_t, std::uint32_t>;
+    eve::algo::traits tr {eve::algo::overflow<std::numeric_limits<before_max_idx_t>::max()>};
+    TTS_CONSTEXPR_EQUAL(eve::algo::get_overflow<decltype(tr)>(),
+                        std::numeric_limits<before_max_idx_t>::max());
 };
 
 // Funciton with traits support


### PR DESCRIPTION
min_element that keeps track of the index. 
Ofc there can never be enough testing and there is some chance that our test infra does not cover something and we don't have fuzzing.

Specifically I am not sure that enough "repeats" covered in test cases, generic testing might not tackle this aggresively enough.

Regardless, I think it's in OK shape - let's review and merge if it's OK.