### PR TITLE
Replace underlying by translate in concepts

### DIFF
--- a/include/eve/concept/value.hpp
+++ b/include/eve/concept/value.hpp
@@ -12,7 +12,6 @@
 #include <eve/concept/vectorized.hpp>
 #include <eve/traits/is_logical.hpp>
 #include <eve/traits/translation.hpp>
-#include <eve/traits/element_type.hpp>
 
 #include <concepts>
 #include <type_traits>
@@ -44,7 +43,7 @@ namespace eve
   //! - `int`
   //! - `eve::wide<int, eve::fixed<1>>`
   //================================================================================================
-  template<typename T> concept integral_value        = value<T> && std::integral<translate_t<element_type_t<T>>>;
+  template<typename T> concept integral_value        = value<T> && std::integral<translate_element_type_t<T>>;
 
   //================================================================================================
   //! @ingroup simd_concepts
@@ -57,7 +56,7 @@ namespace eve
   //! - `float`
   //! - `eve::wide<int, eve::fixed<1>>`
   //================================================================================================
-  template<typename T> concept signed_value          = value<T> && std::is_signed_v<translate_t<element_type_t<T>>>;
+  template<typename T> concept signed_value          = value<T> && std::is_signed_v<translate_element_type_t<T>>;
 
   //================================================================================================
   //! @ingroup simd_concepts
@@ -69,7 +68,7 @@ namespace eve
   //! - `unsigned int`
   //! - `eve::wide<std::uint8_t, eve::fixed<1>>`
   //================================================================================================
-  template<typename T> concept unsigned_value        = value<T> && std::unsigned_integral<translate_t<element_type_t<T>>>;
+  template<typename T> concept unsigned_value        = value<T> && std::unsigned_integral<translate_element_type_t<T>>;
 
   //================================================================================================
   //! @ingroup simd_concepts
@@ -81,7 +80,7 @@ namespace eve
   //! - `short int`
   //! - `eve::wide<int, eve::fixed<1>>`
   //================================================================================================
-  template<typename T> concept signed_integral_value = value<T> && std::signed_integral<translate_t<element_type_t<T>>>;
+  template<typename T> concept signed_integral_value = value<T> && std::signed_integral<translate_element_type_t<T>>;
 
   //================================================================================================
   //! @ingroup simd_concepts
@@ -93,7 +92,7 @@ namespace eve
   //! - `double`
   //! - `eve::wide<float, eve::fixed<2>>`
   //================================================================================================
-  template<typename T> concept floating_value        = value<T> && std::floating_point<translate_t<element_type_t<T>>>;
+  template<typename T> concept floating_value        = value<T> && std::floating_point<translate_element_type_t<T>>;
 
   //================================================================================================
   //! @ingroup simd_concepts

--- a/include/eve/concept/value.hpp
+++ b/include/eve/concept/value.hpp
@@ -11,7 +11,8 @@
 #include <eve/concept/vectorizable.hpp>
 #include <eve/concept/vectorized.hpp>
 #include <eve/traits/is_logical.hpp>
-#include <eve/traits/underlying_type.hpp>
+#include <eve/traits/translation.hpp>
+#include <eve/traits/element_type.hpp>
 
 #include <concepts>
 #include <type_traits>
@@ -43,7 +44,7 @@ namespace eve
   //! - `int`
   //! - `eve::wide<int, eve::fixed<1>>`
   //================================================================================================
-  template<typename T> concept integral_value        = value<T> && std::integral<underlying_type_t<T>>;
+  template<typename T> concept integral_value        = value<T> && std::integral<translate_t<element_type_t<T>>>;
 
   //================================================================================================
   //! @ingroup simd_concepts
@@ -56,7 +57,7 @@ namespace eve
   //! - `float`
   //! - `eve::wide<int, eve::fixed<1>>`
   //================================================================================================
-  template<typename T> concept signed_value          = value<T> && std::is_signed_v<underlying_type_t<T>>;
+  template<typename T> concept signed_value          = value<T> && std::is_signed_v<translate_t<element_type_t<T>>>;
 
   //================================================================================================
   //! @ingroup simd_concepts
@@ -68,7 +69,7 @@ namespace eve
   //! - `unsigned int`
   //! - `eve::wide<std::uint8_t, eve::fixed<1>>`
   //================================================================================================
-  template<typename T> concept unsigned_value        = value<T> && std::unsigned_integral<underlying_type_t<T>>;
+  template<typename T> concept unsigned_value        = value<T> && std::unsigned_integral<translate_t<element_type_t<T>>>;
 
   //================================================================================================
   //! @ingroup simd_concepts
@@ -80,7 +81,7 @@ namespace eve
   //! - `short int`
   //! - `eve::wide<int, eve::fixed<1>>`
   //================================================================================================
-  template<typename T> concept signed_integral_value = value<T> && std::signed_integral<underlying_type_t<T>>;
+  template<typename T> concept signed_integral_value = value<T> && std::signed_integral<translate_t<element_type_t<T>>>;
 
   //================================================================================================
   //! @ingroup simd_concepts
@@ -92,7 +93,7 @@ namespace eve
   //! - `double`
   //! - `eve::wide<float, eve::fixed<2>>`
   //================================================================================================
-  template<typename T> concept floating_value        = value<T> && std::floating_point<underlying_type_t<T>>;
+  template<typename T> concept floating_value        = value<T> && std::floating_point<translate_t<element_type_t<T>>>;
 
   //================================================================================================
   //! @ingroup simd_concepts

--- a/include/eve/concept/value.hpp
+++ b/include/eve/concept/value.hpp
@@ -11,7 +11,7 @@
 #include <eve/concept/vectorizable.hpp>
 #include <eve/concept/vectorized.hpp>
 #include <eve/traits/is_logical.hpp>
-#include <eve/traits/translation.hpp>
+#include <eve/traits/element_type.hpp>
 
 #include <concepts>
 #include <type_traits>

--- a/include/eve/concept/vectorizable.hpp
+++ b/include/eve/concept/vectorizable.hpp
@@ -9,7 +9,6 @@
 
 #include <eve/concept/scalar.hpp>
 #include <eve/traits/translation.hpp>
-#include <eve/traits/element_type.hpp>
 #include <concepts>
 
 namespace eve
@@ -25,7 +24,7 @@ namespace eve
   //! - `std::int32_t`
   //================================================================================================
   template<typename T>
-  concept integral_scalar_value  = arithmetic_scalar_value<T> && std::integral<translate_t<element_type_t<T>>>;
+  concept integral_scalar_value  = arithmetic_scalar_value<T> && std::integral<translate_element_type_t<T>>;
 
   //================================================================================================
   //! @ingroup simd_concepts
@@ -39,7 +38,7 @@ namespace eve
   //! - `float`
   //================================================================================================
   template<typename T>
-  concept signed_scalar_value  = arithmetic_scalar_value<T> && std::is_signed_v<translate_t<element_type_t<T>>>;
+  concept signed_scalar_value  = arithmetic_scalar_value<T> && std::is_signed_v<translate_element_type_t<T>>;
 
   //================================================================================================
   //! @ingroup simd_concepts
@@ -52,7 +51,7 @@ namespace eve
   //! - `std::uint32_t`
   //================================================================================================
   template<typename T>
-  concept unsigned_scalar_value = arithmetic_scalar_value<T> && std::unsigned_integral<translate_t<element_type_t<T>>>;
+  concept unsigned_scalar_value = arithmetic_scalar_value<T> && std::unsigned_integral<translate_element_type_t<T>>;
 
   //================================================================================================
   //! @ingroup simd_concepts
@@ -65,7 +64,7 @@ namespace eve
   //! - `std::int32_t`
   //================================================================================================
   template<typename T>
-  concept signed_integral_scalar_value = arithmetic_scalar_value<T> && std::signed_integral<translate_t<element_type_t<T>>>;
+  concept signed_integral_scalar_value = arithmetic_scalar_value<T> && std::signed_integral<translate_element_type_t<T>>;
 
   //================================================================================================
   //! @ingroup simd_concepts
@@ -79,5 +78,5 @@ namespace eve
   //! - `double`
   //================================================================================================
   template<typename T>
-  concept floating_scalar_value = arithmetic_scalar_value<T> && std::floating_point<translate_t<element_type_t<T>>>;
+  concept floating_scalar_value = arithmetic_scalar_value<T> && std::floating_point<translate_element_type_t<T>>;
 }

--- a/include/eve/concept/vectorizable.hpp
+++ b/include/eve/concept/vectorizable.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 #include <eve/concept/scalar.hpp>
-#include <eve/traits/translation.hpp>
+#include <eve/traits/element_type.hpp>
 #include <concepts>
 
 namespace eve

--- a/include/eve/concept/vectorizable.hpp
+++ b/include/eve/concept/vectorizable.hpp
@@ -8,6 +8,8 @@
 #pragma once
 
 #include <eve/concept/scalar.hpp>
+#include <eve/traits/translation.hpp>
+#include <eve/traits/element_type.hpp>
 #include <concepts>
 
 namespace eve
@@ -23,7 +25,7 @@ namespace eve
   //! - `std::int32_t`
   //================================================================================================
   template<typename T>
-  concept integral_scalar_value  = arithmetic_scalar_value<T> && std::integral<T>;
+  concept integral_scalar_value  = arithmetic_scalar_value<T> && std::integral<translate_t<element_type_t<T>>>;
 
   //================================================================================================
   //! @ingroup simd_concepts
@@ -37,7 +39,7 @@ namespace eve
   //! - `float`
   //================================================================================================
   template<typename T>
-  concept signed_scalar_value  = arithmetic_scalar_value<T> && std::is_signed_v<T>;
+  concept signed_scalar_value  = arithmetic_scalar_value<T> && std::is_signed_v<translate_t<element_type_t<T>>>;
 
   //================================================================================================
   //! @ingroup simd_concepts
@@ -50,7 +52,7 @@ namespace eve
   //! - `std::uint32_t`
   //================================================================================================
   template<typename T>
-  concept unsigned_scalar_value = arithmetic_scalar_value<T> && std::unsigned_integral<T>;
+  concept unsigned_scalar_value = arithmetic_scalar_value<T> && std::unsigned_integral<translate_t<element_type_t<T>>>;
 
   //================================================================================================
   //! @ingroup simd_concepts
@@ -63,7 +65,7 @@ namespace eve
   //! - `std::int32_t`
   //================================================================================================
   template<typename T>
-  concept signed_integral_scalar_value = arithmetic_scalar_value<T> && std::signed_integral<T>;
+  concept signed_integral_scalar_value = arithmetic_scalar_value<T> && std::signed_integral<translate_t<element_type_t<T>>>;
 
   //================================================================================================
   //! @ingroup simd_concepts
@@ -77,5 +79,5 @@ namespace eve
   //! - `double`
   //================================================================================================
   template<typename T>
-  concept floating_scalar_value = arithmetic_scalar_value<T> && std::floating_point<T>;
+  concept floating_scalar_value = arithmetic_scalar_value<T> && std::floating_point<translate_t<element_type_t<T>>>;
 }

--- a/include/eve/traits/element_type.hpp
+++ b/include/eve/traits/element_type.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <eve/detail/wide_forward.hpp>
+#include <eve/traits/translation.hpp>
 #include <type_traits>
 
 namespace eve
@@ -53,4 +54,8 @@ namespace eve
 
   template<typename T>
   using element_type_t = typename element_type<T>::type;
+
+  // Translate an element_type directly
+  template <typename T>
+  using translate_element_type_t = translate_t<element_type_t<T>>;
 }

--- a/include/eve/traits/translation.hpp
+++ b/include/eve/traits/translation.hpp
@@ -7,6 +7,7 @@
 //==================================================================================================
 #pragma once
 
+#include <eve/traits/element_type.hpp>
 #include <type_traits>
 
 namespace eve
@@ -32,7 +33,11 @@ namespace eve
   // Recursively translate the type `T` until `translation_of<T>` is `T`
   template <typename T>
   using translate_t = typename recursive_translate<T>::type;
-  
+
+  // Translate an element_type directly
+  template <typename T>
+  using translate_element_type_t = translate_t<element_type_t<T>>;
+
   // Covers every enum
   template <typename T>
   requires (std::is_enum_v<T>)

--- a/include/eve/traits/translation.hpp
+++ b/include/eve/traits/translation.hpp
@@ -7,9 +7,7 @@
 //==================================================================================================
 #pragma once
 
-#include <eve/traits/element_type.hpp>
 #include <type_traits>
-
 namespace eve
 {
   // Default case: normal types do not have specific storage type
@@ -33,10 +31,6 @@ namespace eve
   // Recursively translate the type `T` until `translation_of<T>` is `T`
   template <typename T>
   using translate_t = typename recursive_translate<T>::type;
-
-  // Translate an element_type directly
-  template <typename T>
-  using translate_element_type_t = translate_t<element_type_t<T>>;
 
   // Covers every enum
   template <typename T>

--- a/test/unit/api/translation/base.cpp
+++ b/test/unit/api/translation/base.cpp
@@ -34,3 +34,31 @@ TTS_CASE_TPL("Equivalent struct trait impl", eve::test::scalar::all_types)
   TTS_CONSTEXPR_EXPECT((eve::has_plain_translation<S>)) << "S should have a translated type";
   TTS_CONSTEXPR_EXPECT((std::same_as<eve::translate_t<S>, T>)) << "The translated type of S should be T";
 };
+
+TTS_CASE_TPL("Checks behavior of concepts over translated type", eve::test::scalar::all_types)
+<typename T>(tts::type<T>)
+{
+  using S = BaseStruct<T>;
+
+  TTS_CONSTEXPR_EXPECT(eve::value<S>);
+
+  if constexpr(eve::integral_value<S>)
+  {
+    TTS_CONSTEXPR_EXPECT(eve::integral_value<S>);
+    TTS_CONSTEXPR_EXPECT(eve::integral_scalar_value<S>);
+    TTS_CONSTEXPR_EXPECT_NOT(eve::floating_value<S>);
+
+    enum class E: T { };
+
+    TTS_CONSTEXPR_EXPECT(eve::value<E>);
+    TTS_CONSTEXPR_EXPECT(eve::integral_value<E>);
+    TTS_CONSTEXPR_EXPECT(eve::integral_scalar_value<E>);
+    TTS_CONSTEXPR_EXPECT_NOT(eve::floating_value<E>);
+  }
+  else
+  {
+    TTS_CONSTEXPR_EXPECT_NOT(eve::integral_value<S>);
+    TTS_CONSTEXPR_EXPECT_NOT(eve::integral_scalar_value<S>);
+    TTS_CONSTEXPR_EXPECT(eve::floating_value<S>);
+  }
+};


### PR DESCRIPTION
Two motivations :
 + we want translatable types to behave as their equivalent types.
 + experience in the Fluxion and Kyosu library that build SIMDizable structure, a type having an underlying_type does not means it has to be picked by its underlying_type matching concepts. It makes external library concepts interaction with EVE complicated.

So now, we look at the `element_type_t<translate_t<>>` of a type before matching the basic concepts.