### PR TITLE
More shuffles 2

### DIFF
--- a/include/eve/detail/function/canonical_shuffle_adapter.hpp
+++ b/include/eve/detail/function/canonical_shuffle_adapter.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <eve/concept/pattern.hpp>
+#include <eve/detail/idxm.hpp>
 
 namespace eve
 {
@@ -32,19 +33,37 @@ template<typename InternalShuffle> struct canocical_shuffle_adapter_bound
 {
   InternalShuffle internalShuffle;
 
-  template<std::ptrdiff_t G, std::ptrdiff_t... I, simd_value T, typename ... Ts>
+  template<std::ptrdiff_t G, std::ptrdiff_t... I, simd_value T, typename... Ts>
   EVE_FORCEINLINE auto operator()(pattern_t<I...> p, eve::fixed<G> g, T x, Ts... xs) const noexcept
   {
-    static_assert(G <= T::size(), "Group sized passed is bigger than a register, very likely a bug");
+    static_assert(G <= T::size(),
+                  "Group sized passed is bigger than a register, very likely a bug");
     static_assert((std::same_as<T, Ts> && ...), "You can only shuffle the same type");
+
+    static_assert(detail::idxm::validate_pattern(
+        eve::lane<G>, pattern<I...>, eve::as<T> {}, eve::as<Ts> {}...));
     return canonical_shuffle_adapter_impl(internalShuffle, p, g, x, xs...);
   }
 
+  template<pattern_formula Gen, std::ptrdiff_t G, simd_value T, typename... Ts>
+  EVE_FORCEINLINE auto operator()(Gen, eve::fixed<G> g, T x, Ts... xs) const noexcept
+      -> decltype(operator()(fix_pattern<T::size() / G> (Gen {}), g, x, xs...))
+  {
+    return operator()(fix_pattern<T::size() / G> (Gen {}), g, x, xs...);
+  }
+
   template<std::ptrdiff_t... I>
-  EVE_FORCEINLINE auto operator()(pattern_t<I...> p, simd_value auto x, auto ... xs) const noexcept
+  EVE_FORCEINLINE auto operator()(pattern_t<I...> p, simd_value auto x, auto... xs) const noexcept
       -> decltype(operator()(p, eve::lane<1>, x, xs...))
   {
     return operator()(p, eve::lane<1>, x, xs...);
+  }
+
+  EVE_FORCEINLINE auto
+  operator()(pattern_formula auto gen, simd_value auto x, auto... xs) const noexcept
+      -> decltype(operator()(gen, eve::lane<1>, x, xs...))
+  {
+    return operator()(gen, eve::lane<1>, x, xs...);
   }
 };
 
@@ -57,9 +76,9 @@ template<typename Internal> struct reverse_arguments
     return kumi::apply(internal, kumi::reverse(kumi::tuple {args...}));
   }
 
-  template <typename ...Ts>
+  template<typename... Ts>
   EVE_FORCEINLINE auto operator()(auto... args) const noexcept
-    requires( !std::same_as<no_matching_shuffle_t, decltype(impl(args...))> )
+  requires(!std::same_as<no_matching_shuffle_t, decltype(impl(args...))>)
   {
     return impl(args...);
   }
@@ -67,12 +86,34 @@ template<typename Internal> struct reverse_arguments
 
 template<typename Internal> reverse_arguments(Internal internal) -> reverse_arguments<Internal>;
 
+/*
+ * as_canonical_shuffle is an internal function for writing platform specific
+ * shuffles.
+ *
+ * It does the following simplifications
+ *
+ * * transforms the interfance to (pattern, group_size, wides...);
+ * * wide logicals are converted to masks
+ * * converts all types to std::uint<>_t.
+ * * smaller than fundamental cardinals get padded with we_ to fundamental
+ * * ups the group size if the pattern allows it ({2, 3, 0, 1} => {1, 0})
+ * * ups the element size if the group size allows it: uint32x2 => uint64x1
+ * * when shuffling two registers, if the result uses just one - reduce to shuffling one register
+ * * when shuffling two registers, prefers a lexicographically smaller pattern:
+ *    uint32x2 x 2 : {2, 0} and {0, 2} are the same shuffle, just registers swapped.
+ *                   will produce {0, 2}
+ */
 template<typename InternalShuffle>
 constexpr auto
 as_canonical_shuffle(InternalShuffle internalShuffle)
 {
   return reverse_arguments {canocical_shuffle_adapter_bound<InternalShuffle> {internalShuffle}};
 }
+
+// As an internal helper
+template<typename T>
+concept matched_shuffle = !std::same_as<no_matching_shuffle_t, T>;
+
 }
 
 #include <eve/detail/function/simd/common/canonical_shuffle_adapter.hpp>

--- a/include/eve/detail/idxm.hpp
+++ b/include/eve/detail/idxm.hpp
@@ -1,0 +1,214 @@
+//==================================================================================================
+/*
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+*/
+//==================================================================================================
+#pragma once
+
+#include <eve/pattern.hpp>
+
+#include <span>
+
+/*
+ * idxm => index math
+ * algorithms for pattern index manipulations.
+ * Mostly tested through shuffles.
+ */
+
+namespace eve::detail::idxm
+{
+
+constexpr bool
+are_below_ignoring_specials(std::span<const std::ptrdiff_t> idxs, std::ptrdiff_t ub)
+{
+  // std::any_of but in compile time that's not free.
+  for( auto x : idxs )
+  {
+    if( x == na_ || x == we_ ) continue;
+    if( x >= ub ) return false;
+  }
+  return true;
+}
+
+template<auto arr>
+constexpr auto
+to_pattern()
+{
+  return []<std::size_t... i>(std::index_sequence<i...>)
+  { return pattern<arr[i]...>; }(std::make_index_sequence<arr.size()> {});
+}
+
+template<std::size_t N>
+constexpr auto
+swap_xy(std::array<std::ptrdiff_t, N> in, std::ptrdiff_t s) -> std::array<std::ptrdiff_t, N>
+{
+  std::array<std::ptrdiff_t, N> swapped = in;
+
+  for( auto& x : swapped )
+  {
+    if( x == na_ || x == we_ ) continue;
+    if( x >= s ) x -= s;
+    else x += s;
+  }
+
+  return swapped;
+}
+
+template<std::ptrdiff_t G, std::ptrdiff_t... I, typename T, typename... Ts>
+constexpr bool
+validate_pattern(eve::fixed<G>, pattern_t<I...>, eve::as<T>, eve::as<Ts>...)
+{
+  std::ptrdiff_t max_idx = T::size() * (sizeof...(Ts) + 1) / G;
+  for( auto i : {I...} )
+  {
+    // we/na
+    if( -2 <= i && i < max_idx ) continue;
+    return false;
+  }
+
+  return true;
+}
+
+template<std::size_t Fundamental, std::size_t PatternSize>
+constexpr auto
+fix_indexes_to_fundamental(const std::array<std::ptrdiff_t, PatternSize>& p,
+                           std::ptrdiff_t                                 cardinal)
+{
+  std::array<std::ptrdiff_t, std::max(PatternSize, Fundamental)> res {};
+  std::size_t                                                    i = 0;
+
+  std::ptrdiff_t wide_offest = (std::ptrdiff_t)Fundamental - cardinal;
+
+  for( ; i != PatternSize; ++i )
+  {
+    std::ptrdiff_t x = p[i];
+    if( x >= cardinal ) { x += wide_offest * (x / cardinal); }
+    res[i] = x;
+  }
+
+  for( ; i != res.size(); ++i ) { res[i] = we_; }
+
+  return res;
+}
+
+template<std::size_t N>
+constexpr std::optional<std::array<std::ptrdiff_t, N / 2>>
+is_repeating_pattern(const std::array<std::ptrdiff_t, N>& p)
+{
+  std::array<std::ptrdiff_t, N / 2> res = {};
+
+  constexpr std::ptrdiff_t half = N / 2;
+  for( std::size_t i = 0; i != N / 2; ++i )
+  {
+    std::ptrdiff_t x = p[i];
+    std::ptrdiff_t y = p[i + (std::size_t)half];
+
+    if( x >= half ) return std::nullopt;
+    if( 0 <= y && y < half ) return std::nullopt;
+
+    if( y > 0 ) y -= half;
+
+    if( x == y || y == we_ )
+    {
+      res[i] = x;
+      continue;
+    }
+
+    if( x == we_ )
+    {
+      res[i] = y;
+      continue;
+    }
+
+    return std::nullopt;
+  }
+
+  return res;
+}
+
+constexpr bool
+has_zeroes(std::span<const std::ptrdiff_t> idxs)
+{
+  // std::any_of but in compile time that's not free.
+  for( auto x : idxs )
+  {
+    if( x == na_ ) return true;
+  }
+  return false;
+}
+
+// returns the starting index
+constexpr std::optional<std::ptrdiff_t>
+is_in_order(std::span<const std::ptrdiff_t> idxs)
+{
+  std::size_t i = 0, s = idxs.size();
+
+  // find not we_ but in compile time that's not free
+  while( true )
+  {
+    if( i == s ) return we_;
+    if( idxs[i] != we_ ) break;
+    ++i;
+  }
+  if( idxs[i] == na_ ) return std::nullopt;
+
+  std::ptrdiff_t expected = idxs[i];
+  std::ptrdiff_t from     = expected - (std::ptrdiff_t)i;
+
+  // [we_, we_, 1] is not in order, for any we_.
+  if( from < 0 ) return std::nullopt;
+
+  while( true )
+  {
+    ++i;
+    ++expected;
+    if( i == s ) return from;
+    if( idxs[i] == we_ ) continue;
+    if( idxs[i] != expected ) return std::nullopt;
+  }
+}
+
+constexpr std::optional<std::ptrdiff_t>
+is_rotate(std::span<const std::ptrdiff_t> idxs)
+{
+  if( idxs.empty() ) { return 0; }
+
+  auto point = std::min_element(idxs.begin(),
+                                idxs.end(),
+                                [](auto x, auto y)
+                                {
+                                  // we_ should be not prefered
+                                  // na_ means not a rotate, but we will detect it later
+                                  return (unsigned)x < (unsigned)y;
+                                });
+
+  // all are we_
+  if( *point == we_ ) return 0;
+
+  // find where 0 is. We can be to the left or to the right.
+  if( *point <= point - idxs.begin() )
+  {
+    // [3, we_, |1, 2] => [3, | we_, 1, 2]
+    point -= *point;
+  }
+  else
+  {
+    // [|1, 2, 3, we_] => [1, 2, 3, | we_]
+    point += idxs.size() - *point;
+  }
+
+  std::ptrdiff_t rotation = point - idxs.begin();
+
+  // these filter out na_
+  auto rhs_start = is_in_order({point, idxs.end()});
+  if( rhs_start != 0 && rhs_start != we_ ) return std::nullopt;
+
+  auto lhs_start = is_in_order({idxs.begin(), point});
+  if( lhs_start != (idxs.size() - rotation) && lhs_start != we_ ) return std::nullopt;
+
+  return rotation;
+}
+
+} // namespace eve::detail::idxm

--- a/include/eve/module/core/regular/impl/shuffle_l0.hpp
+++ b/include/eve/module/core/regular/impl/shuffle_l0.hpp
@@ -52,41 +52,6 @@ is_zero(std::span<const std::ptrdiff_t> idxs)
 }
 
 constexpr bool
-has_zeroes(std::span<const std::ptrdiff_t> idxs)
-{
-  // std::any_of but in compile time that's not free.
-  for( auto x : idxs )
-  {
-    if( x == na_ ) return true;
-  }
-  return false;
-}
-
-constexpr bool
-are_below_ignoring_speicals(std::span<const std::ptrdiff_t> idxs, std::ptrdiff_t ub)
-{
-  // std::any_of but in compile time that's not free.
-  for( auto x : idxs )
-  {
-    if( x == na_ || x == we_ ) continue;
-    if( x >= ub ) return false;
-  }
-  return true;
-}
-
-constexpr bool
-are_above_ignoring_speicals(std::span<const std::ptrdiff_t> idxs, std::ptrdiff_t lb)
-{
-  // std::any_of but in compile time that's not free.
-  for( auto x : idxs )
-  {
-    if( x == na_ || x == we_ ) continue;
-    if( x < lb ) return false;
-  }
-  return true;
-}
-
-constexpr bool
 is_blend(std::span<const std::ptrdiff_t> idxs)
 {
   std::ptrdiff_t s = std::ssize(idxs);

--- a/include/eve/module/core/regular/impl/simd/arm/neon/shuffle_l0.hpp
+++ b/include/eve/module/core/regular/impl/simd/arm/neon/shuffle_l0.hpp
@@ -24,7 +24,7 @@ requires std::same_as<abi_t<T, N>, arm_64_>
   else if constexpr( idx::is_zero(idxs) ) return wide<T, N> {0};
   else if constexpr( sizeof(T) == 4 )
   {
-    if constexpr( idx::has_zeroes(idxs) )
+    if constexpr( idxm::has_zeroes(idxs) )
     {
       if constexpr( idx::matches(idxs, {0, na_}, {na_, 1}) )
       {

--- a/include/eve/module/core/regular/impl/simd/x86/try_each_group_position.hpp
+++ b/include/eve/module/core/regular/impl/simd/x86/try_each_group_position.hpp
@@ -1,0 +1,32 @@
+//==================================================================================================
+/*
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+*/
+//==================================================================================================
+#pragma once
+
+#include <eve/module/core/regular/shuffle_l0.hpp>
+
+namespace eve::detail
+{
+
+constexpr auto try_each_group_rotate_halfs_pattern = [](int i, int size)
+{
+  int half = size / 2;
+  return (i >= half) * half + (i + 1) % half;
+};
+
+template<arithmetic_scalar_value T, typename N, std::ptrdiff_t G>
+EVE_FORCEINLINE auto
+try_each_group_position_(EVE_SUPPORTS(avx2_), wide<T, N> x, eve::fixed<G>) noexcept
+requires std::same_as<abi_t<T, N>, x86_256_> && (G < N::value / 2)
+{
+  auto x_1 = shuffle_l0(x, lane<G>, try_each_group_rotate_halfs_pattern);
+
+  return kumi::cat(try_each_group_position(x, eve::lane<G * 2>),
+                   try_each_group_position(x_1, eve::lane<G * 2>));
+}
+
+}

--- a/include/eve/module/core/regular/try_each_group_position.hpp
+++ b/include/eve/module/core/regular/try_each_group_position.hpp
@@ -49,3 +49,7 @@ namespace eve
 }
 
 #include <eve/module/core/regular/impl/try_each_group_position.hpp>
+
+#if defined(EVE_INCLUDE_X86_HEADER)
+#  include <eve/module/core/regular/impl/simd/x86/try_each_group_position.hpp>
+#endif

--- a/include/eve/pattern.hpp
+++ b/include/eve/pattern.hpp
@@ -94,12 +94,18 @@ namespace eve
   //================================================================================================
 
   //! @relates eve::pattern_t
+  //! @brief what callable can be a pattern formula
+  template <typename F>
+  concept pattern_formula = std::constructible_from<F> && std::regular_invocable<F, int, int>
+    && !requires { { F::size() }; };
+
+  //! @relates eve::pattern_t
   //! @brief Formula-based pattern holder
-  template<typename F> struct as_pattern { constexpr as_pattern(F) {} };
+  template<pattern_formula F> struct as_pattern { constexpr as_pattern(F) {} };
 
   //! @relates eve::pattern_t
   //! @brief Converts a formula pattern to index pattern
-  template<std::ptrdiff_t Sz, typename F> constexpr auto fix_pattern(F)
+  template<std::ptrdiff_t Sz, pattern_formula F> constexpr auto fix_pattern(F)
   {
     return []<auto... N>( std::integer_sequence<std::ptrdiff_t,N...> )
     {
@@ -107,7 +113,7 @@ namespace eve
     }( std::make_integer_sequence<std::ptrdiff_t,Sz>{} );
   }
 
-  template<std::ptrdiff_t Sz, typename F> constexpr auto fix_pattern(as_pattern<F>)
+  template<std::ptrdiff_t Sz, pattern_formula F> constexpr auto fix_pattern(as_pattern<F>)
   {
     return fix_pattern<Sz>( F{} );
   }
@@ -117,7 +123,7 @@ namespace eve
   template<std::ptrdiff_t N, shuffle_pattern Pattern >
   constexpr auto pattern_clamp(Pattern const&) noexcept
   {
-    return fix_pattern<N>( Pattern{} );
+    return fix_pattern<N>( [](int i, int size) { return Pattern{}(i, size); } );
   }
 
   //================================================================================================

--- a/test/unit/api/regular/swizzle/shuffle_test.hpp
+++ b/test/unit/api/regular/swizzle/shuffle_test.hpp
@@ -140,6 +140,27 @@ concat(const A0& a0, const As&...as)
   return (concat_op {a0} + ... + as).self;
 }
 
+template<std::size_t Len>
+constexpr arr<Len>
+toRightHalf(arr<Len> in)
+{
+  for( auto& x : in )
+  {
+    if( x < 0 ) continue;
+    x += (std::ptrdiff_t)Len;
+  }
+  return in;
+}
+
+template<std::size_t N, std::size_t Len>
+constexpr std::array<arr<Len * 2>, N>
+matchRightLane(const std::array<arr<Len>, N>& in)
+{
+  std::array<arr<Len * 2>, N> res = {};
+  for( std::size_t i = 0; i != N; ++i ) { res[i] = concat(in[i], toRightHalf(in[i])); }
+  return res;
+}
+
 // Do not repeat patterns that occur when doubling up
 // We also don't test all we_ because there is a lot of them
 [[maybe_unused]] constexpr std::array kLen1Tests = {
@@ -234,9 +255,7 @@ concat(const A0& a0, const As&...as)
 }();
 
 // Too many to do all
-[[maybe_unused]]
-
-constexpr std::array kLen4No0Tests_Scrambled = {
+[[maybe_unused]] constexpr std::array kLen4No0Tests_Scrambled = {
     arr<4> {0, 1, 0, 0}, //
     arr<4> {1, 0, 1, 1}, //
     // ---
@@ -253,6 +272,22 @@ constexpr std::array kLen4No0Tests_Scrambled = {
 
 [[maybe_unused]] constexpr std::array kLen4N0Tests_CrossLane =
     concat(kLen4No0Tests_IndependentHalves_Reversed, kLen4No0Tests_Scrambled);
+
+// Do not repeat shuffle 4
+[[maybe_unused]]
+constexpr std::array kRotate8 = {
+    arr<8> {1, 2, 3, 4, 5, 6, 7, 0},               //
+    arr<8> {3, 4, 5, 6, 7, 0, 1, 2},               //
+    arr<8> {5, 6, 7, 0, 1, 2, 3, 4},               //
+    arr<8> {7, 0, 1, 2, 3, 4, 5, 6},               //
+    arr<8> {1, eve::we_, 3, 4, 5, eve::we_, 7, 0}, //
+};
+
+[[maybe_unused]]
+constexpr std::array kRotate16 = {
+    arr<16> {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0}, //
+    arr<16> {3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2}, //
+};
 
 // -----------------------------------------------------------------------------
 // 2 register tests
@@ -285,7 +320,6 @@ constexpr std::array kLen4No0Tests_Scrambled = {
     arr<2> {2, 1}, //
     arr<2> {3, 0}, //
     arr<2> {3, 1}, //
-                   //---------------------
 };
 
 [[maybe_unused]] constexpr std::array kLen4x2_No0sBlendTests = {
@@ -305,7 +339,6 @@ constexpr std::array kLen4No0Tests_Scrambled = {
     // --------------------
     arr<4> {4, 5, 6, 3}, //
     arr<4> {4, 5, 2, 7}, //
-    // --------------------
 };
 
 // Not doing all

--- a/test/unit/internals/canonical_shuffle_adapter.cpp
+++ b/test/unit/internals/canonical_shuffle_adapter.cpp
@@ -16,7 +16,30 @@ template<typename T, std::ptrdiff_t G = 1>
 constexpr auto some_pattern =
     eve::fix_pattern<T::size() / G>([](int i, int size) { return size - i - 1; });
 
+template<typename T, std::ptrdiff_t G = 1>
+constexpr auto some_pattern2 =
+    eve::fix_pattern<T::size() / G>([](int i, int size) { return size * 2 - 2 * i - 1; });
+
 template<typename T, std::ptrdiff_t G = 1> using some_p_t = decltype(some_pattern<T, G>);
+
+template<typename T, std::ptrdiff_t G = 1> using some_p2_t = decltype(some_pattern2<T, G>);
+
+TTS_CASE("Canonical shuffle with lambdas")
+{
+  // using very_wide to not care for fundamental cardinals
+  constexpr auto shuffle = eve::detail::as_canonical_shuffle(
+      [](auto p, auto, auto x)
+      {
+        constexpr auto expected = eve::pattern<7, 6, 5, 4, 3, 2, 1, 0>;
+        TTS_EQUAL(expected, p);
+        return x;
+      });
+
+  constexpr auto formula = [](int i, int size) { return size - i - 1; };
+
+  shuffle(eve::wide<std::uint64_t, eve::fixed<8>> {}, formula);
+  shuffle(eve::wide<std::uint32_t, eve::fixed<16>> {}, eve::lane<2>, formula);
+};
 
 TTS_CASE("Canonical shuffle propagates not found")
 {
@@ -24,7 +47,7 @@ TTS_CASE("Canonical shuffle propagates not found")
   constexpr auto op = []<typename T, typename N>(auto /*p*/, auto /*g*/, eve::wide<T, N> x, auto...)
   requires(sizeof(T) > 1)
   {
-    if constexpr( std::same_as<T, float> ) return eve::detail::no_matching_shuffle;
+    if constexpr( sizeof(T) == 4 ) return eve::detail::no_matching_shuffle;
     else return x;
   };
   constexpr auto shuffle = eve::detail::as_canonical_shuffle(op);
@@ -35,20 +58,20 @@ TTS_CASE("Canonical shuffle propagates not found")
   TTS_CONSTEXPR_EXPECT((std::invocable<decltype(shuffle),
                                        eve::wide<std::int16_t>,
                                        eve::wide<std::int16_t>,
-                                       some_p_t<eve::wide<std::int16_t>>>));
+                                       some_p2_t<eve::wide<std::int16_t>>>));
 
   TTS_CONSTEXPR_EXPECT_NOT(
       (std::invocable<decltype(shuffle), eve::wide<float>, some_p_t<eve::wide<float>>>));
   TTS_CONSTEXPR_EXPECT_NOT((std::invocable<decltype(shuffle),
                                            eve::wide<float>,
                                            eve::wide<float>,
-                                           some_p_t<eve::wide<float>>>));
+                                           some_p2_t<eve::wide<float>>>));
   TTS_CONSTEXPR_EXPECT_NOT(
       (std::invocable<decltype(shuffle), eve::wide<char>, some_p_t<eve::wide<char>>>));
   TTS_CONSTEXPR_EXPECT_NOT((std::invocable<decltype(shuffle),
                                            eve::wide<char>,
                                            eve::wide<char>,
-                                           some_p_t<eve::wide<char>>>));
+                                           some_p2_t<eve::wide<char>>>));
 };
 
 TTS_CASE_TPL("Check canonical shuffle, wide logicals", eve::test::simd::all_types)
@@ -68,8 +91,9 @@ TTS_CASE_TPL("Check canonical shuffle, wide logicals", eve::test::simd::all_type
           ++numTimesCalled;
           return x;
         });
-    using P = some_p_t<T>;
-    auto r  = hasShuffle(eve::logical<T> {true}, P {});
+    using P  = some_p_t<T>;
+    using P2 = some_p2_t<T>;
+    auto r   = hasShuffle(eve::logical<T> {true}, P {});
 
     TTS_EQUAL(numTimesCalled, 1);
     TTS_TYPE_IS(decltype(r), eve::logical<T>);
@@ -79,15 +103,24 @@ TTS_CASE_TPL("Check canonical shuffle, wide logicals", eve::test::simd::all_type
 
     TTS_CONSTEXPR_EXPECT((std::invocable<decltype(hasShuffle), eve::logical<T>, P>));
     TTS_CONSTEXPR_EXPECT(
-        (std::invocable<decltype(hasShuffle), eve::logical<T>, eve::logical<T>, P>));
+        (std::invocable<decltype(hasShuffle), eve::logical<T>, eve::logical<T>, P2>));
     TTS_CONSTEXPR_EXPECT_NOT((std::invocable<decltype(notFound), eve::logical<T>, P>));
-    TTS_CONSTEXPR_EXPECT_NOT((std::invocable<decltype(notFound), eve::logical<T>, P>));
+    TTS_CONSTEXPR_EXPECT_NOT(
+        (std::invocable<decltype(notFound), eve::logical<T>, eve::logical<T>, P2>));
     TTS_CONSTEXPR_EXPECT((std::invocable<decltype(hasShuffle), eve::logical<T>, eve::fixed<1>, P>));
+    TTS_CONSTEXPR_EXPECT((
+        std::invocable<decltype(hasShuffle), eve::logical<T>, eve::logical<T>, eve::fixed<1>, P2>));
 
     if constexpr( T::size() >= 2 )
     {
+      using half_T = eve::wide<eve::element_type_t<T>, eve::fixed<T::size() / 2>>;
       TTS_CONSTEXPR_EXPECT_NOT(
-          (std::invocable<decltype(notFound), eve::logical<T>, eve::fixed<2>, P>));
+          (std::invocable<decltype(notFound), eve::logical<T>, eve::fixed<2>, some_p_t<half_T>>));
+      TTS_CONSTEXPR_EXPECT_NOT((std::invocable<decltype(notFound),
+                                               eve::logical<T>,
+                                               eve::logical<T>,
+                                               eve::fixed<2>,
+                                               some_p2_t<half_T>>));
     }
   }
 };
@@ -138,12 +171,13 @@ TTS_CASE_TPL("Check canonical shuffle, bundle", eve::test::simd::all_types)
         if constexpr( sizeof(e_t) == 2 ) return eve::detail::no_matching_shuffle;
         else return x;
       });
-  using P = some_p_t<w_t>;
+  using P  = some_p_t<w_t>;
+  using P2 = some_p2_t<w_t>;
 
   if constexpr( sizeof(e_t) == 2 )
   {
     TTS_CONSTEXPR_EXPECT_NOT((std::invocable<decltype(shuffle), w_t, P>));
-    TTS_CONSTEXPR_EXPECT_NOT((std::invocable<decltype(shuffle), w_t, w_t, P>));
+    TTS_CONSTEXPR_EXPECT_NOT((std::invocable<decltype(shuffle), w_t, w_t, P2>));
     TTS_CONSTEXPR_EXPECT_NOT((std::invocable<decltype(shuffle), ww_t, P>));
   }
   else
@@ -153,7 +187,7 @@ TTS_CASE_TPL("Check canonical shuffle, bundle", eve::test::simd::all_types)
     TTS_TYPE_IS(decltype(r), w_t);
 
     numTimesCalled = 0;
-    auto r1        = shuffle(w_t {}, w_t {}, P {});
+    auto r1        = shuffle(w_t {}, w_t {}, P2 {});
     TTS_EQUAL(numTimesCalled, 3);
     TTS_TYPE_IS(decltype(r1), w_t);
 
@@ -175,20 +209,40 @@ simplify_test(P0Gen, P1Gen)
 {
   constexpr auto p0 = eve::fix_pattern<T0::size() / G0>(P0Gen {});
   constexpr auto p1 = eve::fix_pattern<T1::size() / G1>(P1Gen {});
-
   {
     auto [x_, g_, p_] = eve::detail::simplify_plain_shuffle(p0, eve::lane<G0>, T0 {});
 
-    TTS_TYPE_IS(std::remove_cvref_t<decltype(get<0>(x_))>, T1);
+    TTS_TYPE_IS(decltype(x_), kumi::tuple<T1>);
     TTS_CONSTEXPR_EQUAL(decltype(g_)::value, G1);
     TTS_EQUAL(p_, p1);
   }
 
   {
+    // second part is cut out
     auto [x_, g_, p_] = eve::detail::simplify_plain_shuffle(p0, eve::lane<G0>, T0 {}, T0 {});
 
-    TTS_TYPE_IS(std::remove_cvref_t<decltype(get<0>(x_))>, T1);
-    TTS_TYPE_IS(std::remove_cvref_t<decltype(get<1>(x_))>, T1);
+    TTS_TYPE_IS(decltype(x_), kumi::tuple<T1>)
+        << "p0: " << p0 << " T::size(): " << T0::size() << " g: " << G0;
+    TTS_CONSTEXPR_EQUAL(decltype(g_)::value, G1);
+    TTS_EQUAL(p_, p1);
+  }
+}
+
+template<typename T0,
+         std::ptrdiff_t G0,
+         typename T1,
+         std::ptrdiff_t G1,
+         typename P0Gen,
+         typename P1Gen>
+void
+simplify2_test(P0Gen, P1Gen)
+{
+  constexpr auto p0 = eve::fix_pattern<T0::size() / G0>(P0Gen {});
+  constexpr auto p1 = eve::fix_pattern<T1::size() / G1>(P1Gen {});
+  {
+    auto [x_, g_, p_] = eve::detail::simplify_plain_shuffle(p0, eve::lane<G0>, T0 {}, T0 {});
+
+    TTS_TYPE_IS(decltype(x_), (kumi::tuple<T1, T1>));
     TTS_CONSTEXPR_EQUAL(decltype(g_)::value, G1);
     TTS_EQUAL(p_, p1);
   }
@@ -200,6 +254,9 @@ simplify_test()
 {
   auto p = [](int i, int size) { return size - i - 1; };
   simplify_test<T0, G0, T1, G1>(p, p);
+
+  auto p2 = [](int i, int) { return i + 1; };
+  simplify2_test<T0, G0, T1, G1>(p2, p2);
 }
 
 TTS_CASE("Check simplification, types")
@@ -211,51 +268,58 @@ TTS_CASE("Check simplification, types")
   }
 
   simplify_test<eve::wide<std::uint8_t>, 2, eve::wide<std::uint16_t>, 1>();
+  simplify_test<eve::wide<std::int8_t>, 4, eve::wide<std::uint32_t>, 1>();
+  simplify_test<eve::wide<std::uint8_t>, 4, eve::wide<std::uint32_t>, 1>();
+  simplify_test<eve::wide<std::int16_t>, 4, eve::wide<std::uint64_t>, 1>();
+  simplify_test<eve::wide<std::uint16_t>, 4, eve::wide<std::uint64_t>, 1>();
+  simplify_test<eve::wide<std::int8_t>, 1, eve::wide<std::uint8_t>, 1>();
+  simplify_test<eve::wide<std::int16_t>, 1, eve::wide<std::uint16_t>, 1>();
+  simplify_test<eve::wide<std::uint16_t>, 1, eve::wide<std::uint16_t>, 1>();
 
-  if constexpr( eve::current_api == eve::avx )
+  simplify_test<eve::wide<float, eve::fixed<16>>, 1, eve::wide<std::uint32_t, eve::fixed<16>>, 1>();
+  simplify_test<eve::wide<float, eve::fixed<16>>, 2, eve::wide<std::uint64_t, eve::fixed<8>>, 1>();
+
+  if constexpr( eve::current_api != eve::neon )
   {
-    simplify_test<eve::wide<std::int8_t>, 4, eve::wide<float>, 1>();
-    simplify_test<eve::wide<std::uint8_t>, 4, eve::wide<float>, 1>();
-    simplify_test<eve::wide<std::int16_t>, 4, eve::wide<double>, 1>();
-    simplify_test<eve::wide<std::uint16_t>, 4, eve::wide<double>, 1>();
-    simplify_test<eve::wide<float>, 2, eve::wide<double>, 1>();
-    simplify_test<eve::wide<std::uint16_t, eve::fixed<8>>,
-                  4,
-                  eve::wide<std::uint64_t, eve::fixed<2>>,
-                  1>();
+    simplify_test<eve::wide<double, eve::fixed<8>>,
+                  2,
+                  eve::wide<std::uint64_t, eve::fixed<8>>,
+                  2>();
   }
   else
   {
-    simplify_test<eve::wide<std::int8_t>, 4, eve::wide<std::uint32_t>, 1>();
-    simplify_test<eve::wide<std::uint8_t>, 4, eve::wide<std::uint32_t>, 1>();
-    simplify_test<eve::wide<std::int16_t>, 4, eve::wide<std::uint64_t>, 1>();
-    simplify_test<eve::wide<std::uint16_t>, 4, eve::wide<std::uint64_t>, 1>();
-    if constexpr( eve::current_api == eve::neon )
-    {
-      simplify_test<eve::wide<float>, 2, eve::wide<std::uint64_t>, 1>();
-    }
-    else { simplify_test<eve::wide<float>, 2, eve::wide<double>, 1>(); }
+    simplify_test<eve::wide<double, eve::fixed<8>>, 2, eve::wide<double, eve::fixed<8>>, 2>();
   }
-
-  simplify_test<eve::wide<std::int8_t>, 1, eve::wide<std::uint8_t>, 1>();
-  simplify_test<eve::wide<std::int16_t>, 1, eve::wide<std::uint16_t>, 1>();
-  simplify_test<eve::wide<std::int16_t>, 1, eve::wide<std::uint16_t>, 1>();
-
-  using very_wide = eve::wide<double, eve::fixed<8>>;
-  simplify_test<very_wide, 2, very_wide, 2>();
 };
 
 template<typename T, typename N>
 void
 simplify_test_pad_to_fundamental()
 {
-  auto p0 = [](int i, int size) { return size - i; };
+  auto p0 = [](int i, int size) { return size - i - 1; };
   auto p1 = [](int i, int)
   {
-    if( i < N::value ) return N::value - i;
+    if( i < N::value ) return N::value - i - 1;
     else return eve::we_;
   };
   simplify_test<eve::wide<T, N>, 1, eve::wide<T, eve::fundamental_cardinal_t<T>>, 1>(p0, p1);
+
+  if( N::value == 1 ) return;
+
+  auto p0x2 = [](int i, int size)
+  {
+    if( i % 2 == 0 ) return i;
+    return i + size;
+  };
+
+  auto p1x2 = [](int i, int size)
+  {
+    if( i >= N::value ) return (int)eve::we_;
+    if( i % 2 == 0 ) return i;
+    else return i + size;
+  };
+
+  simplify2_test<eve::wide<T, N>, 1, eve::wide<T, eve::fundamental_cardinal_t<T>>, 1>(p0x2, p1x2);
 }
 
 TTS_CASE("Check simplification, pad to fundamental")
@@ -270,7 +334,6 @@ TTS_CASE("Check simplification, pad to fundamental")
   simplify_test_pad_to_fundamental<std::uint8_t, eve::fixed<2>>();
   simplify_test_pad_to_fundamental<std::uint16_t, eve::fixed<2>>();
   simplify_test_pad_to_fundamental<std::uint32_t, eve::fixed<2>>();
-  simplify_test_pad_to_fundamental<float, eve::fixed<2>>();
 };
 
 template<std::ptrdiff_t... I>
@@ -297,9 +360,6 @@ TTS_CASE("Check upscale_pattern")
 
 TTS_CASE("Check simplification, upscale")
 {
-  simplify_test<eve::wide<double>, 1, eve::wide<double>, eve::expected_cardinal_v<double>>(
-      [](int i, int) { return i; }, [](int i, int) { return i; });
-
   using up_wide =
       std::conditional_t<eve::supports_simd, eve::wide<std::uint16_t>, eve::wide<std::uint8_t>>;
 
@@ -314,11 +374,62 @@ TTS_CASE("Check simplification, upscale")
       [](int i, int size) { return size - i - 1; });
 };
 
+TTS_CASE("Check simplification, 2 register")
+{
+  using T = eve::wide<std::uint64_t, eve::fixed<8>>;
+
+  // pick lexicographical min
+  {
+    // 0 1 2 3 | 4 5 6 7
+    constexpr auto p0 = eve::pattern<eve::we_, 5, 1, 2>;
+    constexpr auto p1 = eve::pattern<eve::we_, 1, 5, 6>;
+    auto [x_, g_, p_] = eve::detail::simplify_plain_shuffle(p0, eve::lane<2>, T {}, T {});
+
+    TTS_TYPE_IS(decltype(x_), (kumi::tuple<T, T>));
+    TTS_EQUAL(p_, p1);
+  }
+
+  // Only one register, low
+  {
+    constexpr auto p0 = eve::pattern<eve::we_, 0, 2, 1>;
+    auto [x_, g_, p_] = eve::detail::simplify_plain_shuffle(p0, eve::lane<2>, T {}, T {});
+
+    TTS_TYPE_IS(decltype(x_), kumi::tuple<T>);
+    TTS_EQUAL(p_, p0);
+  }
+
+  // Only one register, high
+  {
+    constexpr auto p0 = eve::pattern<eve::we_, 4, 6, 5>;
+    constexpr auto p1 = eve::pattern<eve::we_, 0, 2, 1>;
+    auto [x_, g_, p_] = eve::detail::simplify_plain_shuffle(p0, eve::lane<2>, T {}, T {});
+
+    TTS_TYPE_IS(decltype(x_), kumi::tuple<T>);
+    TTS_EQUAL(p_, p1);
+  }
+
+  // Only one register, 1 element, low
+  {
+    constexpr auto p0 = eve::pattern<0>;
+    auto [x_, g_, p_] = eve::detail::simplify_plain_shuffle(p0, eve::lane<8>, T {}, T {});
+    TTS_TYPE_IS(decltype(x_), kumi::tuple<T>);
+    TTS_EQUAL(p_, p0);
+  }
+  // Only one register, 1 element, high
+  {
+    constexpr auto p0 = eve::pattern<1>;
+    constexpr auto p1 = eve::pattern<0>;
+    auto [x_, g_, p_] = eve::detail::simplify_plain_shuffle(p0, eve::lane<8>, T {}, T {});
+    TTS_TYPE_IS(decltype(x_), kumi::tuple<T>);
+    TTS_EQUAL(p_, p1);
+  }
+};
+
 TTS_CASE_TPL("Check simplifcation is used", eve::test::simd::all_types)
 <typename T>(tts::type<T>)
 {
   // previous tests is enough
-  if constexpr( !eve::supports_simd )
+  if constexpr( eve::has_emulated_abi_v<T> )
   {
     TTS_PASS();
     return;
@@ -328,7 +439,7 @@ TTS_CASE_TPL("Check simplifcation is used", eve::test::simd::all_types)
       []<typename U, typename N, std::ptrdiff_t G>(
           auto, eve::fixed<G>, eve::wide<U, N> x, std::same_as<eve::wide<U, N>> auto...)
       {
-        TTS_CONSTEXPR_EXPECT(std::unsigned_integral<U> || std::floating_point<U>);
+        TTS_CONSTEXPR_EXPECT(std::unsigned_integral<U>);
         if constexpr( T::size() > 1 )
         {
           int expectedG = sizeof(eve::element_type_t<T>) == 8 ? 2 : 1;
@@ -340,7 +451,7 @@ TTS_CASE_TPL("Check simplifcation is used", eve::test::simd::all_types)
 
   constexpr int G = T::size() == 1 ? 1 : 2;
   shuffle(T {}, eve::lane<G>, some_pattern<T, G>);
-  shuffle(T {}, T {}, eve::lane<G>, some_pattern<T, G>);
+  shuffle(T {}, T {}, eve::lane<G>, some_pattern2<T, G>);
 };
 
 } // namespace

--- a/test/unit/internals/idxm.cpp
+++ b/test/unit/internals/idxm.cpp
@@ -1,0 +1,238 @@
+//==================================================================================================
+/**
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+**/
+//==================================================================================================
+#include "test.hpp"
+
+#include <eve/detail/idxm.hpp>
+
+namespace
+{
+
+template<std::size_t N>
+constexpr std::array<std::ptrdiff_t, N>
+to_idxs(std::array<int, N> x)
+{
+  std::array<std::ptrdiff_t, N> r;
+  std::copy(x.begin(), x.end(), r.begin());
+  return r;
+}
+
+constexpr int we_ = -2;
+constexpr int na_ = -1;
+
+TTS_CASE("are_below_ignoring_specials")
+{
+  auto test = []<std::size_t N>(std::array<int, N> _in, std::ptrdiff_t ub, bool expected)
+  {
+    auto in     = to_idxs(_in);
+    bool actual = eve::detail::idxm::are_below_ignoring_specials(in, ub);
+
+    TTS_EQUAL(expected, actual) << tts::as_string(in);
+  };
+
+  test(std::array {0, 1}, 1, false);
+  test(std::array {0, 1}, 2, true);
+  test(std::array {na_, 1}, 2, true);
+  test(std::array {we_, 0}, 1, true);
+  test(std::array {we_, we_}, 1, true);
+};
+
+TTS_CASE("to_pattern")
+{
+  constexpr auto arr    = to_idxs(std::array {0, 1, we_, na_});
+  auto           actual = eve::detail::idxm::to_pattern<arr>();
+  TTS_EQUAL((eve::pattern<0, 1, eve::we_, eve::na_>), actual);
+};
+
+TTS_CASE("swap_xy")
+{
+  auto test =
+      []<std::size_t N>(std::array<int, N> _expected, std::array<int, N> _input, std::ptrdiff_t s)
+  {
+    std::array<std::ptrdiff_t, N> expected = to_idxs(_expected);
+    std::array<std::ptrdiff_t, N> input    = to_idxs(_input);
+
+    TTS_EQUAL(expected, eve::detail::idxm::swap_xy(input, s)) << tts::as_string(input) << " " << s;
+    TTS_EQUAL(input, eve::detail::idxm::swap_xy(expected, s))
+        << tts::as_string(expected) << " " << s;
+  };
+
+  // T::size() == 1
+  test(std::array {we_}, std::array {we_}, 1);
+  test(std::array {0}, std::array {1}, 1);
+  test(std::array {0, 0}, std::array {1, 1}, 1);
+
+  // T::size() == 2
+  test(std::array {3, we_}, std::array {1, we_}, 2);
+  test(std::array {3, na_}, std::array {1, na_}, 2);
+
+  test(std::array {3, 1}, std::array {1, 3}, 2);
+  test(std::array {2, 1}, std::array {0, 3}, 2);
+  test(std::array {2, 1}, std::array {0, 3}, 2);
+};
+
+TTS_CASE("validate_pattern")
+{
+  auto test = [](auto g, auto p, bool expected)
+  {
+    using T     = eve::wide<std::int32_t, eve::fixed<2>>;
+    bool actual = eve::detail::idxm::validate_pattern(g, p, eve::as<T> {}, eve::as<T> {});
+    TTS_EQUAL(expected, actual) << "p: " << p << " g: " << g;
+  };
+  test(eve::lane<1>, eve::pattern<0, 1, 2, 3>, true);
+  test(eve::lane<1>, eve::pattern<0, 1, 2, 4>, false);
+
+  test(eve::lane<1>, eve::pattern<0, 1, 2, eve::we_>, true);
+  test(eve::lane<1>, eve::pattern<0, 1, 2, eve::na_>, true);
+  test(eve::lane<2>, eve::pattern<0, 1, 2, 3>, false);
+  test(eve::lane<1>, eve::pattern<0, 1, 2, -5>, false);
+};
+
+TTS_CASE("fix_indexes_to_fundamental")
+{
+  auto test =
+      []<std::ptrdiff_t Fundamental, std::size_t N1, std::size_t N2>(eve::fixed<Fundamental>,
+                                                                     std::array<int, N1> _p,
+                                                                     std::ptrdiff_t      cardinal,
+                                                                     std::array<int, N2> _expected)
+  {
+    auto p        = to_idxs(_p);
+    auto expected = to_idxs(_expected);
+    auto actual   = eve::detail::idxm::fix_indexes_to_fundamental<Fundamental>(p, cardinal);
+
+    TTS_EQUAL(expected, actual) << tts::as_string(p) << ", " << cardinal;
+  };
+
+  test(eve::lane<4>, std::array {0, 1, 2, 3}, 4, std::array {0, 1, 2, 3});
+  test(eve::lane<8>, std::array {0, 1, 2, 3}, 4, std::array {0, 1, 2, 3, we_, we_, we_, we_});
+  // 2 wides
+  test(eve::lane<4>, std::array {0, 2}, 2, std::array {0, 4, we_, we_});
+  test(eve::lane<4>, std::array {3, 1}, 2, std::array {5, 1, we_, we_});
+  // 3 wides
+  // 0, 1, 2, 3, 4, 5 =>
+  // 0, 1, -, -, 4, 5, -, -, 8, 9, -, -
+  test(eve::lane<4>, std::array {2, 5}, 2, std::array {4, 9, we_, we_});
+};
+
+TTS_CASE("is_repeating_pattern")
+{
+  auto yes_test = []<std::size_t N>(std::array<int, N> _full, std::array<int, N / 2> _half)
+  {
+    auto full = to_idxs(_full);
+    auto half = to_idxs(_half);
+
+    auto res = eve::detail::idxm::is_repeating_pattern(full);
+    TTS_EXPECT(res) << tts::as_string(full);
+    if( res ) { TTS_EQUAL(*res, half) << tts::as_string(full); }
+  };
+
+  auto no_test = []<std::size_t N>(std::array<int, N> _full)
+  {
+    auto full = to_idxs(_full);
+    auto res  = eve::detail::idxm::is_repeating_pattern(full);
+    TTS_EXPECT_NOT(res) << tts::as_string(full) << " res: " << tts::as_string(*res);
+  };
+
+  yes_test(std::array {0, 1}, std::array {0});
+  yes_test(std::array {0, we_}, std::array {0});
+  yes_test(std::array {we_, 1}, std::array {0});
+  yes_test(std::array {we_, we_}, std::array {we_});
+  yes_test(std::array {na_, na_}, std::array {na_});
+  yes_test(std::array {we_, na_}, std::array {na_});
+  yes_test(std::array {na_, we_}, std::array {na_});
+
+  no_test(std::array {0, 0});
+  no_test(std::array {1, 1});
+  no_test(std::array {na_, 1});
+
+  yes_test(std::array {1, 0, 3, 2}, std::array {1, 0});
+  yes_test(std::array {1, we_, 3, 2}, std::array {1, 0});
+  yes_test(std::array {we_, 0, 3, we_}, std::array {1, 0});
+  yes_test(std::array {we_, we_, 3, 2}, std::array {1, 0});
+  yes_test(std::array {na_, 0, na_, we_}, std::array {na_, 0});
+
+  no_test(std::array {1, 0, 2, 3});
+  no_test(std::array {na_, 0, we_, 3});
+};
+
+TTS_CASE("has_zeroes")
+{
+  auto test = []<std::size_t N>(std::array<int, N> _in, bool expected)
+  {
+    auto in     = to_idxs(_in);
+    bool actual = eve::detail::idxm::has_zeroes(in);
+
+    TTS_EQUAL(expected, actual) << tts::as_string(in);
+  };
+
+  test(std::array {1, 2}, false);
+  test(std::array {we_, 1}, false);
+  test(std::array {we_, 1, na_}, true);
+};
+
+TTS_CASE("is_in_order")
+{
+  auto test = []<std::size_t N>(std::array<int, N> _in, std::ptrdiff_t expected)
+  {
+    auto in     = to_idxs(_in);
+    auto actual = eve::detail::idxm::is_in_order(in).value_or(-1);
+
+    TTS_EQUAL(expected, actual) << tts::as_string(in);
+  };
+
+  test(std::array {1, 2}, 1);
+  test(std::array {0, 1}, 0);
+  test(
+      std::array {
+          we_,
+          0,
+      },
+      -1);
+  test(std::array {we_, we_, 1}, -1);
+  test(std::array {we_, 1, we_}, 0);
+
+  test(std::array {1, we_, 3}, 1);
+  test(std::array {1, we_, 2}, -1);
+};
+
+TTS_CASE("is_rotate")
+{
+  auto test = []<std::size_t N>(std::array<int, N> _in, std::ptrdiff_t expected)
+  {
+    auto in     = to_idxs(_in);
+    auto actual = eve::detail::idxm::is_rotate(in);
+
+    if( expected == -1 )
+    {
+      TTS_EXPECT_NOT(actual) << tts::as_string(in) << " actual: " << *actual;
+      return;
+    }
+
+    if( actual ) { TTS_EQUAL(*actual, expected) << tts::as_string(in); }
+    else { TTS_EQUAL(-1, expected) << tts::as_string(in); }
+  };
+
+  TTS_EQUAL(eve::detail::idxm::is_rotate({}), 0);
+
+  test(std::array {0, 1}, 0);
+  test(std::array {1, 0}, 1);
+  test(std::array {1, we_}, 1);
+
+  test(std::array {0, 1, 2, 3}, 0);
+  test(std::array {0, we_, 2, 3}, 0);
+  test(std::array {we_, we_, 2, 3}, 0);
+
+  test(std::array {3, 0, 1, 2}, 1);
+  test(std::array {3, we_, 1, 2}, 1);
+  test(std::array {2, 3, we_, 1}, 2);
+
+  test(std::array {0, 0}, -1);
+  test(std::array {0, 0, 0, 0}, -1);
+  test(std::array {1, 2, 3, 1}, -1);
+};
+
+}


### PR DESCRIPTION
List of things done: 

* extracted idxm with proper tests
 * converted all types to std::uint<>_t.
 * fixed fundamental cardinal for shuffling multiple registers
 * better unification for 2 register shuffles: now  we will swap two registers to get a smaller pattern, lexicographically
 * shuffling 2 registers => shuffling 1 register. There will be at some point a good solution for mutliple registers but this is for now
 *  set up the repeating shuffle detection for x86. When in lane shuffle duplicates.
 * wrote a "rotate" detection
 * alignr(x, x)
 * canonical shuffle formula based