### PR TITLE
Add fall-through checks to if-constexpr chains

### DIFF
--- a/include/eve/detail/meta.hpp
+++ b/include/eve/detail/meta.hpp
@@ -15,6 +15,8 @@
 #include <cstdint>
 #include <cstddef>
 
+#define EVE_UNREACHABLE() []<bool c=false>(){static_assert(c, "[EVE] Fallthrough rejected");}()
+
 namespace eve::detail
 {
   // Values list helper

--- a/include/eve/module/core/regular/impl/simd/arm/neon/abs.hpp
+++ b/include/eve/module/core/regular/impl/simd/arm/neon/abs.hpp
@@ -40,7 +40,9 @@ namespace eve::detail
       {
         if      constexpr( cat == category::float64x2 ) return vabsq_f64(v);
         else if constexpr( cat == category::float64x1 ) return vabs_f64(v);
+        else    EVE_UNREACHABLE();
       }
+      else      EVE_UNREACHABLE();
     }
   }
 }

--- a/include/eve/module/core/regular/impl/simd/arm/neon/average.hpp
+++ b/include/eve/module/core/regular/impl/simd/arm/neon/average.hpp
@@ -45,5 +45,6 @@ requires arm_abi<abi_t<T, N>>
   else if constexpr( cat == category::uint32x2 ) return vhadd_u32(v0, v1);
   else if constexpr( cat == category::uint16x4 ) return vhadd_u16(v0, v1);
   else if constexpr( cat == category::uint8x8 ) return vhadd_u8(v0, v1);
+  else    EVE_UNREACHABLE();
 }
 }

--- a/include/eve/module/core/regular/impl/simd/arm/neon/bit_andnot.hpp
+++ b/include/eve/module/core/regular/impl/simd/arm/neon/bit_andnot.hpp
@@ -48,6 +48,8 @@ requires arm_abi<abi_t<T, N>>
       return vreinterpret_f64_u64(vbic_u64(vreinterpret_u64_f64(v0), vreinterpret_u64_f64(v1)));
     else if constexpr( cat == category::float64x2 )
       return vreinterpretq_f64_u64(vbicq_u64(vreinterpretq_u64_f64(v0), vreinterpretq_u64_f64(v1)));
+    else     EVE_UNREACHABLE();
   }
+  else       EVE_UNREACHABLE();
 }
 }

--- a/include/eve/module/core/regular/impl/simd/arm/neon/bit_notand.hpp
+++ b/include/eve/module/core/regular/impl/simd/arm/neon/bit_notand.hpp
@@ -48,6 +48,8 @@ requires arm_abi<abi_t<T, N>>
       return vreinterpret_f64_u64(vbic_u64(vreinterpret_u64_f64(v1), vreinterpret_u64_f64(v0)));
     else if constexpr( cat == category::float64x2 )
       return vreinterpretq_f64_u64(vbicq_u64(vreinterpretq_u64_f64(v1), vreinterpretq_u64_f64(v0)));
+    else     EVE_UNREACHABLE();
   }
+  else       EVE_UNREACHABLE();
 }
 }

--- a/include/eve/module/core/regular/impl/simd/arm/neon/bit_notor.hpp
+++ b/include/eve/module/core/regular/impl/simd/arm/neon/bit_notor.hpp
@@ -48,6 +48,8 @@ requires arm_abi<abi_t<T, N>>
       return vreinterpret_f64_u64(vorn_u64(vreinterpret_u64_f64(v1), vreinterpret_u64_f64(v0)));
     else if constexpr( cat == category::float64x2 )
       return vreinterpretq_f64_u64(vornq_u64(vreinterpretq_u64_f64(v1), vreinterpretq_u64_f64(v0)));
+    else     EVE_UNREACHABLE();
   }
+  else       EVE_UNREACHABLE();
 }
 }

--- a/include/eve/module/core/regular/impl/simd/arm/neon/bit_ornot.hpp
+++ b/include/eve/module/core/regular/impl/simd/arm/neon/bit_ornot.hpp
@@ -46,6 +46,8 @@ requires arm_abi<abi_t<T, N>>
       return vreinterpret_f64_u64(vorn_u64(vreinterpret_u64_f64(v0), vreinterpret_u64_f64(v1)));
     else if constexpr( cat == category::float64x2 )
       return vreinterpretq_f64_u64(vornq_u64(vreinterpretq_u64_f64(v0), vreinterpretq_u64_f64(v1)));
+    else     EVE_UNREACHABLE();
   }
+  else       EVE_UNREACHABLE();
 }
 }

--- a/include/eve/module/core/regular/impl/simd/arm/neon/bit_select.hpp
+++ b/include/eve/module/core/regular/impl/simd/arm/neon/bit_select.hpp
@@ -43,5 +43,6 @@ namespace eve::detail
     else if constexpr( cat == category::uint32x4  ) return vbslq_u32(m, v0, v1);
     else if constexpr( cat == category::uint16x8  ) return vbslq_u16(m, v0, v1);
     else if constexpr( cat == category::uint8x16  ) return vbslq_u8(m, v0, v1);
+    else                                                   EVE_UNREACHABLE();
   }
 }

--- a/include/eve/module/core/regular/impl/simd/arm/neon/convert.hpp
+++ b/include/eve/module/core/regular/impl/simd/arm/neon/convert.hpp
@@ -36,6 +36,7 @@ EVE_FORCEINLINE wide<U, N>
   else if constexpr( c_i == category::float64x2 && c_o == category::int32x2   ) return vmovn_s64(vcvtq_s64_f64(v));
   else if constexpr( c_i == category::float64x2 && c_o == category::uint32x2  ) return vmovn_u64(vcvtq_u64_f64(v));
   else if constexpr( c_i == category::float64x2                               ) return convert(convert(v, as<std::int32_t>()), tgt);
+  else                                                                          EVE_UNREACHABLE();
 }
 
 //================================================================================================
@@ -62,6 +63,7 @@ EVE_FORCEINLINE wide<U, N>
     else if constexpr( sizeof(U) == 8                      ) return map(convert, v, tgt);
     else if constexpr( match(c_o, category::signed_   )    ) return convert(convert(v, t_i32), tgt);
     else if constexpr( match(c_o, category::unsigned_ )    ) return convert(convert(v, t_u32), tgt);
+    else                                                     EVE_UNREACHABLE();
   }
   else if constexpr( N {} == 4 )
   {
@@ -75,7 +77,9 @@ EVE_FORCEINLINE wide<U, N>
     else if constexpr( c_o == category::int8x8   ) return convert(convert(v, t_i16), tgt);
     else if constexpr( c_o == category::uint8x8  ) return convert(convert(v, t_u16), tgt);
     else if constexpr( sizeof(U) == 8            ) return convert_slice(v, tgt);
+    else                                           EVE_UNREACHABLE();
   }
+  else EVE_UNREACHABLE();
 }
 
 //================================================================================================

--- a/include/eve/module/core/regular/impl/simd/arm/neon/deinterleave_groups_shuffle.hpp
+++ b/include/eve/module/core/regular/impl/simd/arm/neon/deinterleave_groups_shuffle.hpp
@@ -64,6 +64,7 @@ template<typename T, typename N, std::ptrdiff_t G>
     else if constexpr( c == category::uint8x16 ) return vuzp1q_u8(v, swapped);
     else if constexpr( c == category::int8x8 ) return vuzp1_s8(v, swapped);
     else if constexpr( c == category::uint8x8 ) return vuzp1_u8(v, swapped);
+    else reject_fallthrough<T>(c);
   }
 }
 
@@ -148,6 +149,8 @@ template<typename T, typename N, std::ptrdiff_t G>
     auto s = wide_to_neon_struct(v0, v1);
     if constexpr( c == category::int8x8 ) return vtbl2_s8(s, idx);
     else if constexpr( c == category::uint8x8 ) return vtbl2_u8(s, idx);
+    else EVE_UNREACHABLE();
   }
+  else EVE_UNREACHABLE();
 }
 }

--- a/include/eve/module/core/regular/impl/simd/arm/neon/detail/shift.hpp
+++ b/include/eve/module/core/regular/impl/simd/arm/neon/detail/shift.hpp
@@ -42,6 +42,7 @@ EVE_FORCEINLINE wide<T, N>
   else if constexpr( c == category::uint16x4 ) return vshl_u16(v0, s1);
   else if constexpr( c == category::int8x8 ) return vshl_s8(v0, s1);
   else if constexpr( c == category::uint8x8 ) return vshl_u8(v0, s1);
+  else    reject_fallthrough<T>(c);
 }
 
 template<integral_scalar_value T, typename N, std::ptrdiff_t S>

--- a/include/eve/module/core/regular/impl/simd/arm/neon/lookup.hpp
+++ b/include/eve/module/core/regular/impl/simd/arm/neon/lookup.hpp
@@ -91,6 +91,10 @@ namespace eve::detail
           }
         }
       }
+      else
+      {
+        EVE_UNREACHABLE();
+      }
     }
   }
 }

--- a/include/eve/module/core/regular/impl/simd/arm/neon/max.hpp
+++ b/include/eve/module/core/regular/impl/simd/arm/neon/max.hpp
@@ -47,8 +47,10 @@ namespace eve::detail
         if constexpr( cat == category::float64x1 ) return vmax_f64(v0, v1);
         else if constexpr( cat == category::float64x2 ) return vmaxq_f64(v0, v1);
         else if constexpr( sizeof(T) == 8 ) return map(max, v0, v1);
+        else EVE_UNREACHABLE();
       }
       else if constexpr( sizeof(T) == 8 ) return map(max, v0, v1);
+      else EVE_UNREACHABLE();
     }
   }
 }

--- a/include/eve/module/core/regular/impl/simd/arm/neon/maximum.hpp
+++ b/include/eve/module/core/regular/impl/simd/arm/neon/maximum.hpp
@@ -66,6 +66,7 @@ EVE_FORCEINLINE wide<T, N>
       else if constexpr( c == category::uint16x4 ) return vpmax_u16(a, b);
       else if constexpr( c == category::int8x8 ) return vpmax_s8(a, b);
       else if constexpr( c == category::uint8x8 ) return vpmax_u8(a, b);
+      else reject_fallthrough<T>(c);
     };
 
     using type = wide<T, N>;
@@ -94,6 +95,7 @@ EVE_FORCEINLINE wide<T, N>
 
       return wide<T, N>(l, l);
     }
+    else EVE_UNREACHABLE();
   }
 }
 }

--- a/include/eve/module/core/regular/impl/simd/arm/neon/min.hpp
+++ b/include/eve/module/core/regular/impl/simd/arm/neon/min.hpp
@@ -45,8 +45,10 @@ namespace eve::detail
         if constexpr( cat == category::float64x1 ) return vmin_f64(v0, v1);
         else if constexpr( cat == category::float64x2 ) return vminq_f64(v0, v1);
         else if constexpr( sizeof(T) == 8 ) return map(min, v0, v1);
+        else    EVE_UNREACHABLE();
       }
       else if constexpr( sizeof(T) == 8 ) return map(min, v0, v1);
+      else    EVE_UNREACHABLE();
     }
   }
 }

--- a/include/eve/module/core/regular/impl/simd/arm/neon/minimum.hpp
+++ b/include/eve/module/core/regular/impl/simd/arm/neon/minimum.hpp
@@ -66,6 +66,7 @@ EVE_FORCEINLINE wide<T, N>
       else if constexpr( c == category::uint16x4 ) return vpmin_u16(a, b);
       else if constexpr( c == category::int8x8 ) return vpmin_s8(a, b);
       else if constexpr( c == category::uint8x8 ) return vpmin_u8(a, b);
+      else    EVE_UNREACHABLE();
     };
 
     using type = wide<T, N>;
@@ -94,6 +95,7 @@ EVE_FORCEINLINE wide<T, N>
 
       return wide<T, N>(l, l);
     }
+    else EVE_UNREACHABLE();
   }
 }
 }

--- a/include/eve/module/core/regular/impl/simd/arm/neon/minus.hpp
+++ b/include/eve/module/core/regular/impl/simd/arm/neon/minus.hpp
@@ -34,6 +34,8 @@ minus_(EVE_SUPPORTS(neon128_), wide<T, N> const& v) noexcept requires arm_abi<ab
   {
     if constexpr( cat == category::float64x2 ) return vnegq_f64(v);
     else if constexpr( cat == category::float64x1 ) return vneg_f64(v);
+    else    EVE_UNREACHABLE();
   }
+  else      EVE_UNREACHABLE();
 }
 }

--- a/include/eve/module/core/regular/impl/simd/arm/neon/nearest.hpp
+++ b/include/eve/module/core/regular/impl/simd/arm/neon/nearest.hpp
@@ -27,6 +27,7 @@ requires arm_abi<abi_t<T, N>>
     else if constexpr( cat == category::float64x2 ) return vrndnq_f64(v);
     else if constexpr( cat == category::float32x2 ) return vrndn_f32(v);
     else if constexpr( cat == category::float32x4 ) return vrndnq_f32(v);
+    else    EVE_UNREACHABLE();
   }
   else return map(nearest, v);
 }

--- a/include/eve/module/core/regular/impl/simd/arm/neon/rec.hpp
+++ b/include/eve/module/core/regular/impl/simd/arm/neon/rec.hpp
@@ -29,6 +29,7 @@ namespace eve::detail
       {
         if constexpr( cat == category::float64x1 ) return vrecpe_f64(v);
         else if constexpr( cat == category::float64x2 ) return vrecpeq_f64(v);
+        else    EVE_UNREACHABLE();
       }
       else
         return T {1} / v;

--- a/include/eve/module/core/regular/impl/simd/arm/neon/rsqrt.hpp
+++ b/include/eve/module/core/regular/impl/simd/arm/neon/rsqrt.hpp
@@ -29,6 +29,7 @@ namespace eve::detail
       {
         if constexpr( cat == category::float64x1 ) return vrsqrte_f64(v0);
         else if constexpr( cat == category::float64x2 ) return vrsqrteq_f64(v0);
+        else    EVE_UNREACHABLE();
       }
       else return map(rsqrt, v0);
     }
@@ -62,6 +63,7 @@ namespace eve::detail
           inv        = vmulq_f64(vrsqrtsq_f64(v0, inv * inv), inv);
           return that_t(vmulq_f64(vrsqrtsq_f64(v0, inv * inv), inv));
         }
+        else EVE_UNREACHABLE();
       }
       else return map(rsqrt, v0);
     }

--- a/include/eve/module/core/regular/impl/simd/arm/neon/sqrt.hpp
+++ b/include/eve/module/core/regular/impl/simd/arm/neon/sqrt.hpp
@@ -31,6 +31,7 @@ namespace eve::detail
       else if constexpr( cat == category::float64x1 ) return vsqrt_f64(v0);
       else if constexpr( cat == category::float64x2 ) return vsqrtq_f64(v0);
       else if constexpr( cat == category::float32x4 ) return vsqrtq_f32(v0);
+      else    EVE_UNREACHABLE();
     }
     else
     {

--- a/include/eve/module/core/regular/impl/simd/arm/neon/store.hpp
+++ b/include/eve/module/core/regular/impl/simd/arm/neon/store.hpp
@@ -48,7 +48,9 @@ store_(EVE_SUPPORTS(neon128_), wide<T, N> value, T *ptr) noexcept requires arm_a
     {
       if constexpr( cat == category::float64x1 ) vst1_f64(ptr, value);
       else if constexpr( cat == category::float64x2 ) vst1q_f64(ptr, value);
+      else    EVE_UNREACHABLE();
     }
+    else      EVE_UNREACHABLE();
   }
 }
 
@@ -88,7 +90,9 @@ store_(EVE_SUPPORTS(neon128_),
     {
       if constexpr( cat == category::float64x1 ) vst1_f64_ex(ptr, value, 64);
       else if constexpr( cat == category::float64x2 ) vst1_f64_ex(ptr, value, 128);
+      else    EVE_UNREACHABLE();
     }
+    else      EVE_UNREACHABLE();
   }
 }
 #else

--- a/include/eve/module/core/regular/impl/simd/arm/neon/trunc.hpp
+++ b/include/eve/module/core/regular/impl/simd/arm/neon/trunc.hpp
@@ -29,6 +29,7 @@ namespace eve::detail
         else if constexpr( cat == category::float64x2 ) return vrndq_f64(v);
         else if constexpr( cat == category::float32x2 ) return vrnd_f32(v);
         else if constexpr( cat == category::float32x4 ) return vrndq_f32(v);
+        else    EVE_UNREACHABLE();
       }
       else return map(trunc, v);
     }


### PR DESCRIPTION
A lof ot code in EVE is composed of `if-constexpr` chains which do not have a final `else` branch. Most of the time this is not a problem as the implicit `else` branch is never reached. However, when debugging EVE or adding new functionalities, such branches may be reached and in some cases introduce UB in the program without any compiler diagnostic.

I propose to add a new macro, `EVE_UNREACHEABLE` which raises an error using `static_assert` when reached, and use this macro in every as-of-now implicit `else` `constexpr` branch to ensure that no fall-through ever occur without the user noticing.

As an example, calling an eve function with a type no covered in its `if-constexpr` chain leads to the following code gen under GCC:
```x86asm
test():
     brk
```
Under clang, no assembly is generated as the compiler consider the caller function UB.
With the macro, the following error is raised:
```c++
error: static assertion failed: [EVE] Fallthrough rejected
   43 |         else    EVE_UNREACHABLE();
```

This implies that most of the source files should be modified to accommodate this change, this PR only applies to the neon backend as a demonstration.