### PR TITLE
copy_if

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -13,7 +13,6 @@ AlignOperands: true
 AlignTrailingComments: true
 AllowAllParametersOfDeclarationOnNextLine: false
 AllowAllConstructorInitializersOnNextLine: false
-AllowAllParametersOfDeclarationOnNextLine: false
 AllowShortBlocksOnASingleLine: Always
 AllowShortCaseLabelsOnASingleLine: true
 AllowShortFunctionsOnASingleLine: All

--- a/include/eve/module/algo.hpp
+++ b/include/eve/module/algo.hpp
@@ -28,6 +28,7 @@
 #include <eve/module/algo/algo/concepts.hpp>
 #include <eve/module/algo/algo/container/soa_vector.hpp>
 #include <eve/module/algo/algo/copy.hpp>
+#include <eve/module/algo/algo/copy_if.hpp>
 #include <eve/module/algo/algo/equal.hpp>
 #include <eve/module/algo/algo/fill.hpp>
 #include <eve/module/algo/algo/find.hpp>
@@ -55,6 +56,7 @@
 #include <eve/module/algo/algo/traits.hpp>
 #include <eve/module/algo/algo/transform.hpp>
 #include <eve/module/algo/algo/transform_reduce.hpp>
+#include <eve/module/algo/algo/two_stage_iteration.hpp>
 #include <eve/module/algo/views/backward.hpp>
 #include <eve/module/algo/views/convert.hpp>
 #include <eve/module/algo/views/iota.hpp>

--- a/include/eve/module/algo/algo/copy_if.hpp
+++ b/include/eve/module/algo/algo/copy_if.hpp
@@ -1,0 +1,141 @@
+//==================================================================================================
+/*
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+*/
+//==================================================================================================
+#pragma once
+
+#include <eve/module/algo/algo/common_forceinline_lambdas.hpp>
+#include <eve/module/algo/algo/traits.hpp>
+#include <eve/module/algo/algo/two_stage_iteration.hpp>
+#include <eve/module/algo/algo/views/convert.hpp>
+#include <eve/module/core.hpp>
+
+namespace eve::algo
+{
+
+template<typename TraitsSupport> struct copy_if_ : TraitsSupport
+{
+  template<typename O, typename P> struct delegate
+  {
+    O of;
+    O ol;
+    P p;
+
+    static constexpr auto compress_copy()
+    {
+      auto density = density_for_compress_copy<typename TraitsSupport::traits_type>();
+      return eve::compress_copy[eve::unsafe][density];
+    }
+
+    EVE_FORCEINLINE
+    bool tail(auto f, auto ignore)
+    {
+      auto loaded = eve::load[ignore](f);
+      auto m      = p(loaded);
+      // this max is a bit annoying, it might not be needed.
+      auto out_ignore = eve::keep_first(std::min(ol - of, eve::iterator_cardinal_v<O>));
+      of              = compress_copy()[ignore][out_ignore](f, loaded, m, of);
+      return of == ol;
+    }
+
+    EVE_FORCEINLINE
+    std::ptrdiff_t left_for_stage1() const { return ol - of; }
+
+    EVE_FORCEINLINE
+    bool step_1(auto f)
+    {
+      auto loaded = eve::load(f);
+      auto m      = p(loaded);
+      of          = compress_copy()(f, loaded, m, of);
+      return false;
+    }
+
+    EVE_FORCEINLINE
+    bool step_2(auto f)
+    {
+      auto loaded = eve::load(f);
+      auto m      = p(loaded);
+      // ol - of < cardinal
+      of = compress_copy()[eve::ignore_none][eve::keep_first(ol - of)](f, loaded, m, of);
+      return of == ol;
+    }
+  };
+
+  template<relaxed_range In, relaxed_range Out, typename P>
+  EVE_FORCEINLINE auto operator()(In&& in, Out&& out, P p) const -> unaligned_iterator_t<Out>
+  {
+    if( in.begin() == in.end() || out.begin() == out.end() ) return out.begin();
+
+    auto [processed_in, processed_out] = temporary_preprocess_ranges_hack(
+        TraitsSupport::get_traits(), in, views::convert(out, as<value_type_t<In>> {}));
+
+    auto iteration =
+        two_stage_iteration(processed_in.traits(), processed_in.begin(), processed_in.end());
+
+    auto of = unalign(processed_out.begin());
+    auto ol = unalign(processed_out.end());
+
+    delegate<decltype(of), P> d {of, ol, p};
+    iteration(d);
+    return eve::unalign(out.begin()) + (d.of - processed_out.begin());
+  }
+};
+
+//================================================================================================
+//! @addtogroup algos
+//! @{
+//!  @var copy_if
+//!  @brief SIMD variation on std::copy_if.
+//!
+//!   **Defined in Header**
+//!
+//!   @code
+//!   #include <eve/module/algo.hpp>
+//!   @endcode
+//!
+//!   The main difference from std::copy_if is that it accepts output range and not
+//!   an output iterator. If the output doesn't have enough space, algorithm will fill
+//!   all of the avaliable output and then stop.
+//!   The interface difference allows eve to store more then just selected elements
+//!   which is important for efficiency.
+//!
+//!   @note fix-1656: unfortunately at the moment, we only return where writing output
+//!   finished. We should return where the input stopped too but we couldn't solve that
+//!   efficiently so far.
+//!
+//!   Tuning:
+//!    * eve::algo::dense_output/eve::algo::sparse_output - if you expect very sparse
+//!      output (one or two trues per register) - you can pass sparse_output to try to
+//!      optimize for that.
+//!    * Does not support unrolling at the moment. In the exepriments with compress it
+//!      didn't prove beneficial, but you can always try with `eve::algo::for_each`, assuming you
+//!      can overallocate the output.
+//!    * Algorithm switches to a much slower version, when there is not enough space to write
+//!      a full register. Allocating more than input size won't help though.
+//!
+//!   @groupheader{Callable Signatures}
+//!
+//!   @code
+//!   namespace eve::algo
+//!   {
+//!      template<relaxed_range In, relaxed_range Out, typename P>
+//!      auto copy_if(In&& in, Out&& out, P p) -> unaligned_iterator_t<Out>
+//!   }
+//!
+//!   ** Parameters **
+//!
+//!    * in - relaxed_range input
+//!    * out - relaxed_range output
+//!    * p - simd prediocate for elmenets of `in`
+//!
+//!   ** Return value **
+//!
+//!    relaxed_iterator past the last written element.
+//! @}
+//================================================================================================
+inline constexpr auto copy_if = function_with_traits<copy_if_>;
+
+}

--- a/include/eve/module/algo/algo/preprocess_range.hpp
+++ b/include/eve/module/algo/algo/preprocess_range.hpp
@@ -78,6 +78,7 @@ namespace eve::algo
   EVE_FORCEINLINE auto preprocess_range_::operator()(Traits with_equivalents_, I_ f_, S_ l_) const
   {
     auto traits_ = process_equivalents(with_equivalents_);
+
     auto f = detail::fix_up_cardinal(traits_, f_);
     auto l = detail::fix_up_cardinal(traits_, l_);
 
@@ -95,4 +96,14 @@ namespace eve::algo
 
     return preprocess_range_result { default_to(traits_, deduced), f, l};
   }
+
+  // FIX: 1629 - support common type and such
+  template<typename Traits, typename... Rs>
+  EVE_FORCEINLINE auto temporary_preprocess_ranges_hack(Traits tr, Rs&&...rs)
+  {
+    constexpr auto to_consider = kumi::cat(get_types_to_consider_for<Traits, Rs> {}...);
+    auto           traits2     = default_to(tr, traits {consider_types_key = to_consider});
+    return kumi::tuple {preprocess_range(traits2, rs)...};
+  }
+
 }

--- a/include/eve/module/algo/algo/set_intersection.hpp
+++ b/include/eve/module/algo/algo/set_intersection.hpp
@@ -30,15 +30,6 @@ set_intersection_result(I1, I2, O) -> set_intersection_result<I1, I2, O>;
 
 namespace detail
 {
-  // FIX: 1629 - support common type and such
-  template<typename Traits, typename... Rs>
-  EVE_FORCEINLINE auto temporary_preprocess_ranges_hack(Traits tr, Rs&&...rs)
-  {
-    constexpr auto to_consider = kumi::cat(get_types_to_consider_for<Traits, Rs> {}...);
-    auto           traits2     = default_to(tr, traits {consider_types_key = to_consider});
-    return kumi::tuple {preprocess_range(traits2, rs)...};
-  }
-
   template<typename TraitsSupport> struct set_intersection_r1_small_ : TraitsSupport
   {
     template<typename R1, typename R2, typename RO, typename Less, typename Equal> struct delegate

--- a/include/eve/module/algo/algo/two_stage_iteration.hpp
+++ b/include/eve/module/algo/algo/two_stage_iteration.hpp
@@ -1,0 +1,147 @@
+//==================================================================================================
+/*
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+*/
+//==================================================================================================
+#pragma once
+
+namespace eve::algo
+{
+
+namespace detail
+{
+  struct two_stage_iteration_common
+  {
+    template<typename Traits, typename I, typename S, typename Delegate>
+    EVE_FORCEINLINE bool main_loop(Traits, I& f, S l, Delegate& delegate) const
+    {
+      // does not support unrolling at the moment
+      while( true )
+      {
+        std::ptrdiff_t left_space = delegate.left_for_stage1();
+        left_space = std::min(left_space, l - f);
+        left_space /= iterator_cardinal_v<I>;
+
+        if( !left_space ) break;
+        do {
+          if( delegate.step_1(f) ) return true;
+          f += iterator_cardinal_v<I>;
+        }
+        while( --left_space );
+      }
+
+      while( f != l )
+      {
+        if( delegate.step_2(f) ) return true;
+        f += iterator_cardinal_v<I>;
+      }
+
+      return false;
+    }
+  };
+
+  template<typename Traits, iterator I, sentinel_for<I> S>
+  struct two_stage_iteration_precise_f_l : two_stage_iteration_common
+  {
+    Traits traits;
+    I      base;
+    I      f;
+    S      l;
+
+    two_stage_iteration_precise_f_l(Traits traits, I f, S l) : traits(traits), base(f), f(f), l(l)
+    {
+      EVE_ASSERT(((l - f) % iterator_cardinal_v<I> == 0),
+                 " len of the range is no divisible by cardinal "
+                     << "when `divisible by cardinal is passed`: "
+                     << "l - f: " << (l - f)
+                     << " iterator_cardinal_v<I>: " << iterator_cardinal_v<I>);
+    }
+
+    template<typename Delegate> EVE_FORCEINLINE void operator()(Delegate& delegate)
+    {
+      main_loop(traits, f, l, delegate);
+    }
+  };
+
+  template<typename Traits, iterator I, sentinel_for<I> S>
+  struct two_stage_iteration_precise_f : two_stage_iteration_common
+  {
+    Traits traits;
+    I      base;
+    I      f;
+    S      l;
+
+    two_stage_iteration_precise_f(Traits traits, I f, S l) : traits(traits), base(f), f(f), l(l) {}
+
+    template<typename Delegate> EVE_FORCEINLINE void operator()(Delegate& delegate)
+    {
+      I precise_l = f + (((l - f) / iterator_cardinal_v<I>)*iterator_cardinal_v<I>);
+
+      if( main_loop(traits, f, precise_l, delegate) ) return;
+
+      if( precise_l == l ) return;
+
+      eve::keep_first ignore {l - precise_l};
+      delegate.tail(f, ignore);
+    }
+  };
+
+  template<typename Traits, iterator I, sentinel_for<I> S>
+  struct two_stage_iteration_aligning : two_stage_iteration_common
+  {
+    Traits                 traits;
+    partially_aligned_t<I> base;
+    I                      f;
+    S                      l;
+
+    two_stage_iteration_aligning(Traits traits, I f, S l)
+        : traits(traits)
+        , base(f.previous_partially_aligned())
+        , f(f)
+        , l(l)
+    {}
+
+    template<typename Delegate> EVE_FORCEINLINE void operator()(Delegate& delegate)
+    {
+      auto aligned_f = base;
+      auto aligned_l = (f + (l - f)).previous_partially_aligned();
+
+      eve::ignore_first ignore_first {f - aligned_f};
+
+      if( aligned_f != aligned_l )
+      {
+        // first chunk, maybe partial
+        if( delegate.tail(aligned_f, ignore_first) ) return;
+
+        ignore_first = eve::ignore_first {0};
+        aligned_f += iterator_cardinal_v<I>;
+
+        if( main_loop(traits, aligned_f, aligned_l, delegate) ) return;
+
+        if( aligned_l == l ) return;
+      }
+
+      eve::ignore_last ignore_last {aligned_l + iterator_cardinal_v<I> - l};
+      delegate.tail(aligned_l, ignore_first && ignore_last);
+    }
+  };
+
+}
+
+struct
+{
+  template<typename Traits, iterator I, sentinel_for<I> S>
+  auto operator()(Traits traits, I f, S l) const
+  {
+    EVE_ASSERT(f != l, "two_stage_iteration requires a non-empty range");
+    if constexpr( !Traits::contains(no_aligning) && !partially_aligned_iterator<I> )
+      return detail::two_stage_iteration_aligning {traits, f, l};
+    else if constexpr( Traits::contains(divisible_by_cardinal) )
+      return detail::two_stage_iteration_precise_f_l {traits, f, l};
+    else return detail::two_stage_iteration_precise_f {traits, f, l};
+  }
+} inline constexpr two_stage_iteration;
+
+}

--- a/include/eve/module/core/compress/simd/common/compress_copy_scalar.hpp
+++ b/include/eve/module/core/compress/simd/common/compress_copy_scalar.hpp
@@ -75,6 +75,7 @@ copy_by_one_checking_each_lambda_checked(I, O, O)
     -> copy_by_one_checking_each_lambda_checked<I, O>;
 
 template<typename M>
+EVE_FORCEINLINE
 bool
 for_each_until_m(M m, auto op)
 {

--- a/test/doc/algo/copy_if.cpp
+++ b/test/doc/algo/copy_if.cpp
@@ -1,0 +1,64 @@
+#include <eve/module/algo.hpp>
+#include <eve/module/core.hpp>
+
+#include <string>
+#include <vector>
+
+#include <tts/tts.hpp>
+
+void
+basic_example()
+{
+  std::vector<int> in {1, 2, 3, 4, 5, 6, 7};
+  std::vector<int> out(in.size(), 0);
+  out.erase(eve::algo::copy_if(in, out, eve::is_even), out.end());
+
+  TTS_EQUAL(out, std::vector({2, 4, 6}));
+}
+
+void
+not_enough_output_space()
+{
+  // We copy up to out.size()
+  std::vector<int> in {5, 0, 4, 12, 11, 1, 2};
+  std::vector<int> out {0, 0};
+
+  // fix-1656 - no way to know where we stopped in `in`
+  auto out_it = eve::algo::copy_if(in, out, [](auto x) { return x > 4; });
+  TTS_EQUAL(out_it, out.end());
+  TTS_EQUAL(out, std::vector({5, 12}));
+}
+
+void
+sparse_output()
+{
+  std::vector<int> in(10'000, 0);
+  in[153]  = 1;
+  in[9002] = 2;
+  std::vector<int> out {0, 0};
+
+  // Tell the library that you expect fairly few element
+  eve::algo::copy_if[eve::algo::sparse_output](in, out, [](auto x) { return x != 0; });
+  TTS_EQUAL(out, std::vector({1, 2}));
+}
+
+void
+tst()
+{
+  std::vector<std::int8_t> v {93, 1,  1,   25,  49, 27,  0,   23,  61, 53, 110,
+                              49, 7,  40,  110, 32, -8,  10,  108, 14, 74, 39,
+                              54, 79, -61, 108, 51, 117, 121, 89,  -5, -83};
+  std::vector<std::int8_t> out(30, 0);
+
+  auto p = [](auto x) { return x != 0; };
+  auto end = eve::algo::copy_if(v, out, p);
+  TTS_EQUAL(end - out.end(), 0);
+}
+
+int
+main()
+{
+  basic_example();
+  not_enough_output_space();
+  sparse_output();
+}

--- a/test/unit/module/algo/algo_test.hpp
+++ b/test/unit/module/algo/algo_test.hpp
@@ -17,17 +17,19 @@
 namespace algo_test
 {
   using selected_types = tts::types<
-      eve::wide<std::int8_t, eve::fixed<1>>
-    , eve::nofs_wide<std::uint8_t>
+      eve::nofs_wide<std::uint8_t>
     , eve::wide<std::int16_t>
     , eve::wide<std::uint16_t, eve::fixed<4>>
     , eve::wide<int>
-    , eve::nofs_wide<float>
     , eve::wide<double>
+#ifndef EVE_HW_ARM_SVE
+    , eve::wide<std::int8_t, eve::fixed<1>>
+    , eve::nofs_wide<float>
     , eve::wide<std::uint64_t>
     , eve::wide < std::uint32_t
                 , eve::fixed<eve::nofs_cardinal_v<std::uint32_t> * 2>
                 >
+#endif
   >;
 
   using selected_pairs_types = tts::types<

--- a/test/unit/module/algo/algorithm/copy_if_generic.cpp
+++ b/test/unit/module/algo/algorithm/copy_if_generic.cpp
@@ -1,0 +1,15 @@
+//==================================================================================================
+/**
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+**/
+//==================================================================================================
+
+#include "copy_if_generic_test.hpp"
+
+TTS_CASE_TPL("Check copy_if", algo_test::selected_types)
+<typename T>(tts::type<T>)
+{
+  algo_test::copy_if_generic_test(eve::as<T>{}, eve::algo::copy_if);
+};

--- a/test/unit/module/algo/algorithm/copy_if_generic_test.hpp
+++ b/test/unit/module/algo/algorithm/copy_if_generic_test.hpp
@@ -1,0 +1,83 @@
+//==================================================================================================
+/*
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+*/
+//==================================================================================================
+#pragma once
+
+#include "unit/module/algo/algo_test.hpp"
+
+#include <eve/module/algo.hpp>
+#include <eve/module/core.hpp>
+
+#include <algorithm>
+#include <random>
+#include <vector>
+
+namespace algo_test
+{
+
+template<typename Algo, typename T> struct copy_if_ptr_test
+{
+  Algo                                alg;
+  std::vector<eve::element_type_t<T>> buf1;
+  std::vector<eve::element_type_t<T>> buf2;
+  std::mt19937                        g {T::size()};
+
+  copy_if_ptr_test(Algo alg) : alg(alg) {}
+
+  void init(auto *page_begin, auto *, auto *, auto *page_end)
+  {
+    std::iota(page_begin, page_end, 1);
+    std::fill(page_begin, page_begin + 300, 0);
+    std::shuffle(page_begin, page_end, g);
+  }
+
+  void run(auto rng)
+  {
+    buf1.clear();
+    buf2.resize(rng.end() - rng.begin());
+
+    auto p = [](auto x) { return x != 0; };
+
+    std::copy_if(eve::unalign(rng.begin()), eve::unalign(rng.end()), std::back_inserter(buf1), p);
+
+    buf2.erase(alg(rng, buf2, p), buf2.end());
+    TTS_EQUAL(buf1, buf2, REQUIRED);
+
+    if( buf2.empty() ) return;
+
+    buf2.pop_back();
+    auto end1 = alg(rng, buf2, p);
+
+    TTS_EQUAL(buf2.end() - end1, 0, REQUIRED);
+
+    buf1.pop_back();
+    TTS_EQUAL(buf1, buf2, REQUIRED);
+  }
+
+  void adjust(auto *, auto *f, auto *l, auto *page_end)
+  {
+    *f = 1;
+    if( l != page_end ) *l = 1;
+  }
+};
+
+template<typename T, typename Algo>
+void
+copy_if_test_page_ends(eve::as<T> tgt, Algo alg)
+{
+  algo_test::page_ends_test(tgt, copy_if_ptr_test<Algo, T> {alg});
+}
+
+template<typename T, typename Algo>
+void
+copy_if_generic_test(eve::as<T> as_t, Algo alg)
+{
+  copy_if_test_page_ends(eve::as<eve::nofs_wide<typename T::value_type>> {}, alg);
+  copy_if_test_page_ends(as_t, alg[eve::algo::force_cardinal<T::size()>]);
+}
+
+}

--- a/test/unit/module/algo/algorithm/remove.cpp
+++ b/test/unit/module/algo/algorithm/remove.cpp
@@ -130,6 +130,11 @@ TTS_CASE_TPL("Check remove test", algo_test::selected_types)
 {
   remove_generic_test_page_ends(eve::as<T>{}, eve::algo::remove);
   remove_generic_test_page_ends(eve::as<T>{}, eve::algo::remove[eve::algo::sparse_output]);
-  remove_generic_test_page_ends(eve::as<T>{}, eve::algo::remove[eve::algo::unroll<3>]);
-  remove_generic_test_page_ends(eve::as<T>{}, eve::algo::remove[eve::algo::force_cardinal<T::size()>]);
+  if constexpr ( eve::current_api >= eve::sve)
+    return;
+  else
+  {
+    remove_generic_test_page_ends(eve::as<T>{}, eve::algo::remove[eve::algo::unroll<3>]);
+    remove_generic_test_page_ends(eve::as<T>{}, eve::algo::remove[eve::algo::force_cardinal<T::size()>]);
+  }
 };

--- a/test/unit/module/algo/algorithm/remove.cpp
+++ b/test/unit/module/algo/algorithm/remove.cpp
@@ -131,7 +131,5 @@ TTS_CASE_TPL("Check remove test", algo_test::selected_types)
   remove_generic_test_page_ends(eve::as<T>{}, eve::algo::remove);
   remove_generic_test_page_ends(eve::as<T>{}, eve::algo::remove[eve::algo::sparse_output]);
   remove_generic_test_page_ends(eve::as<T>{}, eve::algo::remove[eve::algo::unroll<3>]);
-  // FIX-#816
-  if constexpr (T::size() < eve::expected_cardinal_v<eve::element_type_t<T>>) return;
   remove_generic_test_page_ends(eve::as<T>{}, eve::algo::remove[eve::algo::force_cardinal<T::size()>]);
 };

--- a/test/unit/module/algo/two_stage_iteration.cpp
+++ b/test/unit/module/algo/two_stage_iteration.cpp
@@ -1,0 +1,196 @@
+//==================================================================================================
+/**
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+**/
+//==================================================================================================
+
+#include "unit/module/algo/algo_test.hpp"
+
+namespace
+{
+
+template<typename I> struct test_delegate
+{
+  I                base;
+  std::ptrdiff_t   stop_at;
+  std::vector<int> left;
+
+  test_delegate(I base, std::ptrdiff_t stop_at, std::vector<int> left)
+      : base(base)
+      , stop_at(stop_at)
+      , left(std::move(left))
+  {}
+
+  std::ptrdiff_t left_for_stage1()
+  {
+    TTS_EXPECT_NOT(left.empty(), REQUIRED);
+    auto r = left.at(0);
+    left.erase(left.begin());
+    return r;
+  }
+
+  void fill(char *& f, std::ptrdiff_t length, char what) const
+  {
+    while( length-- ) *f++ = what;
+  }
+
+  bool tail(I f, auto ignore)
+  {
+    auto tgt = eve::as<eve::wide_value_type_t<I>> {};
+
+    auto ptr = eve::unalign(f.ptr);
+    fill(ptr, ignore.offset(tgt), 'i');
+    fill(ptr, ignore.count(tgt), 't');
+    fill(ptr, ignore.roffset(tgt), 'i');
+
+    return (f - base) == stop_at;
+  }
+
+  bool step_1(I f)
+  {
+    auto ptr = eve::unalign(f.ptr);
+    fill(ptr, eve::iterator_cardinal_v<I>, 'a');
+    return (f - base) == stop_at;
+  }
+
+  bool step_2(I f)
+  {
+    auto ptr = eve::unalign(f.ptr);
+    fill(ptr, eve::iterator_cardinal_v<I>, 'b');
+    return (f - base) == stop_at;
+  }
+};
+
+std::string
+run_test(auto traits, int offset, int length, std::vector<int> left, int stop_at = -1)
+{
+  TTS_EXPECT(length, REQUIRED);
+
+  alignas(64) std::array<char, 100u> buf;
+  buf.fill(0);
+
+  std::fill(buf.begin(), buf.begin() + offset, '_');
+
+  auto f = eve::algo::ptr_iterator<char *, eve::fixed<4>> {buf.data() + offset};
+  auto l = f + length;
+
+  auto          iteration = eve::algo::two_stage_iteration(traits, f, l);
+  test_delegate delegate(iteration.base, stop_at, std::move(left));
+  iteration(delegate);
+  return std::string(buf.data());
+}
+
+TTS_CASE("eve.algo two_stage_iteration, aligned, tails")
+{
+  auto run = [](int offset, int length, std::vector<int> left = {0})
+  { return run_test(eve::algo::traits {}, offset, length, std::move(left)); };
+
+  TTS_EQUAL("tiii", run(0, 1));
+  TTS_EQUAL("ttii", run(0, 2));
+  TTS_EQUAL("ttti", run(0, 3));
+  TTS_EQUAL("tttt", run(0, 4));
+
+  TTS_EQUAL("itii", run(1, 1));
+  TTS_EQUAL("itti", run(1, 2));
+  TTS_EQUAL("ittt", run(1, 3));
+
+  TTS_EQUAL("ittt"
+            "ttii",
+            run(1, 5));
+
+  TTS_EQUAL("iiit"
+            "bbbb"
+            "ttii",
+            run(3, 7));
+};
+
+TTS_CASE("eve.algo two_stage_iteration, no aligning, tails")
+{
+  auto run = [](int offset, int length, std::vector<int> left = {0})
+  { return run_test(eve::algo::traits {eve::algo::no_aligning}, offset, length, std::move(left)); };
+
+  TTS_EQUAL("tiii", run(0, 1));
+  TTS_EQUAL("ttii", run(0, 2));
+  TTS_EQUAL("ttti", run(0, 3));
+  TTS_EQUAL("bbbb", run(0, 4));
+
+  TTS_EQUAL("_"
+            "tiii",
+            run(1, 1));
+  TTS_EQUAL("_"
+            "ttii",
+            run(1, 2));
+  TTS_EQUAL("_"
+            "ttti",
+            run(1, 3));
+
+  TTS_EQUAL("_"
+            "bbbb"
+            "tiii",
+            run(1, 5));
+
+  TTS_EQUAL("___"
+            "bbbb"
+            "ttti",
+            run(3, 7));
+};
+
+TTS_CASE("eve.algo two_stage_iteration, no aligning, divisble, tails")
+{
+  auto run = [](int offset, int length, std::vector<int> left = {0})
+  {
+    return run_test(eve::algo::traits {eve::algo::no_aligning, eve::algo::divisible_by_cardinal},
+                    offset,
+                    length,
+                    std::move(left));
+  };
+
+  TTS_EQUAL("_"
+            "bbbb",
+            run(1, 4));
+  TTS_EQUAL("_"
+            "bbbb"
+            "bbbb",
+            run(1, 8));
+};
+
+TTS_CASE("eve.algo two_stage_iteration, main")
+{
+  auto run = [](int offset, int length, std::vector<int> left = {0})
+  { return run_test(eve::algo::traits {}, offset, length, std::move(left)); };
+
+  TTS_EQUAL("ittt"
+            "aaaa"
+            "tiii",
+            run(1, 8, {5, 5}));
+
+  TTS_EQUAL("ittt"
+            "aaaa"
+            "aaaa"
+            "tiii",
+            run(1, 12, {10, 5}));
+
+  TTS_EQUAL("ittt"
+            "aaaa"
+            "bbbb"
+            "tiii",
+            run(1, 12, {5, 3}));
+
+  TTS_EQUAL("ittt"
+            "aaaa"
+            "aaaa"
+            "bbbb"
+            "tiii",
+            run(1, 16, {10, 3}));
+
+  TTS_EQUAL("ittt"
+            "aaaa"
+            "bbbb"
+            "bbbb"
+            "tiii",
+            run(1, 16, {5, 3}));
+};
+
+} // namespace


### PR DESCRIPTION
eve::algo::copy_if.

Same as with `set_intersection` had to design with output range.

Here it meant an introduciton of a new iteration pattern:

do tails once.

Then duplicate  the main loop:

1. When there is enough space in the output for the whole registter.
2. When it's not. 