### PR TITLE
Fix clang-16 regression over inline namespace

### DIFF
--- a/include/eve/traits/invoke/tag_invoke.hpp
+++ b/include/eve/traits/invoke/tag_invoke.hpp
@@ -44,10 +44,12 @@ namespace eve
 //! @}
 //==================================================================================================
 
-inline namespace callable_ns
+namespace callable_ns
 {
   inline constexpr func_ns::invoker tag_invoke = {};
 }
+
+using namespace callable_ns;
 
 //==================================================================================================
 //! @addtogroup invoke


### PR DESCRIPTION
This made the tag_invoke new mechanism to stop working for reasons.
