### PR TITLE
shuffling emulated doubles on neon is level 0

### DIFF
--- a/include/eve/detail/shuffle_v2/simd/common/shuffle_v2_driver.hpp
+++ b/include/eve/detail/shuffle_v2/simd/common/shuffle_v2_driver.hpp
@@ -267,7 +267,13 @@ shuffle_v2_overly_large_groups(NativeSelector        selector,
   }
   else if constexpr( G == T::size() )
   {
-    auto l     = eve::index < ((I == na_) || ...) ? 1 : 0 > ;
+    // This section is not technically necessary, we could've done G <= T::size(),
+    // but it helps to simplify some code.
+    //
+    // Level: if we just shuffle, then it's 0. If we need a 0 constant - that's 1 but
+    //        not on emulated, on emulated we don't count anything.
+    constexpr bool has_zeroes = ((I == na_) || ...);
+    auto l     = eve::index < (has_zeroes && !has_emulated_abi_v<T>) ? 1 : 0 > ;
     auto get_i = [&]<std::ptrdiff_t i>(eve::index_t<i>)
     {
       if constexpr( i == na_ ) return eve::zero(eve::as<T> {});

--- a/test/unit/api/regular/shuffle_v2/shuffle_v2_driver.cpp
+++ b/test/unit/api/regular/shuffle_v2/shuffle_v2_driver.cpp
@@ -297,9 +297,18 @@ TTS_CASE_TPL("arm-v7, emulate double", tts::types<double>)
   {
     auto shuffle = eve::detail::make_shuffle_v2([] { TTS_FAIL("should not be reached"); });
     eve::wide<T> x {1, 2};
-    auto [shuffled, l] = shuffle(x, [](int i, int size) { return size - i - 1; });
-    TTS_EQUAL(l(), 0);
-    TTS_EQUAL(shuffled, (eve::wide<T> {2, 1}));
+    {
+      auto [shuffled, l] = shuffle(x, [](int i, int size) { return size - i - 1; });
+      TTS_EQUAL(l(), 0);
+      TTS_EQUAL(shuffled, (eve::wide<T> {2, 1}));
+    }
+
+    // Special case - shuffle one constant
+    {
+      auto [shuffled, l] = shuffle(x, eve::lane<2>, [](int, int) { return eve::na_; });
+      TTS_EQUAL(l(), 0);
+      TTS_EQUAL(shuffled, (eve::wide<T> {0.0, 0.0}));
+    }
   }
 };
 

--- a/test/unit/api/regular/shuffle_v2/shuffle_v2_driver_intergration.cpp
+++ b/test/unit/api/regular/shuffle_v2/shuffle_v2_driver_intergration.cpp
@@ -123,9 +123,7 @@ TTS_CASE_TPL("G >= T::size()", eve::test::simd::all_types)
   auto tst  = [call]<std::ptrdiff_t... I>(auto expected, std::ptrdiff_t expected_l, auto... args)
   {
     auto [shuffled, l] = call(args...);
-    if( eve::supports_simd ) TTS_EQUAL(l(), expected_l);
-    else TTS_EQUAL(l(), 0);
-
+    TTS_EQUAL(l(), expected_l);
     TTS_EQUAL(expected, shuffled);
   };
 
@@ -143,7 +141,7 @@ TTS_CASE_TPL("G >= T::size()", eve::test::simd::all_types)
         eve::lane<T::size() * 2>,
         eve::pattern<0, 0>);
     tst(TxTxTxT {T {1}, T {2}, T {0}, T {0}},
-        1,
+        eve::has_emulated_abi_v<T> ? 0 : 1,
         T {1},
         T {2},
         eve::lane<T::size() * 2>,
@@ -175,7 +173,7 @@ TTS_CASE_TPL("G >= T::size()", eve::test::simd::all_types)
         eve::lane<T::size() * 2>,
         eve::pattern<0, 0>);
     tst(UxUxUxU {U {1, false}, U {2, true}, U {0, false}, U {0, false}},
-        1,
+        eve::has_emulated_abi_v<T> && eve::has_emulated_abi_v<eve::wide<std::uint8_t>> ? 0 : 1,
         U {1, false},
         U {2, true},
         eve::lane<T::size() * 2>,

--- a/test/unit/api/regular/shuffle_v2/slide_left_1.cpp
+++ b/test/unit/api/regular/shuffle_v2/slide_left_1.cpp
@@ -58,7 +58,7 @@ TTS_CASE_TPL("Check slide_left, 1 arg, generic", eve::test::simd::all_types)
 <typename T>(tts::type<T>)
 {
   static constexpr std::ptrdiff_t reg_size = sizeof(eve::element_type_t<T>) * T::size();
-  if constexpr( eve::current_api <= eve::sse4_2 || eve::current_api == eve::asimd ||
+  if constexpr( eve::current_api <= eve::sse4_2 || eve::current_api >= eve::neon ||
     ( eve::current_api >= eve::avx2 && reg_size <= 32 ) ||
     ( eve::current_api >= eve::avx512 && sizeof(eve::element_type_t<T>) >= 2 ) ||
     ( eve::current_api >= eve::sve) )


### PR DESCRIPTION
Fixing the issue for slide_left for doubles on neon.

Conflict of 2 default shuffle levels + a special case: emulation is always 0, while just 1 constant is level 1.
emulation always 0 should win. 