### PR TITLE
Adapt constants for translated_type - Refactoring & adaptation

### DIFF
--- a/include/eve/concept/scalar.hpp
+++ b/include/eve/concept/scalar.hpp
@@ -9,6 +9,7 @@
 
 #include <eve/detail/kumi.hpp>
 #include <eve/detail/meta.hpp>
+#include <eve/traits/translation.hpp>
 #include <eve/concept/translation.hpp>
 
 #include <cstddef>
@@ -35,15 +36,15 @@ template<typename Type> struct logical;
 //! @ingroup simd_concepts
 //! @concept plain_scalar_value
 //! @brief Specify that a type represents a plain scalar value
-//! The concept `plain_scalar_value<T>` is satisfied if and only if T is an instance of
-//! any non-bool, non-long double, arithmetic types.
+//! The concept `plain_scalar_value<T>` is satisfied if and only if the translation of T is an
+//! instance of any non-bool, non-long double, arithmetic types.
 //!
 //! ## Example Types
 //! - `float`
 //! - `int`
 //==================================================================================================
 template<typename T>
-concept plain_scalar_value = detail::is_plain<T>();
+concept plain_scalar_value = detail::is_plain<translate_t<T>>();
 
 //==================================================================================================
 //! @ingroup simd_concepts
@@ -100,8 +101,8 @@ concept product_scalar_value = detail::scalar_tuple<T>();
 //! @concept arithmetic_scalar_value
 //! @brief Specify that a type represents a type suitable for vectorization
 //! The concept `arithmetic_scalar_value<T>` is satisfied if and only if T can be used as a base
-//! type for @ref eve::wide , i.e it's either satisfying @ref eve::plain_scalar_value,
-//! @ref eve::product_scalar_value or @ref eve::has_plain_translation.
+//! type for @ref eve::wide , i.e it's either satisfying @ref eve::plain_scalar_value or
+//! @ref eve::product_scalar_value.
 //!
 //! ## Example Types
 //! - `kumi::tuple<float,int>`
@@ -109,7 +110,7 @@ concept product_scalar_value = detail::scalar_tuple<T>();
 //! - `float`
 //==================================================================================================
 template<typename T>
-concept arithmetic_scalar_value = plain_scalar_value<T> || product_scalar_value<T> || has_plain_translation<T>;
+concept arithmetic_scalar_value = plain_scalar_value<T> || product_scalar_value<T>;
 
 //================================================================================================
 //! @concept scalar_value

--- a/include/eve/concept/value.hpp
+++ b/include/eve/concept/value.hpp
@@ -36,7 +36,7 @@ namespace eve
   //! @ingroup simd_concepts
   //! @concept integral_value
   //! @brief The concept `integral_value<T>` is satisfied if and only if T satisfies
-  //! `eve::value` and the underlying_type satisfies `std::integral`
+  //! `eve::value` and the element type satisfies `std::integral`
   //!
   //! @groupheader{Examples}
   //! - `eve::wide<char>`
@@ -49,7 +49,7 @@ namespace eve
   //! @ingroup simd_concepts
   //! @concept signed_value
   //! @brief The concept `signed_value<T>` is satisfied if and only if T satisfies
-  //! `eve::value` and the underlying_type satisfies `std::is_signed`
+  //! `eve::value` and the element type satisfies `std::is_signed`
   //!
   //! @groupheader{Examples}
   //! - `eve::wide<char>`
@@ -62,7 +62,7 @@ namespace eve
   //! @ingroup simd_concepts
   //! @concept unsigned_value
   //! @brief The concept `unsigned_value<T>` is satisfied if and only if T satisfies
-  //! `eve::value` and the underlying_type satisfies `std::unsigned_integral`
+  //! `eve::value` and the element type satisfies `std::unsigned_integral`
   //!
   //! @groupheader{Examples}
   //! - `unsigned int`
@@ -74,7 +74,7 @@ namespace eve
   //! @ingroup simd_concepts
   //! @concept signed_integral_value
   //! @brief The concept `signed_integral_value<T>` is satisfied if and only if T satisfies
-  //! `eve::value` and the underlying_type satisfies `std::signed_integral`
+  //! `eve::value` and the element type satisfies `std::signed_integral`
   //!
   //! @groupheader{Examples}
   //! - `short int`
@@ -86,7 +86,7 @@ namespace eve
   //! @ingroup simd_concepts
   //! @concept floating_value
   //! @brief The concept `floating_value<T>` is satisfied if and only if T satisfies
-  //! `eve::value` and the underlying_type satisfies `std::floating_point`
+  //! `eve::value` and the element type satisfies `std::floating_point`
   //!
   //! @groupheader{Examples}
   //! - `double`
@@ -98,7 +98,7 @@ namespace eve
   //! @ingroup simd_concepts
   //! @concept logical_value
   //! @brief The concept `logical_value<T>` is satisfied if and only if T satisfies
-  //! `eve::value` and the underlying_type satisfies is_logical_v
+  //! `eve::value` and the element type satisfies is_logical_v
   //!
   //! @groupheader{Examples}
   //! - `eve::logical<eve::wide<char>>`
@@ -106,4 +106,16 @@ namespace eve
   //================================================================================================
   template<typename T> concept logical_value         = value<T> && is_logical_v<T>;
 
+
+  //================================================================================================
+  //! @ingroup simd_concepts
+  //! @concept plain_value
+  //! @brief The concept `plain_value<T>` is satisfied if and only if T satisfies
+  //! `eve::plain_simd_value` or `eve::plain_scalar_value`.
+  //!
+  //! @groupheader{Examples}
+  //! - `char`
+  //! - `eve::wide<double>`
+  //================================================================================================
+  template<typename T> concept plain_value         = plain_simd_value<T> || plain_scalar_value<T>;
 }

--- a/include/eve/detail/function/simd/arm/neon/movemask.hpp
+++ b/include/eve/detail/function/simd/arm/neon/movemask.hpp
@@ -9,9 +9,8 @@
 
 #include <eve/arch/logical.hpp>
 #include <eve/detail/meta.hpp>
+#include <eve/detail/function/bit_cast.hpp>
 #include <eve/module/core/regular/convert.hpp>
-
-#include <bit>
 
 namespace eve::detail
 {

--- a/include/eve/module/core/constant/allbits.hpp
+++ b/include/eve/module/core/constant/allbits.hpp
@@ -10,7 +10,6 @@
 #include <eve/arch.hpp>
 #include <eve/traits/overload.hpp>
 #include <eve/module/core/decorator/core.hpp>
-#include <eve/detail/function/bit_cast.hpp>
 #include <bit>
 
 namespace eve
@@ -19,19 +18,16 @@ template<typename Options>
 struct allbits_t : constant_callable<allbits_t, Options, downward_option, upward_option>
 {
   template<typename T>
-  static constexpr EVE_FORCEINLINE T value(eve::as<T> const&, auto const&)
+  static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, auto const&)
   {
-    using e_t           = element_type_t<T>;
     constexpr auto mask = ~0ULL;
-
-    if constexpr( std::integral<e_t> ) return T(mask);
-    else if constexpr(std::same_as<e_t, double>) return T(std::bit_cast<double>(~0ULL));
-    else if constexpr(std::same_as<e_t, float >) return T(std::bit_cast<float>(~0U));
+    if      constexpr(std::integral<T>       )  return T(mask);
+    else if constexpr(std::same_as<T, double>)  return T(std::bit_cast<double>(~0ULL));
+    else if constexpr(std::same_as<T, float >)  return T(std::bit_cast<float>(~0U));
   }
 
-  template<typename T>
-  requires(plain_scalar_value<element_type_t<T>>)
-  constexpr EVE_FORCEINLINE T operator()(as<T> const& v) const { return EVE_DISPATCH_CALL(v); }
+  template<plain_value T>
+  EVE_FORCEINLINE constexpr T operator()(as<T> const& v) const { return EVE_DISPATCH_CALL(v); }
 
   EVE_CALLABLE_OBJECT(allbits_t, allbits_);
 };
@@ -53,7 +49,7 @@ struct allbits_t : constant_callable<allbits_t, Options, downward_option, upward
 //!   @code
 //!   namespace eve
 //!   {
-//!     template<eve::value T> constexpr T allbits(as<T> x) noexcept;
+//!     template<eve::plain_value T> constexpr T allbits(as<T> x) noexcept;
 //!   }
 //!   @endcode
 //!

--- a/include/eve/module/core/constant/bitincrement.hpp
+++ b/include/eve/module/core/constant/bitincrement.hpp
@@ -19,15 +19,12 @@ struct bitincrement_t : constant_callable<bitincrement_t, Options, downward_opti
   template<typename T>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, auto const&)
   {
-    using e_t = element_type_t<T>;
-
-    if      constexpr(std::integral<e_t>        ) return T(1);
-    else if constexpr(std::same_as<e_t, float>  ) return T(0x1p-149);
-    else if constexpr(std::same_as<e_t, double> ) return T(0x0.0000000000001p-1022);
+    if      constexpr(std::integral<T>        ) return T(1);
+    else if constexpr(std::same_as<T, float>  ) return T(0x1p-149);
+    else if constexpr(std::same_as<T, double> ) return T(0x0.0000000000001p-1022);
   }
 
-  template<typename T>
-  requires(plain_scalar_value<element_type_t<T>>)
+  template<plain_value T>
   EVE_FORCEINLINE constexpr T operator()(as<T> const& v) const { return EVE_DISPATCH_CALL(v); }
 
   EVE_CALLABLE_OBJECT(bitincrement_t, bitincrement_);
@@ -50,7 +47,7 @@ struct bitincrement_t : constant_callable<bitincrement_t, Options, downward_opti
 //!   @code
 //!   namespace eve
 //!   {
-//!     template< eve::value T > constexpr T bitincrement(as<T> x) noexcept;
+//!     template< eve::plain_value T > constexpr T bitincrement(as<T> x) noexcept;
 //!   }
 //!   @endcode
 //!

--- a/include/eve/module/core/constant/constant.hpp
+++ b/include/eve/module/core/constant/constant.hpp
@@ -9,11 +9,10 @@
 
 #include <eve/as.hpp>
 #include <eve/concept/value.hpp>
-#include <eve/detail/function/bit_cast.hpp>
-#include <eve/detail/implementation.hpp>
-#include <eve/detail/meta.hpp>
 
-#include <type_traits>
+#include <eve/detail/implementation.hpp>
+#include <eve/detail/function/bit_cast.hpp>
+#include <eve/traits/underlying_type.hpp>
 
 namespace eve
 {
@@ -53,13 +52,12 @@ namespace eve
 //! @}
 //================================================================================================
 
-template<typename T, auto BitsPattern>
-requires(plain_scalar_value<element_type_t<T>>)
+template<value T, auto BitsPattern>
 EVE_FORCEINLINE auto Constant(eve::as<T> const& = {})
 {
-  using t_t = element_type_t<T>;
+  using t_t = translate_element_type_t<T>;
 
-  if constexpr( std::is_integral_v<t_t> ) { return static_cast<T>(BitsPattern); }
+  if constexpr( std::integral<t_t> ) { return static_cast<T>(BitsPattern); }
   else
   {
     if constexpr( sizeof(t_t) != sizeof(BitsPattern) )
@@ -68,7 +66,7 @@ EVE_FORCEINLINE auto Constant(eve::as<T> const& = {})
                     "[eve::constant] floating_point case - BitsPattern has not the correct size");
       return T {};
     }
-    else { return static_cast<T>(bit_cast(BitsPattern, as<t_t> {})); }
+    else return static_cast<T>(bit_cast(BitsPattern, as<t_t> {}));
   }
 }
 }

--- a/include/eve/module/core/constant/constant.hpp
+++ b/include/eve/module/core/constant/constant.hpp
@@ -9,10 +9,8 @@
 
 #include <eve/as.hpp>
 #include <eve/concept/value.hpp>
-
 #include <eve/detail/implementation.hpp>
 #include <eve/detail/function/bit_cast.hpp>
-#include <eve/traits/underlying_type.hpp>
 
 namespace eve
 {
@@ -53,7 +51,7 @@ namespace eve
 //================================================================================================
 
 template<value T, auto BitsPattern>
-EVE_FORCEINLINE auto Constant(eve::as<T> const& = {})
+EVE_FORCEINLINE auto constant(eve::as<T> const& = {})
 {
   using t_t = translate_element_type_t<T>;
 

--- a/include/eve/module/core/constant/eps.hpp
+++ b/include/eve/module/core/constant/eps.hpp
@@ -8,7 +8,6 @@
 #pragma once
 
 #include <eve/arch.hpp>
-
 #include <eve/traits/overload.hpp>
 #include <eve/module/core/decorator/core.hpp>
 

--- a/include/eve/module/core/constant/eps.hpp
+++ b/include/eve/module/core/constant/eps.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <eve/arch.hpp>
+
 #include <eve/traits/overload.hpp>
 #include <eve/module/core/decorator/core.hpp>
 
@@ -19,15 +20,12 @@ namespace eve
     template<typename T>
     static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, auto const&)
     {
-      using e_t = element_type_t<T>;
-
-           if constexpr(std::integral<e_t>        ) return T(1);
-      else if constexpr(std::same_as<e_t, float>  ) return T(0x1p-23);
-      else if constexpr(std::same_as<e_t, double> ) return T(0x1p-52);
+      if      constexpr(std::integral<T>        ) return T(1);
+      else if constexpr(std::same_as<T, float>  ) return T(0x1p-23);
+      else if constexpr(std::same_as<T, double> ) return T(0x1p-52);
     }
 
-    template<typename T>
-    requires(plain_scalar_value<element_type_t<T>>)
+    template<plain_value T>
     EVE_FORCEINLINE constexpr T operator()(as<T> const& v) const { return EVE_DISPATCH_CALL(v); }
 
     EVE_CALLABLE_OBJECT(eps_t, eps_);
@@ -50,7 +48,7 @@ namespace eve
 //!   @code
 //!   namespace eve
 //!   {
-//!     template<eve::value T> constexpr T eps(as<T> x) noexcept;
+//!     template<eve::plain_value T> constexpr T eps(as<T> x) noexcept;
 //!   }
 //!   @endcode
 //!

--- a/include/eve/module/core/constant/exponentmask.hpp
+++ b/include/eve/module/core/constant/exponentmask.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <eve/arch.hpp>
+
 #include <eve/traits/overload.hpp>
 #include <eve/module/core/decorator/core.hpp>
 
@@ -16,19 +17,16 @@ namespace eve
   template<typename Options>
   struct exponentmask_t : constant_callable<exponentmask_t, Options, downward_option, upward_option>
   {
-    template<floating_value T>
-    static EVE_FORCEINLINE constexpr as_integer_t<T> value(eve::as<T> const&, auto const&)
+    template<typename T>
+    static EVE_FORCEINLINE constexpr auto value(eve::as<T> const&, auto const&)
     {
-      using e_t = element_type_t<T>;
       using i_t = as_integer_t<T>;
-
-      if constexpr(std::same_as<e_t, float>  ) return i_t(0x7f800000);
-      else if constexpr(std::same_as<e_t, double> ) return i_t(0x7ff0000000000000LL);
+      if      constexpr(std::same_as<T, float>  ) return i_t(0x7f800000);
+      else if constexpr(std::same_as<T, double> ) return i_t(0x7ff0000000000000LL);
     }
 
-    template<typename T>
-    requires(plain_scalar_value<element_type_t<T>>)
-    EVE_FORCEINLINE constexpr auto operator()(as<T> const& v) const { return EVE_DISPATCH_CALL(v); }
+    template<floating_value T>
+    EVE_FORCEINLINE constexpr as_integer_t<T> operator()(as<T> const& v) const { return EVE_DISPATCH_CALL(v); }
 
     EVE_CALLABLE_OBJECT(exponentmask_t, exponentmask_);
   };
@@ -50,8 +48,7 @@ namespace eve
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::floating_value T >
-//!      as_unsigned<T> exponentmask(as<T> t) noexcept;
+//!     template<eve::floating_value T> constexpr eve::as_integer_t<T> exponentmask(as<T> t) noexcept;
 //!   }
 //!   @endcode
 //!

--- a/include/eve/module/core/constant/exponentmask.hpp
+++ b/include/eve/module/core/constant/exponentmask.hpp
@@ -8,7 +8,6 @@
 #pragma once
 
 #include <eve/arch.hpp>
-
 #include <eve/traits/overload.hpp>
 #include <eve/module/core/decorator/core.hpp>
 

--- a/include/eve/module/core/constant/false.hpp
+++ b/include/eve/module/core/constant/false.hpp
@@ -18,7 +18,7 @@ template<typename Options>
 struct false_t : constant_callable<false_t, Options, downward_option, upward_option>
 {
   template<typename T>
-  static constexpr EVE_FORCEINLINE as_logical_t<T> value(eve::as<T> const&, auto const&)
+  static EVE_FORCEINLINE constexpr auto value(eve::as<T> const&, auto const&)
   {
     return as_logical_t<T>(false);
   }
@@ -46,7 +46,7 @@ struct false_t : constant_callable<false_t, Options, downward_option, upward_opt
 //!   @code
 //!   namespace eve
 //!   {
-//!      template<eve::value T> constexpr eve::as_logical<T> false_(as<T> x) noexcept;
+//!      template<eve::plain_value T> constexpr eve::as_logical<T> false_(as<T> x) noexcept;
 //!   }
 //!   @endcode
 //!

--- a/include/eve/module/core/constant/half.hpp
+++ b/include/eve/module/core/constant/half.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <eve/arch.hpp>
+
 #include <eve/traits/overload.hpp>
 #include <eve/module/core/decorator/core.hpp>
 
@@ -16,18 +17,15 @@ namespace eve
   template<typename Options>
   struct half_t : constant_callable<half_t, Options, downward_option, upward_option>
   {
-    template<floating_value T>
+    template<typename T>
     static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, auto const&)
     {
-      using e_t = element_type_t<T>;
-
-           if constexpr(std::same_as<e_t, float>  ) return T(0x1p-1);
-      else if constexpr(std::same_as<e_t, double> ) return T(0x1p-1f);
+      if      constexpr(std::same_as<T, float> ) return T(0x1p-1);
+      else if constexpr(std::same_as<T, double>) return T(0x1p-1f);
     }
 
-    template<typename T>
-    requires(plain_scalar_value<element_type_t<T>>)
-      EVE_FORCEINLINE constexpr T operator()(as<T> const& v) const { return EVE_DISPATCH_CALL(v); }
+    template<floating_value T>
+    EVE_FORCEINLINE constexpr T operator()(as<T> const& v) const { return EVE_DISPATCH_CALL(v); }
 
     EVE_CALLABLE_OBJECT(half_t, half_);
   };
@@ -49,18 +47,17 @@ namespace eve
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::floating_value T >
-//!      T half(as<T> x) noexcept;
+//!     template<eve::floating_value T> constexpr T half(as<T> x) noexcept;
 //!   }
 //!   @endcode
 //!
 //!   **Parameters**
 //!
-//!     * `x` :  [Type wrapper](@ref eve::as) instance embedding the type of the constant.
+//!   * `x` :  [Type wrapper](@ref eve::as) instance embedding the type of the constant.
 //!
 //!    **Return value**
 //!
-//!      The call `eve::half(as<T>())`  is semantically equivalent to T(0.5).
+//!    The call `eve::half(as<T>())` is semantically equivalent to T(0.5).
 //!
 //!  @groupheader{Example}
 //!

--- a/include/eve/module/core/constant/half.hpp
+++ b/include/eve/module/core/constant/half.hpp
@@ -8,7 +8,6 @@
 #pragma once
 
 #include <eve/arch.hpp>
-
 #include <eve/traits/overload.hpp>
 #include <eve/module/core/decorator/core.hpp>
 

--- a/include/eve/module/core/constant/inf.hpp
+++ b/include/eve/module/core/constant/inf.hpp
@@ -16,17 +16,14 @@ namespace eve
   template<typename Options>
   struct inf_t : constant_callable<inf_t, Options, downward_option, upward_option>
   {
-    template<floating_value T>
+    template<typename T>
     static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, auto const&)
     {
-      using e_t = element_type_t<T>;
-
-      return T(std::numeric_limits<e_t>::infinity());
-   }
+      return std::numeric_limits<T>::infinity();
+    }
 
     template<floating_value T>
-    requires(plain_scalar_value<element_type_t<T>>)
-      EVE_FORCEINLINE constexpr T operator()(as<T> const& v) const { return EVE_DISPATCH_CALL(v); }
+    EVE_FORCEINLINE constexpr T operator()(as<T> const& v) const { return EVE_DISPATCH_CALL(v); }
 
     EVE_CALLABLE_OBJECT(inf_t, inf_);
   };
@@ -48,8 +45,7 @@ namespace eve
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
-//!      T inf(as<T> x) noexcept;
+//!     template<eve::floating_value T> constexpr T inf(as<T> x);
 //!   }
 //!   @endcode
 //!

--- a/include/eve/module/core/constant/iota.hpp
+++ b/include/eve/module/core/constant/iota.hpp
@@ -44,8 +44,9 @@ struct iota_t : callable<iota_t, Options, conditional_option>
 //!   @code
 //!   namespace eve
 //!   {
-//!      template <eve::conditional_expr C,
-//!                eve::arithmetic_simd_value T>
+//!      template < eve::conditional_expr C
+//!               , eve::arithmetic_simd_value T
+//!               >
 //!      T iota[C cond](as<T> tgt);
 //!   }
 //!   @endcode
@@ -64,6 +65,7 @@ struct iota_t : callable<iota_t, Options, conditional_option>
 //!
 //!  @godbolt{test/doc/core/constant/iota.cpp}
 //! @}
+//================================================================================================
 inline constexpr auto iota = functor<iota_t>;
 }
 

--- a/include/eve/module/core/constant/logeps.hpp
+++ b/include/eve/module/core/constant/logeps.hpp
@@ -7,8 +7,6 @@
 //==================================================================================================
 #pragma once
 
-#pragma once
-
 #include <eve/arch.hpp>
 #include <eve/traits/overload.hpp>
 #include <eve/module/core/decorator/core.hpp>
@@ -18,15 +16,11 @@ namespace eve
   template<typename Options>
   struct logeps_t : constant_callable<logeps_t, Options, downward_option, upward_option>
   {
-    template<floating_value T, typename Opts>
+    template<typename T, typename Opts>
     static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
     {
-      using e_t = element_type_t<T>;
-
-      if constexpr(std::same_as<e_t, float>)
-        return T(-0x1.fe2804p+3);
-      else
-        return T(-0x1.205966f2b4f12p+5);
+      if      constexpr(std::same_as<T, float> ) return T(-0x1.fe2804p+3);
+      else if constexpr(std::same_as<T, double>) return T(-0x1.205966f2b4f12p+5);
     }
 
     template<floating_value T>
@@ -52,8 +46,7 @@ namespace eve
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
-//!      T logeps(as<T> x) noexcept;
+//!     template<eve::floating_value T> constexpr T logeps(as<T> x);
 //!   }
 //!   @endcode
 //!

--- a/include/eve/module/core/constant/mantissamask.hpp
+++ b/include/eve/module/core/constant/mantissamask.hpp
@@ -16,19 +16,17 @@ namespace eve
   template<typename Options>
   struct mantissamask_t : constant_callable<mantissamask_t, Options, downward_option, upward_option>
   {
-    template<floating_value T>
-    static EVE_FORCEINLINE constexpr as_integer_t<T> value(eve::as<T> const&, auto const&)
+    template<typename T>
+    static EVE_FORCEINLINE constexpr auto value(eve::as<T> const&, auto const&)
     {
-      using e_t = element_type_t<T>;
-      using i_t = as_integer_t<T>;
+      using i_t = as_uinteger_t<T>;
 
-      if constexpr(std::same_as<e_t, float>  ) return i_t(0x807FFFFFU);
-      else if constexpr(std::same_as<e_t, double> ) return i_t(0x800FFFFFFFFFFFFFULL);
+      if      constexpr(std::same_as<T, float>  ) return i_t(0x807FFFFFU);
+      else if constexpr(std::same_as<T, double> ) return i_t(0x800FFFFFFFFFFFFFULL);
     }
 
-    template<typename T>
-    requires(plain_scalar_value<element_type_t<T>>)
-      EVE_FORCEINLINE constexpr auto operator()(as<T> const& v) const { return EVE_DISPATCH_CALL(v); }
+    template<floating_value T>
+    EVE_FORCEINLINE constexpr as_uinteger_t<T> operator()(as<T> const& v) const { return EVE_DISPATCH_CALL(v); }
 
     EVE_CALLABLE_OBJECT(mantissamask_t, mantissamask_);
   };
@@ -50,8 +48,7 @@ namespace eve
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
-//!      eve::as_unsigned<T> mantissamask(as<T> x) noexcept;
+//!     template<eve::floating_value T> constexpr eve::as_uinteger_t<T> mantissamask(as<T> x);
 //!   }
 //!   @endcode
 //!

--- a/include/eve/module/core/constant/maxexponent.hpp
+++ b/include/eve/module/core/constant/maxexponent.hpp
@@ -16,19 +16,17 @@ namespace eve
   template<typename Options>
   struct maxexponent_t : constant_callable<maxexponent_t, Options, downward_option, upward_option>
   {
-    template<floating_value T>
-    static EVE_FORCEINLINE constexpr as_integer_t<T> value(eve::as<T> const&, auto const&)
+    template<typename T>
+    static EVE_FORCEINLINE constexpr auto value(eve::as<T> const&, auto const&)
     {
-      using e_t = element_type_t<T>;
       using i_t = as_integer_t<T>;
 
-      if constexpr(std::same_as<e_t, float>  ) return  i_t(127);
-      else if constexpr(std::same_as<e_t, double> ) return  i_t(1023);
+      if      constexpr(std::same_as<T, float>  ) return i_t(127);
+      else if constexpr(std::same_as<T, double> ) return i_t(1023);
     }
 
-    template<typename T>
-    requires(plain_scalar_value<element_type_t<T>>)
-      EVE_FORCEINLINE constexpr auto operator()(as<T> const& v) const { return EVE_DISPATCH_CALL(v); }
+    template<floating_value T>
+    EVE_FORCEINLINE constexpr as_integer_t<T> operator()(as<T> const& v) const { return EVE_DISPATCH_CALL(v); }
 
     EVE_CALLABLE_OBJECT(maxexponent_t, maxexponent_);
   };
@@ -37,7 +35,7 @@ namespace eve
 //! @addtogroup core_constants
 //! @{
 //!   @var maxexponent
-//!   @brief Computes the  the greatest exponent of a floating point IEEE value
+//!   @brief Computes the greatest exponent of a floating point IEEE value
 //!
 //!   **Defined in Header**
 //!
@@ -50,8 +48,7 @@ namespace eve
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
-//!      eve::as_integer<T> maxexponent(as<T> x) noexcept;
+//!     template<eve::floating_value T> constexpr eve::as_integer<T> maxexponent(as<T> x);
 //!   }
 //!   @endcode
 //!

--- a/include/eve/module/core/constant/maxexponentm1.hpp
+++ b/include/eve/module/core/constant/maxexponentm1.hpp
@@ -16,19 +16,17 @@ namespace eve
   template<typename Options>
   struct maxexponentm1_t : constant_callable<maxexponentm1_t, Options, downward_option, upward_option>
   {
-    template<floating_value T>
-    static EVE_FORCEINLINE constexpr as_integer_t<T> value(eve::as<T> const&, auto const&)
+    template<typename T>
+    static EVE_FORCEINLINE constexpr auto value(eve::as<T> const&, auto const&)
     {
-      using e_t = element_type_t<T>;
       using i_t = as_integer_t<T>;
 
-      if constexpr(std::same_as<e_t, float>  ) return  i_t(126);
-      else if constexpr(std::same_as<e_t, double> ) return  i_t(1022);
+      if      constexpr(std::same_as<T, float>  ) return i_t(126);
+      else if constexpr(std::same_as<T, double> ) return i_t(1022);
     }
 
-    template<typename T>
-    requires(plain_scalar_value<element_type_t<T>>)
-      EVE_FORCEINLINE constexpr auto operator()(as<T> const& v) const { return EVE_DISPATCH_CALL(v); }
+    template<floating_value T>
+    EVE_FORCEINLINE constexpr as_integer_t<T> operator()(as<T> const& v) const { return EVE_DISPATCH_CALL(v); }
 
     EVE_CALLABLE_OBJECT(maxexponentm1_t, maxexponentm1_);
   };
@@ -50,8 +48,7 @@ namespace eve
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
-//!      eve::as_integer<T> maxexponentm1m1(as<T> x) noexcept;
+//!     template<eve::plafloating_valuein_value T> constexpr eve::as_integer_t<T> maxexponentm1m1(as<T> x);
 //!   }
 //!   @endcode
 //!

--- a/include/eve/module/core/constant/maxexponentp1.hpp
+++ b/include/eve/module/core/constant/maxexponentp1.hpp
@@ -16,19 +16,17 @@ namespace eve
   template<typename Options>
   struct maxexponentp1_t : constant_callable<maxexponentp1_t, Options, downward_option, upward_option>
   {
-    template<floating_value T>
-    static EVE_FORCEINLINE constexpr as_integer_t<T> value(eve::as<T> const&, auto const&)
+    template<typename T>
+    static EVE_FORCEINLINE constexpr auto value(eve::as<T> const&, auto const&)
     {
-      using e_t = element_type_t<T>;
       using i_t = as_integer_t<T>;
 
-      if constexpr(std::same_as<e_t, float>  ) return  i_t(128);
-      else if constexpr(std::same_as<e_t, double> ) return  i_t(1024);
+      if      constexpr(std::same_as<T, float>  ) return  i_t(128);
+      else if constexpr(std::same_as<T, double> ) return  i_t(1024);
     }
 
-    template<typename T>
-    requires(plain_scalar_value<element_type_t<T>>)
-      EVE_FORCEINLINE constexpr auto operator()(as<T> const& v) const { return EVE_DISPATCH_CALL(v); }
+    template<floating_value T>
+    EVE_FORCEINLINE constexpr as_integer_t<T> operator()(as<T> const& v) const { return EVE_DISPATCH_CALL(v); }
 
     EVE_CALLABLE_OBJECT(maxexponentp1_t, maxexponentp1_);
   };
@@ -50,8 +48,7 @@ namespace eve
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
-//!      eve::as_integer<T> maxexponentp1(as<T> x) noexcept;
+//!     template<eve::floating_value T> constexpr eve::as_integer<T> maxexponentp1(as<T> x);
 //!   }
 //!   @endcode
 //!

--- a/include/eve/module/core/constant/maxflint.hpp
+++ b/include/eve/module/core/constant/maxflint.hpp
@@ -19,16 +19,12 @@ namespace eve
     template<typename T>
     static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, auto const&)
     {
-      using e_t = element_type_t<T>;
-
-           if      constexpr(std::integral<e_t>   ) return T(std::numeric_limits<e_t>::max());
-      else if constexpr(std::same_as<e_t, float>  ) return T(0x1p+24);
-      else if constexpr(std::same_as<e_t, double> ) return T(0x1p+53);
+      if      constexpr(std::same_as<T, float>  ) return T(0x1p+24);
+      else if constexpr(std::same_as<T, double> ) return T(0x1p+53);
     }
 
-    template<typename T>
-    requires(plain_scalar_value<element_type_t<T>>)
-      EVE_FORCEINLINE constexpr T operator()(as<T> const& v) const { return EVE_DISPATCH_CALL(v); }
+    template<floating_value T>
+    EVE_FORCEINLINE constexpr T operator()(as<T> const& v) const { return EVE_DISPATCH_CALL(v); }
 
     EVE_CALLABLE_OBJECT(maxflint_t, maxflint_);
   };
@@ -51,8 +47,7 @@ namespace eve
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
-//!      T maxflint(as<T> x) noexcept;
+//!     template<eve::floating_value T> constexpr T maxflint(as<T> x) noexcept;
 //!   }
 //!   @endcode
 //!

--- a/include/eve/module/core/constant/mhalf.hpp
+++ b/include/eve/module/core/constant/mhalf.hpp
@@ -16,18 +16,15 @@ namespace eve
   template<typename Options>
   struct mhalf_t : constant_callable<mhalf_t, Options, downward_option, upward_option>
   {
-    template<floating_value T>
+    template<typename T>
     static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, auto const&)
     {
-      using e_t = element_type_t<T>;
-
-           if constexpr(std::same_as<e_t, float>  ) return T(-0x1p-1);
-      else if constexpr(std::same_as<e_t, double> ) return T(-0x1p-1f);
+      if      constexpr(std::same_as<T, float>  ) return T(-0x1p-1);
+      else if constexpr(std::same_as<T, double> ) return T(-0x1p-1f);
     }
 
     template<floating_value T>
-    requires(plain_scalar_value<element_type_t<T>>)
-      EVE_FORCEINLINE constexpr T operator()(as<T> const& v) const { return EVE_DISPATCH_CALL(v); }
+    EVE_FORCEINLINE constexpr T operator()(as<T> const& v) const { return EVE_DISPATCH_CALL(v); }
 
     EVE_CALLABLE_OBJECT(mhalf_t, mhalf_);
   };
@@ -49,18 +46,17 @@ namespace eve
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
-//!      T mhalf(as<T> x) noexcept;
+//!     template<eve::floating_value T> constexpr T mhalf(as<T> x) noexcept;
 //!   }
 //!   @endcode
 //!
 //!   **Parameters**
 //!
-//!     * `x` :  [Type wrapper](@ref eve::as) instance embedding the type of the constant.
+//!   * `x` :  [Type wrapper](@ref eve::as) instance embedding the type of the constant.
 //!
 //!    **Return value**
 //!
-//!      The call `eve::mhalf(as<T>())` is semantically equivalent to  `T(-0.5)`.
+//!    The call `eve::mhalf(as<T>())` is semantically equivalent to `T(-0.5)`.
 //!
 //!  @groupheader{Example}
 //!

--- a/include/eve/module/core/constant/mindenormal.hpp
+++ b/include/eve/module/core/constant/mindenormal.hpp
@@ -6,6 +6,7 @@
 */
 //==================================================================================================
 #pragma once
+
 #include <eve/arch.hpp>
 #include <eve/traits/overload.hpp>
 #include <eve/module/core/decorator/core.hpp>
@@ -18,16 +19,13 @@ namespace eve
     template<typename T>
     static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, auto const&)
     {
-      using e_t = element_type_t<T>;
-
-      if      constexpr(std::integral<e_t>        ) return T(1);
-      else if constexpr(std::same_as<e_t, float>  ) return T( 0x1p-149);
-      else if constexpr(std::same_as<e_t, double> ) return T(0x0.0000000000001p-1022);
+      if      constexpr(std::integral<T>        ) return T(1);
+      else if constexpr(std::same_as<T, float>  ) return T( 0x1p-149);
+      else if constexpr(std::same_as<T, double> ) return T(0x0.0000000000001p-1022);
     }
 
-    template<typename T>
-    requires(plain_scalar_value<element_type_t<T>>)
-      EVE_FORCEINLINE constexpr T operator()(as<T> const& v) const { return EVE_DISPATCH_CALL(v); }
+    template<plain_value T>
+    EVE_FORCEINLINE constexpr T operator()(as<T> const& v) const { return EVE_DISPATCH_CALL(v); }
 
     EVE_CALLABLE_OBJECT(mindenormal_t, mindenormal_);
   };
@@ -49,8 +47,7 @@ namespace eve
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::floating_value T >
-//!      T mindenormal(as<T> x) noexcept;
+//!     template<eve::plain_value T> constexpr T mindenormal(as<T> x) noexcept;
 //!   }
 //!   @endcode
 //!

--- a/include/eve/module/core/constant/minexponent.hpp
+++ b/include/eve/module/core/constant/minexponent.hpp
@@ -19,11 +19,10 @@ namespace eve
     template<typename T>
     static EVE_FORCEINLINE constexpr auto value(eve::as<T> const&, auto const&)
     {
-      using e_t = element_type_t<T>;
       using i_t = as_integer_t<T>;
 
-      if constexpr(std::same_as<e_t, float>  ) return  i_t(-126);
-      else if constexpr(std::same_as<e_t, double> ) return  i_t(-1022);
+      if      constexpr(std::same_as<T, float>  ) return i_t(-126);
+      else if constexpr(std::same_as<T, double> ) return i_t(-1022);
     }
 
     template<floating_value T>
@@ -49,8 +48,7 @@ namespace eve
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
-//!      eve::as_integer<T> minexponent(as<T> x) noexcept;
+//!     template<eve::floating_value T> constexpr eve::as_integer_t<T> minexponent(as<T> x) noexcept;
 //!   }
 //!   @endcode
 //!

--- a/include/eve/module/core/constant/minf.hpp
+++ b/include/eve/module/core/constant/minf.hpp
@@ -19,13 +19,11 @@ namespace eve
     template<typename T>
     static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, auto const&)
     {
-      using e_t = element_type_t<T>;
-      return T(-std::numeric_limits<e_t>::infinity());
+      return  T(-std::numeric_limits<T>::infinity());
     }
 
     template<floating_value T>
-    requires(plain_scalar_value<element_type_t<T>>)
-      EVE_FORCEINLINE constexpr T operator()(as<T> const& v) const { return EVE_DISPATCH_CALL(v); }
+    EVE_FORCEINLINE constexpr T operator()(as<T> const& v) const { return EVE_DISPATCH_CALL(v); }
 
     EVE_CALLABLE_OBJECT(minf_t, minf_);
   };
@@ -47,8 +45,7 @@ namespace eve
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
-//!      T minf(as<T> x) noexcept;
+//!      template<floating_value> constexpr T minf(as<T> x) noexcept;
 //!   }
 //!   @endcode
 //!
@@ -58,8 +55,8 @@ namespace eve
 //!
 //!    **Return value**
 //!
-//!      The call `eve::minf(as<T>())` is semantically equivalent to
-//!      `T(-std::numeric_limits<eve::element_type_t<T>>::``infinity())`
+//!    The call `eve::minf(as<T>())` is semantically equivalent to
+//!    T(-std::numeric_limits<eve::element_type_t<T>>::``infinity())`
 //!
 //!  @groupheader{Example}
 //!

--- a/include/eve/module/core/constant/mone.hpp
+++ b/include/eve/module/core/constant/mone.hpp
@@ -17,14 +17,13 @@ namespace eve
   struct mone_t : constant_callable<mone_t, Options, downward_option, upward_option>
   {
     template<typename T>
-    static constexpr EVE_FORCEINLINE T value(eve::as<T> const&, auto const&)
+    static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, auto const&)
     {
       return T(-1);
     }
 
-    template<typename T>
-    requires(plain_scalar_value<element_type_t<T>>)
-      constexpr EVE_FORCEINLINE T operator()(as<T> const& v) const { return EVE_DISPATCH_CALL(v); }
+    template<plain_value T>
+    EVE_FORCEINLINE constexpr T operator()(as<T> const& v) const { return EVE_DISPATCH_CALL(v); }
 
     EVE_CALLABLE_OBJECT(mone_t, mone_);
   };
@@ -46,8 +45,7 @@ namespace eve
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
-//!      T mone(as<T> x) noexcept;
+//!     template<eve::plain_value T> constexpr T mone(as<T> x) noexcept;
 //!   }
 //!   @endcode
 //!

--- a/include/eve/module/core/constant/mzero.hpp
+++ b/include/eve/module/core/constant/mzero.hpp
@@ -7,24 +7,25 @@
 //==================================================================================================
 #pragma once
 
+#include <eve/arch.hpp>
+#include <eve/traits/overload.hpp>
+#include <eve/module/core/decorator/core.hpp>
+
 namespace eve
 {
   template<typename Options>
   struct mzero_t : constant_callable<mzero_t, Options, downward_option, upward_option>
   {
     template<typename T>
-    static constexpr EVE_FORCEINLINE T value(eve::as<T> const&, auto const&)
+    static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, auto const&)
     {
-      using e_t = element_type_t<T>;
-
-           if constexpr(std::integral<e_t>        ) return T(0);
-      else if constexpr(std::same_as<e_t, float>  ) return T(-0.0f);
-      else if constexpr(std::same_as<e_t, double> ) return T(-0.0);
+      if      constexpr(std::integral<T>        ) return T(0);
+      else if constexpr(std::same_as<T, float>  ) return T(-0.0f);
+      else if constexpr(std::same_as<T, double> ) return T(-0.0);
    }
 
-    template<typename T>
-    requires(plain_scalar_value<element_type_t<T>>)
-      constexpr EVE_FORCEINLINE T operator()(as<T> const& v) const { return EVE_DISPATCH_CALL(v); }
+    template<plain_value T>
+    EVE_FORCEINLINE constexpr T operator()(as<T> const& v) const { return EVE_DISPATCH_CALL(v); }
 
     EVE_CALLABLE_OBJECT(mzero_t, mzero_);
   };
@@ -52,8 +53,7 @@ namespace eve
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
-//!      T mzero(as<T> x) noexcept;
+//!     template<eve::plain_value T> constexpr T mzero(as<T> x) noexcept;
 //!   }
 //!   @endcode
 //!
@@ -71,5 +71,4 @@ namespace eve
 //! @}
 //================================================================================================
   inline constexpr auto mzero = functor<mzero_t>;
-
 }

--- a/include/eve/module/core/constant/nan.hpp
+++ b/include/eve/module/core/constant/nan.hpp
@@ -8,7 +8,6 @@
 #pragma once
 
 #include <eve/arch.hpp>
-
 #include <eve/traits/overload.hpp>
 #include <eve/module/core/decorator/core.hpp>
 #include <eve/module/core/constant/allbits.hpp>

--- a/include/eve/module/core/constant/nan.hpp
+++ b/include/eve/module/core/constant/nan.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <eve/arch.hpp>
+
 #include <eve/traits/overload.hpp>
 #include <eve/module/core/decorator/core.hpp>
 #include <eve/module/core/constant/allbits.hpp>
@@ -23,9 +24,8 @@ namespace eve
       return allbits(eve::as<T>());
    }
 
-    template<eve::value T>
-    requires(plain_scalar_value<element_type_t<T>>)
-      EVE_FORCEINLINE constexpr T operator()(as<T> const& v) const { return EVE_DISPATCH_CALL(v); }
+    template<floating_value T>
+    EVE_FORCEINLINE constexpr T operator()(as<T> const& v) const { return EVE_DISPATCH_CALL(v); }
 
     EVE_CALLABLE_OBJECT(nan_t, nan_);
   };
@@ -48,8 +48,7 @@ namespace eve
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::floating_value T >
-//!      T nan(as<T> x) noexcept;
+//!      template<eve::floating_value T> constexpr T nan(as<T> x) noexcept;
 //!   }
 //!   @endcode
 //!
@@ -59,7 +58,7 @@ namespace eve
 //!
 //!    **Return value**
 //!
-//!      The call `eve::nan(as<T>())`  is semantically equivalent to  `T(0.0/0.0)`.
+//!    The call `eve::nan(as<T>())`  is semantically equivalent to  `T(0.0/0.0)`.
 //!
 //!  @groupheader{Example}
 //!

--- a/include/eve/module/core/constant/nbmantissabits.hpp
+++ b/include/eve/module/core/constant/nbmantissabits.hpp
@@ -19,16 +19,14 @@ namespace eve
     template<typename T>
     static EVE_FORCEINLINE constexpr as_integer_t<T> value(eve::as<T> const&, auto const&)
     {
-      using e_t = element_type_t<T>;
       using i_t = as_integer_t<T>;
 
-           if constexpr(std::same_as<e_t, float>  ) return  i_t(23);
-      else if constexpr(std::same_as<e_t, double> ) return  i_t(52);
+      if      constexpr(std::same_as<T, float>  ) return  i_t(23);
+      else if constexpr(std::same_as<T, double> ) return  i_t(52);
     }
 
     template<floating_value T>
-    requires(plain_scalar_value<element_type_t<T>>)
-      EVE_FORCEINLINE constexpr as_integer_t<T> operator()(as<T> const& v) const { return EVE_DISPATCH_CALL(v); }
+    EVE_FORCEINLINE constexpr as_integer_t<T> operator()(as<T> const& v) const { return EVE_DISPATCH_CALL(v); }
 
     EVE_CALLABLE_OBJECT(nbmantissabits_t, nbmantissabits_);
   };
@@ -50,8 +48,7 @@ namespace eve
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::floating_value T >
-//!      T nbmantissabits(as<T> x) noexcept;
+//!     template<eve::floating_value T> constexpr T nbmantissabits(as<T> x) noexcept;
 //!   }
 //!   @endcode
 //!

--- a/include/eve/module/core/constant/one.hpp
+++ b/include/eve/module/core/constant/one.hpp
@@ -17,14 +17,13 @@ namespace eve
   struct one_t : constant_callable<one_t, Options, downward_option, upward_option>
   {
     template<typename T>
-    static constexpr EVE_FORCEINLINE T value(eve::as<T> const&, auto const&)
+    static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, auto const&)
     {
       return T(1);
     }
 
-    template<typename T>
-    requires(plain_scalar_value<element_type_t<T>>)
-      constexpr EVE_FORCEINLINE T operator()(as<T> const& v) const { return EVE_DISPATCH_CALL(v); }
+    template<plain_value T>
+    EVE_FORCEINLINE constexpr T operator()(as<T> const& v) const { return EVE_DISPATCH_CALL(v); }
 
     EVE_CALLABLE_OBJECT(one_t, one_);
   };
@@ -46,8 +45,7 @@ namespace eve
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
-//!      T one(as<T> x) noexcept;
+//!     template<eve::plain_value T> constexpr T one(as<T> x) noexcept;
 //!   }
 //!   @endcode
 //!

--- a/include/eve/module/core/constant/oneosqrteps.hpp
+++ b/include/eve/module/core/constant/oneosqrteps.hpp
@@ -19,20 +19,16 @@ namespace eve
     template<typename T, typename Opts>
     static EVE_FORCEINLINE constexpr T value(eve::as<T> const&,  Opts const&)
     {
-      using e_t = element_type_t<T>;
-
-      if constexpr(std::same_as<e_t, float>  )     {
-        if constexpr(Opts::contains(upward))
-          return T(0x1.6a09e8p+11f);
-        else
-          return T(0x1.6a09e6p+11f);
+      if constexpr(std::same_as<T, float>)
+      {
+        if constexpr(Opts::contains(upward))        return T(0x1.6a09e8p+11f);
+        else                                        return T(0x1.6a09e6p+11f);
       }
-      else if constexpr(std::same_as<e_t, double> ) return T(0x1p+26);
+      else if constexpr(std::same_as<T, double> ) return T(0x1p+26);
     }
 
     template<floating_value T>
-    requires(plain_scalar_value<element_type_t<T>>)
-      EVE_FORCEINLINE constexpr T operator()(as<T> const& v) const { return EVE_DISPATCH_CALL(v); }
+    EVE_FORCEINLINE constexpr T operator()(as<T> const& v) const { return EVE_DISPATCH_CALL(v); }
 
     EVE_CALLABLE_OBJECT(oneosqrteps_t, oneosqrteps_);
   };
@@ -54,8 +50,7 @@ namespace eve
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
-//!      T oneosqrteps(as<T> x) noexcept;
+//!     template<eve::floating_value T> constexpr T oneosqrteps(as<T> x) noexcept;
 //!   }
 //!   @endcode
 //!

--- a/include/eve/module/core/constant/signmask.hpp
+++ b/include/eve/module/core/constant/signmask.hpp
@@ -9,6 +9,7 @@
 
 #include <eve/arch.hpp>
 #include <eve/traits/overload.hpp>
+#include <eve/concept/value.hpp>
 #include <eve/module/core/decorator/core.hpp>
 
 namespace eve
@@ -19,23 +20,20 @@ namespace eve
     template<typename T>
     static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, auto const&)
     {
-      using e_t = eve::element_type_t<T>;
+      if      constexpr( std::same_as<T, float>   ) return T(-0x0p+0f);
+      else if constexpr( std::same_as<T, double>  ) return T(-0x0p+0);
+      else if constexpr( std::same_as<T, uint8_t> ) return T(0x80U);
+      else if constexpr( std::same_as<T, uint16_t>) return T(0x8000U);
+      else if constexpr( std::same_as<T, uint32_t>) return T(0x80000000U);
+      else if constexpr( std::same_as<T, uint64_t>) return T(0x8000000000000000ULL);
+      else if constexpr( std::same_as<T, int8_t>  ) return T(-128);
+      else if constexpr( std::same_as<T, int16_t> ) return T(-32768);
+      else if constexpr( std::same_as<T, int32_t> ) return T(-2147483648LL);
+      else if constexpr( std::same_as<T, int64_t> ) return T(-9223372036854775807LL - 1);
+    }
 
-         if constexpr( std::same_as<e_t, float> )     return T(-0x0p+0f);
-    else if constexpr( std::same_as<e_t, double> )    return T(-0x0p+0);
-    else if constexpr( std::same_as<e_t, uint8_t> )   return T(0x80U);
-    else if constexpr( std::same_as<e_t, uint16_t> )  return T(0x8000U);
-    else if constexpr( std::same_as<e_t, uint32_t> )  return T(0x80000000U);
-    else if constexpr( std::same_as<e_t, uint64_t> )  return T(0x8000000000000000ULL);
-    else if constexpr( std::same_as<e_t, int8_t> )    return T(-128);
-    else if constexpr( std::same_as<e_t, int16_t> )   return T(-32768);
-    else if constexpr( std::same_as<e_t, int32_t> )   return T(-2147483648LL);
-    else if constexpr( std::same_as<e_t, int64_t> )   return T(-9223372036854775807LL - 1);
-  }
-
-    template<typename T>
-    requires(plain_scalar_value<element_type_t<T>>)
-      EVE_FORCEINLINE constexpr T operator()(as<T> const& v) const { return EVE_DISPATCH_CALL(v); }
+    template<plain_value T>
+    EVE_FORCEINLINE constexpr T operator()(as<T> const& v) const { return EVE_DISPATCH_CALL(v); }
 
     EVE_CALLABLE_OBJECT(signmask_t, signmask_);
   };
@@ -57,8 +55,7 @@ namespace eve
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
-//!      T signmask(as<T> x) noexcept;
+//!     template<eve::plain_value T> constexpr T signmask(as<T> x) noexcept;
 //!   }
 //!   @endcode
 //!

--- a/include/eve/module/core/constant/smallestposval.hpp
+++ b/include/eve/module/core/constant/smallestposval.hpp
@@ -19,16 +19,13 @@ namespace eve
     template<typename T>
     static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, auto const&)
     {
-      using e_t = element_type_t<T>;
-
-           if constexpr(std::integral<e_t>        ) return T(1);
-      else if constexpr(std::same_as<e_t, float>  ) return T(0x1p-126);
-      else if constexpr(std::same_as<e_t, double> ) return T(0x1p-1022);
+      if      constexpr(std::integral<T>       )  return T(1);
+      else if constexpr(std::same_as<T, float> )  return T(0x1p-126);
+      else if constexpr(std::same_as<T, double>)  return T(0x1p-1022);
     }
 
-    template<typename T>
-    requires(plain_scalar_value<element_type_t<T>>)
-      EVE_FORCEINLINE constexpr T operator()(as<T> const& v) const { return EVE_DISPATCH_CALL(v); }
+    template<plain_value T>
+    EVE_FORCEINLINE constexpr T operator()(as<T> const& v) const { return EVE_DISPATCH_CALL(v); }
 
     EVE_CALLABLE_OBJECT(smallestposval_t, smallestposval_);
   };
@@ -50,8 +47,7 @@ namespace eve
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
-//!      T smallestposval(as<T> x) noexcept;
+//!     template<eve::plain_value T> constexpr T smallestposval(as<T> x) noexcept;
 //!   }
 //!   @endcode
 //!

--- a/include/eve/module/core/constant/sqrteps.hpp
+++ b/include/eve/module/core/constant/sqrteps.hpp
@@ -7,7 +7,6 @@
 //==================================================================================================
 #pragma once
 
-
 #include <eve/arch.hpp>
 #include <eve/traits/overload.hpp>
 #include <eve/module/core/decorator/core.hpp>
@@ -20,21 +19,16 @@ namespace eve
     template<typename T, typename Opts>
     static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
     {
-      using e_t = element_type_t<T>;
-
-      if constexpr(std::same_as<e_t, float>  )
+      if constexpr(std::same_as<T, float>  )
       {
-        if constexpr(Opts::contains(upward))
-          return T(0x1.6a09e8p-12f);
-        else
-          return T(0x1.6a09e6p-12f);
+        if constexpr(Opts::contains(upward))        return T(0x1.6a09e8p-12f);
+        else                                        return T(0x1.6a09e6p-12f);
       }
-      else if constexpr(std::same_as<e_t, double> ) return T(0x1p-26);
+      else if constexpr(std::same_as<T, double> ) return T(0x1p-26);
     }
 
     template<floating_value T>
-    requires(plain_scalar_value<element_type_t<T>>)
-      EVE_FORCEINLINE constexpr T operator()(as<T> const& v) const { return EVE_DISPATCH_CALL(v); }
+    EVE_FORCEINLINE constexpr T operator()(as<T> const& v) const { return EVE_DISPATCH_CALL(v); }
 
     EVE_CALLABLE_OBJECT(sqrteps_t, sqrteps_);
   };
@@ -56,8 +50,7 @@ namespace eve
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
-//!      T sqrteps(as<T> x) noexcept;
+//!     template<eve::floating_value T> constexpr T sqrteps(as<T> x) noexcept;
 //!   }
 //!   @endcode
 //!

--- a/include/eve/module/core/constant/sqrtsmallestposval.hpp
+++ b/include/eve/module/core/constant/sqrtsmallestposval.hpp
@@ -19,16 +19,13 @@ namespace eve
     template<typename T>
     static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, auto const&)
     {
-      using e_t = element_type_t<T>;
-
-           if constexpr(std::integral<e_t>        ) return T(1);
-      else if constexpr(std::same_as<e_t, float>  ) return T(0x1p-63);
-      else if constexpr(std::same_as<e_t, double> ) return T(0x1p-511);
+      if      constexpr(std::integral<T>        ) return T(1);
+      else if constexpr(std::same_as<T, float>  ) return T(0x1p-63);
+      else if constexpr(std::same_as<T, double> ) return T(0x1p-511);
     }
 
-    template<typename T>
-    requires(plain_scalar_value<element_type_t<T>>)
-      EVE_FORCEINLINE constexpr T operator()(as<T> const& v) const { return EVE_DISPATCH_CALL(v); }
+    template<plain_value T>
+    EVE_FORCEINLINE constexpr T operator()(as<T> const& v) const { return EVE_DISPATCH_CALL(v); }
 
     EVE_CALLABLE_OBJECT(sqrtsmallestposval_t, sqrtsmallestposval_);
   };
@@ -50,8 +47,7 @@ namespace eve
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
-//!      T sqrtsmallestposval(as<T> x) noexcept;
+//!     template< eve::plain_value T> constexpr T sqrtsmallestposval(as<T> x) noexcept;
 //!   }
 //!   @endcode
 //!

--- a/include/eve/module/core/constant/sqrtvalmax.hpp
+++ b/include/eve/module/core/constant/sqrtvalmax.hpp
@@ -18,23 +18,20 @@ namespace eve
     template<typename T>
     static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, auto const&)
     {
-      using e_t = element_type_t<T>;
-
-           if constexpr( std::same_as<e_t, float> )         return T(0x1.fffffep+63);
-      else if constexpr( std::same_as<e_t, double> )        return T(0x1.fffffffffffffp+511);
-      else if constexpr( std::same_as<e_t, std::uint8_t> )  return T(15);
-      else if constexpr( std::same_as<e_t, std::uint16_t> ) return T(255);
-      else if constexpr( std::same_as<e_t, std::uint32_t> ) return T(65535);
-      else if constexpr( std::same_as<e_t, std::uint64_t> ) return T(4294967296ULL);
-      else if constexpr( std::same_as<e_t, std::int8_t> )   return T(11);
-      else if constexpr( std::same_as<e_t, std::int16_t> )  return T(181);
-      else if constexpr( std::same_as<e_t, std::int32_t> )  return T(46340);
-      else if constexpr( std::same_as<e_t, std::int64_t> )  return T(3037000499LL);
+      if      constexpr( std::same_as<T, float>         ) return T(0x1.fffffep+63);
+      else if constexpr( std::same_as<T, double>        ) return T(0x1.fffffffffffffp+511);
+      else if constexpr( std::same_as<T, std::uint8_t>  ) return T(15);
+      else if constexpr( std::same_as<T, std::uint16_t> ) return T(255);
+      else if constexpr( std::same_as<T, std::uint32_t> ) return T(65535);
+      else if constexpr( std::same_as<T, std::uint64_t> ) return T(4294967296ULL);
+      else if constexpr( std::same_as<T, std::int8_t>   ) return T(11);
+      else if constexpr( std::same_as<T, std::int16_t>  ) return T(181);
+      else if constexpr( std::same_as<T, std::int32_t>  ) return T(46340);
+      else if constexpr( std::same_as<T, std::int64_t>  ) return T(3037000499LL);
     }
 
-    template<typename T>
-    requires(plain_scalar_value<element_type_t<T>>)
-      EVE_FORCEINLINE constexpr T operator()(as<T> const& v) const { return EVE_DISPATCH_CALL(v); }
+    template<plain_value T>
+    EVE_FORCEINLINE constexpr T operator()(as<T> const& v) const { return EVE_DISPATCH_CALL(v); }
 
     EVE_CALLABLE_OBJECT(sqrtvalmax_t, sqrtvalmax_);
   };
@@ -56,8 +53,7 @@ namespace eve
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
-//!      T sqrtvalmax(as<T> x) noexcept;
+//!     template<eve::plain_value T> constexpr T sqrtvalmax(as<T> x) noexcept;
 //!   }
 //!   @endcode
 //!

--- a/include/eve/module/core/constant/true.hpp
+++ b/include/eve/module/core/constant/true.hpp
@@ -17,7 +17,7 @@ template<typename Options>
 struct true_t : constant_callable<true_t, Options, downward_option, upward_option>
 {
   template<typename T>
-  static constexpr EVE_FORCEINLINE as_logical_t<T> value(eve::as<T> const&, auto const&)
+  static EVE_FORCEINLINE constexpr auto value(eve::as<T> const&, auto const&)
   {
     return as_logical_t<T>(true);
   }
@@ -45,8 +45,7 @@ struct true_t : constant_callable<true_t, Options, downward_option, upward_optio
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
-//!      as_logical<T> true_(as<T> x) noexcept;
+//!     template<typename T> constexpr as_logical<T> true_(as<T> x);
 //!   }
 //!   @endcode
 //!

--- a/include/eve/module/core/constant/true.hpp
+++ b/include/eve/module/core/constant/true.hpp
@@ -6,6 +6,7 @@
 */
 //==================================================================================================
 #pragma once
+
 #include <eve/arch.hpp>
 #include <eve/traits/as_logical.hpp>
 #include <eve/traits/overload.hpp>

--- a/include/eve/module/core/constant/twotonmb.hpp
+++ b/include/eve/module/core/constant/twotonmb.hpp
@@ -19,12 +19,8 @@ namespace eve
     template<typename T, typename Opts>
     static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
     {
-      using e_t = element_type_t<T>;
-
-      if constexpr(std::same_as<e_t, float>)
-        return T(0x1p+23f);
-      else
-        return T(0x1p+52);
+      if constexpr(std::same_as<T, float>)  return T(0x1p+23f);
+      else                                  return T(0x1p+52);
     }
 
     template<floating_value T>
@@ -50,8 +46,7 @@ namespace eve
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
-//!      T nbmantissabits(as<T> x) noexcept;
+//!     template<eve::floating_value T> constexpr T twotonmb(as<T> x) noexcept;
 //!   }
 //!   @endcode
 //!
@@ -66,7 +61,7 @@ namespace eve
 //!
 //!  @groupheader{Example}
 //!
-//!  @godbolt{doc/core/constant/nbmantissabits.cpp}
+//!  @godbolt{doc/core/constant/twotonmb.cpp}
 //! @}
 //================================================================================================
  inline constexpr auto twotonmb = functor<twotonmb_t>;

--- a/include/eve/module/core/constant/valmax.hpp
+++ b/include/eve/module/core/constant/valmax.hpp
@@ -19,11 +19,10 @@ namespace eve
     template<typename T, typename Opts>
     static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
     {
-      using e_t = element_type_t<T>;
-      return T(std::numeric_limits<e_t>::max());
+      return std::numeric_limits<T>::max();
     }
 
-    template<eve::value T>
+    template<plain_value T>
     EVE_FORCEINLINE constexpr T operator()(as<T> const& v) const { return EVE_DISPATCH_CALL(v); }
 
     EVE_CALLABLE_OBJECT(valmax_t, valmax_);
@@ -46,8 +45,7 @@ namespace eve
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
-//!      T valmax(as<T> x) noexcept;
+//!     template<eve::plain_value T> constexpr T valmax(as<T> x) noexcept;
 //!   }
 //!   @endcode
 //!

--- a/include/eve/module/core/constant/valmin.hpp
+++ b/include/eve/module/core/constant/valmin.hpp
@@ -19,11 +19,10 @@ namespace eve
     template<typename T, typename Opts>
     static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
     {
-      using e_t = element_type_t<T>;
-      return T(std::numeric_limits<e_t>::lowest());
+      return std::numeric_limits<T>::lowest();
     }
 
-    template<eve::value T>
+    template<plain_value T>
     EVE_FORCEINLINE constexpr T operator()(as<T> const& v) const { return EVE_DISPATCH_CALL(v); }
 
     EVE_CALLABLE_OBJECT(valmin_t, valmin_);
@@ -46,8 +45,7 @@ namespace eve
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
-//!      T valmin(as<T> x) noexcept;
+//!     template<eve::plain_value T> constexpr T valmin(as<T> x) noexcept;
 //!   }
 //!   @endcode
 //!

--- a/include/eve/module/core/constant/zero.hpp
+++ b/include/eve/module/core/constant/zero.hpp
@@ -13,33 +13,29 @@
 
 namespace eve
 {
-//   template<typename Options>
-//   struct zero_t;
-
-//   inline constexpr auto zero = functor<zero_t>;
-
-
   template<typename Options>
   struct zero_t : constant_callable<zero_t, Options, downward_option, upward_option>
   {
+    struct fill_zero
+    {
+      constexpr EVE_FORCEINLINE auto operator()(auto& m) const { return m = functor<zero_t>(as(m)); }
+    };
+
     template<typename T>
-    static constexpr EVE_FORCEINLINE T value(eve::as<T> const&, auto const&)
+    static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, auto const&)
     {
       if constexpr( kumi::product_type<T> )
       {
-        // Can't just T{kumi::map} because that does not work for scalar product types
+        // Can't just T{kumi::map} because that may not work for scalar product types
         T res;
-        // This better inline.
-        kumi::for_each([](auto& m) { m = functor<zero_t>(as(m)); }, res);
-
+        kumi::for_each(fill_zero{}, res);
         return res;
       }
-      else
-        return T(0);
+      else return T(0);
     }
 
-    template<typename T>
-      constexpr EVE_FORCEINLINE T operator()(as<T> const& v) const { return EVE_DISPATCH_CALL(v); }
+    template<eve::value T>
+    EVE_FORCEINLINE constexpr T operator()(as<T> const& v) const { return EVE_DISPATCH_CALL(v); }
 
     EVE_CALLABLE_OBJECT(zero_t, zero_);
   };
@@ -61,7 +57,7 @@ namespace eve
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::plain_value T >
 //!      T zero(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/core/detail/horn.hpp
+++ b/include/eve/module/core/detail/horn.hpp
@@ -27,7 +27,7 @@ EVE_FORCEINLINE constexpr auto
 horn(T const&) noexcept
 {
   using t_t = element_type_t<T>;
-  return T(eve::Constant<t_t, Coef>());
+  return T(eve::constant<t_t, Coef>());
 }
 
 template<typename T, auto Coef0, auto Coef1, auto... Args>
@@ -35,6 +35,6 @@ EVE_FORCEINLINE constexpr auto
 horn(T const& x) noexcept
 {
   using t_t = element_type_t<T>;
-  return eve::fma(x, horn<T, Coef1, Args...>(x), T(eve::Constant<t_t, Coef0>()));
+  return eve::fma(x, horn<T, Coef1, Args...>(x), T(eve::constant<t_t, Coef0>()));
 }
 }

--- a/include/eve/module/core/detail/horn1.hpp
+++ b/include/eve/module/core/detail/horn1.hpp
@@ -30,7 +30,7 @@ EVE_FORCEINLINE constexpr T
 horn1(const T& x) noexcept
 {
   using t_t = element_type_t<T>;
-  return x + eve::Constant<t_t, Coef>();
+  return x + eve::constant<t_t, Coef>();
 }
 
 template<typename T, auto Coef0, auto Coef1, auto... Args>
@@ -38,6 +38,6 @@ EVE_FORCEINLINE constexpr T
 horn1(const T& x) noexcept
 {
   using t_t = element_type_t<T>;
-  return eve::fma(x, horn1<T, Coef1, Args...>(x), eve::Constant<t_t, Coef0>());
+  return eve::fma(x, horn1<T, Coef1, Args...>(x), eve::constant<t_t, Coef0>());
 }
 }

--- a/include/eve/module/math/constant/catalan.hpp
+++ b/include/eve/module/math/constant/catalan.hpp
@@ -19,7 +19,7 @@ struct catalan_t : constant_callable<catalan_t, Options, downward_option, upward
   template<typename T, typename Opts>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
   {
-    if constexpr(std::same_as<element_type_t<T>, float>)
+    if constexpr(std::same_as<T, float>)
     {
       if constexpr(Opts::contains(upward))        return T(0x1.d4f972p-1);
       else if constexpr(Opts::contains(downward)) return T(0x1.d4f97p-1);
@@ -57,8 +57,7 @@ struct catalan_t : constant_callable<catalan_t, Options, downward_option, upward
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
-//!      T catalan(as<T> x) noexcept;
+//!     template< eve::floating_value T > constexpr T catalan(as<T> x) noexcept;
 //!   }
 //!   @endcode
 //!

--- a/include/eve/module/math/constant/cbrt_pi.hpp
+++ b/include/eve/module/math/constant/cbrt_pi.hpp
@@ -19,7 +19,7 @@ struct cbrt_pi_t : constant_callable<cbrt_pi_t, Options, downward_option, upward
   template<typename T, typename Opts>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
   {
-    if constexpr(std::same_as<element_type_t<T>, float>)
+    if constexpr(std::same_as<T, float>)
     {
       if constexpr(Opts::contains(upward))        return T(0x1.76ef8p+0);
       else if constexpr(Opts::contains(downward)) return T(0x1.76ef7ep+0);
@@ -56,7 +56,7 @@ struct cbrt_pi_t : constant_callable<cbrt_pi_t, Options, downward_option, upward
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T cbrt_pi(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/math/constant/cos_1.hpp
+++ b/include/eve/module/math/constant/cos_1.hpp
@@ -19,7 +19,7 @@ struct cos_1_t : constant_callable<cos_1_t, Options, downward_option, upward_opt
   template<typename T, typename Opts>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
   {
-    if constexpr(std::same_as<element_type_t<T>, float>)
+    if constexpr(std::same_as<T, float>)
     {
       if constexpr(Opts::contains(upward))        return T(0x1.14a282p-1);
       else if constexpr(Opts::contains(downward)) return T(0x1.14a28p-1);
@@ -56,7 +56,7 @@ struct cos_1_t : constant_callable<cos_1_t, Options, downward_option, upward_opt
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T cos_1(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/math/constant/cosh_1.hpp
+++ b/include/eve/module/math/constant/cosh_1.hpp
@@ -19,7 +19,7 @@ struct cosh_1_t : constant_callable<cosh_1_t, Options, downward_option, upward_o
   template<typename T, typename Opts>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
   {
-    if constexpr(std::same_as<element_type_t<T>, float>)
+    if constexpr(std::same_as<T, float>)
     {
       if constexpr(Opts::contains(upward))        return T(0x1.8b0756p+0);
       else if constexpr(Opts::contains(downward)) return T(0x1.8b0754p+0);
@@ -56,7 +56,7 @@ struct cosh_1_t : constant_callable<cosh_1_t, Options, downward_option, upward_o
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T cosh_1(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/math/constant/egamma.hpp
+++ b/include/eve/module/math/constant/egamma.hpp
@@ -19,7 +19,7 @@ struct egamma_t : constant_callable<egamma_t, Options, downward_option, upward_o
   template<typename T, typename Opts>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
   {
-    if constexpr(std::same_as<element_type_t<T>, float>)
+    if constexpr(std::same_as<T, float>)
     {
       if constexpr(Opts::contains(upward))        return T(0x1.2788dp-1 );
       else if constexpr(Opts::contains(downward)) return T(0x1.2788cep-1);
@@ -57,7 +57,7 @@ struct egamma_t : constant_callable<egamma_t, Options, downward_option, upward_o
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T egamma(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/math/constant/egamma_sqr.hpp
+++ b/include/eve/module/math/constant/egamma_sqr.hpp
@@ -19,7 +19,7 @@ struct egamma_sqr_t : constant_callable<egamma_sqr_t, Options, downward_option, 
   template<typename T, typename Opts>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
   {
-    if constexpr(std::same_as<element_type_t<T>, float>)
+    if constexpr(std::same_as<T, float>)
     {
       if constexpr(Opts::contains(upward))        return T(0x1.552c98p-2);
       else if constexpr(Opts::contains(downward)) return T(0x1.552c96p-2);
@@ -57,7 +57,7 @@ struct egamma_sqr_t : constant_callable<egamma_sqr_t, Options, downward_option, 
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T egamma_sqr(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/math/constant/epso_2.hpp
+++ b/include/eve/module/math/constant/epso_2.hpp
@@ -19,9 +19,8 @@ struct epso_2_t : constant_callable<epso_2_t, Options, downward_option, upward_o
   template<typename T, typename Opts>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
   {
-    using e_t = element_type_t<T>;
-    if constexpr(std::same_as<e_t, float>  ) return T(0x1p-24);
-    else if constexpr(std::same_as<e_t, double> ) return T(0x1p-53);
+    if constexpr(std::same_as<T, float>)  return T(0x1p-24);
+    else                                  return T(0x1p-53);
   }
 
   template<floating_value T>
@@ -47,7 +46,7 @@ struct epso_2_t : constant_callable<epso_2_t, Options, downward_option, upward_o
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T epso_2(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/math/constant/euler.hpp
+++ b/include/eve/module/math/constant/euler.hpp
@@ -19,7 +19,7 @@ struct euler_t : constant_callable<euler_t, Options, downward_option, upward_opt
   template<typename T, typename Opts>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
   {
-    if constexpr(std::same_as<element_type_t<T>, float>)
+    if constexpr(std::same_as<T, float>)
     {
       if constexpr(Opts::contains(upward))   return T(0x1.5bf0aap+1);
       if constexpr(Opts::contains(downward)) return T(0x1.5bf0a8p+1);
@@ -56,7 +56,7 @@ struct euler_t : constant_callable<euler_t, Options, downward_option, upward_opt
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T euler(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/math/constant/exp_pi.hpp
+++ b/include/eve/module/math/constant/exp_pi.hpp
@@ -19,7 +19,7 @@ struct exp_pi_t : constant_callable<exp_pi_t, Options, downward_option, upward_o
   template<typename T, typename Opts>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
   {
-    if constexpr(std::same_as<element_type_t<T>, float>)
+    if constexpr(std::same_as<T, float>)
     {
       if constexpr(Opts::contains(upward))        return T(0x1.724048p+4);
       else if constexpr(Opts::contains(downward)) return T(0x1.724046p+4);
@@ -56,7 +56,7 @@ struct exp_pi_t : constant_callable<exp_pi_t, Options, downward_option, upward_o
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T exp_pi(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/math/constant/extreme_value_skewness.hpp
+++ b/include/eve/module/math/constant/extreme_value_skewness.hpp
@@ -19,7 +19,7 @@ struct extreme_value_skewness_t : constant_callable<extreme_value_skewness_t, Op
   template<typename T, typename Opts>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
   {
-    if constexpr(std::same_as<element_type_t<T>, float>)
+    if constexpr(std::same_as<T, float>)
     {
       if constexpr(Opts::contains(upward))        return T(0x1.23b95cp+0);
       else if constexpr(Opts::contains(downward)) return T(0x1.23b95ap+0);
@@ -57,7 +57,7 @@ struct extreme_value_skewness_t : constant_callable<extreme_value_skewness_t, Op
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T extreme_value_skewness(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/math/constant/four_minus_pi.hpp
+++ b/include/eve/module/math/constant/four_minus_pi.hpp
@@ -19,7 +19,7 @@ struct four_minus_pi_t : constant_callable<four_minus_pi_t, Options, downward_op
   template<typename T, typename Opts>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
   {
-    if constexpr(std::same_as<element_type_t<T>, float>)
+    if constexpr(std::same_as<T, float>)
     {
       if constexpr(Opts::contains(upward))        return T(0x1.b7812cp-1);
       else if constexpr(Opts::contains(downward)) return T(0x1.b7812ap-1);
@@ -56,7 +56,7 @@ struct four_minus_pi_t : constant_callable<four_minus_pi_t, Options, downward_op
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T four_minus_pi(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/math/constant/four_pio_3.hpp
+++ b/include/eve/module/math/constant/four_pio_3.hpp
@@ -19,7 +19,7 @@ struct four_pio_3_t : constant_callable<four_pio_3_t, Options, downward_option, 
   template<typename T, typename Opts>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
   {
-    if constexpr(std::same_as<element_type_t<T>, float>)
+    if constexpr(std::same_as<T, float>)
     {
       if constexpr(Opts::contains(upward))        return T(0x1.0c1524p+2);
       else if constexpr(Opts::contains(downward)) return T(0x1.0c1522p+2);
@@ -56,7 +56,7 @@ struct four_pio_3_t : constant_callable<four_pio_3_t, Options, downward_option, 
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T four_pio_3(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/math/constant/glaisher.hpp
+++ b/include/eve/module/math/constant/glaisher.hpp
@@ -19,7 +19,7 @@ struct glaisher_t : constant_callable<glaisher_t, Options, downward_option, upwa
   template<typename T, typename Opts>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
   {
-    if constexpr(std::same_as<element_type_t<T>, float>)
+    if constexpr(std::same_as<T, float>)
     {
       if constexpr(Opts::contains(upward))        return T(0x1.484d26p+0);
       else if constexpr(Opts::contains(downward)) return T(0x1.484d24p+0);
@@ -56,7 +56,7 @@ struct glaisher_t : constant_callable<glaisher_t, Options, downward_option, upwa
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T glaisher(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/math/constant/inv_2eps.hpp
+++ b/include/eve/module/math/constant/inv_2eps.hpp
@@ -19,7 +19,7 @@ struct inv_2eps_t : constant_callable<inv_2eps_t, Options, downward_option, upwa
   template<typename T, typename Opts>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
   {
-    if constexpr(std::same_as<element_type_t<T>, float>)
+    if constexpr(std::same_as<T, float>)
       return T(0x1p+22);
     else
       return T(0x1p+51);
@@ -48,7 +48,7 @@ struct inv_2eps_t : constant_callable<inv_2eps_t, Options, downward_option, upwa
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T inv_2eps(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/math/constant/inv_2pi.hpp
+++ b/include/eve/module/math/constant/inv_2pi.hpp
@@ -19,7 +19,7 @@ struct inv_2pi_t : constant_callable<inv_2pi_t, Options, downward_option, upward
   template<typename T, typename Opts>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
   {
-    if constexpr(std::same_as<element_type_t<T>, float>)
+    if constexpr(std::same_as<T, float>)
     {
       if constexpr(Opts::contains(upward))        return T(0x1.45f308p-3);
       else if constexpr(Opts::contains(downward)) return T(0x1.45f306p-3);
@@ -56,7 +56,7 @@ struct inv_2pi_t : constant_callable<inv_2pi_t, Options, downward_option, upward
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T inv_2pi(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/math/constant/inv_e.hpp
+++ b/include/eve/module/math/constant/inv_e.hpp
@@ -19,7 +19,7 @@ struct inv_e_t : constant_callable<inv_e_t, Options, downward_option, upward_opt
   template<typename T, typename Opts>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
   {
-    if constexpr(std::same_as<element_type_t<T>, float>)
+    if constexpr(std::same_as<T, float>)
     {
       if constexpr(Opts::contains(upward))        return T(0x1.78b564p-2);
       else if constexpr(Opts::contains(downward)) return T(0x1.78b562p-2);
@@ -56,7 +56,7 @@ struct inv_e_t : constant_callable<inv_e_t, Options, downward_option, upward_opt
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T inv_e(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/math/constant/inv_egamma.hpp
+++ b/include/eve/module/math/constant/inv_egamma.hpp
@@ -19,7 +19,7 @@ struct inv_egamma_t : constant_callable<inv_egamma_t, Options, downward_option, 
   template<typename T, typename Opts>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
   {
-    if constexpr(std::same_as<element_type_t<T>, float>)
+    if constexpr(std::same_as<T, float>)
     {
       if constexpr(Opts::contains(upward))        return T(0x1.bb8228p+0);
       else if constexpr(Opts::contains(downward)) return T(0x1.bb8226p+0);
@@ -57,7 +57,7 @@ struct inv_egamma_t : constant_callable<inv_egamma_t, Options, downward_option, 
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T inv_egamma(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/math/constant/inv_pi.hpp
+++ b/include/eve/module/math/constant/inv_pi.hpp
@@ -19,7 +19,7 @@ struct inv_pi_t : constant_callable<inv_pi_t, Options, downward_option, upward_o
   template<typename T, typename Opts>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
   {
-    if constexpr(std::same_as<element_type_t<T>, float>)
+    if constexpr(std::same_as<T, float>)
     {
       if constexpr(Opts::contains(upward))        return T(0x1.45f308p-2);
       else if constexpr(Opts::contains(downward)) return T(0x1.45f306p-2);
@@ -56,7 +56,7 @@ struct inv_pi_t : constant_callable<inv_pi_t, Options, downward_option, upward_o
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T inv_pi(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/math/constant/invcbrt_pi.hpp
+++ b/include/eve/module/math/constant/invcbrt_pi.hpp
@@ -19,7 +19,7 @@ struct invcbrt_pi_t : constant_callable<invcbrt_pi_t, Options, downward_option, 
   template<typename T, typename Opts>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
   {
-    if constexpr(std::same_as<element_type_t<T>, float>)
+    if constexpr(std::same_as<T, float>)
     {
       if constexpr(Opts::contains(upward))        return T(0x1.5d95ep-1);
       else if constexpr(Opts::contains(downward)) return T(0x1.5d95dep-1);
@@ -56,7 +56,7 @@ struct invcbrt_pi_t : constant_callable<invcbrt_pi_t, Options, downward_option, 
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T invcbrt_pi(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/math/constant/invlog10_2.hpp
+++ b/include/eve/module/math/constant/invlog10_2.hpp
@@ -19,7 +19,7 @@ struct invlog10_2_t : constant_callable<invlog10_2_t, Options, downward_option, 
   template<typename T, typename Opts>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
   {
-    if constexpr(std::same_as<element_type_t<T>, float>)
+    if constexpr(std::same_as<T, float>)
     {
       if constexpr(Opts::contains(upward))        return T(0x1.a934f2p+1);
       else if constexpr(Opts::contains(downward)) return T(0x1.a934fp+1 );
@@ -56,7 +56,7 @@ struct invlog10_2_t : constant_callable<invlog10_2_t, Options, downward_option, 
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T invlog10_2(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/math/constant/invlog10_e.hpp
+++ b/include/eve/module/math/constant/invlog10_e.hpp
@@ -19,7 +19,7 @@ struct invlog10_e_t : constant_callable<invlog10_e_t, Options, downward_option, 
   template<typename T, typename Opts>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
   {
-    if constexpr(std::same_as<element_type_t<T>, float>)
+    if constexpr(std::same_as<T, float>)
     {
       if constexpr(Opts::contains(upward))        return T(0x1.26bb1cp+1);
       else if constexpr(Opts::contains(downward)) return T(0x1.26bb1ap+1);
@@ -56,7 +56,7 @@ struct invlog10_e_t : constant_callable<invlog10_e_t, Options, downward_option, 
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T invlog10_e(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/math/constant/invlog_10.hpp
+++ b/include/eve/module/math/constant/invlog_10.hpp
@@ -19,7 +19,7 @@ struct invlog_10_t : constant_callable<invlog_10_t, Options, downward_option, up
   template<typename T, typename Opts>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
   {
-    if constexpr(std::same_as<element_type_t<T>, float>)
+    if constexpr(std::same_as<T, float>)
     {
       if constexpr(Opts::contains(upward))        return T(0x1.bcb7b2p-2);
       else if constexpr(Opts::contains(downward)) return T(0x1.bcb7bp-2 );
@@ -56,7 +56,7 @@ struct invlog_10_t : constant_callable<invlog_10_t, Options, downward_option, up
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T invlog_10(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/math/constant/invlog_2.hpp
+++ b/include/eve/module/math/constant/invlog_2.hpp
@@ -19,7 +19,7 @@ struct invlog_2_t : constant_callable<invlog_2_t, Options, downward_option, upwa
   template<typename T, typename Opts>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
   {
-    if constexpr(std::same_as<element_type_t<T>, float>)
+    if constexpr(std::same_as<T, float>)
     {
       if constexpr(Opts::contains(upward))        return T(0x1.715478p+0);
       else if constexpr(Opts::contains(downward)) return T(0x1.715476p+0);
@@ -56,7 +56,7 @@ struct invlog_2_t : constant_callable<invlog_2_t, Options, downward_option, upwa
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T invlog_2(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/math/constant/invlog_phi.hpp
+++ b/include/eve/module/math/constant/invlog_phi.hpp
@@ -19,7 +19,7 @@ struct invlog_phi_t : constant_callable<invlog_phi_t, Options, downward_option, 
   template<typename T, typename Opts>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
   {
-    if constexpr(std::same_as<element_type_t<T>, float>)
+    if constexpr(std::same_as<T, float>)
     {
       if constexpr(Opts::contains(upward))        return T(0x1.09fec2p+1);
       else if constexpr(Opts::contains(downward)) return T(0x1.09fecp+1);
@@ -57,7 +57,7 @@ struct invlog_phi_t : constant_callable<invlog_phi_t, Options, downward_option, 
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T invlog_phi(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/math/constant/invsqrt_2.hpp
+++ b/include/eve/module/math/constant/invsqrt_2.hpp
@@ -19,7 +19,7 @@ struct invsqrt_2_t : constant_callable<invsqrt_2_t, Options, downward_option, up
   template<typename T, typename Opts>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
   {
-    if constexpr(std::same_as<element_type_t<T>, float>)
+    if constexpr(std::same_as<T, float>)
     {
       if constexpr(Opts::contains(upward))        return T(0x1.6a09e8p-1);
       else if constexpr(Opts::contains(downward)) return T(0x1.6a09e6p-1);
@@ -56,7 +56,7 @@ struct invsqrt_2_t : constant_callable<invsqrt_2_t, Options, downward_option, up
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T invsqrt_2(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/math/constant/khinchin.hpp
+++ b/include/eve/module/math/constant/khinchin.hpp
@@ -19,7 +19,7 @@ struct khinchin_t : constant_callable<khinchin_t, Options, downward_option, upwa
   template<typename T, typename Opts>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
   {
-    if constexpr(std::same_as<element_type_t<T>, float>)
+    if constexpr(std::same_as<T, float>)
     {
       if constexpr(Opts::contains(upward))        return T(0x1.57bce6p+1);
       else if constexpr(Opts::contains(downward)) return T(0x1.57bce4p+1);
@@ -56,7 +56,7 @@ struct khinchin_t : constant_callable<khinchin_t, Options, downward_option, upwa
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T khinchin(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/math/constant/log10_e.hpp
+++ b/include/eve/module/math/constant/log10_e.hpp
@@ -19,7 +19,7 @@ struct log10_e_t : constant_callable<log10_e_t, Options, downward_option, upward
   template<typename T, typename Opts>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
   {
-    if constexpr(std::same_as<element_type_t<T>, float>)
+    if constexpr(std::same_as<T, float>)
     {
       if constexpr(Opts::contains(upward))        return T(0x1.bcb7b2p-2);
       else if constexpr(Opts::contains(downward)) return T(0x1.bcb7bp-2 );
@@ -56,7 +56,7 @@ struct log10_e_t : constant_callable<log10_e_t, Options, downward_option, upward
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T log10_e(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/math/constant/log2_e.hpp
+++ b/include/eve/module/math/constant/log2_e.hpp
@@ -19,7 +19,7 @@ struct log2_e_t : constant_callable<log2_e_t, Options, downward_option, upward_o
   template<typename T, typename Opts>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
   {
-    if constexpr(std::same_as<element_type_t<T>, float>)
+    if constexpr(std::same_as<T, float>)
     {
       if constexpr(Opts::contains(upward))        return T(0x1.715478p+0);
       else if constexpr(Opts::contains(downward)) return T(0x1.715476p+0);
@@ -56,7 +56,7 @@ struct log2_e_t : constant_callable<log2_e_t, Options, downward_option, upward_o
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T log2_e(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/math/constant/log_10.hpp
+++ b/include/eve/module/math/constant/log_10.hpp
@@ -19,7 +19,7 @@ struct log_10_t : constant_callable<log_10_t, Options, downward_option, upward_o
   template<typename T, typename Opts>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
   {
-    if constexpr(std::same_as<element_type_t<T>, float>)
+    if constexpr(std::same_as<T, float>)
     {
       if constexpr(Opts::contains(upward))        return T(0x1.26bb1cp+1);
       else if constexpr(Opts::contains(downward)) return T(0x1.26bb1ap+1);
@@ -56,7 +56,7 @@ struct log_10_t : constant_callable<log_10_t, Options, downward_option, upward_o
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T log_10(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/math/constant/log_2.hpp
+++ b/include/eve/module/math/constant/log_2.hpp
@@ -19,7 +19,7 @@ struct log_2_t : constant_callable<log_2_t, Options, downward_option, upward_opt
   template<typename T, typename Opts>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
   {
-    if constexpr(std::same_as<element_type_t<T>, float>)
+    if constexpr(std::same_as<T, float>)
     {
       if constexpr(Opts::contains(upward))        return T(0x1.62e43p-1 );
       else if constexpr(Opts::contains(downward)) return T(0x1.62e42ep-1);
@@ -56,7 +56,7 @@ struct log_2_t : constant_callable<log_2_t, Options, downward_option, upward_opt
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T log_2(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/math/constant/log_phi.hpp
+++ b/include/eve/module/math/constant/log_phi.hpp
@@ -19,7 +19,7 @@ struct log_phi_t : constant_callable<log_phi_t, Options, downward_option, upward
   template<typename T, typename Opts>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
   {
-    if constexpr(std::same_as<element_type_t<T>, float>)
+    if constexpr(std::same_as<T, float>)
     {
       if constexpr(Opts::contains(upward))        return T(0x1.ecc2ccp-2);
       else if constexpr(Opts::contains(downward)) return T(0x1.ecc2cap-2);
@@ -56,7 +56,7 @@ struct log_phi_t : constant_callable<log_phi_t, Options, downward_option, upward
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T log_phi(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/math/constant/loglog_2.hpp
+++ b/include/eve/module/math/constant/loglog_2.hpp
@@ -19,7 +19,7 @@ struct loglog_2_t : constant_callable<loglog_2_t, Options, downward_option, upwa
   template<typename T, typename Opts>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
   {
-    if constexpr(std::same_as<element_type_t<T>, float>)
+    if constexpr(std::same_as<T, float>)
     {
       if constexpr(Opts::contains(upward))        return T(-0x1.774f28p-2);
       else if constexpr(Opts::contains(downward)) return T(-0x1.774f2ap-2);
@@ -56,7 +56,7 @@ struct loglog_2_t : constant_callable<loglog_2_t, Options, downward_option, upwa
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T loglog_2(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/math/constant/maxlog.hpp
+++ b/include/eve/module/math/constant/maxlog.hpp
@@ -19,7 +19,7 @@ struct maxlog_t : constant_callable<maxlog_t, Options, downward_option, upward_o
   template<typename T, typename Opts>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
   {
-    if constexpr(std::same_as<element_type_t<T>, float>)
+    if constexpr(std::same_as<T, float>)
     {
       return T(0x1.61814ap+6);
     }
@@ -52,7 +52,7 @@ struct maxlog_t : constant_callable<maxlog_t, Options, downward_option, upward_o
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T maxlog(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/math/constant/maxlog10.hpp
+++ b/include/eve/module/math/constant/maxlog10.hpp
@@ -19,7 +19,7 @@ struct maxlog10_t : constant_callable<maxlog10_t, Options, downward_option, upwa
   template<typename T, typename Opts>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
   {
-    if constexpr(std::same_as<element_type_t<T>, float>)
+    if constexpr(std::same_as<T, float>)
     {
       return T(0x1.31d8b2p+5);
     }
@@ -52,7 +52,7 @@ struct maxlog10_t : constant_callable<maxlog10_t, Options, downward_option, upwa
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T maxlog10(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/math/constant/maxlog2.hpp
+++ b/include/eve/module/math/constant/maxlog2.hpp
@@ -19,7 +19,7 @@ struct maxlog2_t : constant_callable<maxlog2_t, Options, downward_option, upward
   template<typename T, typename Opts>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
   {
-    if constexpr(std::same_as<element_type_t<T>, float>)
+    if constexpr(std::same_as<T, float>)
     {
       return T(0x1.fcp+6);
     }
@@ -52,7 +52,7 @@ struct maxlog2_t : constant_callable<maxlog2_t, Options, downward_option, upward
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T maxlog2(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/math/constant/minlog.hpp
+++ b/include/eve/module/math/constant/minlog.hpp
@@ -19,7 +19,7 @@ namespace eve
     template<typename T, typename Opts>
     static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
     {
-      if constexpr(std::same_as<element_type_t<T>, float>)
+      if constexpr(std::same_as<T, float>)
       {
         return T(-0x1.5d814ap+6);
       }
@@ -52,7 +52,7 @@ namespace eve
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T minlog(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/math/constant/minlog10.hpp
+++ b/include/eve/module/math/constant/minlog10.hpp
@@ -19,7 +19,7 @@ struct minlog10_t : constant_callable<minlog10_t, Options, downward_option, upwa
   template<typename T, typename Opts>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
   {
-    if constexpr(std::same_as<element_type_t<T>, float>)
+    if constexpr(std::same_as<T, float>)
     {
       return T(-0x1.2f703p+5);
     }
@@ -52,7 +52,7 @@ struct minlog10_t : constant_callable<minlog10_t, Options, downward_option, upwa
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T minlog10(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/math/constant/minlog10denormal.hpp
+++ b/include/eve/module/math/constant/minlog10denormal.hpp
@@ -19,7 +19,7 @@ struct minlog10denormal_t : constant_callable<minlog10denormal_t, Options, downw
   template<typename T, typename Opts>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
   {
-    if constexpr(std::same_as<element_type_t<T>, float>)
+    if constexpr(std::same_as<T, float>)
     {
       return T(-0x1.693c6cp+5);
     }
@@ -52,7 +52,7 @@ struct minlog10denormal_t : constant_callable<minlog10denormal_t, Options, downw
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T minlog10denormal(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/math/constant/minlog2.hpp
+++ b/include/eve/module/math/constant/minlog2.hpp
@@ -19,7 +19,7 @@ namespace eve
     template<typename T, typename Opts>
     static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
     {
-      if constexpr(std::same_as<element_type_t<T>, float>)
+      if constexpr(std::same_as<T, float>)
         return T(-0x1.fcp+6);
       else
         return T(-0x1.ffp+9);
@@ -48,7 +48,7 @@ namespace eve
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T minlog2(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/math/constant/minlog2denormal.hpp
+++ b/include/eve/module/math/constant/minlog2denormal.hpp
@@ -19,7 +19,7 @@ struct minlog2denormal_t : constant_callable<minlog2denormal_t, Options, downwar
   template<typename T, typename Opts>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
   {
-    if constexpr(std::same_as<element_type_t<T>, float>)
+    if constexpr(std::same_as<T, float>)
       return T(-0x1.2cp+7);
     else
       return T(-0x1.0cbffffffffffp+10);
@@ -48,7 +48,7 @@ struct minlog2denormal_t : constant_callable<minlog2denormal_t, Options, downwar
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T minlog2denormal(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/math/constant/minlogdenormal.hpp
+++ b/include/eve/module/math/constant/minlogdenormal.hpp
@@ -19,7 +19,7 @@ struct minlogdenormal_t : constant_callable<minlogdenormal_t, Options, downward_
   template<typename T, typename Opts>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
   {
-    if constexpr(std::same_as<element_type_t<T>, float>)
+    if constexpr(std::same_as<T, float>)
     {
       return T(-0x1.9fe36ap+6);
     }
@@ -52,7 +52,7 @@ struct minlogdenormal_t : constant_callable<minlogdenormal_t, Options, downward_
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T minlogdenormal(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/math/constant/oneotwoeps.hpp
+++ b/include/eve/module/math/constant/oneotwoeps.hpp
@@ -19,15 +19,12 @@ namespace eve
     template<typename T>
     static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, auto const&)
     {
-      using e_t = element_type_t<T>;
-
-      if constexpr(std::same_as<e_t, float>  ) return T(0x1p22);
-      else if constexpr(std::same_as<e_t, double> ) return T(0x1p51);
+      if constexpr(std::same_as<T, float>)  return T(0x1p22);
+      else                                  return T(0x1p51);
     }
 
-    template<typename T>
-    requires(floating_scalar_value<element_type_t<T>>)
-      EVE_FORCEINLINE constexpr T operator()(as<T> const& v) const { return EVE_DISPATCH_CALL(v); }
+    template<floating_value T>
+    EVE_FORCEINLINE constexpr T operator()(as<T> const& v) const { return EVE_DISPATCH_CALL(v); }
 
     EVE_CALLABLE_OBJECT(oneotwoeps_t, oneotwoeps_);
   };
@@ -49,7 +46,7 @@ namespace eve
 //!   @code
 //!   namespace eve
 //!   {
-//!     template<eve::value T> constexpr T oneotwoeps(as<T> x) noexcept;
+//!     template<eve::floating_value T> constexpr T oneotwoeps(as<T> x) noexcept;
 //!   }
 //!   @endcode
 //!

--- a/include/eve/module/math/constant/phi.hpp
+++ b/include/eve/module/math/constant/phi.hpp
@@ -19,7 +19,7 @@ struct phi_t : constant_callable<phi_t, Options, downward_option, upward_option>
   template<typename T, typename Opts>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
   {
-    if constexpr(std::same_as<element_type_t<T>, float>)
+    if constexpr(std::same_as<T, float>)
     {
       if constexpr(Opts::contains(upward))        return T(0x1.9e377cp+0);
       else if constexpr(Opts::contains(downward)) return T(0x1.9e377ap+0);
@@ -56,7 +56,7 @@ struct phi_t : constant_callable<phi_t, Options, downward_option, upward_option>
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T phi(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/math/constant/pi.hpp
+++ b/include/eve/module/math/constant/pi.hpp
@@ -19,7 +19,7 @@ struct pi_t : constant_callable<pi_t, Options, downward_option, upward_option>
   template<typename T, typename Opts>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
   {
-    if constexpr(std::same_as<element_type_t<T>, float>)
+    if constexpr(std::same_as<T, float>)
     {
       if constexpr(Opts::contains(upward))        return T(0x1.921fb6p+1);
       else if constexpr(Opts::contains(downward)) return T(0x1.921fb4p+1);
@@ -56,7 +56,7 @@ struct pi_t : constant_callable<pi_t, Options, downward_option, upward_option>
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T pi(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/math/constant/pi2.hpp
+++ b/include/eve/module/math/constant/pi2.hpp
@@ -19,7 +19,7 @@ struct pi2_t : constant_callable<pi2_t, Options, downward_option, upward_option>
   template<typename T, typename Opts>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
   {
-    if constexpr(std::same_as<element_type_t<T>, float>)
+    if constexpr(std::same_as<T, float>)
     {
       if constexpr(Opts::contains(upward))        return T(0x1.3bd3cep+3);
       else if constexpr(Opts::contains(downward)) return T(0x1.3bd3ccp+3);
@@ -56,7 +56,7 @@ struct pi2_t : constant_callable<pi2_t, Options, downward_option, upward_option>
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T pi2(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/math/constant/pi2o_16.hpp
+++ b/include/eve/module/math/constant/pi2o_16.hpp
@@ -19,7 +19,7 @@ struct pi2o_16_t : constant_callable<pi2o_16_t, Options, downward_option, upward
   template<typename T, typename Opts>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
   {
-    if constexpr(std::same_as<element_type_t<T>, float>)
+    if constexpr(std::same_as<T, float>)
     {
       if constexpr(Opts::contains(upward))        return T(0x1.3bd3cep-1);
       else if constexpr(Opts::contains(downward)) return T(0x1.3bd3ccp-1);
@@ -56,7 +56,7 @@ struct pi2o_16_t : constant_callable<pi2o_16_t, Options, downward_option, upward
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T pi2o_16(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/math/constant/pi2o_6.hpp
+++ b/include/eve/module/math/constant/pi2o_6.hpp
@@ -19,7 +19,7 @@ struct pi2o_6_t : constant_callable<pi2o_6_t, Options, downward_option, upward_o
   template<typename T, typename Opts>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
   {
-    if constexpr(std::same_as<element_type_t<T>, float>)
+    if constexpr(std::same_as<T, float>)
     {
       if constexpr(Opts::contains(upward))        return T(0x1.a51a68p+0);
       else if constexpr(Opts::contains(downward)) return T(0x1.a51a66p+0);
@@ -56,7 +56,7 @@ struct pi2o_6_t : constant_callable<pi2o_6_t, Options, downward_option, upward_o
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T pi2o_6(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/math/constant/pi3.hpp
+++ b/include/eve/module/math/constant/pi3.hpp
@@ -19,7 +19,7 @@ struct pi3_t : constant_callable<pi3_t, Options, downward_option, upward_option>
   template<typename T, typename Opts>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
   {
-    if constexpr(std::same_as<element_type_t<T>, float>)
+    if constexpr(std::same_as<T, float>)
     {
       if constexpr(Opts::contains(upward))        return T(0x1.f019b6p+4);
       else if constexpr(Opts::contains(downward)) return T(0x1.f019b4p+4);
@@ -56,7 +56,7 @@ struct pi3_t : constant_callable<pi3_t, Options, downward_option, upward_option>
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T pi3(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/math/constant/pi_minus_3.hpp
+++ b/include/eve/module/math/constant/pi_minus_3.hpp
@@ -19,7 +19,7 @@ struct pi_minus_3_t : constant_callable<pi_minus_3_t, Options, downward_option, 
   template<typename T, typename Opts>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
   {
-    if constexpr(std::same_as<element_type_t<T>, float>)
+    if constexpr(std::same_as<T, float>)
     {
       if constexpr(Opts::contains(upward))        return T(0x1.21fb56p-3);
       else if constexpr(Opts::contains(downward)) return T(0x1.21fb54p-3);
@@ -56,7 +56,7 @@ struct pi_minus_3_t : constant_callable<pi_minus_3_t, Options, downward_option, 
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T pi_minus_3(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/math/constant/pi_pow_e.hpp
+++ b/include/eve/module/math/constant/pi_pow_e.hpp
@@ -19,7 +19,7 @@ struct pi_pow_e_t : constant_callable<pi_pow_e_t, Options, downward_option, upwa
   template<typename T, typename Opts>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
   {
-    if constexpr(std::same_as<element_type_t<T>, float>)
+    if constexpr(std::same_as<T, float>)
     {
       if constexpr(Opts::contains(upward))        return T(0x1.6758b6p+4);
       else if constexpr(Opts::contains(downward)) return T(0x1.6758b4p+4);
@@ -56,7 +56,7 @@ struct pi_pow_e_t : constant_callable<pi_pow_e_t, Options, downward_option, upwa
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T pi_pow_e(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/math/constant/pio_2.hpp
+++ b/include/eve/module/math/constant/pio_2.hpp
@@ -19,7 +19,7 @@ struct pio_2_t : constant_callable<pio_2_t, Options, downward_option, upward_opt
   template<typename T, typename Opts>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
   {
-    if constexpr(std::same_as<element_type_t<T>, float>)
+    if constexpr(std::same_as<T, float>)
     {
       if constexpr(Opts::contains(upward))        return T(0x1.921fb6p+0);
       else if constexpr(Opts::contains(downward)) return T(0x1.921fb4p+0);
@@ -56,7 +56,7 @@ struct pio_2_t : constant_callable<pio_2_t, Options, downward_option, upward_opt
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T pio_2(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/math/constant/pio_3.hpp
+++ b/include/eve/module/math/constant/pio_3.hpp
@@ -19,7 +19,7 @@ struct pio_3_t : constant_callable<pio_3_t, Options, downward_option, upward_opt
   template<typename T, typename Opts>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
   {
-    if constexpr(std::same_as<element_type_t<T>, float>)
+    if constexpr(std::same_as<T, float>)
     {
       if constexpr(Opts::contains(upward))        return T(0x1.0c1524p+0);
       else if constexpr(Opts::contains(downward)) return T(0x1.0c1522p+0);
@@ -56,7 +56,7 @@ struct pio_3_t : constant_callable<pio_3_t, Options, downward_option, upward_opt
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T pio_3(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/math/constant/pio_4.hpp
+++ b/include/eve/module/math/constant/pio_4.hpp
@@ -19,7 +19,7 @@ struct pio_4_t : constant_callable<pio_4_t, Options, downward_option, upward_opt
   template<typename T, typename Opts>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
   {
-    if constexpr(std::same_as<element_type_t<T>, float>)
+    if constexpr(std::same_as<T, float>)
     {
       if constexpr(Opts::contains(upward))        return T(0x1.921fb6p-1);
       else if constexpr(Opts::contains(downward)) return T(0x1.921fb4p-1);
@@ -56,7 +56,7 @@ struct pio_4_t : constant_callable<pio_4_t, Options, downward_option, upward_opt
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T pio_4(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/math/constant/pio_6.hpp
+++ b/include/eve/module/math/constant/pio_6.hpp
@@ -19,7 +19,7 @@ struct pio_6_t : constant_callable<pio_6_t, Options, downward_option, upward_opt
   template<typename T, typename Opts>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
   {
-    if constexpr(std::same_as<element_type_t<T>, float>)
+    if constexpr(std::same_as<T, float>)
     {
       if constexpr(Opts::contains(upward))        return T(0x1.0c1524p-1);
       else if constexpr(Opts::contains(downward)) return T(0x1.0c1522p-1);
@@ -56,7 +56,7 @@ struct pio_6_t : constant_callable<pio_6_t, Options, downward_option, upward_opt
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T pio_6(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/math/constant/quarter.hpp
+++ b/include/eve/module/math/constant/quarter.hpp
@@ -19,7 +19,7 @@ struct quarter_t : constant_callable<quarter_t, Options, downward_option, upward
   template<typename T, typename Opts>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
   {
-    return T(0x1p-2);
+    return T(0.25);
   }
 
   template<floating_value T>
@@ -45,7 +45,7 @@ struct quarter_t : constant_callable<quarter_t, Options, downward_option, upward
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T quarter(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/math/constant/rayleigh_kurtosis.hpp
+++ b/include/eve/module/math/constant/rayleigh_kurtosis.hpp
@@ -19,7 +19,7 @@ struct rayleigh_kurtosis_t : constant_callable<rayleigh_kurtosis_t, Options, dow
   template<typename T, typename Opts>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
   {
-    if constexpr(std::same_as<element_type_t<T>, float>)
+    if constexpr(std::same_as<T, float>)
     {
       if constexpr(Opts::contains(upward))        return T(0x1.9f5f18p+1);
       else if constexpr(Opts::contains(downward)) return T(0x1.9f5f16p+1);
@@ -57,7 +57,7 @@ struct rayleigh_kurtosis_t : constant_callable<rayleigh_kurtosis_t, Options, dow
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T rayleigh_kurtosis(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/math/constant/rayleigh_kurtosis_excess.hpp
+++ b/include/eve/module/math/constant/rayleigh_kurtosis_excess.hpp
@@ -19,7 +19,7 @@ struct rayleigh_kurtosis_excess_t : constant_callable<rayleigh_kurtosis_excess_t
   template<typename T, typename Opts>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
   {
-    if constexpr(std::same_as<element_type_t<T>, float>)
+    if constexpr(std::same_as<T, float>)
     {
       if constexpr(Opts::contains(upward))        return T(0x1.f5f162p-3);
       else if constexpr(Opts::contains(downward)) return T(0x1.f5f16p-3);
@@ -57,7 +57,7 @@ struct rayleigh_kurtosis_excess_t : constant_callable<rayleigh_kurtosis_excess_t
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T rayleigh_kurtosis_excess(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/math/constant/rayleigh_skewness.hpp
+++ b/include/eve/module/math/constant/rayleigh_skewness.hpp
@@ -19,7 +19,7 @@ struct rayleigh_skewness_t : constant_callable<rayleigh_skewness_t, Options, dow
   template<typename T, typename Opts>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
   {
-    if constexpr(std::same_as<element_type_t<T>, float>)
+    if constexpr(std::same_as<T, float>)
     {
       if constexpr(Opts::contains(upward))        return T(0x1.4320fp-1);
       else if constexpr(Opts::contains(downward)) return T(0x1.4320eep-1);
@@ -57,7 +57,7 @@ struct rayleigh_skewness_t : constant_callable<rayleigh_skewness_t, Options, dow
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T rayleigh_skewness(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/math/constant/rsqrt_2pi.hpp
+++ b/include/eve/module/math/constant/rsqrt_2pi.hpp
@@ -19,7 +19,7 @@ struct rsqrt_2pi_t : constant_callable<rsqrt_2pi_t, Options, downward_option, up
   template<typename T, typename Opts>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
   {
-    if constexpr(std::same_as<element_type_t<T>, float>)
+    if constexpr(std::same_as<T, float>)
     {
       if constexpr(Opts::contains(upward))        return T(0x1.988454p-2);
       else if constexpr(Opts::contains(downward)) return T(0x1.988452p-2);
@@ -56,7 +56,7 @@ struct rsqrt_2pi_t : constant_callable<rsqrt_2pi_t, Options, downward_option, up
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T rsqrt_2pi(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/math/constant/rsqrt_e.hpp
+++ b/include/eve/module/math/constant/rsqrt_e.hpp
@@ -19,7 +19,7 @@ struct rsqrt_e_t : constant_callable<rsqrt_e_t, Options, downward_option, upward
   template<typename T, typename Opts>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
   {
-    if constexpr(std::same_as<element_type_t<T>, float>)
+    if constexpr(std::same_as<T, float>)
     {
       if constexpr(Opts::contains(upward))        return T(0x1.368b3p-1);
       else if constexpr(Opts::contains(downward)) return T(0x1.368b2ep-1);
@@ -56,7 +56,7 @@ struct rsqrt_e_t : constant_callable<rsqrt_e_t, Options, downward_option, upward
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T rsqrt_e(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/math/constant/rsqrt_pi.hpp
+++ b/include/eve/module/math/constant/rsqrt_pi.hpp
@@ -19,7 +19,7 @@ struct rsqrt_pi_t : constant_callable<rsqrt_pi_t, Options, downward_option, upwa
   template<typename T, typename Opts>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
   {
-    if constexpr(std::same_as<element_type_t<T>, float>)
+    if constexpr(std::same_as<T, float>)
     {
       if constexpr(Opts::contains(upward))        return T(0x1.20dd76p-1);
       else if constexpr(Opts::contains(downward)) return T(0x1.20dd74p-1);
@@ -56,7 +56,7 @@ struct rsqrt_pi_t : constant_callable<rsqrt_pi_t, Options, downward_option, upwa
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T rsqrt_pi(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/math/constant/rsqrt_pio_2.hpp
+++ b/include/eve/module/math/constant/rsqrt_pio_2.hpp
@@ -19,7 +19,7 @@ struct rsqrt_pio_2_t : constant_callable<rsqrt_pio_2_t, Options, downward_option
   template<typename T, typename Opts>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
   {
-    if constexpr(std::same_as<element_type_t<T>, float>)
+    if constexpr(std::same_as<T, float>)
     {
       if constexpr(Opts::contains(upward))        return T(0x1.988454p-1);
       else if constexpr(Opts::contains(downward)) return T(0x1.988452p-1);
@@ -56,7 +56,7 @@ struct rsqrt_pio_2_t : constant_callable<rsqrt_pio_2_t, Options, downward_option
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T rsqrt_pio_2(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/math/constant/sin_1.hpp
+++ b/include/eve/module/math/constant/sin_1.hpp
@@ -19,7 +19,7 @@ struct sin_1_t : constant_callable<sin_1_t, Options, downward_option, upward_opt
   template<typename T, typename Opts>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
   {
-    if constexpr(std::same_as<element_type_t<T>, float>)
+    if constexpr(std::same_as<T, float>)
     {
       if constexpr(Opts::contains(upward))        return T(0x1.aed54ap-1);
       else if constexpr(Opts::contains(downward)) return T(0x1.aed548p-1);
@@ -56,7 +56,7 @@ struct sin_1_t : constant_callable<sin_1_t, Options, downward_option, upward_opt
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T sin_1(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/math/constant/sinh_1.hpp
+++ b/include/eve/module/math/constant/sinh_1.hpp
@@ -19,7 +19,7 @@ struct sinh_1_t : constant_callable<sinh_1_t, Options, downward_option, upward_o
   template<typename T, typename Opts>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
   {
-    if constexpr(std::same_as<element_type_t<T>, float>)
+    if constexpr(std::same_as<T, float>)
     {
       if constexpr(Opts::contains(upward))        return T(0x1.2cd9fep+0);
       else if constexpr(Opts::contains(downward)) return T(0x1.2cd9fcp+0);
@@ -56,7 +56,7 @@ struct sinh_1_t : constant_callable<sinh_1_t, Options, downward_option, upward_o
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T sinh_1(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/math/constant/sixth.hpp
+++ b/include/eve/module/math/constant/sixth.hpp
@@ -19,7 +19,7 @@ struct sixth_t : constant_callable<sixth_t, Options, downward_option, upward_opt
   template<typename T, typename Opts>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
   {
-    if constexpr(std::same_as<element_type_t<T>, float>)
+    if constexpr(std::same_as<T, float>)
     {
       if constexpr(Opts::contains(upward))        return T(0x1.555556p-3);
       else if constexpr(Opts::contains(downward)) return T(0x1.555554p-3);
@@ -56,7 +56,7 @@ struct sixth_t : constant_callable<sixth_t, Options, downward_option, upward_opt
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T sixth(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/math/constant/sqrt_2.hpp
+++ b/include/eve/module/math/constant/sqrt_2.hpp
@@ -19,7 +19,7 @@ struct sqrt_2_t : constant_callable<sqrt_2_t, Options, downward_option, upward_o
   template<typename T, typename Opts>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
   {
-    if constexpr(std::same_as<element_type_t<T>, float>)
+    if constexpr(std::same_as<T, float>)
     {
       if constexpr(Opts::contains(upward))        return T(0x1.6a09e8p+0);
       else if constexpr(Opts::contains(downward)) return T(0x1.6a09e6p+0);
@@ -57,7 +57,7 @@ struct sqrt_2_t : constant_callable<sqrt_2_t, Options, downward_option, upward_o
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T sqrt_2(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/math/constant/sqrt_2pi.hpp
+++ b/include/eve/module/math/constant/sqrt_2pi.hpp
@@ -19,7 +19,7 @@ struct sqrt_2pi_t : constant_callable<sqrt_2pi_t, Options, downward_option, upwa
   template<typename T, typename Opts>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
   {
-    if constexpr(std::same_as<element_type_t<T>, float>)
+    if constexpr(std::same_as<T, float>)
     {
       if constexpr(Opts::contains(upward))        return T(0x1.40d932p+1);
       else if constexpr(Opts::contains(downward)) return T(0x1.40d93p+1);
@@ -56,7 +56,7 @@ struct sqrt_2pi_t : constant_callable<sqrt_2pi_t, Options, downward_option, upwa
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T sqrt_2pi(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/math/constant/sqrt_3.hpp
+++ b/include/eve/module/math/constant/sqrt_3.hpp
@@ -19,7 +19,7 @@ struct sqrt_3_t : constant_callable<sqrt_3_t, Options, downward_option, upward_o
   template<typename T, typename Opts>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
   {
-    if constexpr(std::same_as<element_type_t<T>, float>)
+    if constexpr(std::same_as<T, float>)
     {
       if constexpr(Opts::contains(upward))        return T(0x1.bb67b0p+0);
       else if constexpr(Opts::contains(downward)) return T(0x1.bb67aep+0);
@@ -57,7 +57,7 @@ struct sqrt_3_t : constant_callable<sqrt_3_t, Options, downward_option, upward_o
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T sqrt_3(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/math/constant/sqrt_e.hpp
+++ b/include/eve/module/math/constant/sqrt_e.hpp
@@ -19,7 +19,7 @@ struct sqrt_e_t : constant_callable<sqrt_e_t, Options, downward_option, upward_o
   template<typename T, typename Opts>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
   {
-    if constexpr(std::same_as<element_type_t<T>, float>)
+    if constexpr(std::same_as<T, float>)
     {
       if constexpr(Opts::contains(upward))        return T(0x1.a6129ap+0);
       else if constexpr(Opts::contains(downward)) return T(0x1.a61298p+0);
@@ -56,7 +56,7 @@ struct sqrt_e_t : constant_callable<sqrt_e_t, Options, downward_option, upward_o
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T sqrt_e(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/math/constant/sqrt_pi.hpp
+++ b/include/eve/module/math/constant/sqrt_pi.hpp
@@ -19,7 +19,7 @@ struct sqrt_pi_t : constant_callable<sqrt_pi_t, Options, downward_option, upward
   template<typename T, typename Opts>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
   {
-    if constexpr(std::same_as<element_type_t<T>, float>)
+    if constexpr(std::same_as<T, float>)
     {
       if constexpr(Opts::contains(upward))        return T(0x1.c5bf8ap+0);
       else if constexpr(Opts::contains(downward)) return T(0x1.c5bf88p+0);
@@ -56,7 +56,7 @@ struct sqrt_pi_t : constant_callable<sqrt_pi_t, Options, downward_option, upward
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T sqrt_pi(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/math/constant/sqrt_pio_2.hpp
+++ b/include/eve/module/math/constant/sqrt_pio_2.hpp
@@ -19,7 +19,7 @@ struct sqrt_pio_2_t : constant_callable<sqrt_pio_2_t, Options, downward_option, 
   template<typename T, typename Opts>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
   {
-    if constexpr(std::same_as<element_type_t<T>, float>)
+    if constexpr(std::same_as<T, float>)
     {
       if constexpr(Opts::contains(upward))        return T(0x1.40d932p+0);
       else if constexpr(Opts::contains(downward)) return T(0x1.40d93p+0);
@@ -56,7 +56,7 @@ struct sqrt_pio_2_t : constant_callable<sqrt_pio_2_t, Options, downward_option, 
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T sqrt_pio_2(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/math/constant/sqrtlog_4.hpp
+++ b/include/eve/module/math/constant/sqrtlog_4.hpp
@@ -19,7 +19,7 @@ struct sqrtlog_4_t : constant_callable<sqrtlog_4_t, Options, downward_option, up
   template<typename T, typename Opts>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
   {
-    if constexpr(std::same_as<element_type_t<T>, float>)
+    if constexpr(std::same_as<T, float>)
     {
       if constexpr(Opts::contains(upward))        return T(0x1.2d6acp+0);
       else if constexpr(Opts::contains(downward)) return T(0x1.2d6abep+0);
@@ -56,7 +56,7 @@ struct sqrtlog_4_t : constant_callable<sqrtlog_4_t, Options, downward_option, up
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T sqrtlog_4(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/math/constant/third.hpp
+++ b/include/eve/module/math/constant/third.hpp
@@ -19,7 +19,7 @@ struct third_t : constant_callable<third_t, Options, downward_option, upward_opt
   template<typename T, typename Opts>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
   {
-    if constexpr(std::same_as<element_type_t<T>, float>)
+    if constexpr(std::same_as<T, float>)
     {
       if constexpr(Opts::contains(upward))        return T(0x1.555556p-2);
       else if constexpr(Opts::contains(downward)) return T(0x1.555554p-2);
@@ -56,7 +56,7 @@ struct third_t : constant_callable<third_t, Options, downward_option, upward_opt
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T third(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/math/constant/three_o_4.hpp
+++ b/include/eve/module/math/constant/three_o_4.hpp
@@ -19,7 +19,7 @@ struct three_o_4_t : constant_callable<three_o_4_t, Options, downward_option, up
   template<typename T, typename Opts>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
   {
-    if constexpr(std::same_as<element_type_t<T>, float>)
+    if constexpr(std::same_as<T, float>)
     {
       if constexpr(Opts::contains(upward))        return T(0x1.8p-1);
       else if constexpr(Opts::contains(downward)) return T(0x1.8p-1);
@@ -56,7 +56,7 @@ struct three_o_4_t : constant_callable<three_o_4_t, Options, downward_option, up
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T three_o_4(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/math/constant/three_pio_4.hpp
+++ b/include/eve/module/math/constant/three_pio_4.hpp
@@ -19,7 +19,7 @@ struct three_pio_4_t : constant_callable<three_pio_4_t, Options, downward_option
   template<typename T, typename Opts>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
   {
-    if constexpr(std::same_as<element_type_t<T>, float>)
+    if constexpr(std::same_as<T, float>)
     {
       if constexpr(Opts::contains(upward))        return T(0x1.2d97c8p+1);
       else if constexpr(Opts::contains(downward)) return T(0x1.2d97c6p+1);
@@ -56,7 +56,7 @@ struct three_pio_4_t : constant_callable<three_pio_4_t, Options, downward_option
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T three_pio_4(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/math/constant/two_o_3.hpp
+++ b/include/eve/module/math/constant/two_o_3.hpp
@@ -19,7 +19,7 @@ struct two_o_3_t : constant_callable<two_o_3_t, Options, downward_option, upward
   template<typename T, typename Opts>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
   {
-    if constexpr(std::same_as<element_type_t<T>, float>)
+    if constexpr(std::same_as<T, float>)
     {
       if constexpr(Opts::contains(upward))        return T(0x1.555556p-1);
       else if constexpr(Opts::contains(downward)) return T(0x1.555554p-1);
@@ -56,7 +56,7 @@ struct two_o_3_t : constant_callable<two_o_3_t, Options, downward_option, upward
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T two_o_3(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/math/constant/two_o_pi.hpp
+++ b/include/eve/module/math/constant/two_o_pi.hpp
@@ -19,7 +19,7 @@ struct two_o_pi_t : constant_callable<two_o_pi_t, Options, downward_option, upwa
   template<typename T, typename Opts>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
   {
-    if constexpr(std::same_as<element_type_t<T>, float>)
+    if constexpr(std::same_as<T, float>)
     {
       if constexpr(Opts::contains(upward))        return T(0x1.45f308p-1);
       else if constexpr(Opts::contains(downward)) return T(0x1.45f306p-1);
@@ -56,7 +56,7 @@ struct two_o_pi_t : constant_callable<two_o_pi_t, Options, downward_option, upwa
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T two_o_pi(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/math/constant/two_o_sqrt_pi.hpp
+++ b/include/eve/module/math/constant/two_o_sqrt_pi.hpp
@@ -19,7 +19,7 @@ struct two_o_sqrt_pi_t : constant_callable<two_o_sqrt_pi_t, Options, downward_op
   template<typename T, typename Opts>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
   {
-    if constexpr(std::same_as<element_type_t<T>, float>)
+    if constexpr(std::same_as<T, float>)
     {
       if constexpr(Opts::contains(upward))        return T(0x1.20dd76p+0);
       else if constexpr(Opts::contains(downward)) return T(0x1.20dd74p+0);
@@ -56,7 +56,7 @@ struct two_o_sqrt_pi_t : constant_callable<two_o_sqrt_pi_t, Options, downward_op
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T two_o_sqrt_pi(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/math/constant/two_pi.hpp
+++ b/include/eve/module/math/constant/two_pi.hpp
@@ -19,7 +19,7 @@ struct two_pi_t : constant_callable<two_pi_t, Options, downward_option, upward_o
   template<typename T, typename Opts>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
   {
-    if constexpr(std::same_as<element_type_t<T>, float>)
+    if constexpr(std::same_as<T, float>)
     {
       if constexpr(Opts::contains(upward))        return T(0x1.921fb6p+2);
       else if constexpr(Opts::contains(downward)) return T(0x1.921fb4p+2);
@@ -56,7 +56,7 @@ struct two_pi_t : constant_callable<two_pi_t, Options, downward_option, upward_o
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T two_pi(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/math/constant/two_pio_3.hpp
+++ b/include/eve/module/math/constant/two_pio_3.hpp
@@ -19,7 +19,7 @@ struct two_pio_3_t : constant_callable<two_pio_3_t, Options, downward_option, up
   template<typename T, typename Opts>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
   {
-    if constexpr(std::same_as<element_type_t<T>, float>)
+    if constexpr(std::same_as<T, float>)
     {
       if constexpr(Opts::contains(upward))        return T(0x1.0c1524p+1);
       else if constexpr(Opts::contains(downward)) return T(0x1.0c1522p+1);
@@ -56,7 +56,7 @@ struct two_pio_3_t : constant_callable<two_pio_3_t, Options, downward_option, up
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T two_pio_3(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/math/constant/zeta_2.hpp
+++ b/include/eve/module/math/constant/zeta_2.hpp
@@ -19,7 +19,7 @@ struct zeta_2_t : constant_callable<zeta_2_t, Options, downward_option, upward_o
   template<typename T, typename Opts>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
   {
-    if constexpr(std::same_as<element_type_t<T>, float>)
+    if constexpr(std::same_as<T, float>)
     {
       if constexpr(Opts::contains(upward))        return T(0x1.a51a68p+0);
       else if constexpr(Opts::contains(downward)) return T(0x1.a51a66p+0);
@@ -56,7 +56,7 @@ struct zeta_2_t : constant_callable<zeta_2_t, Options, downward_option, upward_o
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T zeta_2(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/module/math/constant/zeta_3.hpp
+++ b/include/eve/module/math/constant/zeta_3.hpp
@@ -19,7 +19,7 @@ struct zeta_3_t : constant_callable<zeta_3_t, Options, downward_option, upward_o
   template<typename T, typename Opts>
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
   {
-    if constexpr(std::same_as<element_type_t<T>, float>)
+    if constexpr(std::same_as<T, float>)
     {
       if constexpr(Opts::contains(upward))        return T(0x1.33ba02p+0);
       else if constexpr(Opts::contains(downward)) return T(0x1.33bap+0);
@@ -56,7 +56,7 @@ struct zeta_3_t : constant_callable<zeta_3_t, Options, downward_option, upward_o
 //!   @code
 //!   namespace eve
 //!   {
-//!      template< eve::value T >
+//!      template< eve::floating_value T >
 //!      T zeta_3(as<T> x) noexcept;
 //!   }
 //!   @endcode

--- a/include/eve/traits/as_floating_point.hpp
+++ b/include/eve/traits/as_floating_point.hpp
@@ -14,11 +14,8 @@
 namespace eve
 {
   template<typename T>
-  inline constexpr auto under_size = sizeof(translate_element_type_t<T>);
-
-  template<typename T>
   struct  as_floating_point
-        : detail::make_floating_point<(under_size<T> <= 4) ? 4: under_size<T>>
+        : detail::make_floating_point<(sizeof(T) <= 4) ? 4: sizeof(T)>
   {};
 
   template<typename T, typename N>

--- a/include/eve/traits/as_floating_point.hpp
+++ b/include/eve/traits/as_floating_point.hpp
@@ -9,11 +9,16 @@
 
 #include <eve/detail/meta.hpp>
 #include <eve/detail/wide_forward.hpp>
+#include <eve/traits/translation.hpp>
 
 namespace eve
 {
   template<typename T>
-  struct as_floating_point : detail::make_floating_point<(sizeof(T) <= 4) ? 4: sizeof(T)>
+  inline constexpr auto under_size = sizeof(translate_element_type_t<T>);
+
+  template<typename T>
+  struct  as_floating_point
+        : detail::make_floating_point<(under_size<T> <= 4) ? 4: under_size<T>>
   {};
 
   template<typename T, typename N>

--- a/include/eve/traits/as_integer.hpp
+++ b/include/eve/traits/as_integer.hpp
@@ -31,7 +31,7 @@ namespace eve
   template<typename T, typename Sign = detail::default_as_integer_sign_t<T>>
   struct as_integer
   {
-    using type = detail::make_integer_t<sizeof(translate_t<T>), Sign>;
+    using type = detail::make_integer_t<sizeof(T), Sign>;
   };
 
   template<typename T, typename N, typename Sign>

--- a/include/eve/traits/as_integer.hpp
+++ b/include/eve/traits/as_integer.hpp
@@ -9,15 +9,15 @@
 
 #include <eve/detail/meta.hpp>
 #include <eve/detail/wide_forward.hpp>
-#include <eve/traits/element_type.hpp>
+#include <eve/traits/translation.hpp>
 
 namespace eve
 {
   namespace detail
   {
     template<typename T>
-    struct default_as_integer_sign :
-     std::conditional<std::is_signed_v<element_type_t<T>>, signed, unsigned>
+    struct  default_as_integer_sign
+          : std::conditional<std::is_signed_v<translate_element_type_t<T>>, signed, unsigned>
     {
     };
 
@@ -31,7 +31,7 @@ namespace eve
   template<typename T, typename Sign = detail::default_as_integer_sign_t<T>>
   struct as_integer
   {
-    using type = detail::make_integer_t<sizeof(T), Sign>;
+    using type = detail::make_integer_t<sizeof(translate_t<T>), Sign>;
   };
 
   template<typename T, typename N, typename Sign>

--- a/include/eve/traits/as_logical.hpp
+++ b/include/eve/traits/as_logical.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <eve/detail/wide_forward.hpp>
+#include <eve/traits/translation.hpp>
 #include <eve/detail/kumi.hpp>
 
 namespace eve
@@ -31,9 +32,12 @@ namespace eve
   };
 
 
-  template<typename T>
-  requires( kumi::product_type<T> )
+  template<kumi::product_type T>
   struct as_logical<T> : as_logical< kumi::element_t<0,T> >
+  {};
+
+  template<has_plain_translation T>
+  struct as_logical<T> : as_logical< translate_t<T> >
   {};
 
   template<typename T>

--- a/include/eve/traits/overload/default_behaviors.hpp
+++ b/include/eve/traits/overload/default_behaviors.hpp
@@ -327,13 +327,16 @@ namespace eve
         // Compute the raw constant
         auto constant_value = Func<OptionsValues>::value(as<tgt_type>{},opts);
         using type          = decltype(constant_value);
-        using out_t         = std::conditional_t< std::same_as<type,tgt_type>
-                                                , T
-                                                , as_wide_as_t<type, T>
-                                                >;
+        using out_t         = typename std::conditional_t< std::same_as<type,tgt_type>
+                                                         , detail::always<T>
+                                                         , as_wide_as<type, T>
+                                                         >::type;
+
+        auto that = out_t{constant_value};
+
         // Apply a mask if any and replace missing values with 0 if no alternative is provided
-        if constexpr(match_option<condition_key, O, ignore_none_>) return out_t(constant_value);
-        else  return out_t(detail::mask_op(opts[condition_key], detail::return_2nd, type{0}, constant_value));
+        if constexpr(match_option<condition_key, O, ignore_none_>) return that;
+        else return detail::mask_op(opts[condition_key], detail::return_2nd, out_t{0}, that);
       }
     }
   };

--- a/test/doc/core/constant/constant.cpp
+++ b/test/doc/core/constant/constant.cpp
@@ -9,12 +9,12 @@ using wide_dt = eve::wide<double>;
 int main()
 {
   std::cout << "---- simd" << std::setprecision(15) << std::endl
-            << "-> Constant<wide_ft, 0X3F1DE9E7U>()           " << eve::Constant<wide_ft, 0X3F1DE9E7U>()<< std::endl
-            << "-> Constant<wide_dt, 0x3FE3BD3CC9BE45DEULL>() " << eve::Constant<wide_dt, 0x3FE3BD3CC9BE45DEULL>()<< std::endl;
+            << "-> constant<wide_ft, 0X3F1DE9E7U>()           " << eve::constant<wide_ft, 0X3F1DE9E7U>()<< std::endl
+            << "-> constant<wide_dt, 0x3FE3BD3CC9BE45DEULL>() " << eve::constant<wide_dt, 0x3FE3BD3CC9BE45DEULL>()<< std::endl;
 
   std::cout << "---- scalar" << std::endl
-            << "-> Constant<float, 0X3F1DE9E7U>()             " << eve::Constant<float, 0X3F1DE9E7U>()<< std::endl
-            << "-> Constant<double, 0x3FE3BD3CC9BE45DEULL>()  " << eve::Constant<double, 0x3FE3BD3CC9BE45DEULL>()<< std::endl;
+            << "-> constant<float, 0X3F1DE9E7U>()             " << eve::constant<float, 0X3F1DE9E7U>()<< std::endl
+            << "-> constant<double, 0x3FE3BD3CC9BE45DEULL>()  " << eve::constant<double, 0x3FE3BD3CC9BE45DEULL>()<< std::endl;
 
   return 0;
 }

--- a/test/doc/core/constant/nan.cpp
+++ b/test/doc/core/constant/nan.cpp
@@ -3,7 +3,6 @@
 #include <iostream>
 
 using wide_ft = eve::wide<float>;
-using wide_it = eve::wide<std::int16_t>;
 
 template<typename T>
 consteval auto constexpr_nan() { return eve::nan(eve::as<T>{}); }
@@ -11,22 +10,16 @@ consteval auto constexpr_nan() { return eve::nan(eve::as<T>{}); }
 int main()
 {
   wide_ft wxf;
-  wide_it wxi;
 
   std::cout << "---- simd"  << std::endl
             << "-> nan(as<wide_ft>())  = " << eve::nan(eve::as<wide_ft>()) << std::endl
-            << "-> nan(as<wide_it>())  = " << eve::nan(eve::as<wide_it>()) << std::endl
-            << "-> nan(as(wxf))        = " << eve::nan(eve::as(wxf))       << std::endl
-            << "-> nan(as(wxi))        = " << eve::nan(eve::as(wxi))       << std::endl;
+            << "-> nan(as(wxf))        = " << eve::nan(eve::as(wxf))       << std::endl;
 
   double       xf;
-  std::int16_t xi;
 
   std::cout << "---- scalar" << std::endl
             << "-> nan(as<float>())         = " << eve::nan(eve::as(float())) << std::endl
-            << "-> nan(as<std::int16_t>())  = " << eve::nan(eve::as(std::int16_t())) << std::endl
-            << "-> nan(as<xf))              = " << eve::nan(eve::as(xf)) << std::endl
-            << "-> nan(as<xi))              = " << eve::nan(eve::as(xi)) << std::endl;
+            << "-> nan(as<xf))              = " << eve::nan(eve::as(xf)) << std::endl;
 
   std::cout << "-> constexpr nan            = " << constexpr_nan<float>() << std::endl;
 

--- a/test/test.hpp
+++ b/test/test.hpp
@@ -288,7 +288,7 @@ namespace tts
       // Compute a recognizable filler
       for(std::ptrdiff_t i=data.size();i<these.size();++i)
       {
-        p_t filler = eve::Constant<p_t, static_cast<p_t>(0xDEADBEEFBABE0000)>() + p_t(i);
+        p_t filler = eve::constant<p_t, static_cast<p_t>(0xDEADBEEFBABE0000)>() + p_t(i);
         these.set(i, eve::bit_cast(filler,eve::as<v_t>()) );
       }
 

--- a/test/unit/module/core/constant/constant.cpp
+++ b/test/unit/module/core/constant/constant.cpp
@@ -10,8 +10,12 @@
 
 using eve::fixed;
 
+enum class some_enum : std::int16_t {};
+
 TTS_CASE("Constant generation for scalar")
 {
+  TTS_EQUAL((eve::Constant<some_enum, 0x4455>()), some_enum{0x4455});
+
   TTS_ULP_EQUAL((eve::Constant<float, 0x3F8E38E3>()), 1.111111f, 0.5);
   TTS_IEEE_EQUAL((eve::Constant<float, 0xFFFFFFFF>()), eve::nan(eve::as<float>()));
 
@@ -27,6 +31,8 @@ TTS_CASE("Constant generation for scalar")
   TTS_EQUAL((eve::Constant<std::uint64_t, 0xB122334455667788ULL>()), 0xB122334455667788ULL);
   TTS_EQUAL((eve::Constant<std::int64_t, 0x1122334455667788LL>()), 0x1122334455667788LL);
 };
+
+
 
 TTS_CASE_TPL("Constant generation for wide",
              fixed<1>,

--- a/test/unit/module/core/constant/constant.cpp
+++ b/test/unit/module/core/constant/constant.cpp
@@ -14,22 +14,22 @@ enum class some_enum : std::int16_t {};
 
 TTS_CASE("Constant generation for scalar")
 {
-  TTS_EQUAL((eve::Constant<some_enum, 0x4455>()), some_enum{0x4455});
+  TTS_EQUAL((eve::constant<some_enum, 0x4455>()), some_enum{0x4455});
 
-  TTS_ULP_EQUAL((eve::Constant<float, 0x3F8E38E3>()), 1.111111f, 0.5);
-  TTS_IEEE_EQUAL((eve::Constant<float, 0xFFFFFFFF>()), eve::nan(eve::as<float>()));
+  TTS_ULP_EQUAL((eve::constant<float, 0x3F8E38E3>()), 1.111111f, 0.5);
+  TTS_IEEE_EQUAL((eve::constant<float, 0xFFFFFFFF>()), eve::nan(eve::as<float>()));
 
-  TTS_ULP_EQUAL((eve::Constant<double, 0x3FF1C71C71C71C72ULL>()), 1.111111111111111111, 0.5);
-  TTS_IEEE_EQUAL((eve::Constant<double, 0xFFFFFFFFFFFFFFFFULL>()), eve::nan(eve::as<double>()));
+  TTS_ULP_EQUAL((eve::constant<double, 0x3FF1C71C71C71C72ULL>()), 1.111111111111111111, 0.5);
+  TTS_IEEE_EQUAL((eve::constant<double, 0xFFFFFFFFFFFFFFFFULL>()), eve::nan(eve::as<double>()));
 
-  TTS_EQUAL((eve::Constant<std::uint8_t, 0xE5>()), 0xE5);
-  TTS_EQUAL((eve::Constant<std::int8_t, 0x55>()), 0x55);
-  TTS_EQUAL((eve::Constant<std::uint16_t, 0xD455>()), 0xD455);
-  TTS_EQUAL((eve::Constant<std::int16_t, 0x4455>()), 0x4455);
-  TTS_EQUAL((eve::Constant<std::uint32_t, 0xC1334455>()), 0xC1334455);
-  TTS_EQUAL((eve::Constant<std::int32_t, 0x11334455>()), 0x11334455);
-  TTS_EQUAL((eve::Constant<std::uint64_t, 0xB122334455667788ULL>()), 0xB122334455667788ULL);
-  TTS_EQUAL((eve::Constant<std::int64_t, 0x1122334455667788LL>()), 0x1122334455667788LL);
+  TTS_EQUAL((eve::constant<std::uint8_t, 0xE5>()), 0xE5);
+  TTS_EQUAL((eve::constant<std::int8_t, 0x55>()), 0x55);
+  TTS_EQUAL((eve::constant<std::uint16_t, 0xD455>()), 0xD455);
+  TTS_EQUAL((eve::constant<std::int16_t, 0x4455>()), 0x4455);
+  TTS_EQUAL((eve::constant<std::uint32_t, 0xC1334455>()), 0xC1334455);
+  TTS_EQUAL((eve::constant<std::int32_t, 0x11334455>()), 0x11334455);
+  TTS_EQUAL((eve::constant<std::uint64_t, 0xB122334455667788ULL>()), 0xB122334455667788ULL);
+  TTS_EQUAL((eve::constant<std::int64_t, 0x1122334455667788LL>()), 0x1122334455667788LL);
 };
 
 
@@ -45,29 +45,29 @@ TTS_CASE_TPL("Constant generation for wide",
 <typename T>(::tts::type<T>)
 {
   TTS_ULP_EQUAL(
-      (eve::Constant<eve::wide<float, T>, 0x3F8E38E3>()), (eve::wide<float, T>(1.111111f)), 0.5);
-  TTS_IEEE_EQUAL((eve::Constant<eve::wide<float, T>, 0xFFFFFFFF>()),
+      (eve::constant<eve::wide<float, T>, 0x3F8E38E3>()), (eve::wide<float, T>(1.111111f)), 0.5);
+  TTS_IEEE_EQUAL((eve::constant<eve::wide<float, T>, 0xFFFFFFFF>()),
                  (eve::nan(eve::as<eve::wide<float, T>>())));
 
-  TTS_ULP_EQUAL((eve::Constant<eve::wide<double, T>, 0x3FF1C71C71C71C72ULL>()),
+  TTS_ULP_EQUAL((eve::constant<eve::wide<double, T>, 0x3FF1C71C71C71C72ULL>()),
                 (eve::wide<double, T>(1.111111111111111111)),
                 0.5);
-  TTS_IEEE_EQUAL((eve::Constant<eve::wide<double, T>, 0xFFFFFFFFFFFFFFFFULL>()),
+  TTS_IEEE_EQUAL((eve::constant<eve::wide<double, T>, 0xFFFFFFFFFFFFFFFFULL>()),
                  (eve::nan(eve::as<eve::wide<double, T>>())));
 
-  TTS_EQUAL((eve::Constant<eve::wide<std::uint8_t, T>, 0xE5>()),
+  TTS_EQUAL((eve::constant<eve::wide<std::uint8_t, T>, 0xE5>()),
             (eve::wide<std::uint8_t, T>(0xE5)));
-  TTS_EQUAL((eve::Constant<eve::wide<std::int8_t, T>, 0x55>()), (eve::wide<std::int8_t, T>(0x55)));
-  TTS_EQUAL((eve::Constant<eve::wide<std::uint16_t, T>, 0xD455>()),
+  TTS_EQUAL((eve::constant<eve::wide<std::int8_t, T>, 0x55>()), (eve::wide<std::int8_t, T>(0x55)));
+  TTS_EQUAL((eve::constant<eve::wide<std::uint16_t, T>, 0xD455>()),
             (eve::wide<std::uint16_t, T>(0xD455)));
-  TTS_EQUAL((eve::Constant<eve::wide<std::int16_t, T>, 0x4455>()),
+  TTS_EQUAL((eve::constant<eve::wide<std::int16_t, T>, 0x4455>()),
             (eve::wide<std::int16_t, T>(0x4455)));
-  TTS_EQUAL((eve::Constant<eve::wide<std::uint32_t, T>, 0xC1334455>()),
+  TTS_EQUAL((eve::constant<eve::wide<std::uint32_t, T>, 0xC1334455>()),
             (eve::wide<std::uint32_t, T>(0xC1334455)));
-  TTS_EQUAL((eve::Constant<eve::wide<std::int32_t, T>, 0x11334455>()),
+  TTS_EQUAL((eve::constant<eve::wide<std::int32_t, T>, 0x11334455>()),
             (eve::wide<std::int32_t, T>(0x11334455)));
-  TTS_EQUAL((eve::Constant<eve::wide<std::uint64_t, T>, 0xB122334455667788ULL>()),
+  TTS_EQUAL((eve::constant<eve::wide<std::uint64_t, T>, 0xB122334455667788ULL>()),
             (eve::wide<std::uint64_t, T>(0xB122334455667788ULL)));
-  TTS_EQUAL((eve::Constant<eve::wide<std::int64_t, T>, 0x1122334455667788LL>()),
+  TTS_EQUAL((eve::constant<eve::wide<std::int64_t, T>, 0x1122334455667788LL>()),
             (eve::wide<std::int64_t, T>(0x1122334455667788LL)));
 };

--- a/test/unit/module/core/constant/constants.cpp
+++ b/test/unit/module/core/constant/constants.cpp
@@ -9,11 +9,12 @@
 
 #include <eve/module/core.hpp>
 
-TTS_CASE_TPL("Check basic constants behavior", eve::test::simd::ieee_reals)
+enum class some_enum : std::int16_t {};
+
+TTS_CASE_TPL("Check basic constants behavior", eve::test::simd::all_types)
 <typename T>(tts::type<T>)
 {
   using eve::as;
-  using elt_t = eve::element_type_t<T>;
   TTS_IEEE_EQUAL(eve::allbits(as<T>()), eve::bit_not(T(0)));
   TTS_EQUAL(eve::true_(as<T>()), eve::as_logical_t<T>(1));
   TTS_EQUAL(eve::false_(as<T>()), eve::as_logical_t<T>(0));
@@ -29,43 +30,56 @@ TTS_CASE_TPL("Check basic constants behavior", eve::test::simd::ieee_reals)
     TTS_EQUAL(eve::mhalf(as<T>()), T(-0.5));
     TTS_EXPECT(eve::all(eve::is_negative(eve::mzero(as<T>()))));
   }
-  else if constexpr( eve::integral_value<T> ) { TTS_EQUAL(eve::allbits(as<T>()), T(elt_t(~0))); }
 };
 
-TTS_CASE_TPL("Check ieee754 constants", eve::test::simd::ieee_reals)
+TTS_CASE("Check basic constants behavior - translation type")
+{
+  using eve::as;
+  TTS_EQUAL(eve::true_(as<some_enum>()), eve::logical<std::int16_t>(true));
+  TTS_EQUAL(eve::false_(as<some_enum>()), eve::logical<std::int16_t>(false));
+  TTS_EQUAL(eve::one(as<some_enum>()), some_enum{1});
+  TTS_EQUAL(eve::mone(as<some_enum>()), some_enum{-1});
+  TTS_EQUAL(eve::zero(as<some_enum>()), some_enum{0});
+  TTS_EQUAL(eve::allbits(as<some_enum>()), some_enum{~0});
+};
+
+TTS_CASE_TPL("Check ieee754 constants", eve::test::simd::all_types)
 <typename T>(tts::type<T>)
 {
   using eve::as;
   using elt_t = eve::element_type_t<T>;
   using ilt_t = eve::as_integer_t<elt_t>;
   using i_t   = eve::as_integer_t<T, signed>;
+  using u_t   = eve::as_integer_t<T, unsigned>;
   TTS_EQUAL(eve::bitincrement(as<T>()), T(eve::bit_cast(eve::one(as<ilt_t>()), as<elt_t>())));
-  TTS_IEEE_EQUAL(eve::nan(as<T>()), T(0.0 / 0.0));
   TTS_EQUAL(eve::signmask(as<T>()),
-            T(eve::bit_cast(eve::one(as<ilt_t>()) << (sizeof(ilt_t) * 8 - 1), as<elt_t>())));
+            T(eve::bit_cast(ilt_t(1LL << (sizeof(ilt_t) * 8 - 1)), as<elt_t>())));
   TTS_EQUAL(eve::mindenormal(as<T>()), eve::bitincrement(as<T>()));
-  TTS_ULP_EQUAL(eve::sqrteps(as<T>()), eve::sqrt(eve::eps(as<T>())), 0.5);
 
-  if constexpr( std::is_same_v<elt_t, float> )
+  if constexpr( std::same_as<elt_t, float> )
   {
+    TTS_ULP_EQUAL(eve::sqrteps(as<T>()), eve::sqrt(eve::eps(as<T>())), 0.5);
+    TTS_IEEE_EQUAL(eve::nan(as<T>()), T(0.0 / 0.0));
     TTS_EQUAL(eve::eps(as<T>()), T(1.1920929e-7));
     TTS_EQUAL(eve::exponentmask(as<T>()), i_t(0x7f800000U));
     TTS_EQUAL(eve::maxexponentp1(as<T>()), i_t(128));
     TTS_EQUAL(eve::logeps(as<T>()), T(-15.942384719848632812f));
-    TTS_EQUAL(eve::mantissamask(as<T>()), i_t(0x807FFFFFU));
+    TTS_EQUAL(eve::mantissamask(as<T>()), u_t(0x807FFFFFU));
     TTS_EQUAL(eve::oneosqrteps(as<T>()), T(2896.309326171875f));
     TTS_EQUAL(eve::maxexponent(as<T>()), i_t(127));
     TTS_EQUAL(eve::maxexponentm1(as<T>()), i_t(126));
     TTS_EQUAL(eve::nbmantissabits(as<T>()), i_t(23));
     TTS_EQUAL(eve::twotonmb(as<T>()), T(8388608));
   }
-  else if constexpr( std::is_same_v<elt_t, double> )
+  else if constexpr( std::same_as<elt_t, double> )
   {
+    TTS_ULP_EQUAL(eve::sqrteps(as<T>()), eve::sqrt(eve::eps(as<T>())), 0.5);
+    TTS_IEEE_EQUAL(eve::nan(as<T>()), T(0.0 / 0.0));
     TTS_EQUAL(eve::eps(as<T>()), T(2.2204460492503130e-16));
     TTS_EQUAL(eve::exponentmask(as<T>()), i_t(0x7ff0000000000000ULL));
     TTS_EQUAL(eve::maxexponentp1(as<T>()), i_t(1024));
     TTS_EQUAL(eve::logeps(as<T>()), T(-36.043653389117156089696070315825181539926006986734));
-    TTS_EQUAL(eve::mantissamask(as<T>()), i_t(0x800FFFFFFFFFFFFFULL));
+    TTS_EQUAL(eve::mantissamask(as<T>()), u_t(0x800FFFFFFFFFFFFFULL));
     TTS_EQUAL(eve::oneosqrteps(as<T>()), T(67108864.0));
     TTS_EQUAL(eve::maxexponent(as<T>()), i_t(1023));
     TTS_EQUAL(eve::maxexponentm1(as<T>()), i_t(1022));
@@ -74,7 +88,7 @@ TTS_CASE_TPL("Check ieee754 constants", eve::test::simd::ieee_reals)
   }
 };
 
-TTS_CASE_TPL("Check basic masked constants behavior", eve::test::simd::ieee_reals)
+TTS_CASE_TPL("Check basic masked constants behavior", eve::test::simd::all_types)
 <typename T>(tts::type<T>)
 {
   using eve::as;
@@ -107,7 +121,6 @@ TTS_CASE_TPL("Check basic masked constants behavior", eve::test::simd::ieee_real
       TTS_EQUAL(eve::exponentmask[p > 1](as<T>()), test(i_t(0x7f800000U)));
     }
   }
-  else if constexpr( eve::integral_value<T> ) { TTS_EQUAL(eve::allbits(as<T>()), test(T(elt_t(~0)))); }
 
   TTS_IEEE_EQUAL(eve::allbits[eve::ignore_none](as<T>()), eve::allbits(as<T>()));
   TTS_EQUAL(eve::true_[eve::ignore_none](as<T>()), eve::true_(as<T>()));
@@ -140,5 +153,4 @@ TTS_CASE_TPL("Check basic masked constants behavior", eve::test::simd::ieee_real
       TTS_EQUAL(eve::exponentmask[eve::ignore_none](as<T>()), i_t(0x7f800000U));
     }
   }
-  else if constexpr( eve::integral_value<T> ) { TTS_EQUAL(eve::allbits[eve::ignore_none](as<T>()), T(elt_t(~0))); }
 };


### PR DESCRIPTION
Made `constant_callable` deals with translated type by makeing the specific value() interface to only deals with scalar basic value.
Cleaned up constants and related concepts/traits.
