### PR TITLE
#559 - Implement efficient movemask for PPC and enable cheap top_bits for PPC

### DIFF
--- a/include/eve/arch/cpu/top_bits.hpp
+++ b/include/eve/arch/cpu/top_bits.hpp
@@ -118,6 +118,7 @@ namespace detail
       if constexpr ( is_aggregated ) return top_bits<half_logical>::is_cheap;
 
       if ( x86_abi<abi_type> ) return true;
+      if ( ppc_abi<abi_type> ) return true;
 
       if ( arm_abi<abi_type> )
       {

--- a/include/eve/detail/function/movemask.hpp
+++ b/include/eve/detail/function/movemask.hpp
@@ -15,6 +15,10 @@
 #  include <eve/detail/function/simd/x86/movemask.hpp>
 #endif
 
+#if defined(EVE_INCLUDE_POWERPC_HEADER)
+#  include <eve/detail/function/simd/ppc/movemask.hpp>
+#endif
+
 #if defined(EVE_INCLUDE_ARM_HEADER)
 #  include <eve/detail/function/simd/arm/neon/movemask.hpp>
 #endif

--- a/include/eve/detail/function/simd/ppc/movemask.hpp
+++ b/include/eve/detail/function/simd/ppc/movemask.hpp
@@ -25,12 +25,12 @@ namespace eve::detail
       return  []<std::size_t... I,std::size_t... J>
               (std::index_sequence<I...>,std::index_sequence<J...>)
       {
-        using vu8 = __vector unsigned char;
-        return vu8{(I,128)...,(J*spacing)...};
+        using vu8 = typename wide<T,N>::template rebind<std::uint8_t>;
+        return vu8{(I,128)...,((N::value-J-1)*spacing)...};
       }(std::make_index_sequence<16-N::value>{}, std::make_index_sequence<N::value>{});
     }();
 
-    auto result = vec_vbpermq(bit_cast(v.bits(),as(mask)), mask);
+    auto result = vec_vbpermq(bit_cast(v.bits(),as(mask)).storage(), mask.storage());
     return std::pair{result[0], eve::lane<1>};
   }
 }

--- a/include/eve/detail/function/simd/ppc/movemask.hpp
+++ b/include/eve/detail/function/simd/ppc/movemask.hpp
@@ -16,8 +16,8 @@ namespace eve::detail
   // Adapted from this completely unsuspecting thread:
   // https://stackoverflow.com/questions/33938584/on-powerpc-is-there-any-equivalent-of-intels-movemask-intrinsics
   template<arithmetic_scalar_value T, typename N>
-  EVE_FORCEINLINE auto movemask(logical<wide<T, N>> const &v) noexcept
-  requires ppc_abi<abi_t<T, N>>
+  EVE_FORCEINLINE std::pair<std::uint64_t,fixed<1>>
+  movemask(logical<wide<T, N>> const &v) noexcept requires ppc_abi<abi_t<T, N>>
   {
     auto mask = []()
     {
@@ -31,6 +31,6 @@ namespace eve::detail
     }();
 
     auto result = vec_vbpermq(bit_cast(v.bits(),as(mask)).storage(), mask.storage());
-    return std::pair{result[0], eve::lane<1>};
+    return {result[0], eve::lane<1>};
   }
 }

--- a/include/eve/detail/function/simd/ppc/movemask.hpp
+++ b/include/eve/detail/function/simd/ppc/movemask.hpp
@@ -16,11 +16,11 @@ namespace eve::detail
   // Adapted from this completely unsuspecting thread:
   // https://stackoverflow.com/questions/33938584/on-powerpc-is-there-any-equivalent-of-intels-movemask-intrinsics
   template<arithmetic_scalar_value T, typename N>
-  EVE_FORCEINLINE std::pair<std::uint64_t,fixed<1>>
-  movemask(logical<wide<T, N>> const &v) noexcept requires ppc_abi<abi_t<T, N>>
+  EVE_FORCEINLINE
+  std::pair<std::uint64_t,fixed<1>> movemask(logical<wide<T, N>> const &v) noexcept requires ppc_abi<abi_t<T, N>>
   {
     using vu8 = typename wide<T,N>::template rebind<std::uint8_t>;
-    auto mask = vu8([](auto i, auto c)
+    vu8 mask([](auto i, auto c)
     {
       constexpr auto spacing = sizeof(T)*8;
       // Any value above 128 means 0 so this always work without checking if i is above or below N

--- a/include/eve/detail/function/simd/ppc/movemask.hpp
+++ b/include/eve/detail/function/simd/ppc/movemask.hpp
@@ -1,0 +1,36 @@
+//==================================================================================================
+/*
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+*/
+//==================================================================================================
+#pragma once
+
+#include <eve/arch/logical.hpp>
+#include <eve/detail/function/bit_cast.hpp>
+#include <utility>
+
+namespace eve::detail
+{
+  // Adapted from this completely unsuspecting thread:
+  // https://stackoverflow.com/questions/33938584/on-powerpc-is-there-any-equivalent-of-intels-movemask-intrinsics
+  template<arithmetic_scalar_value T, typename N>
+  EVE_FORCEINLINE auto movemask(logical<wide<T, N>> const &v) noexcept
+  requires ppc_abi<abi_t<T, N>>
+  {
+    auto mask = []()
+    {
+      constexpr auto spacing = sizeof(T)*8;
+      return  []<std::size_t... I,std::size_t... J>
+              (std::index_sequence<I...>,std::index_sequence<J...>)
+      {
+        using vu8 = __vector unsigned char;
+        return vu8{(I,128)...,(J*spacing)...};
+      }(std::make_index_sequence<16-N::value>{}, std::make_index_sequence<N::value>{});
+    }();
+
+    auto result = vec_vbpermq(bit_cast(v.bits(),as(mask)), mask);
+    return std::pair{result[0], eve::lane<1>};
+  }
+}

--- a/test/unit/arch/top_bits.cpp
+++ b/test/unit/arch/top_bits.cpp
@@ -42,6 +42,7 @@ TTS_CASE_TPL( "Check top bits raw type", eve::test::simd::all_types)
   using ABI         = typename logical::abi_type;
 
        if constexpr (eve::has_aggregated_abi_v<logical>) TTS_EXPECT(expect_array(tb_storage{}));
+  else if constexpr (std::same_as<ABI, eve::ppc_>) TTS_TYPE_IS(tb_storage, std::uint64_t);
   else if constexpr (eve::current_api >= eve::sve      ) TTS_TYPE_IS(tb_storage, eve::logical<eve::wide<v_t>>);
   else if constexpr (eve::current_api >= eve::avx512   )
   {


### PR DESCRIPTION
This shoudl eb enough to close #559 as the top_bits using movemask is now efficient on PPC