### PR TITLE
Add CPP version guard to eve

### DIFF
--- a/include/eve/detail/abi.hpp
+++ b/include/eve/detail/abi.hpp
@@ -7,6 +7,16 @@
 //==================================================================================================
 #pragma once
 
+#if defined(_MSC_VER)
+#    if _MSVC_LANG < 202002L
+#        error "Eve requires C++20 or higher. Use /std:c++20 or higher to enable C++20 features."
+#    endif
+#else
+#    if __cplusplus < 202002L
+#        error "Eve requires C++20 or higher. Use -std=c++20 or higher to enable C++20 features."
+#    endif
+#endif
+
 // Faster than std::forward
 #define EVE_FWD(...) static_cast<decltype(__VA_ARGS__) &&>(__VA_ARGS__)
 

--- a/include/eve/module/core.hpp
+++ b/include/eve/module/core.hpp
@@ -7,6 +7,16 @@
 //==================================================================================================
 #pragma once
 
+#if defined(_MSC_VER)
+#    if _MSVC_LANG < 202002L
+#        error "Eve requires C++20 or higher. Use /std:c++20 or higher to enable C++20 features."
+#    endif
+#else
+#    if __cplusplus < 202002L
+#        error "Eve requires C++20 or higher. Use -std=c++20 or higher to enable C++20 features."
+#    endif
+#endif
+
 //==================================================================================================
 //! @addtogroup functions
 //! @{

--- a/include/eve/module/core.hpp
+++ b/include/eve/module/core.hpp
@@ -7,16 +7,6 @@
 //==================================================================================================
 #pragma once
 
-#if defined(_MSC_VER)
-#    if _MSVC_LANG < 202002L
-#        error "Eve requires C++20 or higher. Use /std:c++20 or higher to enable C++20 features."
-#    endif
-#else
-#    if __cplusplus < 202002L
-#        error "Eve requires C++20 or higher. Use -std=c++20 or higher to enable C++20 features."
-#    endif
-#endif
-
 //==================================================================================================
 //! @addtogroup functions
 //! @{


### PR DESCRIPTION
Added to `eve/module/core.hpp` instead of `eve/eve.hpp` because not everyone use the later as the main eve header.