### PR TITLE
more slide left things.

### DIFF
--- a/include/eve/detail/shuffle_v2/idxm.hpp
+++ b/include/eve/detail/shuffle_v2/idxm.hpp
@@ -255,6 +255,7 @@ shuffle_within_n(std::span<const std::ptrdiff_t> idxs, std::ptrdiff_t n)
     std::ptrdiff_t ub = part + n;
     for (std::ptrdiff_t i = part; i != ub; ++i) {
       std::ptrdiff_t x = idxs[i];
+      if (x >= ssize) x -= ssize;
       if (x < 0) continue;
       if (x < part) return false;
       if (x >= ub) return false;

--- a/include/eve/detail/shuffle_v2/simd/x86/idxm.hpp
+++ b/include/eve/detail/shuffle_v2/simd/x86/idxm.hpp
@@ -155,4 +155,38 @@ slide_2_left_in_16_pattern(std::ptrdiff_t g_size, std::ptrdiff_t slide)
   return res;
 }
 
+template <std::ptrdiff_t g_size, std::size_t N>
+constexpr std::optional<int> x86_shuffle_ps_2(std::span<const std::ptrdiff_t, N> idxs_)
+{
+  auto idxs = expand_group<g_size / 4>(idxs_);
+  std::ptrdiff_t size  = std::ssize(idxs);
+  std::ptrdiff_t res = 0;
+
+  for (std::ptrdiff_t i = 0; i != size; ++i) {
+    if (idxs[i] < 0) {
+      continue;
+    }
+
+    // 2 indexes from x, 2 indexes from y
+    std::ptrdiff_t active_register_offset = (i & 2) * size / 2;
+    std::ptrdiff_t within_register_offset = i / 4;
+    std::ptrdiff_t offset = active_register_offset + within_register_offset;
+
+    std::ptrdiff_t selected = idxs[i] - offset;
+
+    if (selected < 0 || selected >= 4) {
+      return std::nullopt;
+    }
+
+    res |= selected << (i * 2);
+  }
+
+  return static_cast<int>(res);
+}
+
+template <std::ptrdiff_t g_size, std::size_t N>
+constexpr std::optional<int> x86_shuffle_ps_2(const std::array<std::ptrdiff_t, N> idxs) {
+  return x86_shuffle_ps_2<g_size>(std::span<const std::ptrdiff_t, N>(idxs));
+}
+
 }

--- a/include/eve/detail/shuffle_v2/simd/x86/shuffle_l2.hpp
+++ b/include/eve/detail/shuffle_v2/simd/x86/shuffle_l2.hpp
@@ -14,7 +14,7 @@ namespace eve::detail
 
 template<typename P, arithmetic_scalar_value T, typename N, std::ptrdiff_t G>
 EVE_FORCEINLINE auto
-shuffle_l2_x86_within_128_shifts_and_slides(P p, fixed<G> g, wide<T, N> x)
+shuffle_l2_x86_repeated_128_shifts_and_slides(P p, fixed<G> g, wide<T, N> x)
 {
   if constexpr( current_api == avx && P::reg_size == 32 ) return no_matching_shuffle;
   else if constexpr( auto r = shuffle_l2_element_bit_shift(p, g, x); matched_shuffle<decltype(r)> )
@@ -40,7 +40,7 @@ shuffle_l2_x86_within_128_shifts_and_slides(P p, fixed<G> g, wide<T, N> x)
 
 template<typename P, arithmetic_scalar_value T, typename N, std::ptrdiff_t G>
 EVE_FORCEINLINE auto
-shuffle_l2_x86_within_128_4_shorts(P, fixed<G>, wide<T, N> x)
+shuffle_l2_x86_repeated_128_4_shorts(P, fixed<G>, wide<T, N> x)
 {
   if constexpr( sizeof(T) == 1 ) return no_matching_shuffle;
   else if constexpr( current_api == avx && P::reg_size == 32 ) return no_matching_shuffle;
@@ -79,7 +79,7 @@ shuffle_l2_x86_within_128_4_shorts(P, fixed<G>, wide<T, N> x)
 
 template<typename P, arithmetic_scalar_value T, typename N, std::ptrdiff_t G>
 EVE_FORCEINLINE auto
-shuffle_l2_x86_within_128_4x32(P p, fixed<G> g, wide<T, N> x)
+shuffle_l2_x86_repeated_128_4x32(P p, fixed<G> g, wide<T, N> x)
 {
   if constexpr( sizeof(T) * G < 4 ) return no_matching_shuffle;
   else if constexpr( !P::has_zeroes )
@@ -109,7 +109,7 @@ shuffle_l2_x86_within_128_4x32(P p, fixed<G> g, wide<T, N> x)
 
 template<typename P, arithmetic_scalar_value T, typename N, std::ptrdiff_t G>
 EVE_FORCEINLINE auto
-shuffle_l2_x86_within_128_alignr(P, fixed<G>, wide<T, N> x)
+shuffle_l2_x86_repeated_128_alignr(P, fixed<G>, wide<T, N> x)
 {
   if constexpr( current_api == avx && P::reg_size == 32 ) return no_matching_shuffle;
   else if constexpr( current_api < ssse3 ) return no_matching_shuffle;
@@ -134,25 +134,25 @@ shuffle_l2_x86_within_128_alignr(P, fixed<G>, wide<T, N> x)
  */
 template<typename P, arithmetic_scalar_value T, typename N, std::ptrdiff_t G>
 EVE_FORCEINLINE auto
-shuffle_l2_x86_within_128(P p, fixed<G> g, wide<T, N> x)
+shuffle_l2_x86_repeated_128(P p, fixed<G> g, wide<T, N> x)
 {
   if constexpr( !P::repeated_16 ) return no_matching_shuffle;
-  else if constexpr( auto r = shuffle_l2_x86_within_128_shifts_and_slides(p, g, x);
+  else if constexpr( auto r = shuffle_l2_x86_repeated_128_shifts_and_slides(p, g, x);
                      matched_shuffle<decltype(r)> )
   {
     return r;
   }
-  else if constexpr( auto r = shuffle_l2_x86_within_128_4x32(p, g, x);
+  else if constexpr( auto r = shuffle_l2_x86_repeated_128_4x32(p, g, x);
                      matched_shuffle<decltype(r)> )
   {
     return r;
   }
-  else if constexpr( auto r = shuffle_l2_x86_within_128_4_shorts(p, g, x);
+  else if constexpr( auto r = shuffle_l2_x86_repeated_128_4_shorts(p, g, x);
                      matched_shuffle<decltype(r)> )
   {
     return r;
   }
-  else if constexpr( auto r = shuffle_l2_x86_within_128_alignr(p, g, x);
+  else if constexpr( auto r = shuffle_l2_x86_repeated_128_alignr(p, g, x);
                      matched_shuffle<decltype(r)> )
   {
     return r;
@@ -184,7 +184,7 @@ shuffle_l2_x86_128_insert_one_zero(P, fixed<G>, wide<T, N> x)
 
 template<typename P, arithmetic_scalar_value T, typename N, std::ptrdiff_t G>
 EVE_FORCEINLINE auto
-shuffle_l2_x86_within_256_permute4x64(P p, fixed<G> g, wide<T, N> x)
+shuffle_l2_x86_repeated_256_permute4x64(P p, fixed<G> g, wide<T, N> x)
 {
   if constexpr( P::g_size < 8 ) return no_matching_shuffle;
   else if constexpr( P::has_zeroes && current_api < avx512 ) return no_matching_shuffle;
@@ -232,10 +232,10 @@ shuffle_l2_x86_within_256_permute4x64(P p, fixed<G> g, wide<T, N> x)
  */
 template<typename P, arithmetic_scalar_value T, typename N, std::ptrdiff_t G>
 EVE_FORCEINLINE auto
-shuffle_l2_x86_within_256(P p, fixed<G> g, wide<T, N> x)
+shuffle_l2_x86_repeated_256(P p, fixed<G> g, wide<T, N> x)
 {
   if constexpr( !P::repeated_32 ) return no_matching_shuffle;
-  else if constexpr( auto r = shuffle_l2_x86_within_256_permute4x64(p, g, x);
+  else if constexpr( auto r = shuffle_l2_x86_repeated_256_permute4x64(p, g, x);
                      matched_shuffle<decltype(r)> )
   {
     return r;
@@ -323,7 +323,7 @@ EVE_FORCEINLINE auto
 shuffle_l2_(EVE_SUPPORTS(sse2_), P p, fixed<G> g, wide<T, N> x)
 requires(P::out_reg_size == P::reg_size)
 {
-  if constexpr( auto r = shuffle_l2_x86_within_128(p, g, x); matched_shuffle<decltype(r)> )
+  if constexpr( auto r = shuffle_l2_x86_repeated_128(p, g, x); matched_shuffle<decltype(r)> )
   {
     return r;
   }
@@ -332,7 +332,7 @@ requires(P::out_reg_size == P::reg_size)
   {
     return r;
   }
-  else if constexpr( auto r = shuffle_l2_x86_within_256(p, g, x); matched_shuffle<decltype(r)> )
+  else if constexpr( auto r = shuffle_l2_x86_repeated_256(p, g, x); matched_shuffle<decltype(r)> )
   {
     return r;
   }
@@ -393,28 +393,7 @@ shuffle_l2_x86_blend(P, fixed<G>, wide<T, N> x, wide<T, N> y)
 
 template<typename P, arithmetic_scalar_value T, typename N, std::ptrdiff_t G>
 EVE_FORCEINLINE auto
-shuffle_l2_x86_within_128x2_shuffle_pd(P, fixed<G>, wide<T, N> x, wide<T, N> y)
-{
-  if constexpr( sizeof(T) < 8 ) return no_matching_shuffle;
-  else
-  {
-    // half from x, half from y
-    // No w/e or zeroes are possible here, because it wouldn't be 2 registers.
-    // (repeating with 16 bytes 8 byte element).
-    static_assert(!P::has_zeroes, "verifyig assumption");
-    auto x_f64 = bit_cast(x, eve::as<eve::wide<double, N>> {});
-    auto y_f64 = bit_cast(y, eve::as<eve::wide<double, N>> {});
-
-    constexpr int mm = _MM_SHUFFLE2(P::idxs[1] - 2, P::idxs[0]);
-    if constexpr( P::reg_size == 16 ) return _mm_shuffle_pd(x_f64, y_f64, mm);
-    else if constexpr( P::reg_size == 32 ) return _mm256_shuffle_pd(x_f64, y_f64, mm);
-    else return _mm512_shuffle_pd(x_f64, y_f64, mm);
-  }
-}
-
-template<typename P, arithmetic_scalar_value T, typename N, std::ptrdiff_t G>
-EVE_FORCEINLINE auto
-shuffle_l2_x86_within_128x2_alignr(P, fixed<G>, wide<T, N> x, wide<T, N> y)
+shuffle_l2_x86_repeated_128x2_alignr(P, fixed<G>, wide<T, N> x, wide<T, N> y)
 {
   if constexpr( current_api == avx && P::reg_size == 32 ) return no_matching_shuffle;
   else if constexpr( current_api < ssse3 ) return no_matching_shuffle;
@@ -437,15 +416,60 @@ shuffle_l2_x86_within_128x2_alignr(P, fixed<G>, wide<T, N> x, wide<T, N> y)
 
 template<typename P, arithmetic_scalar_value T, typename N, std::ptrdiff_t G>
 EVE_FORCEINLINE auto
-shuffle_l2_x86_within_128x2(P p, fixed<G> g, wide<T, N> x, wide<T, N> y)
+shuffle_l2_x86_repeated_128x2(P p, fixed<G> g, wide<T, N> x, wide<T, N> y)
 {
   if constexpr( !P::repeated_16 ) return no_matching_shuffle;
-  else if constexpr( auto r = shuffle_l2_x86_within_128x2_shuffle_pd(p, g, x, y);
+  else if constexpr( auto r = shuffle_l2_x86_repeated_128x2_alignr(p, g, x, y);
                      matched_shuffle<decltype(r)> )
   {
     return r;
   }
-  else if constexpr( auto r = shuffle_l2_x86_within_128x2_alignr(p, g, x, y);
+  else return no_matching_shuffle;
+}
+
+template<typename P, arithmetic_scalar_value T, typename N, std::ptrdiff_t G>
+EVE_FORCEINLINE auto
+shuffle_l2_x86_within_128x2_shuffle_ps(P p, fixed<G> g, wide<T, N> x, wide<T, N> y)
+{
+  if constexpr( sizeof(T) < 4 ) return no_matching_shuffle;
+  else if constexpr( P::has_zeroes && current_api < avx512 ) return no_matching_shuffle;
+  else if constexpr( constexpr auto opt_mm = idxm::x86_shuffle_ps_2<P::g_size>(P::idxs); !opt_mm )
+  {
+    return no_matching_shuffle;
+  }
+  else
+  {
+    using floats_t = eve::wide<float, eve::fixed<N::value * sizeof(T) / sizeof(float)>>;
+    auto x_f32     = bit_cast(x, eve::as<floats_t> {});
+    auto y_f32     = bit_cast(y, eve::as<floats_t> {});
+
+    constexpr int mm = *opt_mm;
+    if constexpr( !P::has_zeroes )
+    {
+      if constexpr( P::reg_size == 16 ) return _mm_shuffle_ps(x_f32, y_f32, mm);
+      else if constexpr( P::reg_size == 32 ) return _mm256_shuffle_ps(x_f32, y_f32, mm);
+      else return _mm512_shuffle_ps(x_f32, y_f32, mm);
+    }
+    else
+    {
+      auto mask = is_na_or_we_logical_mask(p, g, as(x)).storage();
+
+      if constexpr( P::reg_size == 16 ) return _mm_maskz_shuffle_ps(mask, x_f32, y_f32, mm);
+      else if constexpr( P::reg_size == 32 ) return _mm256_maskz_shuffle_ps(mask, x_f32, y_f32, mm);
+      else return _mm512_maskz_shuffle_ps(mask, x_f32, y_f32, mm);
+    }
+  }
+}
+
+template<typename P, arithmetic_scalar_value T, typename N, std::ptrdiff_t G>
+EVE_FORCEINLINE auto
+shuffle_l2_x86_within_128x2(P p, fixed<G> g, wide<T, N> x, wide<T, N> y)
+{
+  if constexpr( !idxm::shuffle_within_n(P::idxs, 16 / sizeof(T)) )
+  {
+    return no_matching_shuffle;
+  }
+  else if constexpr( auto r = shuffle_l2_x86_within_128x2_shuffle_ps(p, g, x, y);
                      matched_shuffle<decltype(r)> )
   {
     return r;
@@ -564,6 +588,11 @@ shuffle_l2_(EVE_SUPPORTS(sse2_), P p, fixed<G> g, wide<T, N> x, wide<T, N> y)
 requires(P::out_reg_size == P::reg_size)
 {
   if constexpr( auto r = shuffle_l2_x86_blend(p, g, x, y); matched_shuffle<decltype(r)> )
+  {
+    return r;
+  }
+  else if constexpr( auto r = shuffle_l2_x86_repeated_128x2(p, g, x, y);
+                     matched_shuffle<decltype(r)> )
   {
     return r;
   }

--- a/test/unit/api/regular/shuffle_v2/idxm.cpp
+++ b/test/unit/api/regular/shuffle_v2/idxm.cpp
@@ -166,6 +166,11 @@ TTS_CASE("shuffle_within_halves")
   test(std::array {1, we_, 3, na_}, true);
   test(std::array {we_, we_, we_, 0}, false);
   test(std::array {3, we_, we_, we_}, false);
+
+  // Two registers shuffle
+  test(std::array {0, 4, we_, we_}, true);
+  test(std::array {0, 4, 7, 3}, true);
+  test(std::array {0, 6, 7, 3}, false);
 };
 
 TTS_CASE("shuffle_within_n")

--- a/test/unit/api/regular/shuffle_v2/slide_left_1.cpp
+++ b/test/unit/api/regular/shuffle_v2/slide_left_1.cpp
@@ -57,9 +57,9 @@ TTS_CASE("Explicit") {
 TTS_CASE_TPL("Check slide_left, 1 arg, generic", eve::test::simd::all_types)
 <typename T>(tts::type<T>)
 {
-  static constexpr std::ptrdiff_t reg_size = sizeof(eve::element_type_t<T>) * T::size();
+  // static constexpr std::ptrdiff_t reg_size = sizeof(eve::element_type_t<T>) * T::size();
   if constexpr( eve::current_api <= eve::sse4_2 || eve::current_api >= eve::neon ||
-    ( eve::current_api >= eve::avx2 && reg_size <= 32 ) ||
+    ( eve::current_api == eve::avx2 ) ||
     ( eve::current_api >= eve::avx512 && sizeof(eve::element_type_t<T>) >= 2 ) ||
     ( eve::current_api >= eve::sve) )
   {

--- a/test/unit/api/regular/shuffle_v2/slide_left_1.cpp
+++ b/test/unit/api/regular/shuffle_v2/slide_left_1.cpp
@@ -17,7 +17,7 @@ test_indexes()
   // still will be tested through G == 1
   if constexpr( G > 1 ) return kumi::tuple {eve::index<1>};
   // just reducing compile times a bit
-  else if constexpr ( !eve::unsigned_simd_value<T> ) return kumi::tuple{eve::index<1>};
+  else if constexpr( !eve::unsigned_simd_value<T> ) return kumi::tuple {eve::index<1>};
   else
   {
     return []<std::size_t... i>(std::index_sequence<i...>)
@@ -27,9 +27,10 @@ test_indexes()
 
 #if 0
 TTS_CASE("Slide left 1, example") {
-  using w_i = eve::wide<int, eve::fixed<4>>;
-  w_i x{1, 2, 3, 4};
-  TTS_EQUAL(eve::slide_left2(x, eve::index<1>), w_i({2, 3, 4, 0}));
+  using w_i =  eve::wide<unsigned int, eve::fixed<8>>;
+  w_i x{[](int i, int) { return i; } };
+  std::cerr << eve::shuffle_v2(x, eve::pattern<3, 4, 5, 6, 7, -1, -1, -1>) << std::endl;
+  TTS_PASS();
 };
 #endif
 
@@ -41,7 +42,7 @@ TTS_CASE("Explicit") {
   auto [y, l] = eve::shuffle_v2_core(x, eve::pattern<5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, -1, -1, -1, -1, -1>);
   TTS_EQUAL(l(), 4);
   (void)y;
-#if 0
+#  if 0
   TTS_EQUAL(y, w_i({2, 0}));
 
   TTS_EQUAL(eve::slide_left2.level(eve::as<w_i>{}, eve::fixed<1>{}, eve::index<1>), 2);
@@ -50,18 +51,22 @@ TTS_CASE("Explicit") {
   auto [y, l] = eve::shuffle_v2_core(x, eve::pattern<7, na_, na_, na_, na_, na_, na_, na_>);
   TTS_EQUAL(y, w_i({8, 0, 0, 0, 0, 0, 0, 0}));
   TTS_EQUAL(l(), 4);
-#endif
+#  endif
 };
 #endif
 
 TTS_CASE_TPL("Check slide_left, 1 arg, generic", eve::test::simd::all_types)
 <typename T>(tts::type<T>)
 {
-  // static constexpr std::ptrdiff_t reg_size = sizeof(eve::element_type_t<T>) * T::size();
-  if constexpr( eve::current_api <= eve::sse4_2 || eve::current_api >= eve::neon ||
-    ( eve::current_api == eve::avx2 ) ||
-    ( eve::current_api >= eve::avx512 && sizeof(eve::element_type_t<T>) >= 2 ) ||
-    ( eve::current_api >= eve::sve) )
+  static constexpr std::ptrdiff_t reg_size = sizeof(eve::element_type_t<T>) * T::size();
+  static constexpr std::ptrdiff_t e_t_size = sizeof(eve::element_type_t<T>);
+  if constexpr(                                                                 //
+      (eve::current_api <= eve::sse4_2) ||                                      //
+      (eve::current_api == eve::avx && (reg_size <= 16)) ||                     //
+      (eve::current_api == eve::avx2) ||                                        //
+      (eve::current_api >= eve::avx512 && (e_t_size >= 2 || reg_size <= 32)) || //
+      (eve::current_api >= eve::neon) ||                                        //
+      (eve::current_api >= eve::sve) )
   {
     shuffle_test::named_shuffle1_test<
         /*supports_G_eq_T_Size*/ true>(eve::as<T> {},


### PR DESCRIPTION
Mostly implemented  _mm_shuffle_ps and friends better.
Not tested terribly well - we only test named shuffles at the moment.
Manually ran things, hopefully fine?
We'll figure out instruction testing later.

This continues to build up to this detection: https://github.com/jfalcou/eve/blob/main/include/eve/module/core/regular/impl/simd/x86/slide_left.hpp#L53

Which is still difficult to automate