### PR TITLE
In-place versions of copy_if and transform_copy_if

### DIFF
--- a/include/eve/module/algo.hpp
+++ b/include/eve/module/algo.hpp
@@ -39,6 +39,7 @@
 #include <eve/module/algo/algo/inclusive_scan.hpp>
 #include <eve/module/algo/algo/iota.hpp>
 #include <eve/module/algo/algo/iterator_helpers.hpp>
+#include <eve/module/algo/algo/keep_if.hpp>
 #include <eve/module/algo/algo/max_element.hpp>
 #include <eve/module/algo/algo/max_value.hpp>
 #include <eve/module/algo/algo/min_element.hpp>
@@ -56,6 +57,7 @@
 #include <eve/module/algo/algo/traits.hpp>
 #include <eve/module/algo/algo/transform.hpp>
 #include <eve/module/algo/algo/transform_copy_if.hpp>
+#include <eve/module/algo/algo/transform_keep_if.hpp>
 #include <eve/module/algo/algo/transform_reduce.hpp>
 #include <eve/module/algo/algo/two_stage_iteration.hpp>
 #include <eve/module/algo/views/backward.hpp>

--- a/include/eve/module/algo/algo/copy_if.hpp
+++ b/include/eve/module/algo/algo/copy_if.hpp
@@ -139,6 +139,9 @@ template<typename TraitsSupport> struct copy_if_ : TraitsSupport
 //!
 //!    relaxed_iterator past the last written element.
 //!
+//!   @see `keep_if`
+//!   @see `remove_if`
+//!   @see `transform_keep_if`
 //!   @see `transform_copy_if`
 //!
 //! @}

--- a/include/eve/module/algo/algo/keep_if.hpp
+++ b/include/eve/module/algo/algo/keep_if.hpp
@@ -108,6 +108,7 @@ namespace eve::algo
   //!   @see `copy_if`
   //!   @see `remove_if`
   //!   @see `transform_keep_if`
+  //!   @see `transform_copy_if`
   //!
   //! @}
   //================================================================================================

--- a/include/eve/module/algo/algo/keep_if.hpp
+++ b/include/eve/module/algo/algo/keep_if.hpp
@@ -15,13 +15,12 @@
 #include <eve/module/algo/algo/preprocess_range.hpp>
 #include <eve/module/algo/algo/traits.hpp>
 
-
 #include <array>
 
 namespace eve::algo
 {
   template <typename TraitsSupport>
-  struct remove_if_ : TraitsSupport
+  struct keep_if_ : TraitsSupport
   {
     template <typename UnalignedI, typename P>
     struct delegate
@@ -30,10 +29,10 @@ namespace eve::algo
 
       EVE_FORCEINLINE bool step(auto it, eve::relative_conditional_expr auto ignore, auto /*idx*/)
       {
-        auto loaded = eve::load[ignore](it);
-        auto mask   = !p(loaded); // we decied that ! can be optimized well enough
-        auto density   = density_for_compress_copy<typename TraitsSupport::traits_type>();
-        out            = compress_copy[unsafe][density][ignore](it, loaded, mask, out);
+        auto loaded  = eve::load[ignore](it);
+        auto mask    = p(loaded);
+        auto density = density_for_compress_copy<typename TraitsSupport::traits_type>();
+        out          = compress_copy[unsafe][density][ignore](it, loaded, mask, out);
         return false;
       }
 
@@ -66,8 +65,8 @@ namespace eve::algo
   //================================================================================================
   //! @addtogroup algos
   //! @{
-  //!  @var remove_if
-  //!  @brief SIMD version of std::remove_if
+  //!   @var keep_if
+  //!   @brief In-place version of `eve::algo::copy_if`
   //!
   //!   **Defined in Header**
   //!
@@ -75,39 +74,38 @@ namespace eve::algo
   //!   #include <eve/module/algo.hpp>
   //!   @endcode
   //!
-  //!   TODO: docs
+  //!   Takes values that pass the predicate, and copies them to the beginning of the range.
+  //!   Values past the returned sentinel are to be considered garbage.
   //!
-  //!   @see keep_if
+  //!   Acts like an in-place version of `::copy_if`, or an eager version of filter.
   //!
-  //! @}
-  //================================================================================================
-  inline constexpr auto remove_if = function_with_traits<remove_if_>[no_traits];
-
-  template <typename TraitsSupport>
-  struct remove_ : TraitsSupport
-  {
-    template <relaxed_range Rng, typename T>
-    EVE_FORCEINLINE auto operator()(Rng&& rng, T v) const
-    {
-      return remove_if[TraitsSupport::get_traits()](EVE_FWD(rng), equal_to{v});
-    }
-  };
-
- //================================================================================================
-  //! @addtogroup algos
-  //! @{
-  //!  @var remove
-  //!  @brief SIMD version of std::remove
+  //!   **Tuning**
   //!
-  //!   **Defined in Header**
+  //!   `::dense_output`/`::sparse_output`: if you expect very sparse output (one or two `true`s per register),
+  //!   you can call `::keep_if[::sparse_output](...)` to optimize for that scenario.
   //!
+  //!   @groupheader{Callable Signatures}
+  //!   
   //!   @code
-  //!   #include <eve/module/algo.hpp>
+  //!   {
+  //!     template<relaxed_range Rng, typename P>
+  //!     auto keep_if(Rng&& rng, P p) -> unaligned_iterator_t<Rng>
+  //!   }
   //!   @endcode
   //!
-  //!   TODO: docs
+  //!   **Parameters**
+  //!
+  //!    * `rng`: Range to modify
+  //!    * `p`: SIMD predicate over elements of `rng`
+  //!
+  //!   **Return value**
+  //!
+  //!   Iterator past the last written element.
+  //!
+  //!   @see `copy_if`
+  //!   @see `remove_if`
   //!
   //! @}
   //================================================================================================
-  inline constexpr auto remove = function_with_traits<remove_>[no_traits];
+  inline constexpr auto keep_if = function_with_traits<keep_if_>[no_traits];
 }

--- a/include/eve/module/algo/algo/keep_if.hpp
+++ b/include/eve/module/algo/algo/keep_if.hpp
@@ -66,7 +66,7 @@ namespace eve::algo
   //! @addtogroup algos
   //! @{
   //!   @var keep_if
-  //!   @brief In-place version of `eve::algo::copy_if`
+  //!   @brief In-place version of `std::copy_if`
   //!
   //!   **Defined in Header**
   //!
@@ -77,7 +77,10 @@ namespace eve::algo
   //!   Takes values that pass the predicate, and copies them to the beginning of the range.
   //!   Values past the returned sentinel are to be considered garbage.
   //!
-  //!   Acts like an in-place version of `::copy_if`, or an eager version of filter.
+  //!   Acts like an eager version of filter, or an in-place version of `std::copy_if`:
+  //!   @code
+  //!   std::copy_if(r.begin(), r.end(), r.begin(), predicate);
+  //!   @endcode
   //!
   //!   @note
   //!   If you need to apply a transformation, you can use `eve::algo::views::map` or `eve::algo::transform_keep_if`.

--- a/include/eve/module/algo/algo/keep_if.hpp
+++ b/include/eve/module/algo/algo/keep_if.hpp
@@ -79,6 +79,9 @@ namespace eve::algo
   //!
   //!   Acts like an in-place version of `::copy_if`, or an eager version of filter.
   //!
+  //!   @note
+  //!   If you need to apply a transformation, you can use `eve::algo::views::map` or `eve::algo::transform_keep_if`.
+  //!
   //!   **Tuning**
   //!
   //!   `::dense_output`/`::sparse_output`: if you expect very sparse output (one or two `true`s per register),
@@ -104,6 +107,7 @@ namespace eve::algo
   //!
   //!   @see `copy_if`
   //!   @see `remove_if`
+  //!   @see `transform_keep_if`
   //!
   //! @}
   //================================================================================================

--- a/include/eve/module/algo/algo/remove.hpp
+++ b/include/eve/module/algo/algo/remove.hpp
@@ -78,6 +78,9 @@ namespace eve::algo
   //!   TODO: docs
   //!
   //!   @see keep_if
+  //!   @see copy_if
+  //!   @see transform_keep_if
+  //!   @see transform_copy_if
   //!
   //! @}
   //================================================================================================

--- a/include/eve/module/algo/algo/transform_copy_if.hpp
+++ b/include/eve/module/algo/algo/transform_copy_if.hpp
@@ -143,8 +143,10 @@ namespace eve::algo
   //!
   //!   @godbolt{doc/algo/transform_copy_if.cpp}
   //!
-  //!   @see `transform_keep_if`
+  //!   @see `keep_if`
   //!   @see `copy_if`
+  //!   @see `remove_if`
+  //!   @see `transform_keep_if`
   //!   @see `transform_to`
   //!   @see `views::map`
   //!

--- a/include/eve/module/algo/algo/transform_copy_if.hpp
+++ b/include/eve/module/algo/algo/transform_copy_if.hpp
@@ -107,6 +107,9 @@ namespace eve::algo
   //!   @note
   //!   If the scalar operation is cheap enough, `::copy_if` + `views::map` might be slightly faster.
   //!
+  //!   @note
+  //!   For an in-place version, see `::transform_keep_if`.
+  //!
   //!   Conditionally copies values from an input range to an output range,
   //!   transforming them in the process.
   //!
@@ -140,6 +143,7 @@ namespace eve::algo
   //!
   //!   @godbolt{doc/algo/transform_copy_if.cpp}
   //!
+  //!   @see `transform_keep_if`
   //!   @see `copy_if`
   //!   @see `transform_to`
   //!   @see `views::map`

--- a/include/eve/module/algo/algo/transform_keep_if.hpp
+++ b/include/eve/module/algo/algo/transform_keep_if.hpp
@@ -101,6 +101,8 @@ namespace eve::algo
   //!   Iterator past the last written element.
   //!
   //!   @see `keep_if`
+  //!   @see `copy_if`
+  //!   @see `remove_if`
   //!   @see `transform_copy_if`
   //!   @see `transform_inplace`
   //!   @see `views::map`

--- a/include/eve/module/algo/algo/transform_keep_if.hpp
+++ b/include/eve/module/algo/algo/transform_keep_if.hpp
@@ -15,25 +15,23 @@
 #include <eve/module/algo/algo/preprocess_range.hpp>
 #include <eve/module/algo/algo/traits.hpp>
 
-
 #include <array>
 
 namespace eve::algo
 {
   template <typename TraitsSupport>
-  struct remove_if_ : TraitsSupport
+  struct transform_keep_if_ : TraitsSupport
   {
-    template <typename UnalignedI, typename P>
+    template <typename UnalignedI, typename Func>
     struct delegate
     {
-      explicit delegate(UnalignedI out, P p) : out(out), p(p) {}
+      explicit delegate(UnalignedI out, Func func) : out(out), func(func) {}
 
       EVE_FORCEINLINE bool step(auto it, eve::relative_conditional_expr auto ignore, auto /*idx*/)
       {
-        auto loaded = eve::load[ignore](it);
-        auto mask   = !p(loaded); // we decied that ! can be optimized well enough
-        auto density   = density_for_compress_copy<typename TraitsSupport::traits_type>();
-        out            = compress_copy[unsafe][density][ignore](it, loaded, mask, out);
+        auto loaded       = eve::load[ignore](it);
+        auto [vals, mask] = func(loaded);
+        out               = compress_store[unsafe][ignore](vals, mask, out);
         return false;
       }
 
@@ -45,11 +43,11 @@ namespace eve::algo
       }
 
       UnalignedI out;
-      P p;
+      Func func;
     };
 
-    template <relaxed_range Rng, typename P>
-    EVE_FORCEINLINE auto operator()(Rng&& rng, P p) const
+    template <relaxed_range Rng, typename Func>
+    EVE_FORCEINLINE auto operator()(Rng&& rng, Func func) const
     {
       if (rng.begin() == rng.end()) return unalign(rng.begin());
 
@@ -57,7 +55,7 @@ namespace eve::algo
 
       auto iteration = algo::for_each_iteration(processed.traits(), processed.begin(), processed.end());
       auto out = iteration.base;
-      delegate<unaligned_t<decltype(out)>, P> d{unalign(out), p};
+      delegate<unaligned_t<decltype(out)>, Func> d{unalign(out), func};
       iteration(d);
       return unalign(rng.begin()) + (d.out - processed.begin());
     }
@@ -66,8 +64,8 @@ namespace eve::algo
   //================================================================================================
   //! @addtogroup algos
   //! @{
-  //!  @var remove_if
-  //!  @brief SIMD version of std::remove_if
+  //!   @var transform_keep_if
+  //!   @brief In-place version of `eve::algo::transform_copy_if`
   //!
   //!   **Defined in Header**
   //!
@@ -75,39 +73,35 @@ namespace eve::algo
   //!   #include <eve/module/algo.hpp>
   //!   @endcode
   //!
-  //!   TODO: docs
+  //!   Transforms the range but only keeps the elements that pass a certain predicate.
   //!
-  //!   @see keep_if
+  //!   @note See `::transform_copy_if` and `::keep_if` for more details.
   //!
-  //! @}
-  //================================================================================================
-  inline constexpr auto remove_if = function_with_traits<remove_if_>[no_traits];
-
-  template <typename TraitsSupport>
-  struct remove_ : TraitsSupport
-  {
-    template <relaxed_range Rng, typename T>
-    EVE_FORCEINLINE auto operator()(Rng&& rng, T v) const
-    {
-      return remove_if[TraitsSupport::get_traits()](EVE_FWD(rng), equal_to{v});
-    }
-  };
-
- //================================================================================================
-  //! @addtogroup algos
-  //! @{
-  //!  @var remove
-  //!  @brief SIMD version of std::remove
-  //!
-  //!   **Defined in Header**
-  //!
+  //!   @groupheader{Callable Signatures}
+  //!   
   //!   @code
-  //!   #include <eve/module/algo.hpp>
+  //!   {
+  //!     template<relaxed_range Rng, typename Func>
+  //!     auto transform_keep_if(Rng&& rng, Func func) -> unaligned_iterator_t<Rng>
+  //!   }
   //!   @endcode
   //!
-  //!   TODO: docs
+  //!   **Parameters**
+  //!
+  //!    * `rng`: Range to modify
+  //!    * `func`: Function that takes elements from `rng` as SIMD registers and returns a pair of:
+  //!        - the transformed values
+  //!        - a logical mask
+  //!
+  //!   **Return value**
+  //!
+  //!   Iterator past the last written element.
+  //!
+  //!   @see `keep_if`
+  //!   @see `transform_copy_if`
+  //!   @see `transform_inplace`
   //!
   //! @}
   //================================================================================================
-  inline constexpr auto remove = function_with_traits<remove_>[no_traits];
+  inline constexpr auto transform_keep_if = function_with_traits<transform_keep_if_>[no_traits];
 }

--- a/include/eve/module/algo/algo/transform_keep_if.hpp
+++ b/include/eve/module/algo/algo/transform_keep_if.hpp
@@ -73,7 +73,9 @@ namespace eve::algo
   //!   #include <eve/module/algo.hpp>
   //!   @endcode
   //!
-  //!   Transforms the range but only keeps the elements that pass a certain predicate.
+  //!   Conditionally copies values that pass a predicate to the beginning of the range,
+  //!   transforming them in the process.
+  //!   Values past the returned sentinel are to be considered garbage.
   //!
   //!   @note
   //!   If the scalar operation is cheap enough, `::keep_if` + `views::map` might be slightly faster.

--- a/include/eve/module/algo/algo/transform_keep_if.hpp
+++ b/include/eve/module/algo/algo/transform_keep_if.hpp
@@ -75,6 +75,9 @@ namespace eve::algo
   //!
   //!   Transforms the range but only keeps the elements that pass a certain predicate.
   //!
+  //!   @note
+  //!   If the scalar operation is cheap enough, `::keep_if` + `views::map` might be slightly faster.
+  //!
   //!   @note See `::transform_copy_if` and `::keep_if` for more details.
   //!
   //!   @groupheader{Callable Signatures}
@@ -100,6 +103,7 @@ namespace eve::algo
   //!   @see `keep_if`
   //!   @see `transform_copy_if`
   //!   @see `transform_inplace`
+  //!   @see `views::map`
   //!
   //! @}
   //================================================================================================

--- a/test/doc/algo/keep_if.cpp
+++ b/test/doc/algo/keep_if.cpp
@@ -1,0 +1,27 @@
+//==================================================================================================
+/**
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+**/
+//==================================================================================================
+
+#include <eve/module/core.hpp>
+#include <eve/module/algo.hpp>
+#include <iostream>
+#include <vector>
+#include "print.hpp"
+
+int main()
+{
+  std::vector<int> v= {1,2,3,4,5,6,7,8,9,10,11,12,13};
+
+  std::cout << " -> v                                                      = ";
+  doc_utils::print(v);
+
+  std::cout << " <- v.erase(eve::algo::keep_if(r1, eve::is_odd), v.end())  = ";
+  v.erase(eve::algo::keep_if(v, eve::is_odd), v.end());
+  doc_utils::print(v);
+
+  return 0;
+}

--- a/test/doc/algo/transform_keep_if.cpp
+++ b/test/doc/algo/transform_keep_if.cpp
@@ -1,0 +1,30 @@
+//==================================================================================================
+/**
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+**/
+//==================================================================================================
+
+#include <eve/module/core.hpp>
+#include <eve/module/algo.hpp>
+#include <tts/tts.hpp>
+#include <iostream>
+#include <vector>
+
+int main()
+{
+  std::vector<int> v(16);
+  eve::algo::iota(v, 0);
+  std::cout << "Input vector:\n  " << tts::as_string(v) << "\n\n";
+
+  auto func = [](eve::like<int> auto x) {
+    return kumi::make_tuple(-x, eve::is_even(x));
+  };
+
+  v.erase(eve::algo::transform_keep_if(v, func), v.end());
+  std::cout << "Output (opposites of even numbers):\n  "
+            << tts::as_string(v)
+            << "\n\n";
+  return 0;
+}

--- a/test/unit/module/algo/algorithm/remove.cpp
+++ b/test/unit/module/algo/algorithm/remove.cpp
@@ -6,128 +6,29 @@
 **/
 //==================================================================================================
 
-// g++ 11 regression fires __builtin_memmove spurious warnings
-// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=100516
-
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic ignored "-Wstringop-overread"
-#endif
-
 #include "unit/module/algo/algo_test.hpp"
+#include "unit/module/algo/algorithm/transform_keep_if_and_remove_generic_test.hpp"
 
 #include <eve/module/algo.hpp>
-#include <eve/memory/aligned_allocator.hpp>
 
-#include <iterator>
-#include <vector>
-
-TTS_CASE_TPL("Check remove_if basics", algo_test::selected_types)
-<typename T>(tts::type<T>)
+template<typename TraitsSupport>
+struct transform_keep_if_ignore_op_ : TraitsSupport
 {
-  using e_t = eve::element_type_t<T>;
-
-  std::vector<e_t> v(100u, e_t{15});
-
-  v[3] = v[15] = v[72] = e_t{5};
-
-  v.erase(eve::algo::remove_if[eve::algo::force_cardinal<T::size()>](v, [](auto x) { return x < 10; }), v.end());
-
-  TTS_EQUAL(v.size(), 97u);
-  TTS_EXPECT(std::all_of(v.begin(), v.end(), [](auto x) { return x > 10; }));
-};
-
-TTS_CASE_TPL("Check remove aligned_ptr", algo_test::selected_types)
-<typename T>(tts::type<T>)
-{
-  using e_t = eve::element_type_t<T>;
-  alignas(64) std::array<e_t, 23> data;
-  const e_t keep{5};
-  const e_t drop{1};
-
-  for (std::size_t i = 0; i != data.size(); ++i)
+  auto operator()(auto&& rng, auto func)
   {
-    data[i] = (i % 3) ? keep : drop;
+    auto pred = [&func](auto x) {
+      return !get<1>(func(x));
+    };
+    return eve::algo::remove_if[TraitsSupport::get_traits()](rng, pred);
   }
-
-  std::vector<e_t> expected;
-  std::remove_copy(data.begin(), data.end(), std::back_inserter(expected), drop);
-
-  auto rng = eve::algo::as_range(eve::as_aligned(data.begin()), data.end());
-  std::vector<e_t> actual{data.begin(), eve::algo::remove(rng, drop)};
-
-  TTS_EQUAL(expected, actual);
 };
-
-template <typename T, typename Algo>
-void remove_generic_test_page_ends(eve::as<T>, Algo alg)
-{
-  using e_t     = eve::element_type_t<T>;
-  using card_t  = eve::fixed<4096/ sizeof(e_t)>;
-  std::vector<e_t, eve::aligned_allocator<e_t, card_t>> page(card_t::value, e_t{0});
-
-  constexpr int elements_to_test  = std::min( int(T::size() * 10), 300);
-
-  auto f = page.data();
-  auto l = f + elements_to_test;
-
-  auto prepopulate = [&](auto it) {
-    std::fill(it, l, 0);
-
-    std::ptrdiff_t count = 0;
-
-    while (it + 1 < l) {
-      *it = 1;
-      ++count;
-      it += 2;
-    }
-
-    return count;
-  };
-
-  auto run = [&]() {
-    for (auto* it = f; it < l; ++it) {
-      std::ptrdiff_t count = prepopulate(it);
-      e_t* end = alg(eve::algo::as_range(it, l), 0);
-      TTS_EQUAL(count, (end - it));
-
-      std::vector<e_t> expected_prefix(it - f, 0);
-      TTS_EQUAL(expected_prefix, std::vector<e_t>(f, it));
-
-      std::vector<e_t> expected_suffix(count, 1);
-      TTS_EQUAL(expected_suffix, std::vector<e_t>(it, end));
-
-      *it = 0;
-
-      if (l - page.data() != static_cast<std::ptrdiff_t>(page.size())) {
-        TTS_EQUAL(*l, e_t{0});
-      }
-    }
-  };
-
-  while (f < l) {
-    run();
-    *l = 0;
-    --l;
-    *f = 0;
-    ++f;
-  }
-
-  l = page.data() + page.size();
-  f = l - elements_to_test;
-
-  // from the end
-  while (f < l) {
-    run();
-    if (l != (page.data() + page.size())) { *l = 1; }
-    --l;
-    *f = 1;
-    ++f;
-  }
-}
+auto transform_keep_if_ignore_op = eve::algo::function_with_traits<transform_keep_if_ignore_op_>[eve::algo::remove_if.get_traits()];
 
 TTS_CASE_TPL("Check remove test", algo_test::selected_types)
 <typename T>(tts::type<T>)
 {
+  auto id = [](auto x) { return x; };
+  transform_keep_if_generic_test_aligned_ptr(eve::as<T>{}, transform_keep_if_ignore_op, id);
   remove_generic_test_page_ends(eve::as<T>{}, eve::algo::remove);
   remove_generic_test_page_ends(eve::as<T>{}, eve::algo::remove[eve::algo::sparse_output]);
   if constexpr ( eve::current_api >= eve::sve)

--- a/test/unit/module/algo/algorithm/transform_keep_if_and_remove_generic_test.hpp
+++ b/test/unit/module/algo/algorithm/transform_keep_if_and_remove_generic_test.hpp
@@ -1,0 +1,128 @@
+//==================================================================================================
+/**
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+**/
+//==================================================================================================
+
+// g++ 11 regression fires __builtin_memmove spurious warnings
+// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=100516
+
+#include "eve/module/core/regular/is_not_equal.hpp"
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic ignored "-Wstringop-overread"
+#endif
+
+#include <eve/module/algo.hpp>
+#include <eve/memory/aligned_allocator.hpp>
+
+#include <iterator>
+#include <vector>
+
+template <typename T, typename Algo, typename Op>
+void transform_keep_if_generic_test_aligned_ptr(eve::as<T>, Algo alg, Op op)
+{
+  using e_t = eve::element_type_t<T>;
+  alignas(64) std::array<e_t, 23> data;
+  const e_t keep{5};
+  const e_t drop{1};
+
+  for (std::size_t i = 0; i != data.size(); ++i)
+  {
+    data[i] = (i % 3) ? keep : drop;
+  }
+
+  std::vector<e_t> expected;
+  std::remove_copy(data.begin(), data.end(), std::back_inserter(expected), drop);
+  std::transform(expected.begin(), expected.end(), expected.begin(), op);
+
+  auto rng = eve::algo::as_range(eve::as_aligned(data.begin()), data.end());
+  auto func = [drop, &op](auto x) {
+    return kumi::make_tuple(op(x), eve::is_not_equal(drop, x));
+  };
+  std::vector<e_t> actual{data.begin(), alg(rng, func)};
+
+  TTS_EQUAL(expected, actual);
+};
+
+template <typename T, typename Algo>
+void remove_generic_test_page_ends(eve::as<T>, Algo alg)
+{
+  using e_t     = eve::element_type_t<T>;
+  using card_t  = eve::fixed<4096/ sizeof(e_t)>;
+  std::vector<e_t, eve::aligned_allocator<e_t, card_t>> page(card_t::value, e_t{0});
+
+  constexpr int elements_to_test  = std::min( int(T::size() * 10), 300);
+
+  auto f = page.data();
+  auto l = f + elements_to_test;
+
+  auto prepopulate = [&](auto it) {
+    std::fill(it, l, 0);
+
+    std::ptrdiff_t count = 0;
+
+    while (it + 1 < l) {
+      *it = 1;
+      ++count;
+      it += 2;
+    }
+
+    return count;
+  };
+
+  auto run = [&]() {
+    for (auto* it = f; it < l; ++it) {
+      std::ptrdiff_t count = prepopulate(it);
+      e_t* end = alg(eve::algo::as_range(it, l), 0);
+      TTS_EQUAL(count, (end - it));
+
+      std::vector<e_t> expected_prefix(it - f, 0);
+      TTS_EQUAL(expected_prefix, std::vector<e_t>(f, it));
+
+      std::vector<e_t> expected_suffix(count, 1);
+      TTS_EQUAL(expected_suffix, std::vector<e_t>(it, end));
+
+      *it = 0;
+
+      if (l - page.data() != static_cast<std::ptrdiff_t>(page.size())) {
+        TTS_EQUAL(*l, e_t{0});
+      }
+    }
+  };
+
+  while (f < l) {
+    run();
+    *l = 0;
+    --l;
+    *f = 0;
+    ++f;
+  }
+
+  l = page.data() + page.size();
+  f = l - elements_to_test;
+
+  // from the end
+  while (f < l) {
+    run();
+    if (l != (page.data() + page.size())) { *l = 1; }
+    --l;
+    *f = 1;
+    ++f;
+  }
+}
+
+// TTS_CASE_TPL("Check remove test", algo_test::selected_types)
+// <typename T>(tts::type<T>)
+// {
+  // remove_generic_test_page_ends(eve::as<T>{}, eve::algo::remove);
+  // remove_generic_test_page_ends(eve::as<T>{}, eve::algo::remove[eve::algo::sparse_output]);
+  // if constexpr ( eve::current_api >= eve::sve)
+  //   return;
+  // else
+  // {
+  //   remove_generic_test_page_ends(eve::as<T>{}, eve::algo::remove[eve::algo::unroll<3>]);
+  //   remove_generic_test_page_ends(eve::as<T>{}, eve::algo::remove[eve::algo::force_cardinal<T::size()>]);
+  // }
+// };

--- a/test/unit/module/algo/algorithm/transform_keep_if_and_remove_generic_test.hpp
+++ b/test/unit/module/algo/algorithm/transform_keep_if_and_remove_generic_test.hpp
@@ -112,17 +112,3 @@ void remove_generic_test_page_ends(eve::as<T>, Algo alg)
     ++f;
   }
 }
-
-// TTS_CASE_TPL("Check remove test", algo_test::selected_types)
-// <typename T>(tts::type<T>)
-// {
-  // remove_generic_test_page_ends(eve::as<T>{}, eve::algo::remove);
-  // remove_generic_test_page_ends(eve::as<T>{}, eve::algo::remove[eve::algo::sparse_output]);
-  // if constexpr ( eve::current_api >= eve::sve)
-  //   return;
-  // else
-  // {
-  //   remove_generic_test_page_ends(eve::as<T>{}, eve::algo::remove[eve::algo::unroll<3>]);
-  //   remove_generic_test_page_ends(eve::as<T>{}, eve::algo::remove[eve::algo::force_cardinal<T::size()>]);
-  // }
-// };

--- a/test/unit/module/algo/algorithm/transform_keep_if_generic.cpp
+++ b/test/unit/module/algo/algorithm/transform_keep_if_generic.cpp
@@ -1,0 +1,40 @@
+//==================================================================================================
+/**
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+**/
+//==================================================================================================
+
+#include "unit/module/algo/algo_test.hpp"
+#include "unit/module/algo/algorithm/transform_keep_if_and_remove_generic_test.hpp"
+
+#include <eve/module/algo.hpp>
+
+template<typename TraitsSupport>
+struct remove_ : TraitsSupport
+{
+  auto operator()(auto&& rng, auto to_remove)
+  {
+    auto func = [to_remove](auto x) {
+      return kumi::make_tuple(x, eve::is_not_equal(x, to_remove));
+    };
+    return eve::algo::transform_keep_if[TraitsSupport::get_traits()](rng, func);
+  }
+};
+auto transform_keep_if_as_remove = eve::algo::function_with_traits<remove_>[eve::algo::transform_keep_if.get_traits()];
+
+TTS_CASE_TPL("Check transform_keep_if", algo_test::selected_types)
+<typename T>(tts::type<T>)
+{
+  auto op = [](auto x) { return x + x; };
+  transform_keep_if_generic_test_aligned_ptr(eve::as<T>{}, eve::algo::transform_keep_if, op);
+  remove_generic_test_page_ends(eve::as<T>{}, transform_keep_if_as_remove);
+  if constexpr ( eve::current_api >= eve::sve)
+    return;
+  else
+  {
+    remove_generic_test_page_ends(eve::as<T>{}, transform_keep_if_as_remove[eve::algo::unroll<3>]);
+    remove_generic_test_page_ends(eve::as<T>{}, transform_keep_if_as_remove[eve::algo::force_cardinal<T::size()>]);
+  }
+};


### PR DESCRIPTION
Second part of #1817 

adds the functions `keep_if` and `transform_keep_if`.

currently repeats a lot of code between `transform_keep_if`, `keep_if` and `remove_if`. it might be possible to define `remove_if` in terms of `keep_if`, as it looks like compilers (at least from a (very) quick glance on godbolt) may be able to inline everything correctly.

tests are a bit messy, i wasn't sure if it's better to do it this way or to separate the header into two separate files