### PR TITLE
Reverse in subgroups

### DIFF
--- a/include/eve/detail/shuffle_v2/simd/arm/neon/shuffle_l2.hpp
+++ b/include/eve/detail/shuffle_v2/simd/arm/neon/shuffle_l2.hpp
@@ -130,7 +130,7 @@ shuffle_l2_neon_rev(P, fixed<G>, wide<T, N> x)
     else if constexpr( sizeof(T) == 2 && idxs.size() == 2 ) return vrev32q_u16(x);
     else if constexpr( sizeof(T) == 1 && idxs.size() == 2 ) return vrev16q_u8(x);
     else if constexpr( sizeof(T) == 2 && idxs.size() == 4 ) return vrev64q_u16(x);
-    else if constexpr( idxs.size() == 4 ) return vrevq32_u8(x);
+    else if constexpr( idxs.size() == 4 ) return vrev32q_u8(x);
     else return vrev64q_u8(x);
   }
 }

--- a/include/eve/module/core/named_shuffles/core.hpp
+++ b/include/eve/module/core/named_shuffles/core.hpp
@@ -9,4 +9,5 @@
 
 #include <eve/module/core/named_shuffles/blend.hpp>
 #include <eve/module/core/named_shuffles/reverse.hpp>
+#include <eve/module/core/named_shuffles/reverse_in_subgroups.hpp>
 #include <eve/module/core/named_shuffles/swap_adjacent.hpp>

--- a/include/eve/module/core/named_shuffles/reverse.hpp
+++ b/include/eve/module/core/named_shuffles/reverse.hpp
@@ -21,9 +21,9 @@ namespace eve
 //!
 //!   **Defined in Header**
 //!
-//!   @code
-//!   #include <eve/module/core.hpp>
-//!   @endcode
+//!    @code
+//!    #include <eve/module/core.hpp>
+//!    @endcode
 //!
 //!    As any named shuffle, allows to pass a group size, to treat multiple elements as one.
 //!    Group size has to be 0 < G <= T::size()
@@ -53,6 +53,7 @@ namespace eve
 //!  @godbolt{doc/core/named_shuffles/reverse.cpp}
 //!
 //! @}
+//================================================================================================
 struct reverse_t
 {
   template<simd_value T, std::ptrdiff_t G> static constexpr auto pattern(eve::as<T>, eve::fixed<G>)

--- a/include/eve/module/core/named_shuffles/reverse_in_subgroups.hpp
+++ b/include/eve/module/core/named_shuffles/reverse_in_subgroups.hpp
@@ -1,0 +1,134 @@
+//==================================================================================================
+/*
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+*/
+//==================================================================================================
+#pragma once
+
+#include <eve/module/core/named_shuffles/named_shuffle_utils.hpp>
+#include <eve/module/core/named_shuffles/reverse.hpp>
+#include <eve/module/core/named_shuffles/swap_adjacent.hpp>
+#include <eve/module/core/regular/shuffle_v2.hpp>
+
+namespace eve
+{
+
+//================================================================================================
+//! @addtogroup core_named_shuffles
+//! @{
+//!    @var reverse_in_subgroups
+//!    @brief a named shuffle for reversing all subgroups in a register
+//!
+//!   **Defined in Header**
+//!
+//!    @code
+//!    #include <eve/module/core.hpp>
+//!    @endcode
+//!
+//!    As any named shuffle, allows to pass a group size, to treat multiple elements as one.
+//!    Group size has to be 0 < G <= T::size()
+//!    Subgroup size has to be 1 <= SubG <= T::size() / G
+//!
+//!    @note SubG == T::size() makes this function equivalent eve::reverse.
+//!
+//!    @code
+//!    template <simd_value T, std::ptrdiff_t G, std::ptrdiff_t SubG>
+//!    T reverse_in_subgroups(T x, eve::fixed<G>, eve::fixed<SubG>);  // (1)
+//!
+//!    template <simd_value T, std::ptrdiff_t SubG>
+//!    T reverse_in_subgroups(T x, eve::fixed<SubG>); // (2)
+//!    @endcode
+//!
+//!   **Parameters**
+//!
+//!    * x - simd_value to shuffle
+//!    * G - (optional) - number of elements to treat as one.
+//!    * SubG - size of a subgroup
+//!
+//!   (2) calls (1) with G == 1;
+//!   (1) within each SubG reverses positions elements
+//!
+//!   **Return value**
+//!
+//!     Returns x where each subgroup is reversed.
+//!
+//!  @groupheader{Example}
+//!
+//!  @godbolt{doc/core/named_shuffles/reverse_in_subgroups.cpp}
+//!
+//================================================================================================
+struct reverse_in_subgroups_t
+{
+  template<simd_value T, std::ptrdiff_t G, std::ptrdiff_t SubG>
+  static constexpr auto pattern(eve::as<T>, eve::fixed<G>, eve::fixed<SubG>)
+  {
+    static_assert(SubG <= T::size() / G);
+    static_assert(SubG >= 1);
+
+    return eve::fix_pattern<T::size() / G>(
+        [](int i, int)
+        {
+          int sub_pos    = i / SubG;
+          int in_sub_pos = i % SubG;
+          return sub_pos * SubG + SubG - in_sub_pos - 1;
+        });
+  }
+
+  template<simd_value T, std::ptrdiff_t G, std::ptrdiff_t SubG>
+  static constexpr std::ptrdiff_t level(eve::as<T> tgt, eve::fixed<G> g, eve::fixed<SubG> sub_g)
+  {
+    const std::ptrdiff_t g_size   = sizeof(element_type_t<T>) * G;
+    const std::size_t    sub_size = g_size * SubG;
+    const std::size_t    reg_size   = sizeof(element_type_t<T>) * T::size();
+
+    if constexpr( SubG == 1 ) return 0;
+    else if constexpr( SubG == 2 ) return swap_adjacent.level(tgt, g);
+    else if constexpr( SubG == T::size() / G ) return reverse.level(tgt, g);
+    else if constexpr( eve::has_aggregated_abi_v<T> )
+    {
+      if constexpr( G == T::size() / 2 ) return 0;
+      using half_t = decltype(T {}.slice(lower_));
+      return level(as<half_t> {}, g, sub_g);
+    }
+
+    if( current_api >= sve )
+    {
+      if( !logical_value<T> )
+      {
+        if( sub_size <= 8 ) return 2;
+        return 3;
+      }
+      return level(detail::mask_type(tgt), g, sub_g) + 4;
+    }
+
+    if( current_api >= vmx ) return 3;
+    if( current_api >= neon ) return 2;
+
+    if( current_api == avx512 && logical_value<T> )
+    {
+      return level(detail::mask_type(tgt), g, sub_g) + 4;
+    }
+
+    if (sub_size == 32) {
+      if (g_size == 8) return 2;
+      if (g_size == 4) return 3;
+      return 5;
+    }
+
+    if( g_size >= 4 ) return 2;
+
+    if (current_api == avx && reg_size == 32) return 9;
+
+    if( current_api >= ssse3 ) return 3;
+
+    if( g_size == 2 ) return 4;
+    if (reg_size <= 8) return 8;
+    return 10;
+  }
+};
+
+inline constexpr auto reverse_in_subgroups = detail::named_shuffle_1<reverse_in_subgroups_t> {};
+
+}

--- a/test/doc/core/named_shuffles/reverse_in_subgroups.cpp
+++ b/test/doc/core/named_shuffles/reverse_in_subgroups.cpp
@@ -1,0 +1,18 @@
+#include <eve/module/core.hpp>
+
+#include <tts/tts.hpp>
+
+using w_t = eve::wide<std::uint32_t, eve::fixed<4>>;
+
+int
+main()
+{
+  w_t x {0, 1, 2, 3};
+
+  TTS_EXPECT(eve::all(w_t {0, 1, 2, 3} == eve::reverse_in_subgroups(x, eve::lane<1>)));
+  TTS_EXPECT(eve::all(w_t {1, 0, 3, 2} == eve::reverse_in_subgroups(x, eve::lane<2>)));
+  TTS_EXPECT(eve::all(w_t {3, 2, 1, 0} == eve::reverse_in_subgroups(x, eve::lane<4>)));
+
+  TTS_EXPECT(
+      eve::all(w_t {2, 3, 0, 1} == eve::reverse_in_subgroups(x, eve::lane<2>, eve::lane<2>)));
+}

--- a/test/unit/api/regular/shuffle_v2/reverse_in_subgroups.cpp
+++ b/test/unit/api/regular/shuffle_v2/reverse_in_subgroups.cpp
@@ -1,0 +1,55 @@
+//==================================================================================================
+/**
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+**/
+//==================================================================================================
+#include "unit/api/regular/shuffle_v2/shuffle_v2_test.hpp"
+
+namespace
+{
+
+template<int MaxPow>
+auto
+all_subgroups()
+{
+  constexpr auto ssz = std::bit_width(std::size_t(MaxPow));
+
+  // On sse2 it's cheap enough to compile everything
+  if constexpr( eve::current_api == eve::sse2 )
+  {
+    return []<std::size_t... i>(std::index_sequence<i...>)
+    { return kumi::tuple {eve::lane<1 << i>...}; }(std::make_index_sequence<ssz> {});
+  }
+  else
+  {
+    // removing some cases to reduce compile times
+    if constexpr( ssz == 1 ) { return kumi::tuple {eve::lane<1>}; }
+    else if constexpr( ssz < 3 ) { return kumi::tuple {eve::lane<2>}; }
+    else
+    {
+      // We can go 0 to ssz but we want to remove:
+      // i = 0, i = 1, i = T::size()
+      return []<std::size_t... i>(std::index_sequence<i...>)
+      { return kumi::tuple {eve::lane<1 << (i + 2)>...}; }(std::make_index_sequence<ssz - 3> {});
+    }
+  }
+}
+
+TTS_CASE_TPL("Check reverse, generic", eve::test::simd::all_types)
+<typename T>(tts::type<T>)
+{
+  shuffle_test::named_shuffle1_test<
+      /*supports_G_eq_T_Size*/ true>(eve::as<T> {},
+                                     eve::reverse_in_subgroups,
+                                     []<std::ptrdiff_t G>(eve::fixed<G>)
+                                     {
+                                       auto subgroups = all_subgroups<T::size() / G>();
+                                       auto lifted    = kumi::map(
+                                           [](auto x) { return kumi::make_tuple(x); }, subgroups);
+                                       return lifted;
+                                     });
+};
+
+} // namespace


### PR DESCRIPTION
Waits for https://github.com/jfalcou/eve/pull/1645

If I'm not mistaken, essential for sort.
What's really cool that I didn't have to write any intrinsic code for it (had to fix a bug but that's it).

I just tested that the shuffle levels match what I expected and that's it.