### PR TITLE
Simplify handling of aggregation

### DIFF
--- a/include/eve/arch/cpu/as_register.hpp
+++ b/include/eve/arch/cpu/as_register.hpp
@@ -13,6 +13,7 @@
 #include <eve/detail/kumi.hpp>
 #include <eve/forward.hpp>
 #include <eve/traits/as_wide.hpp>
+#include <cstring>
 #include <array>
 
 namespace eve
@@ -61,91 +62,54 @@ namespace eve
 
   namespace detail
   {
-    template<typename Type, typename Cardinal> struct blob
+    template<typename Type, typename Cardinal>
+    struct  blob
     {
+      using is_product_type             = void;
       using cardinal_t                  = expected_cardinal_t<Type>;
-      static constexpr auto replication = Cardinal::value/cardinal_t::value;
-
       using value_type                  = as_wide_t<Type, cardinal_t>;
       using subvalue_type               = as_wide_t<Type, typename Cardinal::split_type>;
+      static constexpr auto replication = Cardinal::value/expected_cardinal_v<Type>;
 
-      std::array<subvalue_type,2>       segments;
+      std::array<value_type, replication> storage;
 
-      template<std::size_t I> EVE_FORCEINLINE decltype(auto) get() noexcept
+      EVE_FORCEINLINE void combine(subvalue_type const& l, subvalue_type const& h)
       {
-        if constexpr(has_aggregated_abi_v<subvalue_type>)
-        {
-          constexpr auto side = ((2*I)/replication) & 1;
-          return segments[side].storage().template get<I>();
-        }
-        else
-        {
-          constexpr auto side = I & 1;
-          return segments[side];
-        }
+        std::array<subvalue_type,2> data{l,h};
+
+        auto dst = reinterpret_cast<std::byte*>(this);
+        auto src = reinterpret_cast<std::byte*>(data.data());
+        std::memcpy(dst, src, sizeof(*this));
       }
 
-      template<std::size_t I> EVE_FORCEINLINE decltype(auto) get() const noexcept
+      EVE_FORCEINLINE auto slices() const
       {
-        if constexpr(has_aggregated_abi_v<subvalue_type>)
-        {
-          constexpr auto side = ((2*I)/replication) & 1;
-          return segments[side].storage().template get<I>();
-        }
-        else
-        {
-          constexpr auto side = I & 1;
-          return segments[side];
-        }
+        std::array<subvalue_type,2> data{};
+
+        auto src = reinterpret_cast<std::byte const*>(this);
+        auto dst = reinterpret_cast<std::byte*>(data.data());
+        std::memcpy(dst, src, sizeof(*this));
+
+        return data;
       }
 
-      template<typename Func> void for_each(Func f)
-      {
-        [f]<std::size_t... I>(auto& s, std::index_sequence<I...> const&)
-        {
-          (f(s.template get<I>()), ...);
-        }(*this, std::make_index_sequence<replication>{});
-      }
+      template<std::size_t I>
+      friend EVE_FORCEINLINE auto&        get(blob& b) noexcept       { return b.storage[I]; }
 
-      template<typename Func> void for_each(Func f) const
-      {
-        [f]<std::size_t... I>(auto& s, std::index_sequence<I...> const&)
-        {
-          (f(s.template get<I>()), ...);
-        }(*this, std::make_index_sequence<replication>{});
-      }
+      template<std::size_t I>
+      friend EVE_FORCEINLINE auto const&  get(blob const& b) noexcept { return b.storage[I]; }
 
-      template<typename Func, typename Wide> void for_each(Func f, Wide const& w)
-      {
-        [&w,f]<std::size_t... I>(auto& s, std::index_sequence<I...> const&)
-        {
-          (f(s.template get<I>(),w.storage().template get<I>()), ...);
-        }(*this, std::make_index_sequence<replication>{});
-      }
+      template<typename Func>
+      EVE_FORCEINLINE void for_each(Func f, auto... w)       { kumi::for_each(f, *this, w.storage()...); }
 
-      template<typename Func, typename Wide> void for_each(Func f, Wide const& w) const
-      {
-        [&w,f]<std::size_t... I>(auto& s, std::index_sequence<I...> const&)
-        {
-          (f(s.template get<I>(),w.storage().template get<I>()), ...);
-        }(*this, std::make_index_sequence<replication>{});
-      }
+      template<typename Func>
+      EVE_FORCEINLINE void for_each(Func f, auto... w) const { kumi::for_each(f, *this, w.storage()...); }
 
-      template<typename Func> decltype(auto) apply(Func f)
-      {
-        return [f]<std::size_t... I>(auto& s, std::index_sequence<I...> const&)
-        {
-          return f(s.template get<I>()...);
-        }(*this, std::make_index_sequence<replication>{});
-      }
+      template<typename Func>
+      EVE_FORCEINLINE decltype(auto) apply(Func f)        { return kumi::apply(f,*this); }
 
-      template<typename Func> decltype(auto) apply(Func f) const
-      {
-        return [f]<std::size_t... I>(auto& s, std::index_sequence<I...> const&)
-        {
-          return f(s.template get<I>()...);
-        }(*this, std::make_index_sequence<replication>{});
-      }
+      template<typename Func>
+      EVE_FORCEINLINE decltype(auto) apply(Func f) const  { return kumi::apply(f,*this); }
     };
   }
 
@@ -161,3 +125,15 @@ namespace eve
     using type = detail::blob<logical<Type>,Cardinal>;
   };
 }
+
+template<std::size_t I, typename T, typename C>
+struct std::tuple_element<I, eve::detail::blob<T,C>>
+{
+  using type = typename eve::detail::blob<T,C>::value_type;
+};
+
+template<typename T, typename C>
+struct  std::tuple_size<eve::detail::blob<T,C>>
+      : std::integral_constant<std::size_t, eve::detail::blob<T,C>::replication>
+{
+};

--- a/include/eve/arch/cpu/as_register.hpp
+++ b/include/eve/arch/cpu/as_register.hpp
@@ -73,7 +73,7 @@ namespace eve
 
       std::array<value_type, replication> storage;
 
-      EVE_FORCEINLINE void combine(subvalue_type const& l, subvalue_type const& h)
+      EVE_FORCEINLINE void assign_parts(subvalue_type const& l, subvalue_type const& h)
       {
         std::array<subvalue_type,2> data{l,h};
 
@@ -82,7 +82,7 @@ namespace eve
         std::memcpy(dst, src, sizeof(*this));
       }
 
-      EVE_FORCEINLINE auto slices() const
+      EVE_FORCEINLINE auto slice() const
       {
         std::array<subvalue_type,2> data{};
 

--- a/include/eve/detail/function/simd/arm/neon/interleave.hpp
+++ b/include/eve/detail/function/simd/arm/neon/interleave.hpp
@@ -10,6 +10,7 @@
 #include <eve/detail/abi.hpp>
 #include <eve/detail/function/bit_cast.hpp>
 #include <eve/traits/product_type.hpp>
+#include <eve/detail/function/slice.hpp>
 
 namespace eve::detail
 {

--- a/include/eve/detail/function/simd/arm/sve/combine.hpp
+++ b/include/eve/detail/function/simd/arm/sve/combine.hpp
@@ -24,10 +24,7 @@ namespace eve::detail
     if constexpr( N::value  == expected_cardinal_v<T> )
     {
       that_t that;
-
-      that.storage().segments[0] = l;
-      that.storage().segments[1] = h;
-
+      that.storage().combine(l,h);
       return that;
     }
     else
@@ -47,10 +44,7 @@ namespace eve::detail
     if constexpr( N::value  == expected_cardinal_v<T> )
     {
       that_t that;
-
-      that.storage().segments[0] = l;
-      that.storage().segments[1] = h;
-
+      that.storage().combine(l,h);
       return that;
     }
     else

--- a/include/eve/detail/function/simd/arm/sve/combine.hpp
+++ b/include/eve/detail/function/simd/arm/sve/combine.hpp
@@ -24,7 +24,7 @@ namespace eve::detail
     if constexpr( N::value  == expected_cardinal_v<T> )
     {
       that_t that;
-      that.storage().combine(l,h);
+      that.storage().assign_parts(l,h);
       return that;
     }
     else
@@ -44,7 +44,7 @@ namespace eve::detail
     if constexpr( N::value  == expected_cardinal_v<T> )
     {
       that_t that;
-      that.storage().combine(l,h);
+      that.storage().assign_parts(l,h);
       return that;
     }
     else

--- a/include/eve/detail/function/simd/common/bitmask.hpp
+++ b/include/eve/detail/function/simd/common/bitmask.hpp
@@ -62,13 +62,9 @@ namespace eve::detail
       if constexpr( has_aggregated_abi_v<Wide> )
       {
         std::size_t res{0};
-
-        [&]<std::size_t... I>(std::index_sequence<I...> const&)
-        {
-          auto s = p.storage();
-          ((res |= ((s.template get<I>()).bitmap().to_ullong() << I*s.template get<I>().size())),...);
-        }(std::make_index_sequence<Wide::storage_type::replication>{});
-
+        kumi::for_each_index( [&](auto i, auto v) { res |= (v.bitmap().to_ullong() << i*v.size()); }
+                              , p.storage()
+                            );
         return std::bitset<Wide::size()>{res};
       }
       else

--- a/include/eve/detail/function/simd/common/combine.hpp
+++ b/include/eve/detail/function/simd/common/combine.hpp
@@ -29,7 +29,7 @@ namespace eve::detail
     else if constexpr( has_aggregated_abi_v<that_t> )
     {
       that_t that;
-      that.storage().combine(l,h);
+      that.storage().assign_parts(l,h);
       return that;
     }
     else if constexpr( is_bundle_v<abi_t<T, N>> )
@@ -51,7 +51,7 @@ namespace eve::detail
     else if constexpr( has_aggregated_abi_v<that_t> )
     {
       that_t that;
-      that.storage().combine(l,h);
+      that.storage().assign_parts(l,h);
       return that;
     }
     else

--- a/include/eve/detail/function/simd/common/combine.hpp
+++ b/include/eve/detail/function/simd/common/combine.hpp
@@ -29,10 +29,7 @@ namespace eve::detail
     else if constexpr( has_aggregated_abi_v<that_t> )
     {
       that_t that;
-
-      that.storage().segments[0] = l;
-      that.storage().segments[1] = h;
-
+      that.storage().combine(l,h);
       return that;
     }
     else if constexpr( is_bundle_v<abi_t<T, N>> )
@@ -54,10 +51,7 @@ namespace eve::detail
     else if constexpr( has_aggregated_abi_v<that_t> )
     {
       that_t that;
-
-      that.storage().segments[0] = l;
-      that.storage().segments[1] = h;
-
+      that.storage().combine(l,h);
       return that;
     }
     else

--- a/include/eve/detail/function/simd/common/slice.hpp
+++ b/include/eve/detail/function/simd/common/slice.hpp
@@ -51,7 +51,7 @@ namespace eve::detail
   {
     using abi_t   = typename P::abi_type;
 
-    if constexpr( is_aggregated_v<abi_t> )  return a.storage().segments;
+    if constexpr( is_aggregated_v<abi_t> )  return a.storage().slices();
     else                                    return std::array{a.slice(lower_), a.slice(upper_)};
   }
 
@@ -75,7 +75,7 @@ namespace eve::detail
     }
     else if constexpr( is_aggregated_v<abi_t> )
     {
-      return a.storage().segments[Slice::value];
+      return a.storage().slices()[Slice::value];
     }
     else if constexpr( is_bundle_v<abi_t> )
     {

--- a/include/eve/detail/function/simd/common/slice.hpp
+++ b/include/eve/detail/function/simd/common/slice.hpp
@@ -51,7 +51,7 @@ namespace eve::detail
   {
     using abi_t   = typename P::abi_type;
 
-    if constexpr( is_aggregated_v<abi_t> )  return a.storage().slices();
+    if constexpr( is_aggregated_v<abi_t> )  return a.storage().slice();
     else                                    return std::array{a.slice(lower_), a.slice(upper_)};
   }
 
@@ -75,7 +75,7 @@ namespace eve::detail
     }
     else if constexpr( is_aggregated_v<abi_t> )
     {
-      return a.storage().slices()[Slice::value];
+      return a.storage().slice()[Slice::value];
     }
     else if constexpr( is_bundle_v<abi_t> )
     {

--- a/include/eve/detail/function/simd/common/subscript.hpp
+++ b/include/eve/detail/function/simd/common/subscript.hpp
@@ -63,7 +63,7 @@ namespace eve::detail
 
       if constexpr( abi_t::is_wide_logical )
       {
-        auto ptr = reinterpret_cast<detail::alias_t<type>*>(&p.storage().segments[0]);
+        auto ptr = reinterpret_cast<detail::alias_t<type>*>(&p.storage());
         ptr[i] = v;
       }
       else

--- a/include/eve/module/core/constant/allbits.hpp
+++ b/include/eve/module/core/constant/allbits.hpp
@@ -10,6 +10,7 @@
 #include <eve/arch.hpp>
 #include <eve/traits/overload.hpp>
 #include <eve/module/core/decorator/core.hpp>
+#include <eve/detail/function/bit_cast.hpp>
 
 namespace eve
 {

--- a/include/eve/traits/overload/default_behaviors.hpp
+++ b/include/eve/traits/overload/default_behaviors.hpp
@@ -8,7 +8,8 @@
 #pragma once
 
 #include <eve/concept/value.hpp>
-#include <eve/detail/skeleton.hpp>
+#include <eve/detail/skeleton.hpp>  // TEMPORARY
+#include <eve/detail/overload.hpp>  // TEMPORARY
 #include <eve/forward.hpp>
 
 namespace eve


### PR DESCRIPTION
 - actually stores N registers of smallest wide
 - make it a kumi tuple to simplify internal functions
 - fixed implementation of related functions liek slice and combine

This restructuration has a net benefice on ARM codegen and doesn't alter compilation time negatively.