### PR TITLE
gitignore .DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ Testing/*
 doc/docs/*
 .cache/
 .idea/
+
+# file system metadata
+*.DS_Store


### PR DESCRIPTION
Add `.DS_Store` (metadata files created by APFS for indexing purpose) files to the main `.gitignore`. This will make it easier for contributors using macOS to contribute.

@jfalcou 