### PR TITLE
fix-1610: try each group position

### DIFF
--- a/include/eve/module/core/regular/core.hpp
+++ b/include/eve/module/core/regular/core.hpp
@@ -210,6 +210,7 @@
 #include <eve/module/core/regular/swap_if.hpp>
 #include <eve/module/core/regular/swap_pairs.hpp>
 #include <eve/module/core/regular/trunc.hpp>
+#include <eve/module/core/regular/try_each_group_position.hpp>
 #include <eve/module/core/regular/ulpdist.hpp>
 #include <eve/module/core/regular/unalign.hpp>
 #include <eve/module/core/regular/unsafe.hpp>

--- a/include/eve/module/core/regular/impl/try_each_group_position.hpp
+++ b/include/eve/module/core/regular/impl/try_each_group_position.hpp
@@ -1,0 +1,49 @@
+//==================================================================================================
+/*
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+*/
+//==================================================================================================
+#pragma once
+
+#include <eve/module/core/regular/rotate.hpp>
+
+namespace eve::detail
+{
+
+template<simd_value T, std::ptrdiff_t G>
+EVE_FORCEINLINE auto
+try_each_group_position_aggregation(T x, eve::fixed<G> g) noexcept
+{
+  auto [l, h] = x.slice();
+  auto l_pos  = try_each_group_position(l, g);
+  auto h_pos  = try_each_group_position(h, g);
+  auto lh     = kumi::map([](auto x, auto y) { return T {x, y}; }, l_pos, h_pos);
+  auto hl     = kumi::map([](auto x, auto y) { return T {y, x}; }, l_pos, h_pos);
+  return kumi::cat(lh, hl);
+}
+
+template<simd_value T, std::ptrdiff_t G>
+EVE_FORCEINLINE auto
+try_each_group_position_(EVE_SUPPORTS(cpu_), T x, eve::fixed<G> g) noexcept
+{
+       if constexpr( T::size() == G ) { return kumi::tuple<T> {x}; }
+  else if constexpr( logical_value<T> && T::abi_type::is_wide_logical )
+  {
+    auto bits = try_each_group_position(x.bits(), g);
+    return kumi::map([](auto y) { return bit_cast(y, as<T> {}); }, bits);
+  }
+  else if constexpr( has_aggregated_abi_v<T> ) return try_each_group_position_aggregation(x, g);
+  else
+  {
+    // Doubling the group size is likely to yield better shuffles
+    // over rotating many times by one.
+    return kumi::cat(
+      try_each_group_position(x,                        eve::lane<G * 2>),
+      try_each_group_position(rotate(x, eve::index<G>), eve::lane<G * 2>)
+    );
+  }
+}
+
+}

--- a/include/eve/module/core/regular/try_each_group_position.hpp
+++ b/include/eve/module/core/regular/try_each_group_position.hpp
@@ -1,0 +1,51 @@
+//==================================================================================================
+/*
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+*/
+//==================================================================================================
+#pragma once
+
+#include <eve/arch.hpp>
+#include <eve/detail/meta.hpp>
+#include <eve/detail/overload.hpp>
+
+namespace eve
+{
+  //================================================================================================
+  //! @addtogroup core
+  //! @{
+  //!    @var try_each_group_position
+  //!    @brief
+  //!    For a given simd_value and a group size returns a tuple of (x::size() / group_size)
+  //!    permuatitions for this register such that each group will be in each position
+  //!    exactly once.
+  //!
+  //!    This is useful when one needs to try each element against something.
+  //!    Motivational example could be intersection: try each element from one register
+  //!    against another.
+  //!    Groups allow you to treat N elements as one.
+  //!
+  //!    We took the idea for the operation from:
+  //!    "Faster-Than-Native Alternatives for x86 VP2INTERSECT Instructions"
+  //!    by Guillermo Diez-Canas.
+  //!    Link: https://arxiv.org/abs/2112.06342
+  //!
+  //!   **Parameters**
+  //!
+  //!     * `x` : [argument](@ref eve::simd_value).
+  //!     * `fixed<N>` : number of elements in group
+  //!
+  //!    **Return value**
+  //!
+  //!  @groupheader{Example}
+  //!
+  //!  @godbolt{doc/core/regular/try_each_group_position.cpp}
+  //!
+  //!  @}
+  //================================================================================================
+  EVE_MAKE_CALLABLE(try_each_group_position_, try_each_group_position);
+}
+
+#include <eve/module/core/regular/impl/try_each_group_position.hpp>

--- a/test/doc/core/regular/try_each_group_position.cpp
+++ b/test/doc/core/regular/try_each_group_position.cpp
@@ -1,0 +1,14 @@
+#include <iostream>
+#include <eve/module/core.hpp>
+
+using wide_it = eve::wide<std::uint32_t, eve::fixed<4>>;
+
+int main()
+{
+  wide_it x = {1, 2, 3, 4};
+
+  std::cout << "---- simd" << '\n'
+            << "<- x                                        = " << x << '\n'
+            << "-> try_each_group_position(x, eve::lane<1>) = " << eve::try_each_group_position(x, eve::lane<1>) << '\n'
+            << "-> try_each_group_position(x, eve::lane<2>) = " << eve::try_each_group_position(x, eve::lane<2>) << '\n';
+}

--- a/test/unit/api/regular/swizzle/try_each_group_position.cpp
+++ b/test/unit/api/regular/swizzle/try_each_group_position.cpp
@@ -1,0 +1,91 @@
+//==================================================================================================
+/**
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+**/
+//==================================================================================================
+#include "test.hpp"
+
+#include <eve/module/core.hpp>
+
+namespace
+{
+
+template<typename T>
+void
+for_each_group_size(auto op)
+{
+  constexpr auto ssz = std::bit_width(std::size_t(T::size()));
+  [&]<std::size_t... I>(std::index_sequence<I...>) { (op(eve::lane<1 << I>), ...); }
+  (std::make_index_sequence<ssz> {});
+};
+
+template<typename... Ts>
+auto
+to_array(kumi::tuple<Ts...> x)
+{
+  return [&]<std::size_t... i>(std::index_sequence<i...>)
+  {
+    return std::array {kumi::get<i>(x)...};
+  }
+  (std::index_sequence_for<Ts...> {});
+}
+
+TTS_CASE_TPL("Check behavior of try_each_group_position simplest", eve::test::scalar::all_types)
+<typename T>(tts::type<T>) {
+  using T2 = eve::wide<T, eve::fixed<2>>;
+
+  T2 x = {0, 1};
+  kumi::tuple<T2, T2> expected{ T2{0, 1}, T2{1, 0} };
+  kumi::tuple<T2, T2> actual = eve::try_each_group_position(x, eve::lane<1>);
+
+  TTS_EQUAL(get<0>(expected), get<0>(actual));
+  TTS_EQUAL(get<1>(expected), get<1>(actual));
+};
+
+TTS_CASE_TPL("Check behavior of try_each_group_position", eve::test::simd::all_types)
+<typename T>(tts::type<T>)
+{
+  for_each_group_size<T>(
+      [&]<std::ptrdiff_t G>(eve::fixed<G> g)
+      {
+        T x {[](int i, int) { return i / G; }};
+
+        auto r = to_array(eve::try_each_group_position(x, g));
+
+        TTS_EQUAL(std::ssize(r), T::size() / G);
+
+        for (int i = 0; i != T::size() / G; ++i) {
+          T to_offset {0};
+          for (auto permutation : r) {
+            to_offset += eve::if_else(permutation == i, T{1}, T{0});
+          }
+          TTS_EXPECT(eve::all(to_offset == 1)) << to_offset << " " << i;
+        }
+      });
+};
+
+TTS_CASE_TPL("Check behavior of try_each_group_position_logical", eve::test::simd::all_types)
+<typename T>(tts::type<T>)
+{
+  for_each_group_size<T>(
+      [&]<std::ptrdiff_t G>(eve::fixed<G> g)
+      {
+        T x = [](int i, int) { return i / G; };
+
+        // Check that the group will be everywhere.
+        for (int group_num = 0; group_num != T::size() / G; ++group_num) {
+          auto r = to_array(eve::try_each_group_position(x == group_num, g));
+          TTS_EQUAL(std::ssize(r), T::size() / G);
+
+          int count = 0;
+          for (auto permutation : r) {
+            count += eve::count_true(permutation);
+          }
+          TTS_EQUAL(count, T::size());
+        }
+      });
+};
+
+} // namespace

--- a/test/unit/api/tuple/swizzle/try_each_group_position.cpp
+++ b/test/unit/api/tuple/swizzle/try_each_group_position.cpp
@@ -1,0 +1,35 @@
+//==================================================================================================
+/**
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+**/
+//==================================================================================================
+#include "test.hpp"
+#include <eve/module/core.hpp>
+
+namespace
+{
+
+TTS_CASE_TPL( "Check behavior of try_each_group_position", eve::test::scalar::all_types)
+<typename T>(tts::type<T>)
+{
+  using s_t = kumi::tuple<std::int8_t,T,double>;
+  using w_t = eve::wide<s_t>;
+
+  w_t data = [](auto i, auto) { return  s_t { static_cast<std::int8_t>(65+i)
+                                            , static_cast<T>(i + 1)
+                                            , 1.5*(1+i)
+                                            };
+                              };
+  auto r = eve::try_each_group_position(data, eve::lane<1>);
+
+  eve::detail::for_<0,1,w_t::size()>([&]<typename I>(I ) {
+    auto perm = get<I{}()>(r);
+    for (int i = 0; i != w_t::size(); ++i) {
+      TTS_EXPECT(eve::any(perm == data.get(i))) << data.get(i);
+    }
+  });
+};
+
+}


### PR DESCRIPTION
Waits for #1611 to be merged.

Basics implementation, again platform specific improvements will be done later.

```
---- simd
<- x                                        = (1, 2, 3, 4)
-> try_each_group_position(x, eve::lane<1>) = ( (1, 2, 3, 4) (3, 4, 1, 2) (2, 3, 4, 1) (4, 1, 2, 3) )
-> try_each_group_position(x, eve::lane<2>) = ( (1, 2, 3, 4) (3, 4, 1, 2) )
```