### PR TITLE
Force colorized diagnostics on GCC

### DIFF
--- a/cmake/config/compiler.cmake
+++ b/cmake/config/compiler.cmake
@@ -14,7 +14,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   target_compile_options( eve_test INTERFACE -std=c++20 -Werror -Wall -Wpedantic -Wextra -fcolor-diagnostics)
 else()
-  target_compile_options( eve_test INTERFACE -std=c++20 -Werror -Wall -Wpedantic -Wextra -fdiagnostics-color=auto -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow)
+  target_compile_options( eve_test INTERFACE -std=c++20 -Werror -Wall -Wpedantic -Wextra -fdiagnostics-color=always -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow)
 endif()
 
 target_include_directories( eve_test INTERFACE


### PR DESCRIPTION
`-fdiagnostics-color=auto` doesn't enable colorized diagnostics on GCC in some scenarios. Force the colorized diagnostics using the `always` value.