### PR TITLE
Raw frac

### DIFF
--- a/include/eve/module/core/regular/frac.hpp
+++ b/include/eve/module/core/regular/frac.hpp
@@ -18,7 +18,7 @@ namespace eve
 {
 
   template<typename Options>
-  struct frac_t : elementwise_callable<frac_t, Options>
+  struct frac_t : elementwise_callable<frac_t, Options, raw_option>
   {
     template<eve::value T>
     constexpr EVE_FORCEINLINE T operator()(T v) const
@@ -72,6 +72,11 @@ namespace eve
 //!
 //!  @groupheader{Semantic Modifiers}
 //!
+//!   * raw Call
+//!
+//!     The call `eve;::frac[raw](x)` does not guaranties the bit of sign
+//!     conservation when the input is \f$\pm0\f$.
+//!
 //!   * Masked Call
 //!
 //!     The call `eve;::frac[mask](x)` provides a masked version of `eve::frac` which is
@@ -89,10 +94,11 @@ namespace eve
    {
      if constexpr( floating_value<T> )
      {
-       if constexpr( scalar_value<T> ) return !a ? a : a - trunc(a);
-       else                            return if_else(is_eqz(a), a, a - trunc(a));
+       if constexpr(O::contains(raw2))      return a-trunc(a);
+       else if constexpr( scalar_value<T> ) return !a ? a : a - trunc(a);
+       else                                 return if_else(is_eqz(a), a, a - trunc(a));
      }
-     else                              return zero(eve::as(a));
+     else                                   return zero(eve::as(a));
    }
   }
 }

--- a/include/eve/module/core/regular/is_flint.hpp
+++ b/include/eve/module/core/regular/is_flint.hpp
@@ -90,7 +90,7 @@ namespace eve
         if constexpr( integral_value<T> )
           return true_(eve::as<T>());
         else
-          return is_eqz(frac(a));
+          return is_eqz(frac[raw](a));
       }
      else
         return is_flint(a) && (a <= eve::maxflint(eve::as<T>()));

--- a/include/eve/module/core/regular/is_not_flint.hpp
+++ b/include/eve/module/core/regular/is_not_flint.hpp
@@ -86,9 +86,9 @@ namespace eve
       if constexpr( integral_value<T> )
         return false_(eve::as<T>());
       else if (O::contains(pedantic2))
-        return is_nez(frac(a)) || (a > eve::maxflint(eve::as<T>()));
+        return is_nez(frac[raw](a)) || (a > eve::maxflint(eve::as<T>()));
       else
-        return is_nez(frac(a));
+        return is_nez(frac[raw](a));
     }
   }
 }

--- a/include/eve/module/math/regular/tanpi.hpp
+++ b/include/eve/module/math/regular/tanpi.hpp
@@ -91,13 +91,13 @@ namespace eve
         if constexpr( scalar_value<T> )
         {
           if( is_eqz(a0) ) return a0;
-          if( is_not_finite(x) || (frac(x) == half(eve::as<T>())) ) return nan(eve::as<T>());
+          if( is_not_finite(x) || (frac[raw](x) == half(eve::as<T>())) ) return nan(eve::as<T>());
           if( x > maxflint(eve::as<T>()) || is_flint(x) ) return T(0);
         }
         else
         {
           x = if_else(is_greater(x, maxflint(eve::as(x))) || is_flint(x), eve::zero, x);
-          x = if_else(is_not_finite(a0) || (frac(x) == half(eve::as<T>())), eve::allbits, x);
+          x = if_else(is_not_finite(a0) || (frac[raw](x) == half(eve::as<T>())), eve::allbits, x);
         }
         auto [fn, xr, dxr] = rem2(x);
         return tan_finalize(a0 * pi(eve::as<T>()), fn, xr, dxr);

--- a/include/eve/module/special/regular/digamma.hpp
+++ b/include/eve/module/special/regular/digamma.hpp
@@ -177,7 +177,7 @@ inline constexpr auto digamma = functor<digamma_t>;
         {
           auto a         = x;
           x              = oneminus[test](x);
-          auto remainder = frac(x);
+          auto remainder = frac[raw](x);
           remainder      = dec[remainder > 0.5](remainder);
           remainder      = if_else(is_eqz(remainder), nan(as(x)), remainder);
           remainder      = if_else(remainder == T(0.5), zero, pi(as(x)) * cotpi(remainder));


### PR DESCRIPTION
standard wants that frac preserve the zero sign 
this is unnecessary in many uses of frac as just seeing it is not zero
so a raw version of frac is added to gain some cycles in this case
which is used internally at least 4 times