### PR TITLE
Use std::bitcast in eve::bit_cast to ensure constexpr support. 

### DIFF
--- a/include/eve/arch/cpu/logical.hpp
+++ b/include/eve/arch/cpu/logical.hpp
@@ -55,9 +55,6 @@ namespace eve
     //! Default constructor
     EVE_FORCEINLINE constexpr logical() noexcept {}
 
-    //! Copy constructor
-    EVE_FORCEINLINE constexpr logical(logical const&) noexcept = default;
-
     //! Construct from a `bool`
     EVE_FORCEINLINE constexpr logical(bool v) noexcept : value_(v ? true_mask : false_mask) {}
 
@@ -74,13 +71,6 @@ namespace eve
     //! @name Assignment operators
     //! @{
     //==============================================================================================
-    //! Assign another logical
-    EVE_FORCEINLINE constexpr logical &operator=(logical const& v) & noexcept
-    {
-      value_ = v.value_;
-      return *this;
-    }
-
     //! Assign a `bool`
     EVE_FORCEINLINE constexpr logical &operator=(bool v) & noexcept
     {
@@ -129,7 +119,7 @@ namespace eve
     }
 
     //==============================================================================================
-    // Convertion from logical to other formats (mask, bits, bitmap)
+    // Conversion from logical to other formats (mask, bits, bitmap)
     //==============================================================================================
     EVE_FORCEINLINE constexpr operator bool()   const noexcept { return !!value_; }
     EVE_FORCEINLINE constexpr bool value()      const noexcept { return !!value_; }

--- a/include/eve/detail/function/bit_cast.hpp
+++ b/include/eve/detail/function/bit_cast.hpp
@@ -17,7 +17,7 @@ namespace eve
   {
     template<typename T, typename Target>
     requires (sizeof(T) == sizeof(Target))
-    EVE_FORCEINLINE Target operator()(T const& a, as<Target> const& tgt) const noexcept
+    EVE_FORCEINLINE constexpr Target operator()(T const& a, as<Target> const& tgt) const noexcept
     {
       return EVE_DISPATCH_CALL(a,tgt);
     }

--- a/include/eve/detail/function/simd/common/bit_cast.hpp
+++ b/include/eve/detail/function/simd/common/bit_cast.hpp
@@ -7,15 +7,8 @@
 //==================================================================================================
 #pragma once
 
-#include <eve/detail/spy.hpp>
 #include <eve/as.hpp>
-#include <cstring>
-
-#if defined(SPY_COMPILER_IS_GCC)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wuninitialized"
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
+#include <bit>
 
 namespace eve::detail
 {
@@ -23,15 +16,7 @@ namespace eve::detail
   EVE_FORCEINLINE constexpr auto bit_cast_(EVE_REQUIRES(cpu_), O const&, T const &a, as<Target> const &) noexcept
   {
     if constexpr(std::is_same_v<T, Target>) return a;
-    else
-    {
-      [[maybe_unused]] Target that;
-      std::memcpy((char*)&that, (char*)&a, sizeof(a));
-      return that;
-    }
+    else                                    return std::bit_cast<Target>(a);
   }
 }
 
-#if defined(SPY_COMPILER_IS_GCC)
-#pragma GCC diagnostic pop
-#endif


### PR DESCRIPTION
To do so, logical must be trivially copyable (as it should be) so we remove the useless copy/assignment.