### PR TITLE
pedantic hypot correction

### DIFF
--- a/include/eve/module/math/pedantic/impl/hypot.hpp
+++ b/include/eve/module/math/pedantic/impl/hypot.hpp
@@ -34,7 +34,8 @@ namespace eve::detail
         return if_else(is_eqz(h), h, h-x/(2*h)); // Maclaurin correction
       };
       auto h = if_else(is_eqz(ab), zero, ab*doit(aa/ab));
-      return if_else(is_infinite(a) || is_infinite(b), inf(as<r_t>()), h);
+      h = if_else(is_infinite(a) || is_infinite(b), inf(as<r_t>()), h);
+      return if_else(aa < ab*eve::sqrteps(as(a)), ab, h);
     }
     else { return apply_over(pedantic(hypot), r_t(a), r_t(b)); }
   }

--- a/include/eve/module/math/pedantic/impl/hypot.hpp
+++ b/include/eve/module/math/pedantic/impl/hypot.hpp
@@ -11,22 +11,46 @@
 
 namespace eve::detail
 {
-template<value T0, value... Ts>
-auto
-hypot_(EVE_SUPPORTS(cpu_), pedantic_type const&, T0 a0, Ts... args)
-  -> decltype(hypot(a0, args...))
-{
-  using r_t = decltype(hypot(a0, args...));
-  if constexpr( has_native_abi_v<r_t> )
+  ////////////////////////////////////////////////////////////////////////////////////////////////////
+  //  This implementation is inspired by
+  //  AN IMPROVED ALGORITHM FOR HYPOT(A,B) arXiv:1904.09481v6 [math.NA] 14 Jun 2019, CARLOS F. BORGES
+  ////////////////////////////////////////////////////////////////////////////////////////////////////
+
+  template<value T0, value T1>
+  auto  hypot_(EVE_SUPPORTS(cpu_), pedantic_type const&, T0 a, T1 b)
+    -> decltype(hypot(a, b))
   {
-    auto e = -maxmag(exponent(r_t(a0)), exponent(r_t(args))...);
-    auto f = [&](auto a){return sqr_abs(pedantic(ldexp)(r_t(a), e)); };
-    r_t that = add(f(a0), f(args)...);
-    auto r = pedantic(ldexp)(sqrt(that), -e);
-    if(none(is_nan(r))) return r;
-    auto rinf = numeric(maxabs)(a0, args...);
-    return if_else(is_infinite(rinf), rinf, r);
+    using r_t = decltype(hypot(a, b));
+    if constexpr( has_native_abi_v<r_t> )
+    {
+      r_t aa(abs(a));
+      r_t ab(abs(b));
+      auto test = aa > ab;
+      eve::swap_if(test, aa, ab); // now aa < bb
+      auto doit =  [](auto b){    // compute sqrt(1+b*b)
+        auto h = sqrt(inc(sqr(b)));
+        auto h2 = sqr(h);
+        auto x = fma(-b,b,dec(h2)) + fms(h,h,h2);
+        return if_else(is_eqz(h), h, h-x/(2*h)); // Maclaurin correction
+      };
+      auto h = if_else(is_eqz(ab), zero, ab*doit(aa/ab));
+      return if_else(is_infinite(a) || is_infinite(b), inf(as<r_t>()), h);
+    }
+    else { return apply_over(pedantic(hypot), r_t(a), r_t(b)); }
   }
-  else { return apply_over(pedantic(hypot), r_t(a0), r_t(args)...); }
-}
+
+  template<value T0, value T1, value... Ts>
+  auto hypot_(EVE_SUPPORTS(cpu_), pedantic_type const&, T0 a0, T1 a1, Ts... args)
+    -> decltype(hypot(a0, a1, args...))
+  {
+    using r_t = decltype(hypot(a0, a1, args...));
+    if constexpr( has_native_abi_v<r_t> )
+    {
+      r_t that(pedantic(hypot)(r_t(a0), r_t(a1)));
+      ((that = pedantic(hypot)(that, r_t(args))), ...);
+      return that;
+    }
+    else { return apply_over(pedantic(hypot), r_t(a0), r_t(a1), r_t(args)...); }
+  }
+
 }

--- a/test/doc/math/pedantic/hypot.cpp
+++ b/test/doc/math/pedantic/hypot.cpp
@@ -8,12 +8,15 @@ using wide_ft = eve::wide<float, eve::fixed<4>>;
 
 int main()
 {
-  wide_ft pf = {-1.0f, eve::inf(eve::as(1.0f)), -3.0f, eve::valmax(eve::as<float>())/2};
+  wide_ft pf = {-1.0f, eve::inf(eve::as(1.0f)), -3.0f, eve::smallestposval(eve::as<float>())/2};
   wide_ft qf = {-4,    eve::nan(eve::as(1.0f)), -2, -12};
 
   std::cout << "---- simd" << std::setprecision(10) << '\n'
             << "<- pf                       = " << pf << '\n'
             << "<- qf                       = " << qf << '\n'
             << "-> pedantic(hypot)(pf, qf)  = " << eve::pedantic(eve::hypot)(pf, qf) << '\n';
+
+
+  std::cout << eve::pedantic(eve::hypot)(5.0, 1.0e-305) << std::endl;
   return 0;
 }

--- a/test/unit/module/math/hypot.cpp
+++ b/test/unit/module/math/hypot.cpp
@@ -129,12 +129,14 @@ TTS_CASE_WITH("Check corner-cases behavior of eve::hypot variants on wide",
   TTS_EQUAL(eve::pedantic(eve::hypot)(cases.nan, cases.minf), cases.inf);
   TTS_EQUAL(eve::pedantic(eve::hypot)(cases.inf, cases.nan), cases.inf);
   TTS_EQUAL(eve::pedantic(eve::hypot)(cases.mzero, cases.mzero), T(0));
+#ifndef SPY_ARCH_IS_ARM
   TTS_ULP_EQUAL(eve::pedantic(eve::hypot)(cases.valmin / 2, cases.valmin / 2),
                 cases.valmax / eve::sqrt_2(eve::as<T>()),
                 2);
   TTS_ULP_EQUAL(eve::pedantic(eve::hypot)(cases.valmax / 2, cases.valmax / 2),
                 cases.valmax / eve::sqrt_2(eve::as<T>()),
                 2);
+#endif
 };
 
 

--- a/test/unit/module/math/hypot.cpp
+++ b/test/unit/module/math/hypot.cpp
@@ -128,15 +128,15 @@ TTS_CASE_WITH("Check corner-cases behavior of eve::hypot variants on wide",
   TTS_EQUAL(eve::pedantic(eve::hypot)(cases.minf, a0), cases.inf);
   TTS_EQUAL(eve::pedantic(eve::hypot)(cases.nan, cases.minf), cases.inf);
   TTS_EQUAL(eve::pedantic(eve::hypot)(cases.inf, cases.nan), cases.inf);
-
   TTS_EQUAL(eve::pedantic(eve::hypot)(cases.mzero, cases.mzero), T(0));
+#ifndef SPY_ARCH_IS_ARM
   TTS_ULP_EQUAL(eve::pedantic(eve::hypot)(cases.valmin / 2, cases.valmin / 2),
                 cases.valmax / eve::sqrt_2(eve::as<T>()),
                 2);
   TTS_ULP_EQUAL(eve::pedantic(eve::hypot)(cases.valmax / 2, cases.valmax / 2),
                 cases.valmax / eve::sqrt_2(eve::as<T>()),
                 2);
-  ;
+#endif
 };
 
 

--- a/test/unit/module/math/hypot.cpp
+++ b/test/unit/module/math/hypot.cpp
@@ -129,14 +129,12 @@ TTS_CASE_WITH("Check corner-cases behavior of eve::hypot variants on wide",
   TTS_EQUAL(eve::pedantic(eve::hypot)(cases.nan, cases.minf), cases.inf);
   TTS_EQUAL(eve::pedantic(eve::hypot)(cases.inf, cases.nan), cases.inf);
   TTS_EQUAL(eve::pedantic(eve::hypot)(cases.mzero, cases.mzero), T(0));
-#ifndef SPY_ARCH_IS_ARM
   TTS_ULP_EQUAL(eve::pedantic(eve::hypot)(cases.valmin / 2, cases.valmin / 2),
                 cases.valmax / eve::sqrt_2(eve::as<T>()),
                 2);
   TTS_ULP_EQUAL(eve::pedantic(eve::hypot)(cases.valmax / 2, cases.valmax / 2),
                 cases.valmax / eve::sqrt_2(eve::as<T>()),
                 2);
-#endif
 };
 
 


### PR DESCRIPTION
the actual implementation had an overflow bug for calls like pedantic(hypot)(5.0,1.0e-165), the new implementation corrects the problem and is far simpler