### PR TITLE
Make `callable` return lvalue reference if necessary

### DIFF
--- a/include/eve/traits/overload/default_behaviors.hpp
+++ b/include/eve/traits/overload/default_behaviors.hpp
@@ -76,7 +76,7 @@ namespace eve
     requires( !callable_options<T> && !requires(base const& b) { b[t];} && !decorator<T>) =delete;
 
     template<typename... Args>
-    EVE_FORCEINLINE constexpr auto behavior(auto arch, Args&&... args) const
+    EVE_FORCEINLINE constexpr decltype(auto) behavior(auto arch, Args&&... args) const
     {
       return Func<OptionsValues>::deferred_call(arch, EVE_FWD(args)...);
     }


### PR DESCRIPTION
This is a requirement for some external libraries that have callable that do stuff like

```c++
kyosu::real(z) = 9;
```

Where `real` is a function object based on `eve::callable`.