### PR TITLE
in group then group

### DIFF
--- a/include/eve/detail/shuffle_v2/native_shuffle_helpers.hpp
+++ b/include/eve/detail/shuffle_v2/native_shuffle_helpers.hpp
@@ -66,18 +66,18 @@ struct expanded_pattern_t : pattern_t<I...>
   static constexpr auto repeated_16 = idxm::repeated_pattern_of_size<16 / g_size, I...>;
   static constexpr auto repeated_32 = idxm::repeated_pattern_of_size<32 / g_size, I...>;
 
-  static constexpr auto shuffle_16_first = idxm::put_bigger_groups_in_position<16 / g_size>(idxs);
-  static constexpr auto shuffle_8_first = idxm::put_bigger_groups_in_position<8 / g_size>(idxs);
-  static constexpr auto shuffle_4_first = idxm::put_bigger_groups_in_position<4 / g_size>(idxs);
-  static constexpr auto shuffle_2_first = idxm::put_bigger_groups_in_position<2 / g_size>(idxs);
+  static constexpr auto shuffle_16in16 = idxm::group_within_group<16 / g_size>(idxs);
+  static constexpr auto shuffle_8in8 = idxm::group_within_group<8 / g_size>(idxs);
+  static constexpr auto shuffle_4in4 = idxm::group_within_group<4 / g_size>(idxs);
+  static constexpr auto shuffle_2in2 = idxm::group_within_group<2 / g_size>(idxs);
 
-  template <std::ptrdiff_t FirstSize>
-  static constexpr auto shuffle_n_first(eve::fixed<FirstSize>)
+  template <std::ptrdiff_t N>
+  static constexpr auto shuffle_NinN(eve::fixed<N>)
   {
-    if constexpr (FirstSize == 16) return shuffle_16_first;
-    if constexpr (FirstSize == 8) return shuffle_8_first;
-    if constexpr (FirstSize == 4) return shuffle_4_first;
-    if constexpr (FirstSize == 2) return shuffle_2_first;
+    if constexpr (N == 16) return shuffle_16in16;
+    if constexpr (N == 8) return shuffle_8in8;
+    if constexpr (N == 4) return shuffle_4in4;
+    if constexpr (N == 2) return shuffle_2in2;
   }
 
 

--- a/include/eve/detail/shuffle_v2/simd/arm/neon/shuffle_l3.hpp
+++ b/include/eve/detail/shuffle_v2/simd/arm/neon/shuffle_l3.hpp
@@ -77,6 +77,7 @@ shuffle_l3_(EVE_SUPPORTS(neon128_), P p, fixed<G> g, wide<T, N> x)
   requires(P::out_reg_size == P::reg_size)
 {
   if constexpr( auto r = shuffle_l3_and_0(p, g, x); matched_shuffle<decltype(r)> ) return r;
+  else if constexpr ( auto r = shuffle_l3_slide_with_0(p, g, x); matched_shuffle<decltype(r)> ) return r;
   else if constexpr( auto r = shuffle_l3_neon_tbl(p, g, x); matched_shuffle<decltype(r)> ) return r;
   else return no_matching_shuffle_t {};
 }

--- a/include/eve/detail/shuffle_v2/simd/arm/neon/shuffle_l4_l5.hpp
+++ b/include/eve/detail/shuffle_v2/simd/arm/neon/shuffle_l4_l5.hpp
@@ -19,13 +19,13 @@ shuffle_l4_l5_neon_reverse(P, fixed<G> g, wide<T, N> x)
     return kumi::tuple {no_matching_shuffle, eve::index<-1>};
   else
   {
-    // swap havles and reverse halves
-    x = shuffle_l<2>(x, eve::lane<8 / sizeof(T)>, eve::pattern<1, 0>);
+    // swap havles + reverse halves is already computed
+    constexpr auto p0 = get<0>(*P::shuffle_8in8);
+    constexpr auto p1 = get<1>(*P::shuffle_8in8);
+    auto [r0, l0] = shuffle_v2_core(x, eve::lane<G>, idxm::to_pattern<p0>());
+    auto [r1, l1] = shuffle_v2_core(r0, eve::lane<G>, idxm::to_pattern<p1>());
 
-    // halve reverse is already computed
-    constexpr auto within8 = get<1>(*P::shuffle_8_first);
-    x                      = shuffle_l<2>(x, eve::lane<G>, idxm::to_pattern<within8>());
-    return kumi::tuple {x, eve::index<4>};
+    return kumi::tuple {r1, idxm::add_shuffle_levels(l0, l1)};
   }
 }
 

--- a/include/eve/detail/shuffle_v2/simd/common/shuffle_l3.hpp
+++ b/include/eve/detail/shuffle_v2/simd/common/shuffle_l3.hpp
@@ -21,4 +21,15 @@ shuffle_l3_and_0(P p, fixed<G> g, wide<T, N> x)
   }
 }
 
+template<typename P, typename T, typename N, std::ptrdiff_t G>
+EVE_FORCEINLINE auto
+shuffle_l3_slide_with_0(P, fixed<G> g, wide<T, N> x)
+{
+  if constexpr ( constexpr auto p = idxm::slide_as_slide2_with_0(P::idxs); !p ) return no_matching_shuffle;
+  else
+  {
+    return shuffle_l<2>(x, wide<T, N>{0}, g, idxm::to_pattern<*p>());
+  }
+}
+
 }

--- a/include/eve/detail/shuffle_v2/simd/common/simplify_plain_shuffle.hpp
+++ b/include/eve/detail/shuffle_v2/simd/common/simplify_plain_shuffle.hpp
@@ -8,57 +8,16 @@
 #pragma once
 
 #include <eve/arch/fundamental_cardinal.hpp>
+#include <eve/detail/shuffle_v2/idxm.hpp>
 
 namespace eve::detail
 {
-template<std::size_t N>
-constexpr auto
-upscale_pattern_impl(std::array<std::ptrdiff_t, N> p)
-    -> std::optional<std::array<std::ptrdiff_t, N / 2>>
-{
-  if( N == 1 ) return std::nullopt;
-
-  std::array<std::ptrdiff_t, N / 2> res {};
-
-  for( int i = 0; i != N / 2; i += 1 )
-  {
-    int            i2 = i + i;
-    std::ptrdiff_t i0 = p[i2];
-    std::ptrdiff_t i1 = p[i2 + 1];
-
-    if( i0 == na_ || i1 == na_ )
-    {
-      if( i0 == i1 || i0 == we_ || i1 == we_ )
-      {
-        res[i] = na_;
-        continue;
-      }
-      return std::nullopt;
-    }
-
-    if( i0 == we_ && i1 == we_ )
-    {
-      res[i] = we_;
-      continue;
-    }
-
-    if( i0 == we_ ) i0 = i1 - 1;
-    if( i1 == we_ ) i1 = i0 + 1;
-
-    if( i0 + 1 != i1 || i0 % 2 != 0 ) { return std::nullopt; }
-
-    res[i] = i0 / 2;
-  }
-
-  return res;
-}
 
 template<std::ptrdiff_t... I>
 constexpr auto
 upscale_pattern(pattern_t<I...> p)
 {
-  constexpr std::array    p_arr {I...};
-  constexpr std::optional attempt = upscale_pattern_impl(p_arr);
+  constexpr std::optional attempt = idxm::upscale_pattern(std::array{I...});
   if constexpr( !attempt ) return p;
   else return idxm::to_pattern<*attempt>();
 }

--- a/include/eve/detail/shuffle_v2/simd/x86/shuffle_l4_l5.hpp
+++ b/include/eve/detail/shuffle_v2/simd/x86/shuffle_l4_l5.hpp
@@ -43,15 +43,15 @@ shuffle_l4_l5_x86_put_u64x2_in_position(P, fixed<G>, wide<T, N> x)
   // there is nothing we can do for shorts on avx
   else if constexpr( P::reg_size == 32 && P::g_size <= 2 && current_api == avx ) return no;
   else if constexpr( P::has_zeroes && current_api < avx2 ) return no;
-  else if constexpr( !P::shuffle_16_first ) return no;
+  else if constexpr( !P::shuffle_16in16 ) return no;
   else
   {
-    constexpr auto shuffle16x2 = get<0>(*P::shuffle_16_first);
-    constexpr auto within16    = get<1>(*P::shuffle_16_first);
+    constexpr auto p0 = get<0>(*P::shuffle_16in16);
+    constexpr auto p1 = get<1>(*P::shuffle_16in16);
+    auto [r0, l0] = shuffle_v2_core(x, eve::lane<G>, idxm::to_pattern<p0>());
+    auto [r1, l1] = shuffle_v2_core(r0, eve::lane<G>, idxm::to_pattern<p1>());
 
-    x            = shuffle_l<2>(x, eve::lane<16 / sizeof(T)>, idxm::to_pattern<shuffle16x2>());
-    auto [x_, l] = shuffle_v2_core(x, eve::lane<G>, idxm::to_pattern<within16>());
-    return kumi::tuple {x_, idxm::add_shuffle_levels(l, eve::index<2>)};
+    return kumi::tuple {r1, idxm::add_shuffle_levels(l0, l1)};
   }
 }
 

--- a/include/eve/detail/shuffle_v2/simd/x86/shuffle_l6_l7.hpp
+++ b/include/eve/detail/shuffle_v2/simd/x86/shuffle_l6_l7.hpp
@@ -35,18 +35,14 @@ shuffle_x86_l6_l7_u32_then_u16(P, fixed<G>, T x)
   // this is only for sse2
   if constexpr( current_api >= ssse3 ) return no;
   else if constexpr( P::g_size != 2 || P::has_zeroes ) return no;
-  else if constexpr( !P::shuffle_4_first ) return no;
+  else if constexpr( !P::shuffle_4in4 ) return no;
   else
   {
-    constexpr auto shuffle4x4 = get<0>(*P::shuffle_4_first);
-    constexpr auto within4    = get<1>(*P::shuffle_4_first);
-
-    x = shuffle_l<2>(x, eve::lane<4 / P::e_t_size>, idxm::to_pattern<shuffle4x4>());
-
-    // this might be actually 2 and not 4 but should not be a problem, which'd lower
-    // the total level but it's ok - we will still compute correctly
-    auto [x_, l] = shuffle_v2_core(x, eve::lane<G>, idxm::to_pattern<within4>());
-    return kumi::tuple {x_, idxm::add_shuffle_levels(l, eve::index<2>)};
+    constexpr auto p0 = get<0>(*P::shuffle_4in4);
+    constexpr auto p1 = get<1>(*P::shuffle_4in4);
+    auto [r0, l0] = shuffle_v2_core(x, eve::lane<G>, idxm::to_pattern<p0>());
+    auto [r1, l1] = shuffle_v2_core(r0, eve::lane<G>, idxm::to_pattern<p1>());
+    return kumi::tuple {r1, idxm::add_shuffle_levels(l0, l1)};
   }
 }
 

--- a/test/unit/api/regular/shuffle_v2/slide_left_1.cpp
+++ b/test/unit/api/regular/shuffle_v2/slide_left_1.cpp
@@ -34,17 +34,17 @@ TTS_CASE("Slide left 1, example") {
 TTS_CASE("Explicit") {
   using w_i = eve::wide<std::uint32_t, eve::fixed<8>>;
   w_i x{1, 2, 3, 4, 5, 6, 7, 8};
-  //constexpr auto na_ = eve::na_;
-  auto y = eve::slide_left2(x, eve::index<7>);
+  constexpr auto na_ = eve::na_;
+  auto [y, l] = eve::shuffle_v2_core(x, eve::pattern<7, na_, na_, na_, na_, na_, na_, na_>);
   TTS_EQUAL(y, w_i({8, 0, 0, 0, 0, 0, 0, 0}));
-  //TTS_EQUAL(l(), 2);
+  TTS_EQUAL(l(), 4);
 };
 #endif
 
 TTS_CASE_TPL("Check slide_left, 1 arg, generic", eve::test::simd::all_types)
 <typename T>(tts::type<T>)
 {
-  if constexpr( eve::current_api <= eve::sse4_2 )
+  if constexpr( eve::current_api <= eve::sse4_2 || eve::current_api >= eve::asimd )
   {
     shuffle_test::named_shuffle1_test<
         /*supports_G_eq_T_Size*/ true>(eve::as<T> {},

--- a/test/unit/api/regular/shuffle_v2/slide_left_1.cpp
+++ b/test/unit/api/regular/shuffle_v2/slide_left_1.cpp
@@ -44,7 +44,7 @@ TTS_CASE("Explicit") {
 TTS_CASE_TPL("Check slide_left, 1 arg, generic", eve::test::simd::all_types)
 <typename T>(tts::type<T>)
 {
-  if constexpr( eve::current_api <= eve::sse4_2 || eve::current_api >= eve::asimd )
+  if constexpr( eve::current_api <= eve::sse4_2 || eve::current_api == eve::asimd )
   {
     shuffle_test::named_shuffle1_test<
         /*supports_G_eq_T_Size*/ true>(eve::as<T> {},


### PR DESCRIPTION
* in group then group.

The common group of shuffles is: shuffle in groups, then shuffle groups.
Example is avx2 shuffle 128 byte lanes and then intermix them somehow.

There is a question: what to do first: do you shuffle big groups first or in big groups first.
Techincally: big groups first is strictly more powerful.

However, can lead to better 0ing. 

It's not an obvious thing at all and I suspect we will come back to this one again.

Now I implemented "in groups then groups" to solve avx2 slide (partially.

* asimd

for asimd we used to have purely `vextq_u16` based solution.
Now this will prefer `shift_n` when that's avaliable, becasue no constants (horray - the system works).

For neon it's not enabled, because there is a bug in level computation: `emulation` should always return 0 but sometimes it returns 1. Which messes with `neon`, double. 