### PR TITLE
[riscv] Add support for RISC-V vector extension in arch

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -147,9 +147,9 @@ jobs:
           mkdir build && cd build
           cmake .. -G Ninja -DEVE_OPTIONS="${{ matrix.cfg.opts }}" -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchain/${{ matrix.cfg.comp }}.${{ matrix.cfg.arch }}.cmake
       - name: Compiling Unit Tests
-        run:  cd build && ninja unit.meta.exe -j 5
+        run:  cd build && ninja unit.meta.exe unit.arch.exe -j 5
       - name: Running Unit Tests
-        run:  cd build && ctest --output-on-failure -j 4  -R ^unit.meta.*.exe
+        run:  cd build && ctest --output-on-failure -j 4  -R "^unit.meta.*.exe|^unit.arch.*.exe"
 
   ##################################################################################################
   ## Mac OS X Targets

--- a/include/eve/arch/abi_of.hpp
+++ b/include/eve/arch/abi_of.hpp
@@ -65,6 +65,11 @@ namespace eve
             else                                   return emulated_{};
           }
         }
+        else if constexpr( spy::simd_instruction_set == spy::fixed_rvv_
+                           && spy::simd_instruction_set.width >= 64 )
+        {
+          return riscv_ {};
+        }
         else
         {
           return emulated_{};

--- a/include/eve/arch/cpu/tags.hpp
+++ b/include/eve/arch/cpu/tags.hpp
@@ -52,7 +52,7 @@ namespace eve
     using parent  = cpu_;
   };
 
-# if defined(SPY_SIMD_IS_X86_AVX512) || defined(SPY_SIMD_IS_ARM_FIXED_SVE)
+# if defined(SPY_SIMD_IS_X86_AVX512) || defined(SPY_SIMD_IS_ARM_FIXED_SVE) || defined(SPY_SIMD_IS_RISCV_FIXED_RVV)
 #define EVE_WIDE_LOGICAL_NAMESPACE
 #define EVE_BIT_LOGICAL_NAMESPACE   inline
 #else

--- a/include/eve/arch/cpu/top_bits.hpp
+++ b/include/eve/arch/cpu/top_bits.hpp
@@ -479,7 +479,7 @@ EVE_FORCEINLINE Logical to_logical(eve::top_bits<Logical> mmask) noexcept
       using bits_et   = element_type_t<bits_wide>;
       using fit_wide  = logical<wide<bits_et, expected_cardinal_t<bits_et, abi_t>>>;
       fit_wide mask([&](int i, int) { return i < Logical::size() ? mmask.get(i) : false; });
-      return bit_cast( mask, as<Logical>{} );
+      return call_simd_cast( mask, as<Logical>{} );
     }
   }
 }

--- a/include/eve/arch/riscv/as_register.hpp
+++ b/include/eve/arch/riscv/as_register.hpp
@@ -1,0 +1,299 @@
+//==================================================================================================
+/*
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+*/
+//==================================================================================================
+#pragma once
+
+#include <eve/arch/riscv/predef.hpp>
+#include <eve/arch/riscv/rvv_utils.hpp>
+#include <eve/traits/as_integer.hpp>
+
+#include <type_traits>
+#if defined(EVE_INCLUDE_RISCV_HEADER)
+
+namespace eve
+{
+template<typename T> struct logical;
+}
+
+#  if defined(EVE_RETURN_M)
+#    error EVE_RETURN_M already defined
+#  endif
+
+#  if defined(EVE_RETURN_MF)
+#    error EVE_RETURN_MF already defined
+#  endif
+
+#  define EVE_RETURN_MF(REG, LMUL)                                                                 \
+    do {                                                                                           \
+      using type = REG __attribute__((riscv_rvv_vector_bits(__riscv_v_fixed_vlen / LMUL)));        \
+      return type {};                                                                              \
+    }                                                                                              \
+    while( 0 )
+
+#  define EVE_RETURN_M(REG, LMUL)                                                                  \
+    do {                                                                                           \
+      using type = REG __attribute__((riscv_rvv_vector_bits(__riscv_v_fixed_vlen * LMUL)));        \
+      return type {};                                                                              \
+    }                                                                                              \
+    while( 0 )
+
+namespace eve
+{
+template<typename Type, typename Size, rvv_abi ABI> struct as_register<Type, Size, ABI>
+{
+  static constexpr auto lmul = detail::rvv_lmul_v<Type, Size>;
+
+  static consteval auto find_vint_mf8()
+  {
+    constexpr std::size_t element_bit_size = sizeof(Type) * 8;
+    if constexpr( element_bit_size == 8 ) EVE_RETURN_MF(vint8mf8_t, 8);
+  }
+
+  static consteval auto find_vint_mf4()
+  {
+    constexpr size_t element_bit_size = sizeof(Type) * 8;
+    if constexpr( element_bit_size == 8 ) EVE_RETURN_MF(vint8mf4_t, 4);
+    else if constexpr( element_bit_size == 16 ) EVE_RETURN_MF(vint16mf4_t, 4);
+  }
+
+  static consteval auto find_vint_mf2()
+  {
+    constexpr size_t element_bit_size = sizeof(Type) * 8;
+    if constexpr( element_bit_size == 8 ) EVE_RETURN_MF(vint8mf2_t, 2);
+    else if constexpr( element_bit_size == 16 ) EVE_RETURN_MF(vint16mf2_t, 2);
+    else if constexpr( element_bit_size == 32 ) EVE_RETURN_MF(vint32mf2_t, 2);
+  }
+
+  static consteval auto find_vint_m1()
+  {
+    constexpr size_t element_bit_size = sizeof(Type) * 8;
+    if constexpr( element_bit_size == 8 ) EVE_RETURN_M(vint8m1_t, 1);
+    else if constexpr( element_bit_size == 16 ) EVE_RETURN_M(vint16m1_t, 1);
+    else if constexpr( element_bit_size == 32 ) EVE_RETURN_M(vint32m1_t, 1);
+    else if constexpr( element_bit_size == 64 ) EVE_RETURN_M(vint64m1_t, 1);
+  }
+
+  static consteval auto find_vint_m2()
+  {
+    constexpr size_t element_bit_size = sizeof(Type) * 8;
+    if constexpr( element_bit_size == 8 ) EVE_RETURN_M(vint8m2_t, 2);
+    else if constexpr( element_bit_size == 16 ) EVE_RETURN_M(vint16m2_t, 2);
+    else if constexpr( element_bit_size == 32 ) EVE_RETURN_M(vint32m2_t, 2);
+    else if constexpr( element_bit_size == 64 ) EVE_RETURN_M(vint64m2_t, 2);
+  }
+
+  static consteval auto find_vint_m4()
+  {
+    constexpr size_t element_bit_size = sizeof(Type) * 8;
+    if constexpr( element_bit_size == 8 ) EVE_RETURN_M(vint8m4_t, 4);
+    else if constexpr( element_bit_size == 16 ) EVE_RETURN_M(vint16m4_t, 4);
+    else if constexpr( element_bit_size == 32 ) EVE_RETURN_M(vint32m4_t, 4);
+    else if constexpr( element_bit_size == 64 ) EVE_RETURN_M(vint64m4_t, 4);
+  }
+
+  static consteval auto find_vint_m8()
+  {
+    constexpr size_t element_bit_size = sizeof(Type) * 8;
+    if constexpr( element_bit_size == 8 ) EVE_RETURN_M(vint8m8_t, 8);
+    else if constexpr( element_bit_size == 16 ) EVE_RETURN_M(vint16m8_t, 8);
+    else if constexpr( element_bit_size == 32 ) EVE_RETURN_M(vint32m8_t, 8);
+    else if constexpr( element_bit_size == 64 ) EVE_RETURN_M(vint64m8_t, 8);
+  }
+
+  static consteval auto find_vint()
+  {
+    if constexpr( lmul == 1 ) return find_vint_m1();
+    else if constexpr( lmul == 2 ) return find_vint_m2();
+    else if constexpr( lmul == 4 ) return find_vint_m4();
+    else if constexpr( lmul == 8 ) return find_vint_m8();
+    else if constexpr( lmul == -2 ) return find_vint_mf2();
+    else if constexpr( lmul == -4 ) return find_vint_mf4();
+    else if constexpr( lmul == -8 ) return find_vint_mf8();
+  }
+
+  static consteval auto find_vuint_mf8()
+  {
+    constexpr size_t element_bit_size = sizeof(Type) * 8;
+    if constexpr( element_bit_size == 8 ) EVE_RETURN_MF(vuint8mf8_t, 8);
+  }
+
+  static consteval auto find_vuint_mf4()
+  {
+    constexpr size_t element_bit_size = sizeof(Type) * 8;
+    if constexpr( element_bit_size == 8 ) EVE_RETURN_MF(vuint8mf4_t, 4);
+    else if constexpr( element_bit_size == 16 ) EVE_RETURN_MF(vuint16mf4_t, 4);
+  }
+
+  static consteval auto find_vuint_mf2()
+  {
+    constexpr size_t element_bit_size = sizeof(Type) * 8;
+    if constexpr( element_bit_size == 8 ) EVE_RETURN_MF(vuint8mf2_t, 2);
+    else if constexpr( element_bit_size == 16 ) EVE_RETURN_MF(vuint16mf2_t, 2);
+    else if constexpr( element_bit_size == 32 ) EVE_RETURN_MF(vuint32mf2_t, 2);
+  }
+
+  static consteval auto find_vuint_m1()
+  {
+    constexpr size_t element_bit_size = sizeof(Type) * 8;
+    if constexpr( element_bit_size == 8 ) EVE_RETURN_M(vuint8m1_t, 1);
+    else if constexpr( element_bit_size == 16 ) EVE_RETURN_M(vuint16m1_t, 1);
+    else if constexpr( element_bit_size == 32 ) EVE_RETURN_M(vuint32m1_t, 1);
+    else if constexpr( element_bit_size == 64 ) EVE_RETURN_M(vuint64m1_t, 1);
+  }
+
+  static consteval auto find_vuint_m2()
+  {
+    constexpr size_t element_bit_size = sizeof(Type) * 8;
+    if constexpr( element_bit_size == 8 ) EVE_RETURN_M(vuint8m2_t, 2);
+    else if constexpr( element_bit_size == 16 ) EVE_RETURN_M(vuint16m2_t, 2);
+    else if constexpr( element_bit_size == 32 ) EVE_RETURN_M(vuint32m2_t, 2);
+    else if constexpr( element_bit_size == 64 ) EVE_RETURN_M(vuint64m2_t, 2);
+  }
+
+  static consteval auto find_vuint_m4()
+  {
+    constexpr size_t element_bit_size = sizeof(Type) * 8;
+    if constexpr( element_bit_size == 8 ) EVE_RETURN_M(vuint8m4_t, 4);
+    else if constexpr( element_bit_size == 16 ) EVE_RETURN_M(vuint16m4_t, 4);
+    else if constexpr( element_bit_size == 32 ) EVE_RETURN_M(vuint32m4_t, 4);
+    else if constexpr( element_bit_size == 64 ) EVE_RETURN_M(vuint64m4_t, 4);
+  }
+
+  static consteval auto find_vuint_m8()
+  {
+    constexpr size_t element_bit_size = sizeof(Type) * 8;
+    if constexpr( element_bit_size == 8 ) EVE_RETURN_M(vuint8m8_t, 8);
+    else if constexpr( element_bit_size == 16 ) EVE_RETURN_M(vuint16m8_t, 8);
+    else if constexpr( element_bit_size == 32 ) EVE_RETURN_M(vuint32m8_t, 8);
+    else if constexpr( element_bit_size == 64 ) EVE_RETURN_M(vuint64m8_t, 8);
+  }
+
+  static consteval auto find_vuint()
+  {
+    if constexpr( lmul == 1 ) return find_vuint_m1();
+    else if constexpr( lmul == 2 ) return find_vuint_m2();
+    else if constexpr( lmul == 4 ) return find_vuint_m4();
+    else if constexpr( lmul == 8 ) return find_vuint_m8();
+    else if constexpr( lmul == -2 ) return find_vuint_mf2();
+    else if constexpr( lmul == -4 ) return find_vuint_mf4();
+    else if constexpr( lmul == -8 ) return find_vuint_mf8();
+  }
+
+  static consteval auto find_vfloat_mf2()
+  {
+    constexpr size_t element_bit_size = sizeof(Type) * 8;
+    if constexpr( element_bit_size == 32 ) EVE_RETURN_MF(vfloat32mf2_t, 2);
+  }
+
+  static consteval auto find_vfloat_m1()
+  {
+    constexpr size_t element_bit_size = sizeof(Type) * 8;
+    if constexpr( element_bit_size == 32 ) EVE_RETURN_M(vfloat32m1_t, 1);
+    else if constexpr( element_bit_size == 64 ) EVE_RETURN_M(vfloat64m1_t, 1);
+  }
+
+  static consteval auto find_vfloat_m2()
+  {
+    constexpr size_t element_bit_size = sizeof(Type) * 8;
+    if constexpr( element_bit_size == 32 ) EVE_RETURN_M(vfloat32m2_t, 2);
+    else if constexpr( element_bit_size == 64 ) EVE_RETURN_M(vfloat64m2_t, 2);
+  }
+
+  static consteval auto find_vfloat_m4()
+  {
+    constexpr size_t element_bit_size = sizeof(Type) * 8;
+    if constexpr( element_bit_size == 32 ) EVE_RETURN_M(vfloat32m4_t, 4);
+    else if constexpr( element_bit_size == 64 ) EVE_RETURN_M(vfloat64m4_t, 4);
+  }
+
+  static consteval auto find_vfloat_m8()
+  {
+    constexpr size_t element_bit_size = sizeof(Type) * 8;
+    if constexpr( element_bit_size == 32 ) EVE_RETURN_M(vfloat32m8_t, 8);
+    else if constexpr( element_bit_size == 64 ) EVE_RETURN_M(vfloat64m8_t, 8);
+  }
+
+  static consteval auto find_vfloat()
+  {
+    if constexpr( lmul == 1 ) return find_vfloat_m1();
+    else if constexpr( lmul == 2 ) return find_vfloat_m2();
+    else if constexpr( lmul == 4 ) return find_vfloat_m4();
+    else if constexpr( lmul == 8 ) return find_vfloat_m8();
+    else if constexpr( lmul == -2 ) return find_vfloat_mf2();
+    // MF8, MF4 for float not supported.
+  }
+
+  public:
+  static consteval auto find()
+  {
+    constexpr auto width = sizeof(Type) * Size::value * 8;
+
+    static_assert(width <= __riscv_v_fixed_vlen * ABI::max_lmul,
+                  "[eve riscv] - sanity check. Type is not usable in SIMD register (too big)");
+    if constexpr( std::is_floating_point_v<Type> ) return find_vfloat();
+    else if constexpr( std::is_integral_v<Type> && std::is_signed_v<Type> ) return find_vint();
+    else if constexpr( std::is_integral_v<Type> && std::is_unsigned_v<Type> ) return find_vuint();
+  }
+  using type = decltype(find());
+  static_assert(!std::is_void_v<type>,
+                "[eve riscv] - sanity check. Type is not usable in a SIMD register (unknown type)");
+};
+
+#  undef EVE_RETURN_MF
+#  undef EVE_RETURN_M
+
+// ---------------------------------------------------------------------------------------------
+// logical cases
+template<typename Type, typename Size, rvv_abi ABI> struct as_logical_register<Type, Size, ABI>
+{
+  static constexpr size_t ratio = detail::rvv_logical_ratio_v<Type, Size>;
+
+  static constexpr auto find()
+  {
+    if constexpr( ratio == 1 )
+    {
+      using type = vbool1_t __attribute__((riscv_rvv_vector_bits(__riscv_v_fixed_vlen)));
+      return type {};
+    }
+    else if constexpr( ratio == 2 )
+    {
+      using type = vbool2_t __attribute__((riscv_rvv_vector_bits(__riscv_v_fixed_vlen / 2)));
+      return type {};
+    }
+    else if constexpr( ratio == 4 )
+    {
+      using type = vbool4_t __attribute__((riscv_rvv_vector_bits(__riscv_v_fixed_vlen / 4)));
+      return type {};
+    }
+    else if constexpr( ratio == 8 )
+    {
+      using type = vbool8_t __attribute__((riscv_rvv_vector_bits(__riscv_v_fixed_vlen / 8)));
+      return type {};
+    }
+    else if constexpr( ratio == 16 )
+    {
+      using type = vbool16_t __attribute__((riscv_rvv_vector_bits(__riscv_v_fixed_vlen / 16)));
+      return type {};
+    }
+    else if constexpr( ratio == 32 )
+    {
+      using type = vbool32_t __attribute__((riscv_rvv_vector_bits(__riscv_v_fixed_vlen / 32)));
+      return type {};
+    }
+    else if constexpr( ratio == 64 )
+    {
+      using type = vbool64_t __attribute__((riscv_rvv_vector_bits(__riscv_v_fixed_vlen / 64)));
+      return type {};
+    }
+  }
+
+  using type = decltype(find());
+  static_assert(!std::is_void_v<type>,
+                "[eve riscv] - sanity check. Type is not usable as logical(mask) SIMD register");
+};
+}
+#endif

--- a/include/eve/arch/riscv/predef.hpp
+++ b/include/eve/arch/riscv/predef.hpp
@@ -7,13 +7,10 @@
 //==================================================================================================
 #pragma once
 
-#include <eve/arch/cpu/as_register.hpp>
+#include <eve/detail/spy.hpp>
 
-#if !defined(EVE_NO_SIMD)
-#include <eve/arch/x86/as_register.hpp>
-#include <eve/arch/ppc/as_register.hpp>
-#include <eve/arch/arm/sve/as_register.hpp>
-#include <eve/arch/arm/neon/as_register.hpp>
-#include <eve/arch/riscv/as_register.hpp>
+// We successfully detected some native SIMD
+#if defined(SPY_SIMD_IS_RISCV_FIXED_RVV) && !defined(EVE_NO_SIMD)
+#  define EVE_SUPPORTS_NATIVE_SIMD
+#  define EVE_INCLUDE_RISCV_HEADER
 #endif
-

--- a/include/eve/arch/riscv/rvv_common_masks.hpp
+++ b/include/eve/arch/riscv/rvv_common_masks.hpp
@@ -1,0 +1,40 @@
+//==================================================================================================
+/*
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+*/
+//==================================================================================================
+#pragma once
+
+namespace eve::detail
+{
+template<arithmetic_scalar_value T, typename N>
+EVE_FORCEINLINE logical<wide<T, N>>
+                rvv_true()
+{
+  static constexpr size_t ratio = rvv_logical_ratio_v<T, N>;
+  if constexpr( ratio == 1 ) return __riscv_vmset_m_b1(N::value);
+  else if constexpr( ratio == 2 ) return __riscv_vmset_m_b2(N::value);
+  else if constexpr( ratio == 4 ) return __riscv_vmset_m_b4(N::value);
+  else if constexpr( ratio == 8 ) return __riscv_vmset_m_b8(N::value);
+  else if constexpr( ratio == 16 ) return __riscv_vmset_m_b16(N::value);
+  else if constexpr( ratio == 32 ) return __riscv_vmset_m_b32(N::value);
+  else if constexpr( ratio == 64 ) return __riscv_vmset_m_b64(N::value);
+}
+
+template<arithmetic_scalar_value T, typename N>
+EVE_FORCEINLINE logical<wide<T, N>>
+                rvv_none()
+{
+  static constexpr size_t ratio = rvv_logical_ratio_v<T, N>;
+  if constexpr( ratio == 1 ) return __riscv_vmclr_m_b1(N::value);
+  else if constexpr( ratio == 2 ) return __riscv_vmclr_m_b2(N::value);
+  else if constexpr( ratio == 4 ) return __riscv_vmclr_m_b4(N::value);
+  else if constexpr( ratio == 8 ) return __riscv_vmclr_m_b8(N::value);
+  else if constexpr( ratio == 16 ) return __riscv_vmclr_m_b16(N::value);
+  else if constexpr( ratio == 32 ) return __riscv_vmclr_m_b32(N::value);
+  else if constexpr( ratio == 64 ) return __riscv_vmclr_m_b64(N::value);
+}
+
+}

--- a/include/eve/arch/riscv/rvv_common_masks.hpp
+++ b/include/eve/arch/riscv/rvv_common_masks.hpp
@@ -25,7 +25,7 @@ EVE_FORCEINLINE logical<wide<T, N>>
 
 template<arithmetic_scalar_value T, typename N>
 EVE_FORCEINLINE logical<wide<T, N>>
-                rvv_none()
+                rvv_false()
 {
   static constexpr size_t ratio = rvv_logical_ratio_v<T, N>;
   if constexpr( ratio == 1 ) return __riscv_vmclr_m_b1(N::value);

--- a/include/eve/arch/riscv/rvv_utils.hpp
+++ b/include/eve/arch/riscv/rvv_utils.hpp
@@ -1,0 +1,40 @@
+//==================================================================================================
+/*
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+*/
+//==================================================================================================
+#pragma once
+#if defined(EVE_INCLUDE_RISCV_HEADER)
+
+#  ifndef __riscv_v_fixed_vlen
+#    error __riscv_v_fixed_vlen must be defined
+#  endif
+
+namespace eve::detail
+{
+// natural lmul if > 0, frac otherwise
+template<plain_scalar_value scalar_type, typename cardinal>
+constexpr auto rvv_lmul_v = []
+{
+  constexpr std::ptrdiff_t m1_len       = __riscv_v_fixed_vlen;
+  constexpr std::ptrdiff_t min_len      = m1_len * sizeof(scalar_type) / 8;
+  std::ptrdiff_t           expected_len = sizeof(scalar_type) * 8 * cardinal::value;
+  std::ptrdiff_t           reg_len      = std::max(min_len, expected_len);
+  if( reg_len >= m1_len ) return static_cast<int>(reg_len / m1_len);
+  else return -static_cast<int>(m1_len / reg_len);
+}();
+
+template<plain_scalar_value scalar_type, typename cardinal>
+constexpr auto rvv_logical_ratio_v = []
+{
+  auto           lmul         = rvv_lmul_v<scalar_type, cardinal>;
+  constexpr auto element_size = sizeof(scalar_type) * 8;
+  return lmul > 0 ? element_size / lmul : element_size * (-lmul);
+}();
+
+template<plain_scalar_value T>
+using rvv_m1_wide = wide<T, fixed<__riscv_v_fixed_vlen / 8 / sizeof(T)>>;
+}
+#endif

--- a/include/eve/arch/riscv/spec.hpp
+++ b/include/eve/arch/riscv/spec.hpp
@@ -1,0 +1,39 @@
+//==================================================================================================
+/*
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+*/
+//==================================================================================================
+#pragma once
+
+#include <eve/arch/riscv/predef.hpp>
+
+#include <cstddef>
+
+//==================================================================================================
+// Register count
+//==================================================================================================
+#if defined(EVE_INCLUDE_RISCV_HEADER)
+
+namespace eve
+{
+struct register_count
+{
+  static constexpr std::size_t general = 32;
+  static constexpr std::size_t simd    = 32;
+};
+}
+
+//==================================================================================================
+// RVV SIMD ABI
+//==================================================================================================
+#  if !defined(EVE_CURRENT_API)
+#    include <riscv_vector.h>
+#    define EVE_CURRENT_ABI   ::eve::riscv_
+#    define EVE_CURRENT_API   ::eve::rvv_
+#    define EVE_ABI_NAMESPACE riscv_abi_namespace
+#    define EVE_ABI_DETECTED
+#  endif
+
+#endif

--- a/include/eve/arch/riscv/tags.hpp
+++ b/include/eve/arch/riscv/tags.hpp
@@ -1,0 +1,76 @@
+//==================================================================================================
+/*
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+*/
+//==================================================================================================
+#pragma once
+
+#include <eve/arch/cardinals.hpp>
+#include <eve/arch/cpu/tags.hpp>
+#include <eve/arch/riscv/predef.hpp>
+#include <eve/detail/meta.hpp>
+
+#include <optional>
+
+namespace eve
+{
+//================================================================================================
+// ABI tags for all RISCV bits SIMD registers
+//================================================================================================
+template<std::size_t vector_register_bit_size> struct rvv_abi_
+{
+  static constexpr std::size_t max_lmul        = 8;
+  static constexpr std::size_t bits            = vector_register_bit_size * max_lmul;
+  static constexpr std::size_t bytes           = bits / 8;
+  static constexpr bool        is_wide_logical = false;
+
+  template<typename Type>
+  static constexpr std::size_t fundamental_vector_size =
+      vector_register_bit_size * sizeof(Type) / 8;
+
+  template<typename Type>
+  static constexpr std::size_t fundamental_cardinal =
+      fundamental_vector_size<Type> / sizeof(Type) / 8;
+  // Work in terms of vector intrinsics types
+  template<typename Type>
+  static constexpr bool is_full = ((Type::size() * sizeof(typename Type::value_type))
+                                   >= fundamental_vector_size<typename Type::value_type> / 8);
+
+  template<typename Type>
+  static constexpr std::size_t expected_cardinal =
+      vector_register_bit_size / 8 / sizeof(Type) * max_lmul;
+};
+
+#ifdef __riscv_v_fixed_vlen
+struct riscv_ : rvv_abi_<__riscv_v_fixed_vlen>
+{};
+#else
+// Needed for comparison purposes in core EVE.
+// No RISC-V specific code should be generated in this case.
+struct riscv_ : rvv_abi_<1>
+{};
+#endif
+
+//================================================================================================
+// Dispatching tag for RISC-V SIMD implementation
+//================================================================================================
+struct rvv_ : simd_api<simd_, spy::rvv_>
+{
+  using is_rvv = void;
+};
+
+//================================================================================================
+// RISC-V extensions tag objects
+//================================================================================================
+inline constexpr rvv_ rvv = {};
+
+//================================================================================================
+// RISC-V RVV ABI concept
+//================================================================================================
+template<typename T>
+concept rvv_abi = detail::is_one_of<T>(detail::types<riscv_> {});
+template<typename T>
+concept rvv_tag = requires(T) { typename T::is_rvv; };
+}

--- a/include/eve/arch/riscv/top_bits.hpp
+++ b/include/eve/arch/riscv/top_bits.hpp
@@ -1,0 +1,144 @@
+//==================================================================================================
+/*
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+*/
+//==================================================================================================
+#pragma once
+
+#include <eve/detail/meta.hpp>
+namespace eve
+{
+
+template<logical_simd_value Logical>
+requires(current_api == rvv && !has_aggregated_abi_v<Logical>)
+struct top_bits<Logical>
+{
+  using logical_type = Logical;
+  using scalar_type  = typename as_arithmetic_t<logical_type>::value_type;
+  using abi_type     = typename as_arithmetic_t<logical_type>::abi_type;
+
+  static constexpr std::ptrdiff_t static_size   = logical_type::size();
+  static constexpr bool           is_aggregated = false;
+
+  static constexpr auto half_size = (static_size / 2 > 0) ? static_size / 2 : 1;
+  using half_logical              = logical<wide<scalar_type, eve::fixed<half_size>>>;
+  using storage_type              = Logical;
+
+  static constexpr std::ptrdiff_t bits_per_element = 1;
+  static constexpr std::ptrdiff_t static_bits_size = static_size * bits_per_element;
+  static constexpr bool           is_cheap         = true;
+
+  storage_type storage;
+
+  // constructors ---------------------------------
+
+  EVE_FORCEINLINE constexpr top_bits() = default;
+
+  EVE_FORCEINLINE constexpr explicit top_bits(storage_type storage) : storage(storage) {}
+
+  EVE_FORCEINLINE constexpr explicit top_bits(logical_type p)
+  requires(!std::same_as<storage_type, logical_type>)
+      : storage {bit_cast(p, eve::as<storage_type> {})}
+  {
+    operator&=(top_bits(ignore_none_ {}));
+  }
+
+  // -- constructor(ignore)
+  template<relative_conditional_expr C>
+  EVE_FORCEINLINE constexpr explicit top_bits(C c) : storage {c.mask(eve::as<logical_type> {})}
+  {}
+
+  // -- constructor: logical + ignore
+
+  EVE_FORCEINLINE explicit top_bits(logical_type p, relative_conditional_expr auto ignore)
+      : top_bits(p)
+  {
+    operator&=(top_bits(ignore));
+  }
+
+  // -- slicing
+
+  EVE_FORCEINLINE
+  kumi::tuple<top_bits<half_logical>, top_bits<half_logical>> slice() const
+  requires(Logical::size() > 1)
+  {
+    auto [l, h] = to_logical(*this).slice();
+    return {top_bits<half_logical> {l}, top_bits<half_logical> {h}};
+  }
+
+  template<std::size_t Slice> EVE_FORCEINLINE top_bits<half_logical> slice(slice_t<Slice>) const
+  {
+    auto [l, h] = slice();
+
+    if constexpr( Slice == 0 ) return l;
+    else return h;
+  }
+
+  // getters/setter ----------------------
+  static constexpr std::ptrdiff_t size() { return static_size; }
+
+  EVE_FORCEINLINE constexpr void set(std::ptrdiff_t i, bool x) { storage.set(i, x); }
+  EVE_FORCEINLINE constexpr bool get(std::ptrdiff_t i) const { return storage.get(i); }
+
+  EVE_FORCEINLINE constexpr explicit operator bool()
+  {
+    return __riscv_vcpop(storage, static_size) != 0;
+  }
+
+  EVE_FORCEINLINE constexpr auto as_int() const
+  requires(static_bits_size <= 64)
+  {
+    constexpr unsigned byte_size = std::max<std::ptrdiff_t>(1, static_bits_size / 8);
+    using u_type                 = detail::make_integer_t<byte_size, unsigned>;
+    auto raw_value               = std::bit_cast<u_type>(storage);
+    if constexpr( static_bits_size >= 8 ) return raw_value;
+    else
+    {
+      // if static_bit_size < 8, we have some dirty bits in resulted unsigned,
+      // so cleanning them.
+      u_type mask = detail::set_lower_n_bits<u_type>(static_bits_size);
+      return raw_value & mask;
+    }
+  }
+
+  EVE_FORCEINLINE constexpr bool operator==(top_bits const& x) const
+  {
+    // we find any place that have not equal elements.
+    auto neq_res = top_bits(storage != x.storage);
+    // if we find any place, top_bit will be true, so negate it.
+    return !neq_res;
+  }
+
+  EVE_FORCEINLINE top_bits& operator&=(top_bits x)
+  {
+    storage = storage && x.storage;
+    return *this;
+  }
+
+  EVE_FORCEINLINE top_bits& operator|=(top_bits x)
+  {
+    storage = storage || x.storage;
+    return *this;
+  }
+
+  EVE_FORCEINLINE top_bits& operator^=(top_bits x)
+  {
+    storage = storage != x.storage;
+    return *this;
+  }
+
+  EVE_FORCEINLINE constexpr top_bits operator~() const
+  {
+    return top_bits {!storage} & top_bits {ignore_none_ {}};
+  }
+
+  // streaming ----------------------------------
+
+  EVE_FORCEINLINE friend std::ostream& operator<<(std::ostream& o, const top_bits& x)
+  {
+    return o << x.storage << "\n";
+  }
+};
+}

--- a/include/eve/arch/spec.hpp
+++ b/include/eve/arch/spec.hpp
@@ -12,6 +12,7 @@
 #  include <eve/arch/ppc/spec.hpp>
 #  include <eve/arch/arm/sve/spec.hpp>
 #  include <eve/arch/arm/neon/spec.hpp>
+#  include <eve/arch/riscv/spec.hpp>
 #endif
 
 #include <eve/arch/cpu/spec.hpp>

--- a/include/eve/arch/tags.hpp
+++ b/include/eve/arch/tags.hpp
@@ -12,3 +12,4 @@
 #include <eve/arch/ppc/tags.hpp>
 #include <eve/arch/arm/sve/tags.hpp>
 #include <eve/arch/arm/neon/tags.hpp>
+#include <eve/arch/riscv/tags.hpp>

--- a/include/eve/arch/top_bits.hpp
+++ b/include/eve/arch/top_bits.hpp
@@ -39,3 +39,7 @@ namespace eve {
 #if defined(EVE_INCLUDE_SVE_HEADER)
 #  include <eve/arch/arm/sve/top_bits.hpp>
 #endif
+
+#if defined(EVE_INCLUDE_RISCV_HEADER)
+#  include <eve/arch/riscv/top_bits.hpp>
+#endif

--- a/include/eve/detail/function/bit_cast.hpp
+++ b/include/eve/detail/function/bit_cast.hpp
@@ -33,3 +33,7 @@ namespace eve
 #if defined(EVE_INCLUDE_SVE_HEADER)
 #  include <eve/detail/function/simd/arm/sve/bit_cast.hpp>
 #endif
+
+#if defined(EVE_INCLUDE_RISCV_HEADER)
+#  include <eve/detail/function/simd/riscv/bit_cast.hpp>
+#endif

--- a/include/eve/detail/function/bitmask.hpp
+++ b/include/eve/detail/function/bitmask.hpp
@@ -17,3 +17,7 @@
 #if defined(EVE_INCLUDE_SVE_HEADER)
 #  include <eve/detail/function/simd/arm/sve/bitmask.hpp>
 #endif
+
+#if defined(EVE_INCLUDE_RISCV_HEADER)
+#  include <eve/detail/function/simd/riscv/bitmask.hpp>
+#endif

--- a/include/eve/detail/function/combine.hpp
+++ b/include/eve/detail/function/combine.hpp
@@ -25,3 +25,8 @@
 #if defined(EVE_INCLUDE_SVE_HEADER)
 #  include <eve/detail/function/simd/arm/sve/combine.hpp>
 #endif
+
+#if defined(EVE_INCLUDE_RISCV_HEADER)
+#  include <eve/detail/function/simd/riscv/combine.hpp>
+
+#endif

--- a/include/eve/detail/function/friends.hpp
+++ b/include/eve/detail/function/friends.hpp
@@ -25,3 +25,7 @@
 #if defined(EVE_INCLUDE_SVE_HEADER)
 #  include <eve/detail/function/simd/arm/sve/friends.hpp>
 #endif
+
+#if defined(EVE_INCLUDE_RISCV_HEADER)
+#  include <eve/detail/function/simd/riscv/friends.hpp>
+#endif

--- a/include/eve/detail/function/load.hpp
+++ b/include/eve/detail/function/load.hpp
@@ -35,3 +35,7 @@ namespace eve
 #if defined(EVE_INCLUDE_SVE_HEADER)
 #  include <eve/detail/function/simd/arm/sve/load.hpp>
 #endif
+
+#if defined(EVE_INCLUDE_RISCV_HEADER)
+#  include <eve/detail/function/simd/riscv/load.hpp>
+#endif

--- a/include/eve/detail/function/make.hpp
+++ b/include/eve/detail/function/make.hpp
@@ -36,3 +36,7 @@ namespace eve::detail
 #if defined(EVE_INCLUDE_SVE_HEADER)
 #  include <eve/detail/function/simd/arm/sve/make.hpp>
 #endif
+
+#if defined(EVE_INCLUDE_RISCV_HEADER)
+#  include <eve/detail/function/simd/riscv/make.hpp>
+#endif

--- a/include/eve/detail/function/simd/common/to_logical.hpp
+++ b/include/eve/detail/function/simd/common/to_logical.hpp
@@ -78,14 +78,14 @@ to_logical(C c, eve::as<T>) noexcept
 
     if constexpr( std::same_as<C, keep_first> || std::same_as<C, ignore_last> )
     {
-      return bit_cast(to_logical(keep_first(c.count(as<l_t> {})), as<w_t> {}), as<l_t> {});
+      return call_simd_cast(to_logical(keep_first(c.count(as<l_t> {})), as<w_t> {}), as<l_t> {});
     }
     else
     {
       std::ptrdiff_t offset = c.offset(as<T> {});
       std::ptrdiff_t count  = c.count(as<T> {});
       keep_between   full_c {offset, offset + count};
-      return bit_cast(to_logical(full_c, as<w_t> {}), as<l_t> {});
+      return call_simd_cast(to_logical(full_c, as<w_t> {}), as<l_t> {});
     }
   }
   else

--- a/include/eve/detail/function/simd/riscv/bit_cast.hpp
+++ b/include/eve/detail/function/simd/riscv/bit_cast.hpp
@@ -1,0 +1,316 @@
+//==================================================================================================
+/*
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+*/
+//==================================================================================================
+#pragma once
+
+#include <eve/as.hpp>
+#include <eve/concept/simd.hpp>
+#include <eve/detail/category.hpp>
+#include <eve/detail/is_native.hpp>
+#include <eve/traits/as_integer.hpp>
+#include <eve/arch/riscv/rvv_utils.hpp>
+
+namespace eve::detail
+{
+
+template<typename T, typename N, typename U, typename M>
+concept same_storage_size = sizeof(wide<T, N>) == sizeof(wide<U, M>);
+
+template<typename T, typename N, typename U, typename M>
+concept same_wide_size = sizeof(T) *
+N::value == sizeof(U) * M::value;
+
+template<typename T, typename U>
+concept same_element_size = sizeof(T) == sizeof(U);
+
+template<typename T, typename U>
+concept different_type = !
+std::is_same_v<T, U>;
+
+template<typename T, typename N, typename U, typename M>
+concept different_wide_types = different_type<T, U> || N::value !=
+M::value;
+
+template<typename T, typename N, typename U, typename M>
+concept same_type_types = (match(categorize<wide<T, N>>(), category::int_)
+                           && match(categorize<wide<U, M>>(), category::int_))
+                          || (match(categorize<wide<T, N>>(), category::uint_)
+                              && match(categorize<wide<U, M>>(), category::uint_))
+                          || (match(categorize<wide<T, N>>(), category::float_)
+                              && match(categorize<wide<U, M>>(), category::float_));
+
+// change type only
+// For example:
+// int -> unsigned
+// float -> int
+template<callable_options O, scalar_value T, typename N, scalar_value U>
+EVE_FORCEINLINE wide<U, N>
+bit_cast_(EVE_REQUIRES(rvv_), O const&, wide<T, N> x, as<wide<U, N>> const&) noexcept
+requires rvv_abi<abi_t<T, N>> && rvv_abi<abi_t<U, N>> && same_storage_size<T, N, U, N>
+         && same_element_size<T, U> && different_type<T, U> && same_wide_size<T, N, U, N>
+{
+  using out_wide       = wide<U, N>;
+  constexpr auto out_c = categorize<out_wide>();
+
+  constexpr auto out_lmul = detail::rvv_lmul_v<U, N>;
+  if constexpr( match(out_c, category::float64) )
+  {
+    if constexpr( out_lmul == 1 ) return __riscv_vreinterpret_f64m1(x);
+    else if constexpr( out_lmul == 2 ) return __riscv_vreinterpret_f64m2(x);
+    else if constexpr( out_lmul == 4 ) return __riscv_vreinterpret_f64m4(x);
+    else if constexpr( out_lmul == 8 ) return __riscv_vreinterpret_f64m8(x);
+  }
+  else if constexpr( match(out_c, category::int64) )
+  {
+    if constexpr( out_lmul == 1 ) return __riscv_vreinterpret_i64m1(x);
+    else if constexpr( out_lmul == 2 ) return __riscv_vreinterpret_i64m2(x);
+    else if constexpr( out_lmul == 4 ) return __riscv_vreinterpret_i64m4(x);
+    else if constexpr( out_lmul == 8 ) return __riscv_vreinterpret_i64m8(x);
+  }
+  else if constexpr( match(out_c, category::uint64) )
+  {
+    if constexpr( out_lmul == 1 ) return __riscv_vreinterpret_u64m1(x);
+    else if constexpr( out_lmul == 2 ) return __riscv_vreinterpret_u64m2(x);
+    else if constexpr( out_lmul == 4 ) return __riscv_vreinterpret_u64m4(x);
+    else if constexpr( out_lmul == 8 ) return __riscv_vreinterpret_u64m8(x);
+  }
+  else if constexpr( match(out_c, category::float32) )
+  {
+    if constexpr( out_lmul == -2 ) return __riscv_vreinterpret_f32mf2(x);
+    else if constexpr( out_lmul == 1 ) return __riscv_vreinterpret_f32m1(x);
+    else if constexpr( out_lmul == 2 ) return __riscv_vreinterpret_f32m2(x);
+    else if constexpr( out_lmul == 4 ) return __riscv_vreinterpret_f32m4(x);
+    else if constexpr( out_lmul == 8 ) return __riscv_vreinterpret_f32m8(x);
+  }
+  else if constexpr( match(out_c, category::int32) )
+  {
+    if constexpr( out_lmul == -2 ) return __riscv_vreinterpret_i32mf2(x);
+    else if constexpr( out_lmul == 1 ) return __riscv_vreinterpret_i32m1(x);
+    else if constexpr( out_lmul == 2 ) return __riscv_vreinterpret_i32m2(x);
+    else if constexpr( out_lmul == 4 ) return __riscv_vreinterpret_i32m4(x);
+    else if constexpr( out_lmul == 8 ) return __riscv_vreinterpret_i32m8(x);
+  }
+  else if constexpr( match(out_c, category::uint32) )
+  {
+    if constexpr( out_lmul == -2 ) return __riscv_vreinterpret_u32mf2(x);
+    else if constexpr( out_lmul == 1 ) return __riscv_vreinterpret_u32m1(x);
+    else if constexpr( out_lmul == 2 ) return __riscv_vreinterpret_u32m2(x);
+    else if constexpr( out_lmul == 4 ) return __riscv_vreinterpret_u32m4(x);
+    else if constexpr( out_lmul == 8 ) return __riscv_vreinterpret_u32m8(x);
+  }
+  else if constexpr( match(out_c, category::int16) )
+  {
+    if constexpr( out_lmul == -4 ) return __riscv_vreinterpret_i16mf4(x);
+    else if constexpr( out_lmul == -2 ) return __riscv_vreinterpret_i16mf2(x);
+    else if constexpr( out_lmul == 1 ) return __riscv_vreinterpret_i16m1(x);
+    else if constexpr( out_lmul == 2 ) return __riscv_vreinterpret_i16m2(x);
+    else if constexpr( out_lmul == 4 ) return __riscv_vreinterpret_i16m4(x);
+    else if constexpr( out_lmul == 8 ) return __riscv_vreinterpret_i16m8(x);
+  }
+  else if constexpr( match(out_c, category::uint16) )
+  {
+    if constexpr( out_lmul == -4 ) return __riscv_vreinterpret_u16mf4(x);
+    else if constexpr( out_lmul == -2 ) return __riscv_vreinterpret_u16mf2(x);
+    else if constexpr( out_lmul == 1 ) return __riscv_vreinterpret_u16m1(x);
+    else if constexpr( out_lmul == 2 ) return __riscv_vreinterpret_u16m2(x);
+    else if constexpr( out_lmul == 4 ) return __riscv_vreinterpret_u16m4(x);
+    else if constexpr( out_lmul == 8 ) return __riscv_vreinterpret_u16m8(x);
+  }
+  else if constexpr( match(out_c, category::int8) )
+  {
+    if constexpr( out_lmul == -8 ) return __riscv_vreinterpret_i8mf8(x);
+    else if constexpr( out_lmul == -4 ) return __riscv_vreinterpret_i8mf4(x);
+    else if constexpr( out_lmul == -2 ) return __riscv_vreinterpret_i8mf2(x);
+    else if constexpr( out_lmul == 1 ) return __riscv_vreinterpret_i8m1(x);
+    else if constexpr( out_lmul == 2 ) return __riscv_vreinterpret_i8m2(x);
+    else if constexpr( out_lmul == 4 ) return __riscv_vreinterpret_i8m4(x);
+    else if constexpr( out_lmul == 8 ) return __riscv_vreinterpret_i8m8(x);
+  }
+  else if constexpr( match(out_c, category::uint8) )
+  {
+    if constexpr( out_lmul == -8 ) return __riscv_vreinterpret_u8mf8(x);
+    else if constexpr( out_lmul == -4 ) return __riscv_vreinterpret_u8mf4(x);
+    else if constexpr( out_lmul == -2 ) return __riscv_vreinterpret_u8mf2(x);
+    else if constexpr( out_lmul == 1 ) return __riscv_vreinterpret_u8m1(x);
+    else if constexpr( out_lmul == 2 ) return __riscv_vreinterpret_u8m2(x);
+    else if constexpr( out_lmul == 4 ) return __riscv_vreinterpret_u8m4(x);
+    else if constexpr( out_lmul == 8 ) return __riscv_vreinterpret_u8m8(x);
+  }
+}
+
+// change sew only.
+// For example:
+// unsigned -> unsigned char
+// int -> char
+template<callable_options O, scalar_value T, typename N, scalar_value U, typename M>
+EVE_FORCEINLINE wide<U, M>
+bit_cast_(EVE_REQUIRES(rvv_), const O&, wide<T, N> x, as<wide<U, M>> const&) noexcept
+requires rvv_abi<abi_t<T, N>> && rvv_abi<abi_t<U, M>> && same_storage_size<T, N, U, M>
+         && (!same_element_size<T, U>) && same_type_types<T, N, U, M> && same_wide_size<T, N, U, M>
+{
+  using in_wide           = wide<T, N>;
+  using out_wide          = wide<U, M>;
+  constexpr auto out_lmul = rvv_lmul_v<T, M>;
+
+  constexpr auto in_c  = categorize<in_wide>();
+  constexpr auto out_c = categorize<out_wide>();
+
+  if constexpr( match(out_c, category::int8) )
+  {
+    if constexpr( out_lmul == -8 ) return __riscv_vreinterpret_i8mf8(x);
+    else if constexpr( out_lmul == -4 ) return __riscv_vreinterpret_i8mf4(x);
+    else if constexpr( out_lmul == -2 ) return __riscv_vreinterpret_i8mf2(x);
+    else if constexpr( out_lmul == 1 ) return __riscv_vreinterpret_i8m1(x);
+    else if constexpr( out_lmul == 2 ) return __riscv_vreinterpret_i8m2(x);
+    else if constexpr( out_lmul == 4 ) return __riscv_vreinterpret_i8m4(x);
+    else if constexpr( out_lmul == 8 ) return __riscv_vreinterpret_i8m8(x);
+  }
+  else if constexpr( match(out_c, category::uint8) )
+  {
+    if constexpr( out_lmul == -8 ) return __riscv_vreinterpret_u8mf8(x);
+    else if constexpr( out_lmul == -4 ) return __riscv_vreinterpret_u8mf4(x);
+    else if constexpr( out_lmul == -2 ) return __riscv_vreinterpret_u8mf2(x);
+    else if constexpr( out_lmul == 1 ) return __riscv_vreinterpret_u8m1(x);
+    else if constexpr( out_lmul == 2 ) return __riscv_vreinterpret_u8m2(x);
+    else if constexpr( out_lmul == 4 ) return __riscv_vreinterpret_u8m4(x);
+    else if constexpr( out_lmul == 8 ) return __riscv_vreinterpret_u8m8(x);
+  }
+  else if constexpr( match(out_c, category::int16) )
+  {
+    if constexpr( out_lmul == -4 ) return __riscv_vreinterpret_i16mf4(x);
+    else if constexpr( out_lmul == -2 ) return __riscv_vreinterpret_i16mf2(x);
+    else if constexpr( out_lmul == 1 ) return __riscv_vreinterpret_i16m1(x);
+    else if constexpr( out_lmul == 2 ) return __riscv_vreinterpret_i16m2(x);
+    else if constexpr( out_lmul == 4 ) return __riscv_vreinterpret_i16m4(x);
+    else if constexpr( out_lmul == 8 ) return __riscv_vreinterpret_i16m8(x);
+  }
+  else if constexpr( match(out_c, category::uint16) )
+  {
+    if constexpr( out_lmul == -4 ) return __riscv_vreinterpret_u16mf4(x);
+    else if constexpr( out_lmul == -2 ) return __riscv_vreinterpret_u16mf2(x);
+    else if constexpr( out_lmul == 1 ) return __riscv_vreinterpret_u16m1(x);
+    else if constexpr( out_lmul == 2 ) return __riscv_vreinterpret_u16m2(x);
+    else if constexpr( out_lmul == 4 ) return __riscv_vreinterpret_u16m4(x);
+    else if constexpr( out_lmul == 8 ) return __riscv_vreinterpret_u16m8(x);
+  }
+  else if constexpr( match(out_c, category::int32) )
+  {
+    if constexpr( out_lmul == -2 ) return __riscv_vreinterpret_i32mf2(x);
+    else if constexpr( out_lmul == 1 ) return __riscv_vreinterpret_i32m1(x);
+    else if constexpr( out_lmul == 2 ) return __riscv_vreinterpret_i32m2(x);
+    else if constexpr( out_lmul == 4 ) return __riscv_vreinterpret_i32m4(x);
+    else if constexpr( out_lmul == 8 ) return __riscv_vreinterpret_i32m8(x);
+  }
+  else if constexpr( match(out_c, category::uint32) )
+  {
+    if constexpr( out_lmul == -2 ) return __riscv_vreinterpret_u32mf2(x);
+    else if constexpr( out_lmul == 1 ) return __riscv_vreinterpret_u32m1(x);
+    else if constexpr( out_lmul == 2 ) return __riscv_vreinterpret_u32m2(x);
+    else if constexpr( out_lmul == 4 ) return __riscv_vreinterpret_u32m4(x);
+    else if constexpr( out_lmul == 8 ) return __riscv_vreinterpret_u32m8(x);
+  }
+  else if constexpr( match(out_c, category::float32) )
+  {
+    if constexpr( out_lmul == -2 )
+    {
+      auto casted_to_32 = bit_cast(x, as<wide<std::int32_t, M>> {});
+      return __riscv_vreinterpret_f32mf2(casted_to_32);
+    }
+    else if constexpr( out_lmul == 1 )
+    {
+      auto casted_to_32 = bit_cast(x, as<wide<std::int32_t, M>> {});
+      return __riscv_vreinterpret_f32m1(casted_to_32);
+    }
+    else if constexpr( out_lmul == 2 )
+    {
+      auto casted_to_32 = bit_cast(x, as<wide<std::int32_t, M>> {});
+      return __riscv_vreinterpret_f32m2(casted_to_32);
+    }
+    else if constexpr( out_lmul == 4 )
+    {
+      auto casted_to_32 = bit_cast(x, as<wide<std::int32_t, M>> {});
+      return __riscv_vreinterpret_f32m4(casted_to_32);
+    }
+    else if constexpr( out_lmul == 8 )
+    {
+      auto casted_to_32 = bit_cast(x, as<wide<std::int32_t, M>> {});
+      return __riscv_vreinterpret_f32m8(casted_to_32);
+    }
+  }
+  else if constexpr( match(out_c, category::int64) )
+  {
+    if constexpr( out_lmul == 1 ) return __riscv_vreinterpret_i64m1(x);
+    else if constexpr( out_lmul == 2 ) return __riscv_vreinterpret_i64m2(x);
+    else if constexpr( out_lmul == 4 ) return __riscv_vreinterpret_i64m4(x);
+    else if constexpr( out_lmul == 8 ) return __riscv_vreinterpret_i64m8(x);
+  }
+  else if constexpr( match(out_c, category::uint64) )
+  {
+    if constexpr( out_lmul == 1 ) return __riscv_vreinterpret_u64m1(x);
+    else if constexpr( out_lmul == 2 ) return __riscv_vreinterpret_u64m2(x);
+    else if constexpr( out_lmul == 4 ) return __riscv_vreinterpret_u64m4(x);
+    else if constexpr( out_lmul == 8 ) return __riscv_vreinterpret_u64m8(x);
+  }
+  if constexpr( match(out_c, category::float64) )
+  {
+    if constexpr( out_lmul == 1 )
+    {
+      auto casted_to_64 = bit_cast(x, as<wide<std::int64_t, M>> {});
+      return __riscv_vreinterpret_f64m1(casted_to_64);
+    }
+    else if constexpr( out_lmul == 2 )
+    {
+      auto casted_to_64 = bit_cast(x, as<wide<std::int64_t, M>> {});
+      return __riscv_vreinterpret_f64m2(casted_to_64);
+    }
+    else if constexpr( out_lmul == 4 )
+    {
+      auto casted_to_64 = bit_cast(x, as<wide<std::int64_t, M>> {});
+      return __riscv_vreinterpret_f64m4(casted_to_64);
+    }
+    else if constexpr( out_lmul == 8 )
+    {
+      auto casted_to_64 = bit_cast(x, as<wide<std::int64_t, M>> {});
+      return __riscv_vreinterpret_f64m8(casted_to_64);
+    }
+  }
+}
+
+template<callable_options O, scalar_value T, typename N, scalar_value U, typename M>
+EVE_FORCEINLINE wide<U, M>
+bit_cast_(EVE_REQUIRES(rvv_), const O&, wide<T, N> x, as<wide<U, M>> const& to_as) noexcept
+requires rvv_abi<abi_t<T, N>> && rvv_abi<abi_t<U, M>> && same_storage_size<T, N, U, M>
+         && same_wide_size<T, N, U, M> && different_wide_types<T, N, U, M>
+{
+  using in_wide  = wide<T, N>;
+  using out_wide = wide<U, M>;
+
+  constexpr auto in_c  = categorize<in_wide>();
+  constexpr auto out_c = categorize<out_wide>();
+
+  if constexpr( match(in_c, category::float_) )
+  {
+    //  float. We need cast to the to intype with the same width.
+    using sign            = default_as_integer_sign_t<U>;
+    using out_part_scalar = as_integer_t<T, sign>;
+    using out_part_wide   = wide<out_part_scalar, N>;
+    auto part_done        = bit_cast(x, as<out_part_wide> {});
+
+    return bit_cast(part_done, to_as);
+  }
+  else
+  {
+    // first change sew, then cast to type
+    using sign            = default_as_integer_sign_t<T>;
+    using out_part_scalar = as_integer_t<U, sign>;
+    using out_part_wide   = wide<out_part_scalar, M>;
+    auto part_done        = bit_cast(x, as<out_part_wide> {});
+    return bit_cast(part_done, to_as);
+  }
+}
+
+}

--- a/include/eve/detail/function/simd/riscv/bitmask.hpp
+++ b/include/eve/detail/function/simd/riscv/bitmask.hpp
@@ -1,0 +1,39 @@
+//==================================================================================================
+/*
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+*/
+//==================================================================================================
+#pragma once
+
+#include <eve/detail/abi.hpp>
+#include <eve/module/core/regular/if_else.hpp>
+
+#include <bitset>
+
+namespace eve::detail
+{
+//================================================================================================
+// Logical to Bits
+//================================================================================================
+template<typename T, typename N>
+EVE_FORCEINLINE auto
+to_bits(rvv_ const&, logical<wide<T, N>> p) noexcept
+requires rvv_abi<abi_t<T, N>>
+{
+  using uint_type = as_uinteger_t<T>;
+  return eve::if_else(p, static_cast<uint_type>(-1), static_cast<uint_type>(0));
+}
+
+//================================================================================================
+// Logical to Mask
+//================================================================================================
+template<typename T, typename N>
+EVE_FORCEINLINE auto
+to_mask(rvv_ const&, logical<wide<T, N>> p) noexcept
+{
+  return bit_cast(p.bits(), as<typename logical<wide<T, N>>::mask_type> {});
+}
+
+}

--- a/include/eve/detail/function/simd/riscv/combine.hpp
+++ b/include/eve/detail/function/simd/riscv/combine.hpp
@@ -1,0 +1,63 @@
+//==================================================================================================
+/*
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+*/
+//==================================================================================================
+#pragma once
+
+#include <eve/arch.hpp>
+#include <eve/arch/riscv/rvv_common_masks.hpp>
+#include <eve/detail/abi.hpp>
+#include <eve/module/core/regular/if_else.hpp>
+
+namespace eve::detail
+{
+template<typename T, typename N>
+EVE_FORCEINLINE auto
+combine(rvv_ const&, wide<T, N> l, wide<T, N> h) noexcept
+requires rvv_abi<abi_t<T, N>>
+{
+  using that_t = wide<T, typename N::combined_type>;
+
+  constexpr size_t combined_vl = N::combined_type::value;
+  if constexpr( eve::has_aggregated_abi_v<that_t> )
+  {
+    that_t that;
+    that.storage().assign_parts(l, h);
+    return that;
+  }
+  else
+  {
+    auto           wider_l        = simd_cast(l, as<that_t> {});
+    auto           wider_h        = simd_cast(h, as<that_t> {});
+    constexpr auto shift_size     = N::value;
+    that_t         wider_h_placed = __riscv_vslideup(wider_h, wider_h, shift_size, combined_vl);
+    auto           mask_all_ones  = rvv_true<T, N>();
+    auto           wider_mask     = simd_cast(mask_all_ones, as<logical<that_t>> {});
+    return if_else(wider_mask, wider_l, wider_h_placed);
+  }
+}
+
+template<typename T, typename N>
+EVE_FORCEINLINE auto
+combine(rvv_ const&, logical<wide<T, N>> l, logical<wide<T, N>> h) noexcept
+requires rvv_abi<abi_t<T, N>>
+{
+  constexpr size_t combined_vl = N::combined_type::value;
+  using that_t                 = logical<wide<T, typename N::combined_type>>;
+
+  if constexpr( eve::has_aggregated_abi_v<that_t> )
+  {
+    that_t that;
+    that.storage().assign_parts(l, h);
+    return that;
+  }
+  else
+  {
+    // TODO: optimize
+    return to_logical(eve::combine(l.mask(), h.mask()));
+  }
+}
+}

--- a/include/eve/detail/function/simd/riscv/friends.hpp
+++ b/include/eve/detail/function/simd/riscv/friends.hpp
@@ -1,0 +1,265 @@
+//==================================================================================================
+/*
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+*/
+//==================================================================================================
+#pragma once
+
+namespace eve::detail
+{
+
+// *_impl in separate functions, as otherwise compiler can not
+// choose overload between riscv-specific and common one
+template<plain_scalar_value T, typename N, value U>
+EVE_FORCEINLINE auto
+self_greater_impl(wide<T, N> lhs, U rhs) noexcept -> logical<wide<T, N>>
+requires rvv_abi<abi_t<T, N>> && (std::same_as<wide<T, N>, U> || scalar_value<U>)
+{
+  if constexpr( scalar_value<U> && !std::same_as<T, U> )
+    return self_greater(lhs, static_cast<T>(rhs));
+  else
+  {
+    constexpr auto c = categorize<wide<T, N>>();
+    if constexpr( match(c, category::int_) ) return __riscv_vmsgt(lhs, rhs, N::value);
+    else if constexpr( match(c, category::uint_) ) return __riscv_vmsgtu(lhs, rhs, N::value);
+    else if constexpr( match(c, category::float_) ) return __riscv_vmfgt(lhs, rhs, N::value);
+  }
+}
+
+template<plain_scalar_value T, typename N>
+EVE_FORCEINLINE auto
+self_greater(wide<T, N> lhs, wide<T, N> rhs) noexcept -> logical<wide<T, N>>
+requires rvv_abi<abi_t<T, N>>
+{
+  return self_greater_impl(lhs, rhs);
+}
+
+template<plain_scalar_value T, typename N>
+EVE_FORCEINLINE auto
+self_greater(wide<T, N> lhs, std::convertible_to<T> auto rhs) noexcept -> logical<wide<T, N>>
+requires rvv_abi<abi_t<T, N>>
+{
+  return self_greater_impl(lhs, rhs);
+}
+
+template<plain_scalar_value T, typename N, value U>
+EVE_FORCEINLINE auto
+self_less_impl(wide<T, N> lhs, U rhs) noexcept -> logical<wide<T, N>>
+requires rvv_abi<abi_t<T, N>> && (std::same_as<wide<T, N>, U> || scalar_value<U>)
+{
+  if constexpr( scalar_value<U> && !std::same_as<T, U> ) return self_less(lhs, static_cast<T>(rhs));
+  else
+  {
+    constexpr auto c = categorize<wide<T, N>>();
+    if constexpr( match(c, category::int_) ) return __riscv_vmslt(lhs, rhs, N::value);
+    else if constexpr( match(c, category::uint_) ) return __riscv_vmsltu(lhs, rhs, N::value);
+    else if constexpr( match(c, category::float_) ) return __riscv_vmflt(lhs, rhs, N::value);
+  }
+}
+
+template<plain_scalar_value T, typename N>
+EVE_FORCEINLINE auto
+self_less(wide<T, N> lhs, wide<T, N> rhs) noexcept -> logical<wide<T, N>>
+requires rvv_abi<abi_t<T, N>>
+{
+  return self_less_impl(lhs, rhs);
+}
+
+template<plain_scalar_value T, typename N>
+EVE_FORCEINLINE auto
+self_less(wide<T, N> lhs, std::convertible_to<T> auto rhs) noexcept -> logical<wide<T, N>>
+requires rvv_abi<abi_t<T, N>>
+{
+  return self_less_impl(lhs, rhs);
+}
+
+template<plain_scalar_value T, typename N, value U>
+EVE_FORCEINLINE auto
+self_geq_impl(wide<T, N> lhs, U rhs) noexcept -> logical<wide<T, N>>
+requires rvv_abi<abi_t<T, N>> && (std::same_as<wide<T, N>, U> || scalar_value<U>)
+{
+  if constexpr( scalar_value<U> && !std::same_as<T, U> ) return self_geq(lhs, static_cast<T>(rhs));
+  else
+  {
+    constexpr auto c = categorize<wide<T, N>>();
+    if constexpr( match(c, category::int_) ) return __riscv_vmsge(lhs, rhs, N::value);
+    else if constexpr( match(c, category::uint_) ) return __riscv_vmsgeu(lhs, rhs, N::value);
+    else if constexpr( match(c, category::float_) ) return __riscv_vmfge(lhs, rhs, N::value);
+  }
+}
+
+template<plain_scalar_value T, typename N>
+EVE_FORCEINLINE auto
+self_geq(wide<T, N> lhs, wide<T, N> rhs) noexcept -> logical<wide<T, N>>
+requires rvv_abi<abi_t<T, N>>
+{
+  return self_geq_impl(lhs, rhs);
+}
+
+template<plain_scalar_value T, typename N>
+EVE_FORCEINLINE auto
+self_geq(wide<T, N> lhs, std::convertible_to<T> auto rhs) noexcept -> logical<wide<T, N>>
+requires rvv_abi<abi_t<T, N>>
+{
+  return self_geq_impl(lhs, rhs);
+}
+
+template<plain_scalar_value T, typename N, value U>
+EVE_FORCEINLINE auto
+self_leq_impl(wide<T, N> lhs, U rhs) noexcept -> logical<wide<T, N>>
+requires rvv_abi<abi_t<T, N>> && (std::same_as<wide<T, N>, U> || scalar_value<U>)
+{
+  if constexpr( scalar_value<U> && !std::same_as<T, U> ) return self_leq(lhs, static_cast<T>(rhs));
+  else
+  {
+    constexpr auto c = categorize<wide<T, N>>();
+    if constexpr( match(c, category::int_) ) return __riscv_vmsle(lhs, rhs, N::value);
+    else if constexpr( match(c, category::uint_) ) return __riscv_vmsleu(lhs, rhs, N::value);
+    else if constexpr( match(c, category::float_) ) return __riscv_vmfle(lhs, rhs, N::value);
+  }
+}
+
+template<plain_scalar_value T, typename N>
+EVE_FORCEINLINE auto
+self_leq(wide<T, N> lhs, wide<T, N> rhs) noexcept -> logical<wide<T, N>>
+requires rvv_abi<abi_t<T, N>>
+{
+  return self_leq_impl(lhs, rhs);
+}
+
+template<plain_scalar_value T, typename N>
+EVE_FORCEINLINE auto
+self_leq(wide<T, N> lhs, std::convertible_to<T> auto rhs) noexcept -> logical<wide<T, N>>
+requires rvv_abi<abi_t<T, N>>
+{
+  return self_leq_impl(lhs, rhs);
+}
+
+template<plain_scalar_value T, typename N, value U>
+EVE_FORCEINLINE auto
+self_eq_impl(wide<T, N> lhs, U rhs) noexcept -> logical<wide<T, N>>
+requires rvv_abi<abi_t<T, N>> && (std::same_as<wide<T, N>, U> || scalar_value<U>)
+{
+  if constexpr( scalar_value<U> && !std::same_as<T, U> ) return self_eq(lhs, static_cast<T>(rhs));
+  else
+  {
+    constexpr auto c = categorize<wide<T, N>>();
+    if constexpr( match(c, category::integer_) ) return __riscv_vmseq(lhs, rhs, N::value);
+    else if constexpr( match(c, category::float_) ) return __riscv_vmfeq(lhs, rhs, N::value);
+  }
+}
+
+template<plain_scalar_value T, typename N>
+EVE_FORCEINLINE auto
+self_eq(wide<T, N> lhs, wide<T, N> rhs) noexcept -> logical<wide<T, N>>
+requires rvv_abi<abi_t<T, N>>
+{
+  return self_eq_impl(lhs, rhs);
+}
+
+template<plain_scalar_value T, typename N>
+EVE_FORCEINLINE auto
+self_eq(wide<T, N> lhs, std::convertible_to<T> auto rhs) noexcept -> logical<wide<T, N>>
+requires rvv_abi<abi_t<T, N>>
+{
+  return self_eq_impl(lhs, rhs);
+}
+
+template<plain_scalar_value T, typename N, value U>
+EVE_FORCEINLINE auto
+self_neq_impl(wide<T, N> lhs, U rhs) noexcept -> logical<wide<T, N>>
+requires rvv_abi<abi_t<T, N>> && (std::same_as<wide<T, N>, U> || scalar_value<U>)
+{
+  if constexpr( scalar_value<U> && !std::same_as<T, U> ) return self_neq(lhs, static_cast<T>(rhs));
+  else
+  {
+    constexpr auto c = categorize<wide<T, N>>();
+    if constexpr( match(c, category::integer_) ) return __riscv_vmsne(lhs, rhs, N::value);
+    else if constexpr( match(c, category::float_) ) return __riscv_vmfne(lhs, rhs, N::value);
+  }
+}
+
+template<plain_scalar_value T, typename N>
+EVE_FORCEINLINE auto
+self_neq(wide<T, N> lhs, wide<T, N> rhs) noexcept -> logical<wide<T, N>>
+requires rvv_abi<abi_t<T, N>>
+{
+  return self_neq_impl(lhs, rhs);
+}
+
+template<plain_scalar_value T, typename N>
+EVE_FORCEINLINE auto
+self_neq(wide<T, N> lhs, std::convertible_to<T> auto rhs) noexcept -> logical<wide<T, N>>
+requires rvv_abi<abi_t<T, N>>
+{
+  return self_neq_impl(lhs, rhs);
+}
+
+template<plain_scalar_value T, typename N>
+EVE_FORCEINLINE auto
+self_eq(logical<wide<T, N>> lhs, logical<wide<T, N>> rhs) noexcept -> logical<wide<T, N>>
+requires rvv_abi<abi_t<T, N>>
+{
+  return __riscv_vmxnor(lhs, rhs, N::value);
+}
+
+template<plain_scalar_value T, typename N>
+EVE_FORCEINLINE auto
+self_neq(logical<wide<T, N>> lhs, logical<wide<T, N>> rhs) noexcept -> logical<wide<T, N>>
+requires rvv_abi<abi_t<T, N>>
+{
+  return __riscv_vmxor(lhs, rhs, N::value);
+}
+
+template<typename T, typename U, typename N>
+EVE_FORCEINLINE auto
+self_logand(rvv_ const&, logical<wide<T, N>> v, logical<wide<U, N>> w) noexcept
+    -> logical<wide<T, N>>
+requires(rvv_abi<abi_t<T, N>> || rvv_abi<abi_t<U, N>>)
+{
+  if constexpr( !is_aggregated_v<abi_t<T, N>> && !is_aggregated_v<abi_t<U, N>> )
+  {
+    auto                casted_w = bit_cast(w, as<logical<wide<T, N>>> {});
+    logical<wide<T, N>> to_ret   = __riscv_vmand(v, casted_w, N::value);
+    return to_ret;
+  }
+  else
+  {
+    auto [lv, hv] = v.slice();
+    auto [lw, hw] = w.slice();
+    auto res      = logical<wide<T, N>> {lv && lw, hv && hw};
+    return res;
+  }
+}
+
+template<typename T, typename U, typename N>
+EVE_FORCEINLINE auto
+self_logor(rvv_ const&, logical<wide<T, N>> v, logical<wide<U, N>> w) noexcept
+    -> logical<wide<T, N>>
+requires(rvv_abi<abi_t<T, N>> || rvv_abi<abi_t<U, N>>)
+{
+  if constexpr( !is_aggregated_v<abi_t<T, N>> && !is_aggregated_v<abi_t<U, N>> )
+  {
+    auto                casted_w = bit_cast(w, as<logical<wide<T, N>>> {});
+    logical<wide<T, N>> to_ret   = __riscv_vmor(v, casted_w, N::value);
+    return to_ret;
+  }
+  else
+  {
+    auto [lv, hv] = v.slice();
+    auto [lw, hw] = w.slice();
+    return logical<wide<T, N>> {lv || lw, hv || hw};
+  }
+}
+
+template<arithmetic_scalar_value T, typename N>
+EVE_FORCEINLINE auto
+self_lognot(logical<wide<T, N>> v) noexcept -> logical<wide<T, N>>
+requires rvv_abi<abi_t<T, N>>
+{
+  return __riscv_vmnot(v, N::value);
+}
+
+}

--- a/include/eve/detail/function/simd/riscv/load.hpp
+++ b/include/eve/detail/function/simd/riscv/load.hpp
@@ -1,0 +1,113 @@
+//==================================================================================================
+/*
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+*/
+//==================================================================================================
+#pragma once
+
+#include <eve/arch/riscv/rvv_common_masks.hpp>
+#include <eve/as.hpp>
+#include <eve/concept/memory.hpp>
+#include <eve/concept/vectorizable.hpp>
+#include <eve/detail/category.hpp>
+#include <eve/detail/implementation.hpp>
+#include <eve/module/core/regular/safe.hpp>
+#include <eve/module/core/regular/unalign.hpp>
+
+namespace eve::detail
+{
+
+// Fills undefined values with zeros
+template<arithmetic_scalar_value T, typename N, typename PtrTy>
+EVE_FORCEINLINE wide<T, N>
+                perform_alternative_load(logical<wide<T, N>> mask, as<wide<T, N>> tgt, PtrTy p)
+{
+  wide<T, N> zero_init {0};
+  if constexpr( N::value < eve::fundamental_cardinal_v<T> )
+  {
+    auto tgt              = as<wide<T, eve::fundamental_cardinal<T>>> {};
+    auto fundamental_zero = rvv_make_splat(tgt, static_cast<T>(0));
+    zero_init             = bit_cast(fundamental_zero, eve::as<wide<T, N>> {});
+  }
+  constexpr auto c = categorize<wide<T, N>>();
+  if constexpr( match(c, category::size8_) ) return __riscv_vle8_tumu(mask, zero_init, p, N::value);
+  else if constexpr( match(c, category::size16_) )
+    return __riscv_vle16_tumu(mask, zero_init, p, N::value);
+  else if constexpr( match(c, category::size32_) )
+    return __riscv_vle32_tumu(mask, zero_init, p, N::value);
+  else if constexpr( match(c, category::size64_) )
+    return __riscv_vle64_tumu(mask, zero_init, p, N::value);
+}
+
+// Undefined values are undefined
+template<arithmetic_scalar_value T, typename N, typename PtrTy>
+EVE_FORCEINLINE wide<T, N>
+                perform_load(logical<wide<T, N>> mask, as<wide<T, N>> tgt, PtrTy p)
+{
+  constexpr auto c = categorize<wide<T, N>>();
+  if constexpr( match(c, category::size8_) ) return __riscv_vle8(mask, p, N::value);
+  else if constexpr( match(c, category::size16_) ) return __riscv_vle16(mask, p, N::value);
+  else if constexpr( match(c, category::size32_) ) return __riscv_vle32(mask, p, N::value);
+  else if constexpr( match(c, category::size64_) ) return __riscv_vle64(mask, p, N::value);
+}
+
+template<relative_conditional_expr C,
+         arithmetic_scalar_value   T,
+         typename N,
+         simd_compatible_ptr<wide<T, N>> Ptr>
+EVE_FORCEINLINE wide<T, N>
+load_(EVE_SUPPORTS(rvv_), C const& cond, safe_type const& s, eve::as<wide<T, N>> const& tgt, Ptr p)
+requires(rvv_abi<abi_t<T, N>>)
+{
+  auto ptr = unalign(p);
+
+  if constexpr( C::has_alternative )
+  {
+    // as later we replace ignored, we can use unsafe load.
+    auto load_cond = drop_alternative(cond);
+    auto res       = perform_load(load_cond.mask(tgt), tgt, ptr);
+    return eve::replace_ignored(res, cond, cond.alternative);
+  }
+  else if constexpr( C::is_complete && !C::is_inverted ) return wide<T, N>(0);
+  else if constexpr( C::is_complete && C::is_inverted && N() == expected_cardinal_v<T> )
+  {
+    return perform_alternative_load(rvv_true<T, N>(), tgt, ptr);
+  }
+  else return perform_alternative_load(cond.mask(tgt), tgt, ptr);
+}
+
+template<relative_conditional_expr C,
+         typename T,
+         typename N,
+         simd_compatible_ptr<logical<wide<T, N>>> Pointer>
+EVE_FORCEINLINE logical<wide<T, N>>
+                load_(EVE_SUPPORTS(rvv_),
+                      C const                &cond,
+                      safe_type const&,
+                      eve::as<logical<wide<T, N>>> const&,
+                      Pointer ptr) noexcept
+requires rvv_abi<abi_t<T, N>>
+{
+  auto const c1    = map_alternative(cond, [](auto alt) { return alt.mask(); });
+  auto const block = load(c1, safe, eve::as<wide<T, N>> {}, ptr_cast<T const>(ptr));
+  return to_logical(block);
+}
+
+template<relative_conditional_expr C, typename Iterator, typename T, typename N>
+EVE_FORCEINLINE logical<wide<T, N>>
+                load_(EVE_SUPPORTS(rvv_),
+                      C const                &cond,
+                      safe_type const&,
+                      eve::as<logical<wide<T, N>>> const&,
+                      Iterator b,
+                      Iterator e) noexcept
+requires rvv_abi<abi_t<T, N>>
+{
+  auto const c1    = map_alternative(cond, [](auto alt) { return alt.mask(); });
+  auto const block = load(c1, safe, eve::as<wide<T, N>> {}, b, e);
+  return to_logical(block);
+}
+
+}

--- a/include/eve/detail/function/simd/riscv/make.hpp
+++ b/include/eve/detail/function/simd/riscv/make.hpp
@@ -1,0 +1,173 @@
+//==================================================================================================
+/*
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+*/
+//==================================================================================================
+#pragma once
+
+#include <eve/arch/fundamental_cardinal.hpp>
+#include <eve/as.hpp>
+#include <eve/concept/options.hpp>
+#include <eve/conditional.hpp>
+#include <eve/detail/abi.hpp>
+#include <eve/detail/category.hpp>
+#include <eve/detail/function/load.hpp>
+#include <eve/detail/function/simd/riscv/friends.hpp>
+#include <eve/detail/meta.hpp>
+#include <eve/module/core/regular/safe.hpp>
+#include <eve/traits/as_integer.hpp>
+
+namespace eve::detail
+{
+
+template<arithmetic_scalar_value T, typename N>
+requires rvv_abi<abi_t<T, N>>
+EVE_FORCEINLINE wide<T, N>
+                rvv_make_splat(eve::as<wide<T, N>>, T x) noexcept
+{
+  constexpr auto c    = categorize<wide<T, N>>();
+  constexpr auto lmul = rvv_lmul_v<T, N>;
+  wide<T, N>     fill_zero;
+  if constexpr( N::value < eve::fundamental_cardinal_v<T> )
+  {
+    auto tgt              = as<wide<T, eve::fundamental_cardinal<T>>> {};
+    auto fundamental_zero = rvv_make_splat(tgt, static_cast<T>(0));
+    fill_zero             = bit_cast(fundamental_zero, eve::as<wide<T, N>> {});
+  }
+
+  if constexpr( match(c, category::float64) )
+  {
+    if constexpr( lmul == 1 ) return __riscv_vfmv_v_f_f64m1_tu(fill_zero, x, N::value);
+    else if constexpr( lmul == 2 ) return __riscv_vfmv_v_f_f64m2_tu(fill_zero, x, N::value);
+    else if constexpr( lmul == 4 ) return __riscv_vfmv_v_f_f64m4_tu(fill_zero, x, N::value);
+    else if constexpr( lmul == 8 ) return __riscv_vfmv_v_f_f64m8_tu(fill_zero, x, N::value);
+  }
+  else if constexpr( match(c, category::float32) )
+  {
+    if constexpr( lmul == -2 ) return __riscv_vfmv_v_f_f32mf2_tu(fill_zero, x, N::value);
+    else if constexpr( lmul == 1 ) return __riscv_vfmv_v_f_f32m1_tu(fill_zero, x, N::value);
+    else if constexpr( lmul == 2 ) return __riscv_vfmv_v_f_f32m2_tu(fill_zero, x, N::value);
+    else if constexpr( lmul == 4 ) return __riscv_vfmv_v_f_f32m4_tu(fill_zero, x, N::value);
+    else if constexpr( lmul == 8 ) return __riscv_vfmv_v_f_f32m8_tu(fill_zero, x, N::value);
+  }
+  else if constexpr( match(c, category::int64) )
+  {
+    if constexpr( lmul == 1 ) return __riscv_vmv_v_x_i64m1_tu(fill_zero, x, N::value);
+    else if constexpr( lmul == 2 ) return __riscv_vmv_v_x_i64m2_tu(fill_zero, x, N::value);
+    else if constexpr( lmul == 4 ) return __riscv_vmv_v_x_i64m4_tu(fill_zero, x, N::value);
+    else if constexpr( lmul == 8 ) return __riscv_vmv_v_x_i64m8_tu(fill_zero, x, N::value);
+  }
+  else if constexpr( match(c, category::uint64) )
+  {
+    if constexpr( lmul == 1 ) return __riscv_vmv_v_x_u64m1_tu(fill_zero, x, N::value);
+    else if constexpr( lmul == 2 ) return __riscv_vmv_v_x_u64m2_tu(fill_zero, x, N::value);
+    else if constexpr( lmul == 4 ) return __riscv_vmv_v_x_u64m4_tu(fill_zero, x, N::value);
+    else if constexpr( lmul == 8 ) return __riscv_vmv_v_x_u64m8_tu(fill_zero, x, N::value);
+  }
+  else if constexpr( match(c, category::int32) )
+  {
+    if constexpr( lmul == -2 ) return __riscv_vmv_v_x_i32mf2_tu(fill_zero, x, N::value);
+    else if constexpr( lmul == 1 ) return __riscv_vmv_v_x_i32m1_tu(fill_zero, x, N::value);
+    else if constexpr( lmul == 2 ) return __riscv_vmv_v_x_i32m2_tu(fill_zero, x, N::value);
+    else if constexpr( lmul == 4 ) return __riscv_vmv_v_x_i32m4_tu(fill_zero, x, N::value);
+    else if constexpr( lmul == 8 ) return __riscv_vmv_v_x_i32m8_tu(fill_zero, x, N::value);
+  }
+  else if constexpr( match(c, category::uint32) )
+  {
+    if constexpr( lmul == -2 ) return __riscv_vmv_v_x_u32mf2_tu(fill_zero, x, N::value);
+    else if constexpr( lmul == 1 ) return __riscv_vmv_v_x_u32m1_tu(fill_zero, x, N::value);
+    else if constexpr( lmul == 2 ) return __riscv_vmv_v_x_u32m2_tu(fill_zero, x, N::value);
+    else if constexpr( lmul == 4 ) return __riscv_vmv_v_x_u32m4_tu(fill_zero, x, N::value);
+    else if constexpr( lmul == 8 ) return __riscv_vmv_v_x_u32m8_tu(fill_zero, x, N::value);
+  }
+  else if constexpr( match(c, category::int16) )
+  {
+    if constexpr( lmul == -4 ) return __riscv_vmv_v_x_i16mf4_tu(fill_zero, x, N::value);
+    else if constexpr( lmul == -2 ) return __riscv_vmv_v_x_i16mf2_tu(fill_zero, x, N::value);
+    else if constexpr( lmul == 1 ) return __riscv_vmv_v_x_i16m1_tu(fill_zero, x, N::value);
+    else if constexpr( lmul == 2 ) return __riscv_vmv_v_x_i16m2_tu(fill_zero, x, N::value);
+    else if constexpr( lmul == 4 ) return __riscv_vmv_v_x_i16m4_tu(fill_zero, x, N::value);
+    else if constexpr( lmul == 8 ) return __riscv_vmv_v_x_i16m8_tu(fill_zero, x, N::value);
+  }
+  else if constexpr( match(c, category::uint16) )
+  {
+    if constexpr( lmul == -4 ) return __riscv_vmv_v_x_u16mf4_tu(fill_zero, x, N::value);
+    else if constexpr( lmul == -2 ) return __riscv_vmv_v_x_u16mf2_tu(fill_zero, x, N::value);
+    else if constexpr( lmul == 1 ) return __riscv_vmv_v_x_u16m1_tu(fill_zero, x, N::value);
+    else if constexpr( lmul == 2 ) return __riscv_vmv_v_x_u16m2_tu(fill_zero, x, N::value);
+    else if constexpr( lmul == 4 ) return __riscv_vmv_v_x_u16m4_tu(fill_zero, x, N::value);
+    else if constexpr( lmul == 8 ) return __riscv_vmv_v_x_u16m8_tu(fill_zero, x, N::value);
+  }
+  else if constexpr( match(c, category::int8) )
+  {
+    if constexpr( lmul == -8 ) return __riscv_vmv_v_x_i8mf8_tu(fill_zero, x, N::value);
+    else if constexpr( lmul == -4 ) return __riscv_vmv_v_x_i8mf4_tu(fill_zero, x, N::value);
+    else if constexpr( lmul == -2 ) return __riscv_vmv_v_x_i8mf2_tu(fill_zero, x, N::value);
+    else if constexpr( lmul == 1 ) return __riscv_vmv_v_x_i8m1_tu(fill_zero, x, N::value);
+    else if constexpr( lmul == 2 ) return __riscv_vmv_v_x_i8m2_tu(fill_zero, x, N::value);
+    else if constexpr( lmul == 4 ) return __riscv_vmv_v_x_i8m4_tu(fill_zero, x, N::value);
+    else if constexpr( lmul == 8 ) return __riscv_vmv_v_x_i8m8_tu(fill_zero, x, N::value);
+  }
+  else if constexpr( match(c, category::uint8) )
+  {
+    if constexpr( lmul == -8 ) return __riscv_vmv_v_x_u8mf8_tu(fill_zero, x, N::value);
+    else if constexpr( lmul == -4 ) return __riscv_vmv_v_x_u8mf4_tu(fill_zero, x, N::value);
+    else if constexpr( lmul == -2 ) return __riscv_vmv_v_x_u8mf2_tu(fill_zero, x, N::value);
+    else if constexpr( lmul == 1 ) return __riscv_vmv_v_x_u8m1_tu(fill_zero, x, N::value);
+    else if constexpr( lmul == 2 ) return __riscv_vmv_v_x_u8m2_tu(fill_zero, x, N::value);
+    else if constexpr( lmul == 4 ) return __riscv_vmv_v_x_u8m4_tu(fill_zero, x, N::value);
+    else if constexpr( lmul == 8 ) return __riscv_vmv_v_x_u8m8_tu(fill_zero, x, N::value);
+  }
+}
+
+template<arithmetic_scalar_value T, typename N, arithmetic_scalar_value... Vs>
+requires rvv_abi<abi_t<T, N>>
+EVE_FORCEINLINE wide<T, N>
+                rvv_make_enumerated(eve::as<wide<T, N>>, Vs... vs)
+{
+  static_assert(sizeof...(Vs) == N::value, "[eve::make] - Invalid number of arguments");
+  std::array on_stack {static_cast<T>(vs)...};
+  return load(ignore_none, safe, as<wide<T, N>> {}, on_stack.data());
+}
+
+template<callable_options O, arithmetic_scalar_value T, typename N, typename V1, typename... Vs>
+requires rvv_abi<abi_t<T, N>>
+EVE_FORCEINLINE auto
+make_(EVE_REQUIRES(rvv_), O const&, eve::as<wide<T, N>> tgt, V1 v1, Vs... vs) noexcept
+{
+  if constexpr( sizeof...(Vs) == 0 ) return rvv_make_splat(tgt, v1);
+  else return rvv_make_enumerated(tgt, v1, vs...);
+}
+
+//================================================================================================
+// logical cases
+//================================================================================================
+template<callable_options O, arithmetic_scalar_value T, typename N, typename V1, typename... Vs>
+EVE_FORCEINLINE logical<wide<T, N>>
+make_(EVE_REQUIRES(rvv_), O const&, as<logical<wide<T, N>>>, V1 v1, Vs... vs) noexcept
+requires rvv_abi<abi_t<T, N>>
+{
+  using bits_type = typename logical<wide<T, N>>::bits_type;
+  using e_t       = element_type_t<bits_type>;
+  bits_type bits;
+  auto      tgt_wide = as<bits_type> {};
+  if constexpr( sizeof...(Vs) == 0 )
+    bits = rvv_make_splat(tgt_wide, v1 ? static_cast<e_t>(-1) : static_cast<e_t>(0));
+  else
+    bits = rvv_make_enumerated(tgt_wide,
+                               v1 ? static_cast<e_t>(-1) : static_cast<e_t>(0),
+                               (vs ? static_cast<e_t>(-1) : static_cast<e_t>(0))...);
+  auto logic_tgt = as<logical<wide<T, N>>> {};
+  if constexpr( N::value < eve::fundamental_cardinal_v<T> )
+  {
+    auto tgt          = as<wide<e_t, fundamental_cardinal<T>>> {};
+    auto full_bits    = bit_cast(bits, tgt);
+    auto full_logical = full_bits > static_cast<e_t>(0);
+    return simd_cast(full_logical, logic_tgt);
+  }
+  else return simd_cast(bits > static_cast<e_t>(0), logic_tgt);
+}
+
+}

--- a/include/eve/detail/function/simd/riscv/slice.hpp
+++ b/include/eve/detail/function/simd/riscv/slice.hpp
@@ -1,0 +1,172 @@
+//==================================================================================================
+/*
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+*/
+//==================================================================================================
+#pragma once
+
+#include <eve/detail/category.hpp>
+#include <eve/detail/implementation.hpp>
+#include <eve/module/core/regular/simd_cast.hpp>
+
+// Return first or second part of vector.
+
+namespace eve::detail
+{
+// TODO: move this to `simd_cast`
+template<plain_scalar_value T, typename N>
+EVE_FORCEINLINE wide<T, typename N::split_type>
+                riscv_lmul_trunc(wide<T, N> a) noexcept
+requires rvv_abi<abi_t<T, N>>
+{
+  constexpr auto c        = categorize<wide<T, typename N::split_type>>();
+  constexpr auto out_lmul = rvv_lmul_v<T, typename N::split_type>;
+  constexpr auto in_lmul  = rvv_lmul_v<T, N>;
+  if constexpr( out_lmul == in_lmul ) return a.storage();
+  else
+  {
+    static_assert(in_lmul > out_lmul);
+
+    if constexpr( match(c, category::float64) )
+    {
+      if constexpr( out_lmul == 1 ) return __riscv_vlmul_trunc_f64m1(a);
+      else if constexpr( out_lmul == 2 ) return __riscv_vlmul_trunc_f64m2(a);
+      else if constexpr( out_lmul == 4 ) return __riscv_vlmul_trunc_f64m4(a);
+    }
+    else if constexpr( match(c, category::int64) )
+    {
+      if constexpr( out_lmul == 1 ) return __riscv_vlmul_trunc_i64m1(a);
+      else if constexpr( out_lmul == 2 ) return __riscv_vlmul_trunc_i64m2(a);
+      else if constexpr( out_lmul == 4 ) return __riscv_vlmul_trunc_i64m4(a);
+    }
+    else if constexpr( match(c, category::uint64) )
+    {
+      if constexpr( out_lmul == 1 ) return __riscv_vlmul_trunc_u64m1(a);
+      else if constexpr( out_lmul == 2 ) return __riscv_vlmul_trunc_u64m2(a);
+      else if constexpr( out_lmul == 4 ) return __riscv_vlmul_trunc_u64m4(a);
+    }
+    else if constexpr( match(c, category::float32) )
+    {
+      if constexpr( out_lmul == -2 ) return __riscv_vlmul_trunc_f32mf2(a);
+      else if constexpr( out_lmul == 1 ) return __riscv_vlmul_trunc_f32m1(a);
+      else if constexpr( out_lmul == 2 ) return __riscv_vlmul_trunc_f32m2(a);
+      else if constexpr( out_lmul == 4 ) return __riscv_vlmul_trunc_f32m4(a);
+    }
+    else if constexpr( match(c, category::int32) )
+    {
+      if constexpr( out_lmul == -2 ) return __riscv_vlmul_trunc_i32mf2(a);
+      else if constexpr( out_lmul == 1 ) return __riscv_vlmul_trunc_i32m1(a);
+      else if constexpr( out_lmul == 2 ) return __riscv_vlmul_trunc_i32m2(a);
+      else if constexpr( out_lmul == 4 ) return __riscv_vlmul_trunc_i32m4(a);
+    }
+    else if constexpr( match(c, category::uint32) )
+    {
+      if constexpr( out_lmul == -2 ) return __riscv_vlmul_trunc_u32mf2(a);
+      else if constexpr( out_lmul == 1 ) return __riscv_vlmul_trunc_u32m1(a);
+      else if constexpr( out_lmul == 2 ) return __riscv_vlmul_trunc_u32m2(a);
+      else if constexpr( out_lmul == 4 ) return __riscv_vlmul_trunc_u32m4(a);
+    }
+    else if constexpr( match(c, category::int16) )
+    {
+      if constexpr( out_lmul == -4 ) return __riscv_vlmul_trunc_i16mf4(a);
+      else if constexpr( out_lmul == -2 ) return __riscv_vlmul_trunc_i16mf2(a);
+      else if constexpr( out_lmul == 1 ) return __riscv_vlmul_trunc_i16m1(a);
+      else if constexpr( out_lmul == 2 ) return __riscv_vlmul_trunc_i16m2(a);
+      else if constexpr( out_lmul == 4 ) return __riscv_vlmul_trunc_i16m4(a);
+    }
+    else if constexpr( match(c, category::uint16) )
+    {
+      if constexpr( out_lmul == -4 ) return __riscv_vlmul_trunc_u16mf4(a);
+      else if constexpr( out_lmul == -2 ) return __riscv_vlmul_trunc_u16mf2(a);
+      else if constexpr( out_lmul == 1 ) return __riscv_vlmul_trunc_u16m1(a);
+      else if constexpr( out_lmul == 2 ) return __riscv_vlmul_trunc_u16m2(a);
+      else if constexpr( out_lmul == 4 ) return __riscv_vlmul_trunc_u16m4(a);
+    }
+    else if constexpr( match(c, category::int8) )
+    {
+      if constexpr( out_lmul == -8 ) return __riscv_vlmul_trunc_i8mf8(a);
+      else if constexpr( out_lmul == -4 ) return __riscv_vlmul_trunc_i8mf4(a);
+      else if constexpr( out_lmul == -2 ) return __riscv_vlmul_trunc_i8mf2(a);
+      else if constexpr( out_lmul == 1 ) return __riscv_vlmul_trunc_i8m1(a);
+      else if constexpr( out_lmul == 2 ) return __riscv_vlmul_trunc_i8m2(a);
+      else if constexpr( out_lmul == 4 ) return __riscv_vlmul_trunc_i8m4(a);
+    }
+    else if constexpr( match(c, category::uint8) )
+    {
+      if constexpr( out_lmul == -8 ) return __riscv_vlmul_trunc_u8mf8(a);
+      else if constexpr( out_lmul == -4 ) return __riscv_vlmul_trunc_u8mf4(a);
+      else if constexpr( out_lmul == -2 ) return __riscv_vlmul_trunc_u8mf2(a);
+      else if constexpr( out_lmul == 1 ) return __riscv_vlmul_trunc_u8m1(a);
+      else if constexpr( out_lmul == 2 ) return __riscv_vlmul_trunc_u8m2(a);
+      else if constexpr( out_lmul == 4 ) return __riscv_vlmul_trunc_u8m4(a);
+    }
+  }
+}
+
+//================================================================================================
+// Single slice
+//================================================================================================
+
+template<callable_options O, typename T, typename N>
+EVE_FORCEINLINE wide<T, typename N::split_type>
+                slice_(EVE_REQUIRES(rvv_), O const&, wide<T, N> a, lower_slice_t) noexcept
+requires rvv_abi<abi_t<T, N>>
+{
+  constexpr auto in_lmul  = rvv_lmul_v<T, N>;
+  constexpr auto out_lmul = rvv_lmul_v<T, typename N::split_type>;
+  if constexpr( in_lmul == out_lmul ) return a.storage();
+  else
+  {
+    // we need to lower lmul - call lmul trunc.
+    return riscv_lmul_trunc(a);
+  }
+}
+
+template<callable_options O, typename T, typename N>
+EVE_FORCEINLINE wide<T, typename N::split_type>
+                slice_(EVE_REQUIRES(rvv_), O const&, wide<T, N> a, upper_slice_t) noexcept
+requires rvv_abi<abi_t<T, N>>
+{
+  constexpr auto shift_size = N::split_type::value;
+  wide<T, N>     res        = __riscv_vslidedown(a, shift_size, N::value);
+  constexpr auto in_lmul    = rvv_lmul_v<T, N>;
+  constexpr auto out_lmul   = rvv_lmul_v<T, typename N::split_type>;
+  if constexpr( in_lmul == out_lmul ) return res.storage();
+  else
+  {
+    // we need to lower lmul - call lmul trunc.
+    return riscv_lmul_trunc(res);
+  }
+}
+
+template<callable_options O, typename T, typename N>
+EVE_FORCEINLINE logical<wide<T, typename N::split_type>>
+                slice_(EVE_REQUIRES(rvv_), O const&, logical<wide<T, N>> a, lower_slice_t) noexcept
+requires rvv_abi<abi_t<T, N>>
+{
+  return simd_cast(a, as<logical<wide<T, typename N::split_type>>> {});
+}
+
+template<callable_options O, typename T, typename N>
+EVE_FORCEINLINE logical<wide<T, typename N::split_type>>
+                slice_(EVE_REQUIRES(rvv_), O const&, logical<wide<T, N>> a, upper_slice_t) noexcept
+requires rvv_abi<abi_t<T, N>>
+{
+  auto bits_slice = a.bits().slice(upper_slice_t {});
+  // TODO: could be improved when `simd_cast` for RISC-V will support casts between logical-wide.
+  auto neq = bits_slice != 0;
+  return simd_cast(neq, as<logical<wide<T, typename N::split_type>>> {});
+}
+
+//================================================================================================
+// Both slice
+//================================================================================================
+
+EVE_FORCEINLINE auto
+slice_(EVE_REQUIRES(rvv_), callable_options auto const&, simd_value auto x)
+{
+  return std::array {x.slice(lower_), x.slice(upper_)};
+}
+}

--- a/include/eve/detail/function/simd/riscv/subscript.hpp
+++ b/include/eve/detail/function/simd/riscv/subscript.hpp
@@ -1,0 +1,112 @@
+//==================================================================================================
+/*
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+*/
+//==================================================================================================
+#pragma once
+
+#include <eve/arch/riscv/rvv_common_masks.hpp>
+
+namespace eve::detail
+{
+template<callable_options O, typename T, typename N>
+EVE_FORCEINLINE T
+extract_(EVE_REQUIRES(rvv_), O const&, wide<T, N> v, std::size_t i) noexcept
+requires rvv_abi<abi_t<T, N>>
+{
+  auto on_first_needed = __riscv_vslidedown_tu(v, v, i, N::value);
+  if constexpr( std::is_floating_point_v<T> ) return __riscv_vfmv_f(on_first_needed);
+  else return __riscv_vmv_x(on_first_needed);
+}
+
+template<callable_options O, typename T, typename N>
+EVE_FORCEINLINE void
+insert_(EVE_REQUIRES(rvv_),
+        O const&,
+        wide<T, N>                & v,
+        std::size_t                 i,
+        std::convertible_to<T> auto x) noexcept
+requires rvv_abi<abi_t<T, N>>
+{
+  // get mask with 1 on i'th element.
+  logical<wide<T, N>> mask {[i](int j, int) { return j == i; }};
+  v = if_else(mask, static_cast<T>(x), v);
+}
+
+template<callable_options O, typename T, typename N>
+EVE_FORCEINLINE logical<T>
+extract_(EVE_REQUIRES(rvv_), O const&, logical<wide<T, N>> v, std::size_t i) noexcept
+requires rvv_abi<abi_t<T, N>>
+{
+  constexpr size_t                      array_size = (N::value + 7) / 8;
+  std::array<unsigned char, array_size> mask_data;
+  __riscv_vsm(mask_data.data(), v, N::value);
+  size_t needed_element_id = i / 8;
+  return mask_data[needed_element_id] & (1 << (i % 8));
+}
+
+// For riscv logical we can not rely on common algorithm.
+template<callable_options O, typename T, typename N>
+EVE_FORCEINLINE logical<T>
+extract_(EVE_REQUIRES(rvv_), O const&, logical<wide<T, N>> v, std::size_t i) noexcept
+{
+  using Wide  = logical<wide<T, N>>;
+  using abi_t = typename Wide::abi_type;
+  if constexpr( has_aggregated_abi_v<Wide> )
+  {
+    constexpr auto sz = Wide::size() / 2;
+    if( i < sz ) return extract(v.slice(lower_), i);
+    else return extract(v.slice(upper_), i - sz);
+  }
+  else { static_assert("[eve riscv] -- should not be called"); }
+}
+// For riscv logical we can not rely on common algorithm.
+template<callable_options O, typename T, typename N, typename Value>
+EVE_FORCEINLINE void
+insert_(EVE_REQUIRES(rvv_), O const&, logical<wide<T, N>>& p, std::size_t i, Value v) noexcept
+{
+  using Wide = logical<wide<T, N>>;
+  if constexpr( has_aggregated_abi_v<Wide> )
+  {
+    constexpr auto sz = Wide::size() / 2;
+    auto [l, h]       = p.slice();
+
+    if( i < sz ) insert(l, i, v);
+    else insert(h, i - sz, v);
+
+    p = Wide {l, h};
+  }
+  else if constexpr( has_emulated_abi_v<Wide> ) { p.storage()[i] = v; }
+  else static_assert("[eve riscv] -- should not be called");
+}
+
+template<callable_options O, typename T, typename N>
+EVE_FORCEINLINE void
+insert_(EVE_REQUIRES(rvv_),
+        O const&,
+        logical<wide<T, N>>          & v,
+        std::size_t                    i,
+        std::convertible_to<bool> auto x) noexcept
+requires rvv_abi<abi_t<T, N>>
+{
+  constexpr size_t                      array_size = (N::value + 7) / 8;
+  std::array<unsigned char, array_size> mask_data;
+  unsigned char                        *ptr = mask_data.data();
+  __riscv_vsm(ptr, v, N::value);
+  size_t needed_element_id = i / 8;
+  if( static_cast<bool>(x) ) mask_data[needed_element_id] |= (1 << (i % 8));
+  else mask_data[needed_element_id] &= ~(1 << (i % 8));
+  constexpr auto ratio = rvv_logical_ratio_v<T, N>;
+  if constexpr( ratio == 1 ) v = __riscv_vlm_v_b1(ptr, N::value);
+  else if constexpr( ratio == 2 ) v = __riscv_vlm_v_b2(ptr, N::value);
+  else if constexpr( ratio == 4 ) v = __riscv_vlm_v_b4(ptr, N::value);
+  else if constexpr( ratio == 8 ) v = __riscv_vlm_v_b8(ptr, N::value);
+  else if constexpr( ratio == 16 ) v = __riscv_vlm_v_b16(ptr, N::value);
+  else if constexpr( ratio == 32 ) v = __riscv_vlm_v_b32(ptr, N::value);
+  else if constexpr( ratio == 64 ) v = __riscv_vlm_v_b64(ptr, N::value);
+  else static_assert("[eve riscv] -- unexpected ratio for logical");
+}
+
+}

--- a/include/eve/detail/function/simd/riscv/to_logical.hpp
+++ b/include/eve/detail/function/simd/riscv/to_logical.hpp
@@ -1,0 +1,26 @@
+//==================================================================================================
+/*
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+*/
+//==================================================================================================
+#pragma once
+
+#include <eve/arch/as_register.hpp>
+#include <eve/detail/abi.hpp>
+#include <eve/detail/category.hpp>
+#include <eve/forward.hpp>
+#include <eve/traits/as_logical.hpp>
+
+namespace eve::detail
+{
+template<typename T, typename N>
+EVE_FORCEINLINE auto
+to_logical(wide<T, N> v) noexcept
+requires rvv_abi<abi_t<T, N>>
+{
+  return v != static_cast<T>(0);
+}
+
+}

--- a/include/eve/detail/function/slice.hpp
+++ b/include/eve/detail/function/slice.hpp
@@ -74,3 +74,7 @@ namespace eve
 #if defined(EVE_INCLUDE_SVE_HEADER)
 #  include <eve/detail/function/simd/arm/sve/slice.hpp>
 #endif
+
+#if defined(EVE_INCLUDE_RISCV_HEADER)
+#  include <eve/detail/function/simd/riscv/slice.hpp>
+#endif

--- a/include/eve/detail/function/subscript.hpp
+++ b/include/eve/detail/function/subscript.hpp
@@ -49,3 +49,7 @@ namespace eve::detail
 #if defined(EVE_INCLUDE_SVE_HEADER)
 #  include <eve/detail/function/simd/arm/sve/subscript.hpp>
 #endif
+
+#if defined(EVE_INCLUDE_RISCV_HEADER)
+#  include <eve/detail/function/simd/riscv/subscript.hpp>
+#endif

--- a/include/eve/detail/function/to_logical.hpp
+++ b/include/eve/detail/function/to_logical.hpp
@@ -25,3 +25,7 @@
 #if defined(EVE_INCLUDE_SVE_HEADER)
 #  include <eve/detail/function/simd/arm/sve/to_logical.hpp>
 #endif
+
+#if defined(EVE_INCLUDE_RISCV_HEADER)
+#  include <eve/detail/function/simd/riscv/to_logical.hpp>
+#endif

--- a/include/eve/module/core/regular/if_else.hpp
+++ b/include/eve/module/core/regular/if_else.hpp
@@ -81,3 +81,7 @@ EVE_MAKE_CALLABLE(if_else_, if_else);
 #if defined(EVE_INCLUDE_SVE_HEADER)
 #  include <eve/module/core/regular/impl/simd/arm/sve/if_else.hpp>
 #endif
+
+#if defined(EVE_INCLUDE_RISCV_HEADER)
+#  include <eve/module/core/regular/impl/simd/riscv/if_else.hpp>
+#endif

--- a/include/eve/module/core/regular/impl/simd/riscv/if_else.hpp
+++ b/include/eve/module/core/regular/impl/simd/riscv/if_else.hpp
@@ -1,0 +1,63 @@
+//==================================================================================================
+/*
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+*/
+//==================================================================================================
+#pragma once
+
+#include <eve/concept/value.hpp>
+#include <eve/detail/function/simd/riscv/make.hpp>
+#include <eve/detail/implementation.hpp>
+
+namespace eve::detail
+{
+
+template<scalar_value T, typename N>
+EVE_FORCEINLINE wide<T, N>
+if_else_(EVE_SUPPORTS(rvv_), logical<wide<T, N>> c, wide<T, N> vt, wide<T, N> vf) noexcept
+requires rvv_abi<abi_t<T, N>>
+{
+  return __riscv_vmerge_tu(vt, vf, vt, c, N::value);
+}
+
+template<scalar_value T, typename N, scalar_value U>
+EVE_FORCEINLINE wide<T, N>
+                if_else_(EVE_SUPPORTS(rvv_), logical<wide<T, N>> c, U vt, wide<T, N> vf) noexcept
+requires rvv_abi<abi_t<T, N>>
+{
+  if constexpr( !std::same_as<T, U> ) return if_else(c, static_cast<T>(vt), vf);
+  else if constexpr( std::is_floating_point_v<T> ) return __riscv_vfmerge(vf, vt, c, N::value);
+  else return __riscv_vmerge(vf, vt, c, N::value);
+}
+
+template<scalar_value T, typename N, scalar_value U, scalar_value M>
+EVE_FORCEINLINE wide<T, N>
+                if_else_(EVE_SUPPORTS(rvv_), logical<wide<T, N>> c, U vt, M vf) noexcept
+requires rvv_abi<abi_t<T, N>>
+{
+  if constexpr( !std::same_as<U, T> || !std::same_as<M, T> )
+    return if_else(c, static_cast<T>(vt), static_cast<T>(vf));
+  else
+  {
+    auto fwide = detail::rvv_make_splat(as<wide<T, N>> {}, vf);
+    return if_else(c, vt, fwide);
+  }
+}
+
+template<scalar_value T, typename N>
+EVE_FORCEINLINE logical<wide<T, N>>
+                if_else_(EVE_SUPPORTS(rvv_),
+                         logical<wide<T, N>> c,
+                         logical<wide<T, N>> vt,
+                         logical<wide<T, N>> vf) noexcept
+requires rvv_abi<abi_t<T, N>>
+{
+  auto needed_vt = __riscv_vmand(c, vt, N::value);
+  auto neg_mask  = __riscv_vmnot(c, N::value);
+  auto needed_vf = __riscv_vmand(neg_mask, vf, N::value);
+  return __riscv_vmor(needed_vt, needed_vf, N::value);
+}
+
+}

--- a/include/eve/module/core/regular/impl/simd/riscv/simd_cast.hpp
+++ b/include/eve/module/core/regular/impl/simd/riscv/simd_cast.hpp
@@ -1,0 +1,99 @@
+//==================================================================================================
+/*
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+*/
+//==================================================================================================
+#pragma once
+
+namespace eve::detail
+{
+// Logical-wide conversions.
+// For interal utils for RVV, not expected to be used outsize of this file.
+// Needed as for casting between logical-logical with different N,
+// as RISC-V needs to have an intermediate vector register type.
+// These functions cast logical to wide or wide to logical.
+// No additional work (e.g. filling with zeros undefined bits) is expected.
+template<scalar_value T, typename N, scalar_value U, typename M>
+EVE_FORCEINLINE logical<wide<U, M>>
+                rvv_simd_cast(wide<T, N> x, as<logical<wide<U, M>>> const                &tgt) noexcept
+requires rvv_abi<abi_t<T, N>> && rvv_abi<abi_t<U, M>>
+{
+  constexpr auto in_lmul = rvv_lmul_v<T, N>;
+  if constexpr( in_lmul != 1 )
+  {
+    static_assert(
+        in_lmul == 1,
+        "[riscv eve] sanity check. Can not cast wide to logical for not m1 vector register");
+  }
+  else if constexpr( std::is_floating_point_v<T> )
+    return simd_cast(simd_cast(x, as<wide<as_integer_t<T>, N>> {}), tgt);
+  else
+  {
+    static_assert(in_lmul == 1, "[riscv eve] Can not bitcast to logical not m1 vector register");
+    constexpr auto out_lmul = rvv_lmul_v<U, M>;
+    constexpr auto size     = sizeof(U) * 8;
+    constexpr auto bit_size = out_lmul > 0 ? size / out_lmul : size * (-out_lmul);
+    if constexpr( bit_size == 1 ) return __riscv_vreinterpret_b1(x);
+    else if constexpr( bit_size == 2 ) return __riscv_vreinterpret_b2(x);
+    else if constexpr( bit_size == 4 ) return __riscv_vreinterpret_b4(x);
+    else if constexpr( bit_size == 8 ) return __riscv_vreinterpret_b8(x);
+    else if constexpr( bit_size == 16 ) return __riscv_vreinterpret_b16(x);
+    else if constexpr( bit_size == 32 ) return __riscv_vreinterpret_b32(x);
+    else if constexpr( bit_size == 64 ) return __riscv_vreinterpret_b64(x);
+  }
+}
+
+template<scalar_value T, typename N, scalar_value U, typename M>
+EVE_FORCEINLINE wide<U, M>
+                rvv_simd_cast(logical<wide<T, N>> x, as<wide<U, M>> const&) noexcept
+requires rvv_abi<abi_t<T, N>>
+{
+  constexpr auto out_lmul = rvv_lmul_v<U, M>;
+  static_assert(out_lmul == 1,
+                "[riscv eve] Can not bitcast from logical not to m1 vector register");
+  constexpr auto c = categorize<wide<U, M>>();
+  if constexpr( match(c, category::int64) ) return __riscv_vreinterpret_i64m1(x);
+  else if constexpr( match(c, category::uint64) ) return __riscv_vreinterpret_u64m1(x);
+  else if constexpr( match(c, category::int32) ) return __riscv_vreinterpret_i32m1(x);
+  else if constexpr( match(c, category::uint32) ) return __riscv_vreinterpret_u32m1(x);
+  else if constexpr( match(c, category::int16) ) return __riscv_vreinterpret_i16m1(x);
+  else if constexpr( match(c, category::uint16) ) return __riscv_vreinterpret_u16m1(x);
+  else if constexpr( match(c, category::int8) ) return __riscv_vreinterpret_i8m1(x);
+  else if constexpr( match(c, category::uint8) ) return __riscv_vreinterpret_u8m1(x);
+  else if constexpr( match(c, category::float32) )
+    return __riscv_vreinterpret_f32m1(__riscv_vreinterpret_u32m1(x));
+  else if constexpr( match(c, category::float64) )
+    return __riscv_vreinterpret_f64m1(__riscv_vreinterpret_u64m1(x));
+}
+
+// logical-logical - with logical-wide-logical.
+// it is expected that it could be called with different N/M
+// * N >= M: when we have is_full false, we first work with full_type, that bitcast it to smaller
+// type.
+// * N < M: is_full false, we could cast from not full type to full one.
+template<callable_options O, scalar_value T, typename N, scalar_value U, typename M>
+EVE_FORCEINLINE logical<wide<U, M>>
+                simd_cast_(EVE_REQUIRES(rvv_),
+                           const O&,
+                           logical<wide<T, N>>            x,
+                           as<logical<wide<U, M>>> const                &tgt) noexcept
+requires(rvv_abi<abi_t<T, N>> || rvv_abi<abi_t<U, M>>)
+{
+  if constexpr( is_aggregated_v<abi_t<T, N>> || is_aggregated_v<abi_t<U, M>> )
+  {
+    auto [lv, hv] = x.slice();
+    auto half_tgt = as<logical<wide<U, typename M::split_type>>> {};
+    auto to_ret   = logical<wide<U, M>> {simd_cast(lv, half_tgt), simd_cast(hv, half_tgt)};
+    return to_ret;
+  }
+  else
+  {
+    using part_type_cast = detail::rvv_m1_wide<std::uint32_t>;
+    auto u_casted_in     = rvv_simd_cast(x, as<part_type_cast> {});
+    auto to_ret          = rvv_simd_cast(u_casted_in, tgt);
+    return to_ret;
+  }
+}
+}

--- a/include/eve/module/core/regular/simd_cast.hpp
+++ b/include/eve/module/core/regular/simd_cast.hpp
@@ -131,3 +131,7 @@ namespace detail
 #if defined(EVE_INCLUDE_X86_HEADER)
 #  include <eve/module/core/regular/impl/simd/x86/simd_cast.hpp>
 #endif
+
+#if defined(EVE_INCLUDE_RISCV_HEADER)
+#  include <eve/module/core/regular/impl/simd/riscv/simd_cast.hpp>
+#endif

--- a/test/test.hpp
+++ b/test/test.hpp
@@ -158,6 +158,7 @@ namespace eve::test
         case 128: return {0,6,5,0,4,0,0,0,3};
         case 256: return {0,7,6,0,5,0,0,0,4};
         case 512: return {0,8,7,0,6,0,0,0,5};
+        case 1024:  return {0,9,8,0,7,0,0,0,6};
         default : return {};
       };
     };

--- a/test/unit/arch/is_supported.cpp
+++ b/test/unit/arch/is_supported.cpp
@@ -60,6 +60,9 @@ TTS_CASE("Static detections of API")
   std::cout << "ARM SIMD extensions\n";
   std::cout << "NEON  : " << std::boolalpha << (eve::current_api >= eve::neon   ) << "\n";
   std::cout << "ASIMD : " << std::boolalpha << (eve::current_api >= eve::asimd  )  << "\n";
+  std::cout << "========================\n";
+  std::cout << "RISCV SIMD extensions\n";
+  std::cout << "RVV  : " << std::boolalpha << (eve::current_api == eve::rvv) << "\n";
   std::cout << "\n";
 
   TTS_PASS("All static detections - done");
@@ -90,6 +93,9 @@ TTS_CASE("Dynamic detections of API")
   std::cout << "ARM SIMD extensions\n";
   std::cout << "NEON  : " << std::boolalpha << eve::is_supported(eve::neon) << "\n";
   std::cout << "ASIMD : " << std::boolalpha << eve::is_supported(eve::asimd) << "\n";
+  std::cout << "========================\n";
+  std::cout << "RISCV SIMD extensions\n";
+  std::cout << "RVV  : " << std::boolalpha << eve::is_supported(eve::rvv) << "\n";
 
   TTS_PASS("All dynamic detections - done");
 };

--- a/test/unit/arch/top_bits.cpp
+++ b/test/unit/arch/top_bits.cpp
@@ -44,6 +44,7 @@ TTS_CASE_TPL( "Check top bits raw type", eve::test::simd::all_types)
        if constexpr (eve::has_aggregated_abi_v<logical>) TTS_EXPECT(expect_array(tb_storage{}));
   else if constexpr (std::same_as<ABI, eve::ppc_>) TTS_TYPE_IS(tb_storage, std::uint64_t);
   else if constexpr (eve::current_api >= eve::sve      ) TTS_TYPE_IS(tb_storage, eve::logical<eve::wide<v_t>>);
+  else if constexpr( eve::current_api == eve::rvv ) TTS_TYPE_IS(tb_storage, logical);
   else if constexpr (eve::current_api >= eve::avx512   )
   {
     constexpr std::ptrdiff_t min_size = sizeof(v_t) == 1 ? 16 : 8;


### PR DESCRIPTION
First part of initial support for RISC-V vector extension.

Full pack of patches for support could be found in https://github.com/jfalcou/eve/pull/1716

With this patch `unit.arch` tests are fully passed.