### PR TITLE
maybe fix gcc concept bug

### DIFF
--- a/include/eve/arch/cpu/logical_wide.hpp
+++ b/include/eve/arch/cpu/logical_wide.hpp
@@ -26,7 +26,6 @@
 #include <eve/detail/function/make.hpp>
 #include <eve/detail/function/slice.hpp>
 #include <eve/detail/function/subscript.hpp>
-#include <eve/traits/as_integer.hpp>
 
 #include <cstring>
 #include <concepts>
@@ -74,7 +73,7 @@ namespace eve
     using size_type     = std::ptrdiff_t;
 
     //! Type representing the bits of the logical value
-    using bits_type = wide<as_integer_t<Type, unsigned>, Cardinal>;
+    using bits_type = wide<detail::make_integer_t<sizeof(Type), unsigned>, Cardinal>;
 
     //! Type representing the numerical value associated to the mask
     using mask_type = wide<Type, Cardinal>;


### PR DESCRIPTION
The error

```
/__w/eve/eve/include/eve/concept/scalar.hpp:45:49: error: satisfaction value of atomic constraint '(is_plain<T>)() [with T = typename eve::arm_abi_v0::wide<Type, Size>::value_type]' changed from 'false' to 'true'
   45 | concept plain_scalar_value = detail::is_plain<T>();
      |                              ~~~~~~~~~~~~~~~~~~~^~
/__w/eve/eve/include/eve/arch/cpu/logical_wide.hpp:77:11: note: satisfaction value first evaluated to 'false' from here
   77 |     using bits_type = wide<as_integer_t<Type, unsigned>, Cardinal>;
      |           ^~~~~~~~~
```

I think the problem is that as_integer works for wide and logical while being used in logical