### PR TITLE
add algo::transform_copy_if

### DIFF
--- a/include/eve/module/algo.hpp
+++ b/include/eve/module/algo.hpp
@@ -55,6 +55,7 @@
 #include <eve/module/algo/algo/swap_ranges.hpp>
 #include <eve/module/algo/algo/traits.hpp>
 #include <eve/module/algo/algo/transform.hpp>
+#include <eve/module/algo/algo/transform_copy_if.hpp>
 #include <eve/module/algo/algo/transform_reduce.hpp>
 #include <eve/module/algo/algo/two_stage_iteration.hpp>
 #include <eve/module/algo/views/backward.hpp>

--- a/include/eve/module/algo/algo/copy_if.hpp
+++ b/include/eve/module/algo/algo/copy_if.hpp
@@ -96,6 +96,9 @@ template<typename TraitsSupport> struct copy_if_ : TraitsSupport
 //!   #include <eve/module/algo.hpp>
 //!   @endcode
 //!
+//!   @note
+//!   If you need to apply a transformation, you can use `eve::algo::views::map` or `eve::algo::transform_copy_if`.
+//!
 //!   The main difference from std::copy_if is that it accepts output range and not
 //!   an output iterator. If the output doesn't have enough space, algorithm will fill
 //!   all of the avaliable output and then stop.

--- a/include/eve/module/algo/algo/copy_if.hpp
+++ b/include/eve/module/algo/algo/copy_if.hpp
@@ -135,6 +135,9 @@ template<typename TraitsSupport> struct copy_if_ : TraitsSupport
 //!   ** Return value **
 //!
 //!    relaxed_iterator past the last written element.
+//!
+//!   @see `transform_copy_if`
+//!
 //! @}
 //================================================================================================
 inline constexpr auto copy_if = function_with_traits<copy_if_>;

--- a/include/eve/module/algo/algo/transform_copy_if.hpp
+++ b/include/eve/module/algo/algo/transform_copy_if.hpp
@@ -104,15 +104,15 @@ namespace eve::algo
   //!
   //!   @brief Similar to applying `eve::transform_to` and `eve::copy_if` at the same time.
   //!
+  //!   @note
+  //!   If the scalar operation is cheap enough, `::copy_if` + `views::map` might be slightly faster.
+  //!
   //!   Conditionally copies values from an input range to an output range,
   //!   transforming them in the process.
   //!
   //!   If the output range is too small, fills all the available space and then stops.
   //!   
   //!   If the output range's element type is different from the type of the values returned by the transforming function, performs the appropriate conversions.
-  //!
-  //!   @note
-  //!   If the scalar operation is cheap enough, `::copy_if` + `views::map` might be slightly faster.
   //!
   //!   @groupheader{Callable Signatures}
   //!

--- a/include/eve/module/algo/algo/transform_copy_if.hpp
+++ b/include/eve/module/algo/algo/transform_copy_if.hpp
@@ -1,0 +1,169 @@
+//==================================================================================================
+/*
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+*/
+//==================================================================================================
+#pragma once
+
+#include <eve/module/algo/algo/common_forceinline_lambdas.hpp>
+#include <eve/module/algo/algo/traits.hpp>
+#include <eve/module/algo/algo/two_stage_iteration.hpp>
+#include <eve/module/algo/algo/views/convert.hpp>
+#include <eve/module/core.hpp>
+
+#include <utility>
+#include <type_traits>
+
+namespace eve::algo
+{
+
+  namespace detail
+  {
+    template<typename TraitsSupport> struct transform_copy_if_ : TraitsSupport
+    {
+      template<typename OutIt, typename Func> struct delegate
+      {
+        OutIt out_first;
+        OutIt out_last;
+        Func func;
+
+        static constexpr auto compress_copy()
+        {
+          auto density = density_for_compress_copy<typename TraitsSupport::traits_type>();
+          return eve::compress_copy[eve::unsafe][density];
+        }
+
+        EVE_FORCEINLINE
+        bool tail(auto f, auto ignore)
+        {
+          auto out_ignore   = eve::keep_first(std::min(out_last - out_first, eve::iterator_cardinal_v<OutIt>));
+          auto loaded       = eve::load(f);
+          auto [vals, mask] = func(loaded);
+          out_first = eve::compress_store[eve::unsafe][ignore][out_ignore](vals, mask, out_first);
+          return out_first == out_last;
+        }
+
+        EVE_FORCEINLINE
+        std::ptrdiff_t left_for_stage1() const
+        {
+          return out_last - out_first;
+        }
+
+        EVE_FORCEINLINE
+        bool step_1(auto f)
+        {
+          auto loaded       = eve::load(f);
+          auto [vals, mask] = func(loaded);
+          out_first = eve::compress_store[eve::unsafe](vals, mask, out_first);
+          return false;
+        }
+
+        EVE_FORCEINLINE
+        bool step_2(auto f)
+        {
+          // ol - of < cardinal
+          auto out_ignore   = eve::keep_first(out_last - out_first);
+          auto loaded       = eve::load(f);
+          auto [vals, mask] = func(loaded);
+          out_first = eve::compress_store[eve::unsafe][eve::ignore_none][out_ignore](vals, mask, out_first);
+          return out_first == out_last;
+        }
+      };
+
+      template<relaxed_range In, relaxed_range Out, typename Func>
+      EVE_FORCEINLINE
+      auto operator()(In&& in, Out&& out, Func func) const -> unaligned_iterator_t<Out>
+      {
+        if( in.begin() == in.end() || out.begin() == out.end() )
+          return out.begin();
+
+        using out_type = eve::element_type_t<std::remove_reference_t<decltype(get<0>(func(std::declval<wide<value_type_t<In>>>())))>>;
+        auto [processed_in, processed_out] = temporary_preprocess_ranges_hack(
+          TraitsSupport::get_traits(), in, views::convert(out, eve::as<out_type>()));
+
+        auto iteration = two_stage_iteration(processed_in.traits(), processed_in.begin(), processed_in.end());
+
+        auto out_first = unalign(processed_out.begin());
+        auto out_last  = unalign(processed_out.end());
+
+        delegate<decltype(out_first), Func> d {out_first, out_last, func};
+        iteration(d);
+        return eve::unalign(out.begin()) + (d.out_first - processed_out.begin());
+      }
+
+      template<relaxed_range In, relaxed_range Out, typename Op, typename P>
+      EVE_FORCEINLINE
+      auto operator()(In&& in, Out&& out, Op op, P p) const -> unaligned_iterator_t<Out>
+      {
+        return operator()(in, out, [&](auto elt) {
+          return kumi::make_tuple(op(elt), p(elt));
+        });
+      }
+    };
+  }
+
+  //==============================================================================================
+  //! @addtogroup algos
+  //! @{
+  //!   @var transform_copy_if
+  //!
+  //!   **Defined in header**
+  //!
+  //!   @code
+  //!   #include <eve/module/algo.hpp>
+  //!   @endcode
+  //!
+  //!   @brief Similar to applying `eve::transform_to` and `eve::copy_if` at the same time.
+  //!
+  //!   Conditionally copies values from an input range to an output range,
+  //!   transforming them in the process.
+  //!
+  //!   If the output range is too small, fills all the available space and then stops.
+  //!   
+  //!   If the output range's element type is different from the type of the values returned by the transforming function, performs the appropriate conversions.
+  //!
+  //!   There are two overloads: one that takes in two separate operation and predicate functions,
+  //!   and one that takes in a single function that returns a pair.
+  //!   * The first form gives the same input to both functions.
+  //!     You can think of it as applying `eve::copy_if` and then `eve::transform_to`.
+  //!   * The second form is especially useful when the predicate and the transforming operation
+  //!     have some overlap or depend on each other.
+  //!
+  //!   @groupheader{Callable Signatures}
+  //!
+  //!   @code
+  //!   namespace eve::algo
+  //!   {
+  //!     template <eve::algo::relaxed_range In, eve::algo::relaxed_range Out, typename Func>
+  //!     auto operator()(In&& in, Out&& out, Func func) const -> unaligned_iterator_t<Out>
+  //!
+  //!     template <eve::algo::relaxed_range In, eve::algo::relaxed_range Out, typename Op, typename P>
+  //!     auto operator()(In&& in, Out&& out, Op op, P p) const -> unaligned_iterator_t<Out>
+  //!   }
+  //!   @endcode
+  //!
+  //!   **Parameters**
+  //!
+  //!    * `in`: Input range
+  //!    * `out`: Output range
+  //!    * `func`: Function that takes elements from `in` as SIMD registers and returns a pair of:
+  //!        - the transformed values
+  //!        - a logical mask.
+  //!    * `op`: Transformation operation over elements from `in` as SIMD registers
+  //!    * `p`: Predicate over elements from `in` as SIMD registers
+  //!
+  //!   **Return value**
+  //!
+  //!   Output iterator past the last written element.
+  //!
+  //!   @groupheader{Example}
+  //!
+  //!   @godbolt{doc/algo/transform_copy_if.cpp}
+  //!
+  //! @}
+  //==============================================================================================
+  inline constexpr auto transform_copy_if = function_with_traits<detail::transform_copy_if_>;
+
+}

--- a/include/eve/module/algo/algo/transform_copy_if.hpp
+++ b/include/eve/module/algo/algo/transform_copy_if.hpp
@@ -111,6 +111,9 @@ namespace eve::algo
   //!   
   //!   If the output range's element type is different from the type of the values returned by the transforming function, performs the appropriate conversions.
   //!
+  //!   @note
+  //!   If the scalar operation is cheap enough, `::copy_if` + `views::map` might be slightly faster.
+  //!
   //!   @groupheader{Callable Signatures}
   //!
   //!   @code
@@ -136,6 +139,10 @@ namespace eve::algo
   //!   @groupheader{Example}
   //!
   //!   @godbolt{doc/algo/transform_copy_if.cpp}
+  //!
+  //!   @see `copy_if`
+  //!   @see `transform_to`
+  //!   @see `views::map`
   //!
   //! @}
   //==============================================================================================

--- a/include/eve/module/algo/algo/transform_copy_if.hpp
+++ b/include/eve/module/algo/algo/transform_copy_if.hpp
@@ -88,14 +88,6 @@ namespace eve::algo
         return eve::unalign(out.begin()) + (d.of - processed_out.begin());
       }
 
-      template<relaxed_range In, relaxed_range Out, typename Op, typename P>
-      EVE_FORCEINLINE
-      auto operator()(In&& in, Out&& out, Op op, P p) const -> unaligned_iterator_t<Out>
-      {
-        return operator()(in, out, [&](auto elt) {
-          return kumi::make_tuple(op(elt), p(elt));
-        });
-      }
     };
   }
 
@@ -119,23 +111,13 @@ namespace eve::algo
   //!   
   //!   If the output range's element type is different from the type of the values returned by the transforming function, performs the appropriate conversions.
   //!
-  //!   There are two overloads: one that takes in two separate operation and predicate functions,
-  //!   and one that takes in a single function that returns a pair.
-  //!   * The first form gives the same input to both functions.
-  //!     You can think of it as applying `eve::copy_if` and then `eve::transform_to`.
-  //!   * The second form is especially useful when the predicate and the transforming operation
-  //!     have some overlap or depend on each other.
-  //!
   //!   @groupheader{Callable Signatures}
   //!
   //!   @code
   //!   namespace eve::algo
   //!   {
   //!     template <eve::algo::relaxed_range In, eve::algo::relaxed_range Out, typename Func>
-  //!     auto operator()(In&& in, Out&& out, Func func) const -> unaligned_iterator_t<Out>
-  //!
-  //!     template <eve::algo::relaxed_range In, eve::algo::relaxed_range Out, typename Op, typename P>
-  //!     auto operator()(In&& in, Out&& out, Op op, P p) const -> unaligned_iterator_t<Out>
+  //!     auto transform_copy_if(In&& in, Out&& out, Func func) const -> unaligned_iterator_t<Out>
   //!   }
   //!   @endcode
   //!
@@ -146,8 +128,6 @@ namespace eve::algo
   //!    * `func`: Function that takes elements from `in` as SIMD registers and returns a pair of:
   //!        - the transformed values
   //!        - a logical mask.
-  //!    * `op`: Transformation operation over elements from `in` as SIMD registers
-  //!    * `p`: Predicate over elements from `in` as SIMD registers
   //!
   //!   **Return value**
   //!

--- a/test/doc/algo/transform_copy_if.cpp
+++ b/test/doc/algo/transform_copy_if.cpp
@@ -1,0 +1,31 @@
+#include <eve/module/core.hpp>
+#include <eve/module/algo.hpp>
+#include <tts/tts.hpp>
+#include <iostream>
+#include <ranges>
+#include <vector>
+
+int main()
+{
+  std::vector<int> input(16);
+  eve::algo::iota(input, 0);
+  std::cout << "Input vector:\n  " << tts::as_string(input) << "\n\n";
+
+  auto func = [](eve::wide<int> e) {
+    return kumi::make_tuple(-e, e % 2 == 0);
+  };
+
+  std::vector<int> output_big(42);
+  auto end_big = eve::algo::transform_copy_if(input, output_big, func);
+  std::cout << "Output (opposites of even numbers):\n  "
+            << tts::as_string(std::ranges::subrange(output_big.begin(), end_big))
+            << "\n\n";
+
+  std::vector<unsigned char> output_small(5);
+  auto end_small = eve::algo::transform_copy_if(input, output_small, func);
+  std::cout << "Output on a range too small to hold all the results,\nwith conversion to unsigned char:\n  "
+            << tts::as_string(std::ranges::subrange(output_small.begin(), end_small))
+            << std::endl;
+
+  return 0;
+}

--- a/test/doc/algo/transform_copy_if.cpp
+++ b/test/doc/algo/transform_copy_if.cpp
@@ -2,7 +2,6 @@
 #include <eve/module/algo.hpp>
 #include <tts/tts.hpp>
 #include <iostream>
-#include <ranges>
 #include <vector>
 
 int main()
@@ -11,20 +10,20 @@ int main()
   eve::algo::iota(input, 0);
   std::cout << "Input vector:\n  " << tts::as_string(input) << "\n\n";
 
-  auto func = [](eve::wide<int> e) {
-    return kumi::make_tuple(-e, e % 2 == 0);
+  auto func = [](eve::like<int> auto x) {
+    return kumi::make_tuple(-x, eve::is_even(x));
   };
 
   std::vector<int> output_big(42);
-  auto end_big = eve::algo::transform_copy_if(input, output_big, func);
+  output_big.erase(eve::algo::transform_copy_if(input, output_big, func), output_big.end());
   std::cout << "Output (opposites of even numbers):\n  "
-            << tts::as_string(std::ranges::subrange(output_big.begin(), end_big))
+            << tts::as_string(output_big)
             << "\n\n";
 
   std::vector<unsigned char> output_small(5);
-  auto end_small = eve::algo::transform_copy_if(input, output_small, func);
+  output_small.erase(eve::algo::transform_copy_if(input, output_small, func), output_small.end());
   std::cout << "Output on a range too small to hold all the results,\nwith conversion to unsigned char:\n  "
-            << tts::as_string(std::ranges::subrange(output_small.begin(), end_small))
+            << tts::as_string(output_small)
             << std::endl;
 
   return 0;

--- a/test/unit/module/algo/algorithm/copy_if_generic.cpp
+++ b/test/unit/module/algo/algorithm/copy_if_generic.cpp
@@ -11,8 +11,9 @@
 template <typename TraitsSupport>
 struct copy_if_ignore_op_ : TraitsSupport
 {
-  auto operator()(auto&& in, auto&& out, auto, auto p)
+  auto operator()(auto&& in, auto&& out, auto func)
   {
+    auto p = [&](auto x) { return get<1>(func(x)); };
     return eve::algo::copy_if(in, out, p);
   }
 };

--- a/test/unit/module/algo/algorithm/copy_if_generic.cpp
+++ b/test/unit/module/algo/algorithm/copy_if_generic.cpp
@@ -16,7 +16,7 @@ struct copy_if_ignore_op_ : TraitsSupport
     return eve::algo::copy_if(in, out, p);
   }
 };
-auto copy_if_ignore_op = eve::algo::function_with_traits<copy_if_ignore_op_>;
+auto copy_if_ignore_op = eve::algo::function_with_traits<copy_if_ignore_op_>[eve::algo::copy_if.get_traits()];
 
 TTS_CASE_TPL("Check copy_if", algo_test::selected_types)
 <typename T>(tts::type<T>)

--- a/test/unit/module/algo/algorithm/copy_if_generic.cpp
+++ b/test/unit/module/algo/algorithm/copy_if_generic.cpp
@@ -14,7 +14,7 @@ struct copy_if_ignore_op_ : TraitsSupport
   auto operator()(auto&& in, auto&& out, auto func)
   {
     auto p = [&](auto x) { return get<1>(func(x)); };
-    return eve::algo::copy_if(in, out, p);
+    return eve::algo::copy_if[TraitsSupport::get_traits()](in, out, p);
   }
 };
 auto copy_if_ignore_op = eve::algo::function_with_traits<copy_if_ignore_op_>[eve::algo::copy_if.get_traits()];

--- a/test/unit/module/algo/algorithm/copy_if_generic.cpp
+++ b/test/unit/module/algo/algorithm/copy_if_generic.cpp
@@ -6,10 +6,21 @@
 **/
 //==================================================================================================
 
-#include "copy_if_generic_test.hpp"
+#include "transform_copy_if_generic_test.hpp"
+
+template <typename TraitsSupport>
+struct copy_if_ignore_op_ : TraitsSupport
+{
+  auto operator()(auto&& in, auto&& out, auto, auto p)
+  {
+    return eve::algo::copy_if(in, out, p);
+  }
+};
+auto copy_if_ignore_op = eve::algo::function_with_traits<copy_if_ignore_op_>;
 
 TTS_CASE_TPL("Check copy_if", algo_test::selected_types)
 <typename T>(tts::type<T>)
 {
-  algo_test::copy_if_generic_test(eve::as<T>{}, eve::algo::copy_if);
+  auto id = [](auto x) { return x; };
+  algo_test::transform_copy_if_generic_test(eve::as<T>{}, copy_if_ignore_op, id);
 };

--- a/test/unit/module/algo/algorithm/transform_copy_if_generic.cpp
+++ b/test/unit/module/algo/algorithm/transform_copy_if_generic.cpp
@@ -1,0 +1,16 @@
+//==================================================================================================
+/**
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+**/
+//==================================================================================================
+
+#include "transform_copy_if_generic_test.hpp"
+
+TTS_CASE_TPL("Check transform_copy_if", algo_test::selected_types)
+<typename T>(tts::type<T>)
+{
+  auto op = [](auto x) { return x + x; };
+  algo_test::transform_copy_if_generic_test(eve::as<T>{}, eve::algo::transform_copy_if, op);
+};

--- a/test/unit/module/algo/algorithm/transform_copy_if_generic_test.hpp
+++ b/test/unit/module/algo/algorithm/transform_copy_if_generic_test.hpp
@@ -43,16 +43,18 @@ template<typename Algo, typename Op, typename T> struct transform_copy_if_ptr_te
 
     auto p = [](auto x) { return x != 0; };
 
+    auto func = [&](auto x) { return kumi::make_tuple(op(x), p(x)); };
+
     std::copy_if(eve::unalign(rng.begin()), eve::unalign(rng.end()), std::back_inserter(buf1), p);
     std::transform(eve::unalign(buf1.begin()), eve::unalign(buf1.end()), buf1.begin(), op);
 
-    buf2.erase(alg(rng, buf2, op, p), buf2.end());
+    buf2.erase(alg(rng, buf2, func), buf2.end());
     TTS_EQUAL(buf1, buf2, REQUIRED);
 
     if( buf2.empty() ) return;
 
     buf2.pop_back();
-    auto end1 = alg(rng, buf2, op, p);
+    auto end1 = alg(rng, buf2, func);
 
     TTS_EQUAL(buf2.end() - end1, 0, REQUIRED);
 


### PR DESCRIPTION
Implementation of #1817 (partially, no in-place version yet) 

Ended up not migrating `copy_if` and similar functions since `transform_copy_if` uses `compress_store` instead of `compress_copy`.

Wrote some documentation and moved the tests for `copy_if` to `transform_copy_if` as per Denis' advice.

I wonder if the name is alright, since it sort of implies that the function acts like `transform` followed by `copy_if` but it's actually more like the opposite, `copy_if` followed by `transform`.

Tried *roughly* measuring the performance and it seems to be faster than `eve::algo::copy_if` and `eve::algo::transform_to` separately but slower than `std::copy_if` followed by `std::transform`. I don't really know how to properly benchmark things though. Also, maybe the in-place version will be faster?