### PR TITLE
Reinstate dec/inc integral optimisation

### DIFF
--- a/include/eve/module/core/regular/dec.hpp
+++ b/include/eve/module/core/regular/dec.hpp
@@ -11,6 +11,7 @@
 #include <eve/traits/overload.hpp>
 #include <eve/module/core/decorator/core.hpp>
 #include <eve/module/core/constant/one.hpp>
+#include <eve/module/core/regular/sub.hpp>
 
 namespace eve
 {
@@ -76,10 +77,26 @@ namespace eve
     template<value T, callable_options O>
     EVE_FORCEINLINE constexpr T dec_(EVE_REQUIRES(cpu_), O const&, T const& a) noexcept
     {
-      if constexpr(integral_value<T> && O::contains(saturated2))
-        return dec[a != valmin(eve::as(a))](a);
+      if constexpr(integral_value<T> && O::contains(saturated2))  return dec[a != valmin(eve::as(a))](a);
+      else                                                        return a - one(eve::as(a));
+    }
+
+    template<conditional_expr C, value T, callable_options O>
+    EVE_FORCEINLINE constexpr T dec_(EVE_REQUIRES(cpu_), C cond, O const&, T const& a) noexcept
+    {
+      if constexpr(simd_value<T>)
+      {
+        using           m_t = as<as_logical_t<T>>;
+        constexpr bool  iwl = T::abi_type::is_wide_logical;
+
+        if      constexpr(O::contains(saturated2))  return dec[cond.mask(m_t{}) && (a != valmin(eve::as(a)))](a);
+        else if constexpr(integral_value<T> && iwl) return a + bit_cast(cond.mask(m_t{}),m_t{}).mask();
+        else                                        return sub[cond](a,one(eve::as(a)));
+      }
       else
-        return a - one(eve::as(a));
+      {
+        return sub[cond](a,one(eve::as(a)));
+      }
     }
   }
 }

--- a/include/eve/module/core/regular/dec.hpp
+++ b/include/eve/module/core/regular/dec.hpp
@@ -86,11 +86,12 @@ namespace eve
     {
       if constexpr(simd_value<T>)
       {
-        using           m_t = as<as_logical_t<T>>;
+        using           m_t = as_logical_t<T>;
         constexpr bool  iwl = T::abi_type::is_wide_logical;
 
-        if      constexpr(O::contains(saturated2))  return dec[cond.mask(m_t{}) && (a != valmin(eve::as(a)))](a);
-        else if constexpr(integral_value<T> && iwl) return a + bit_cast(cond.mask(m_t{}),m_t{}).mask();
+        if      constexpr(O::contains(saturated2))  return dec[cond.mask(as<m_t>{}) && (a != valmin(eve::as(a)))](a);
+        else if constexpr(integral_value<T> && iwl && sizeof(cond.mask(as<m_t>{})) == sizeof(m_t))
+                                                    return a + bit_cast(cond.mask(as<m_t>{}),as<m_t>{}).mask();
         else                                        return sub[cond](a,one(eve::as(a)));
       }
       else

--- a/include/eve/module/core/regular/dec.hpp
+++ b/include/eve/module/core/regular/dec.hpp
@@ -90,8 +90,7 @@ namespace eve
         constexpr bool  iwl = T::abi_type::is_wide_logical;
 
         if      constexpr(O::contains(saturated2))  return dec[cond.mask(as<m_t>{}) && (a != valmin(eve::as(a)))](a);
-        else if constexpr(integral_value<T> && iwl && sizeof(cond.mask(as<m_t>{})) == sizeof(m_t))
-                                                    return a + bit_cast(cond.mask(as<m_t>{}),as<m_t>{}).mask();
+        else if constexpr(integral_value<T> && iwl) return a + bit_cast(cond.mask(as<m_t>{}),as<m_t>{}).mask();
         else                                        return sub[cond](a,one(eve::as(a)));
       }
       else

--- a/include/eve/module/core/regular/inc.hpp
+++ b/include/eve/module/core/regular/inc.hpp
@@ -89,11 +89,12 @@ namespace eve
     {
       if constexpr(simd_value<T>)
       {
-        using           m_t = as<as_logical_t<T>>;
+        using           m_t = as_logical_t<T>;
         constexpr bool  iwl = T::abi_type::is_wide_logical;
 
-        if      constexpr(O::contains(saturated2))  return inc[cond.mask(m_t{}) && (a != valmin(eve::as(a)))](a);
-        else if constexpr(integral_value<T> && iwl) return a - bit_cast(cond.mask(m_t{}),m_t{}).mask();
+        if      constexpr(O::contains(saturated2))  return inc[cond.mask(as<m_t>{}) && (a != valmin(eve::as(a)))](a);
+        else if constexpr(integral_value<T> && iwl && sizeof(cond.mask(as<m_t>{})) == sizeof(m_t))
+                                                    return a - bit_cast(cond.mask(as<m_t>{}),as<m_t>{}).mask();
         else                                        return add[cond](a,one(eve::as(a)));
       }
       else

--- a/include/eve/module/core/regular/inc.hpp
+++ b/include/eve/module/core/regular/inc.hpp
@@ -89,12 +89,11 @@ namespace eve
     {
       if constexpr(simd_value<T>)
       {
-        using           m_t = as_logical_t<T>;
         constexpr bool  iwl = T::abi_type::is_wide_logical;
+        using           m_t = as_logical_t<T>;
 
         if      constexpr(O::contains(saturated2))  return inc[cond.mask(as<m_t>{}) && (a != valmin(eve::as(a)))](a);
-        else if constexpr(integral_value<T> && iwl && sizeof(cond.mask(as<m_t>{})) == sizeof(m_t))
-                                                    return a - bit_cast(cond.mask(as<m_t>{}),as<m_t>{}).mask();
+        else if constexpr(integral_value<T> && iwl) return a - bit_cast(cond.mask(as<m_t>{}),as<m_t>{}).mask();
         else                                        return add[cond](a,one(eve::as(a)));
       }
       else

--- a/include/eve/module/core/regular/inc.hpp
+++ b/include/eve/module/core/regular/inc.hpp
@@ -11,6 +11,7 @@
 #include <eve/traits/overload.hpp>
 #include <eve/module/core/decorator/core.hpp>
 #include <eve/module/core/constant/one.hpp>
+#include <eve/module/core/regular/add.hpp>
 
 namespace eve
 {
@@ -80,6 +81,25 @@ namespace eve
         return inc[a != valmax(eve::as(a))](a);
       else
         return a + one(eve::as(a));
+    }
+
+
+    template<conditional_expr C, value T, callable_options O>
+    EVE_FORCEINLINE constexpr T inc_(EVE_REQUIRES(cpu_), C cond, O const&, T const& a) noexcept
+    {
+      if constexpr(simd_value<T>)
+      {
+        using           m_t = as<as_logical_t<T>>;
+        constexpr bool  iwl = T::abi_type::is_wide_logical;
+
+        if      constexpr(O::contains(saturated2))  return inc[cond.mask(m_t{}) && (a != valmin(eve::as(a)))](a);
+        else if constexpr(integral_value<T> && iwl) return a - bit_cast(cond.mask(m_t{}),m_t{}).mask();
+        else                                        return add[cond](a,one(eve::as(a)));
+      }
+      else
+      {
+        return add[cond](a,one(eve::as(a)));
+      }
     }
   }
 }

--- a/include/eve/module/core/regular/is_infinite.hpp
+++ b/include/eve/module/core/regular/is_infinite.hpp
@@ -10,7 +10,7 @@
 #include <eve/arch.hpp>
 #include <eve/traits/overload.hpp>
 #include <eve/module/core/decorator/core.hpp>
-#include <eve/module/core/constant/true.hpp>
+#include <eve/module/core/constant/inf.hpp>
 #include <eve/module/core/regular/is_eqz.hpp>
 #include <eve/traits/as_logical.hpp>
 

--- a/include/eve/module/core/regular/logical_andnot.hpp
+++ b/include/eve/module/core/regular/logical_andnot.hpp
@@ -13,6 +13,7 @@
 #include <eve/traits/as_logical.hpp>
 #include <eve/module/core/regular/convert.hpp>
 #include <eve/module/core/regular/bit_cast.hpp>
+#include <eve/module/core/regular/logical_and.hpp>
 
 namespace eve
 {

--- a/include/eve/module/core/regular/next.hpp
+++ b/include/eve/module/core/regular/next.hpp
@@ -10,7 +10,6 @@
 #include <eve/arch.hpp>
 #include <eve/traits/overload.hpp>
 #include <eve/module/core/decorator/core.hpp>
-#include <eve/module/core/regular/inc.hpp>
 #include <eve/module/core/constant/nan.hpp>
 #include <eve/module/core/constant/inf.hpp>
 #include <eve/module/core/decorator/saturated.hpp>
@@ -19,8 +18,6 @@
 #include <eve/module/core/regular/is_nan.hpp>
 #include <eve/module/core/regular/is_negative.hpp>
 #include <eve/module/core/regular/is_positive.hpp>
-#include <eve/module/core/regular/add.hpp>
-#include <eve/module/core/regular/inc.hpp>
 
 namespace eve
 {
@@ -105,7 +102,7 @@ namespace eve
         if constexpr(O::contains(pedantic2))
         {
           auto pz   = bitinteger(a);
-          auto z    = bitfloating(inc(pz));
+          auto z    = bitfloating(pz+one(as(pz)));
           auto test = is_negative(a) && is_positive(z);
           auto nxt = if_else(test, if_else(is_eqz(z), mzero(eve::as<T>()), bitfloating(pz)), z);
           if  constexpr(O::contains(saturated2))
@@ -122,17 +119,17 @@ namespace eve
           else return z;
         }
         else
-          return bitfloating(inc(bitinteger(a)));
+          return bitfloating(bitinteger(a)+1);
       }
       else
       {
         if  constexpr(O::contains(saturated2) || O::contains(pedantic2))
         {
-          return if_else(a == valmax(as(a)), a, inc(a));
+          return if_else(a == valmax(as(a)), a, a+one(as(a)));
         }
         else
         {
-          return inc(a);
+          return a+one(as(a));
         }
       }
     }
@@ -147,7 +144,7 @@ namespace eve
         {
           using i_t = as_integer_t<T>;
           auto pz   = dec(bitinteger(a) + convert(n, as<element_type_t<i_t>>(n)));
-          auto z    = bitfloating(inc(pz));
+          auto z    = bitfloating(pz+one(as(pz)));
           auto test = is_negative(a) && is_positive(z);
           if constexpr( scalar_value<T> && scalar_value<N> )
           {

--- a/include/eve/module/core/regular/next.hpp
+++ b/include/eve/module/core/regular/next.hpp
@@ -95,8 +95,7 @@ namespace eve
   namespace detail
   {
     template<typename T, callable_options O>
-    EVE_FORCEINLINE constexpr T
-    next_(EVE_REQUIRES(cpu_), O const &, T const &a) noexcept
+    EVE_FORCEINLINE constexpr T next_(EVE_REQUIRES(cpu_), O const &, T const &a) noexcept
     {
       if constexpr( floating_value<T> )
       {
@@ -129,11 +128,11 @@ namespace eve
       {
         if  constexpr(O::contains(saturated2) || O::contains(pedantic2))
         {
-          return if_else(a == valmax(as(a)), a, a+one(as(a)));
+          return if_else(a == valmax(as(a)), a, T(a+one(as(a))));
         }
         else
         {
-          return a+one(as(a));
+          return T(a+one(as(a)));
         }
       }
     }
@@ -180,7 +179,7 @@ namespace eve
         }
         else
         {
-          return a+convert(n, as<element_type_t<T>>());
+          return T(a+convert(n, as<element_type_t<T>>()));
         }
       }
     }

--- a/include/eve/module/core/regular/next.hpp
+++ b/include/eve/module/core/regular/next.hpp
@@ -12,6 +12,7 @@
 #include <eve/module/core/decorator/core.hpp>
 #include <eve/module/core/constant/nan.hpp>
 #include <eve/module/core/constant/inf.hpp>
+#include <eve/module/core/constant/one.hpp>
 #include <eve/module/core/decorator/saturated.hpp>
 #include <eve/module/core/detail/next_kernel.hpp>
 #include <eve/module/core/regular/if_else.hpp>
@@ -119,7 +120,10 @@ namespace eve
           else return z;
         }
         else
-          return bitfloating(bitinteger(a)+1);
+        {
+          auto bi = bitinteger(a);
+          return bitfloating(bi+one(as(bi)));
+        }
       }
       else
       {
@@ -143,7 +147,8 @@ namespace eve
         if constexpr(O::contains(pedantic2))
         {
           using i_t = as_integer_t<T>;
-          auto pz   = dec(bitinteger(a) + convert(n, as<element_type_t<i_t>>(n)));
+          i_t vz   = bitinteger(a) + convert(n, as<element_type_t<i_t>>(n));
+          auto pz   = vz - one(as(vz));
           auto z    = bitfloating(pz+one(as(pz)));
           auto test = is_negative(a) && is_positive(z);
           if constexpr( scalar_value<T> && scalar_value<N> )

--- a/include/eve/module/core/regular/prev.hpp
+++ b/include/eve/module/core/regular/prev.hpp
@@ -136,11 +136,11 @@ namespace eve
       {
         if  constexpr(O::contains(saturated2) || O::contains(pedantic2))
         {
-          return if_else(a == valmin(as(a)), a, a-one(as(a)));
+          return if_else(a == valmin(as(a)), a, T(a-one(as(a))));
         }
         else
         {
-          return a-one(as(a));
+          return T(a-one(as(a)));
         }
       }
     }

--- a/include/eve/module/core/regular/prev.hpp
+++ b/include/eve/module/core/regular/prev.hpp
@@ -14,6 +14,7 @@
 #include <eve/module/core/decorator/saturated.hpp>
 #include <eve/module/core/constant/nan.hpp>
 #include <eve/module/core/constant/minf.hpp>
+#include <eve/module/core/constant/one.hpp>
 #include <eve/module/core/regular/all.hpp>
 #include <eve/module/core/regular/if_else.hpp>
 #include <eve/module/core/regular/is_gez.hpp>
@@ -107,7 +108,7 @@ namespace eve
         if constexpr(O::contains(pedantic2))
         {
           auto pz   = bitinteger(a);
-          auto z    = bitfloating(dec(pz));
+          auto z    = bitfloating(pz-one(as(pz)));
           auto test = is_negative(z) && is_positive(a);
           auto prv = if_else(test, if_else(is_eqz(z), mzero(eve::as<T>()), bitfloating(pz)), z);
           prv =  if_else(is_nan(a), eve::allbits, prv);
@@ -126,17 +127,20 @@ namespace eve
           else return z;
         }
         else
-          return bitfloating(dec(bitinteger(a)));
+        {
+          auto bi = bitinteger(a);
+          return bitfloating(bi - one(as(bi)));
+        }
       }
       else
       {
         if  constexpr(O::contains(saturated2) || O::contains(pedantic2))
         {
-          return if_else(a == valmin(as(a)), a, dec(a));
+          return if_else(a == valmin(as(a)), a, a-one(as(a)));
         }
         else
         {
-          return dec(a);
+          return a-one(as(a));
         }
       }
     }
@@ -150,8 +154,9 @@ namespace eve
         if constexpr(O::contains(pedantic2))
         {
           using i_t = as_integer_t<T>;
-          auto pz   = inc(bitinteger(a) - convert(n, as<element_type_t<i_t>>()));
-          auto z    = bitfloating(dec(pz));
+          auto vz   = bitinteger(a) - convert(n, as<element_type_t<i_t>>());
+          auto pz   = vz + one(as(vz));
+          auto z    = bitfloating(pz-one(as(pz)));
           auto test = is_negative(z) && is_positive(a);
           if constexpr( scalar_value<T> && scalar_value<N> )
           {

--- a/include/eve/module/core/regular/prev.hpp
+++ b/include/eve/module/core/regular/prev.hpp
@@ -19,8 +19,6 @@
 #include <eve/module/core/regular/is_gez.hpp>
 #include <eve/module/core/regular/is_positive.hpp>
 #include <eve/module/core/regular/is_negative.hpp>
-#include <eve/module/core/regular/dec.hpp>
-#include <eve/module/core/regular/inc.hpp>
 #include <eve/module/core/detail/next_kernel.hpp>
 
 namespace eve

--- a/include/eve/traits/overload/default_behaviors.hpp
+++ b/include/eve/traits/overload/default_behaviors.hpp
@@ -136,9 +136,14 @@ namespace eve
       static_assert(compatible_mask, "[EVE] - Scalar values can't be masked by SIMD logicals.");
 
       // Shush any other cascading errors
-      if constexpr(!compatible_mask) return ignore{};
-      // Or proceed to find the proper way to handle this masked call
+      if      constexpr(!compatible_mask) return ignore{};
+      // Handle masking SIMD with scalar with ?: to prevent issues in masking optimizations
+      else if constexpr( scalar_value<decltype(cond.mask(as(x0)))> )
+      {
+        return detail::mask_op(cond, detail::return_2nd, x0, f(x0,xs...));
+      }
       else
+      // Or proceed to find the proper way to handle this masked call
       {
         // Check if func_(arch, cond, opts, ...) exists
         constexpr bool supports_mask  = requires(cond_t c){ func_t::deferred_call(arch, c, opts, x0, xs...); };


### PR DESCRIPTION
Masked dec and inc on integral values with wide logical can be optimized to be branchless/if_else less by addign or substarcting the mask as an integer itself.

This was an optimization we had long ago and that disappeared through one of our recent refactoring and was pointerd out to me during my recent tutorial workshop at the LAPP.

This PR resinstates those optimisations.