### PR TITLE
Move self_add into the add callable

### DIFF
--- a/include/eve/arch/cpu/wide.hpp
+++ b/include/eve/arch/cpu/wide.hpp
@@ -26,6 +26,7 @@
 #include <eve/detail/function/slice.hpp>
 #include <eve/detail/function/subscript.hpp>
 #include <eve/module/core/regular/rem.hpp>
+#include <eve/module/core/regular/add.hpp>
 #include <eve/memory/soa_ptr.hpp>
 #include <eve/traits/product_type.hpp>
 
@@ -330,10 +331,16 @@ namespace eve
     void swap(wide& other) { std::swap(this->storage(), other.storage()); }
 
     //! Pre-incrementation operator
-    EVE_FORCEINLINE wide& operator++() noexcept { return *this += wide {1}; }
+    EVE_FORCEINLINE wide& operator++() noexcept
+    {
+      return *this += wide{1};
+    }
 
     //! Pre-decrementation operator
-    EVE_FORCEINLINE wide& operator--() noexcept { return *this -= wide {1}; }
+    EVE_FORCEINLINE wide& operator--() noexcept
+    {
+      return *this -= wide{1};
+    }
 
     //! Post-incrementation operator
     EVE_FORCEINLINE wide operator++(int) noexcept
@@ -532,7 +539,7 @@ namespace eve
     // Arithmetic operators
     //==============================================================================================
     //! Unary plus operator
-    friend EVE_FORCEINLINE auto operator+(wide const& v) noexcept { return v; }
+    friend EVE_FORCEINLINE wide operator+(wide const& v) noexcept { return v; }
 
     //! Unary minus operator. See also: eve::unary_minus
     friend EVE_FORCEINLINE auto operator-(wide const& v) noexcept
@@ -544,36 +551,35 @@ namespace eve
     //! @brief Performs the compound addition on all the wide lanes and assign the result
     //! to the current one. See also: eve::add
     template<value V>
-    friend EVE_FORCEINLINE auto operator+=(wide& w, V v) noexcept
-    -> decltype(detail::self_add(w, v))
+    friend EVE_FORCEINLINE wide& operator+=(wide& w, V v) noexcept
       requires(!kumi::product_type<Type>)
     {
-      return detail::self_add(w, v);
+      w = add(w, v);
+      return w;
     }
 
     //! @brief Performs the addition between all lanes of its parameters
     //! See also: eve::add
-    friend EVE_FORCEINLINE auto operator+(wide const& v, wide const& w) noexcept
+    friend EVE_FORCEINLINE wide operator+(wide const& a, wide const& b) noexcept
     requires(!kumi::product_type<Type>)
     {
-      auto that = v;
-      return that += w;
+      return add(a, b);
     }
 
     //! @brief Performs the addition between a scalar and all lanes of a eve::wide
     //! See also: eve::add
-    friend EVE_FORCEINLINE auto operator+(plain_scalar_value auto s, wide const& v) noexcept
+    friend EVE_FORCEINLINE wide operator+(plain_scalar_value auto s, wide const& v) noexcept
     requires(!kumi::product_type<Type>)
     {
-      return v + wide(s);
+      return add(v, wide{s});
     }
 
     //! @brief Performs the addition between all lanes of a eve::wide and a scalar
     //! See also: eve::add
-    friend EVE_FORCEINLINE auto operator+(wide const& v, plain_scalar_value auto s) noexcept
+    friend EVE_FORCEINLINE wide operator+(wide const& v, plain_scalar_value auto s) noexcept
     requires(!kumi::product_type<Type>)
     {
-      return v + wide(s);
+      return add(v, wide{s});
     }
 
     //! @brief Performs the compound difference on all the wide lanes and assign

--- a/include/eve/detail/function/simd/arm/neon/arithmetic_compounds.hpp
+++ b/include/eve/detail/function/simd/arm/neon/arithmetic_compounds.hpp
@@ -18,51 +18,6 @@
 namespace eve::detail
 {
   //================================================================================================
-  // +=
-  //================================================================================================
-  template<plain_scalar_value T, value U, typename N>
-  EVE_FORCEINLINE decltype(auto) self_add(wide<T, N> &self, U const &other) noexcept
-      requires(scalar_value<U> || std::same_as<wide<T, N>, U>) && arm_abi<abi_t<T, N>>
-  {
-    using type = wide<T, N>;
-
-    if constexpr( plain_scalar_value<U> )
-    {
-      self = self_add(self, type {other});
-    }
-    else if constexpr( std::same_as<type, U> )
-    {
-      constexpr auto c = categorize<type>();
-
-            if constexpr( c == category::int64x1    ) self = vadd_s64 (self, other);
-      else  if constexpr( c == category::int64x2    ) self = vaddq_s64(self, other);
-      else  if constexpr( c == category::uint64x1   ) self = vadd_u64 (self, other);
-      else  if constexpr( c == category::uint64x2   ) self = vaddq_u64(self, other);
-      else  if constexpr( c == category::int32x2    ) self = vadd_s32 (self, other);
-      else  if constexpr( c == category::int32x4    ) self = vaddq_s32(self, other);
-      else  if constexpr( c == category::uint32x2   ) self = vadd_u32 (self, other);
-      else  if constexpr( c == category::uint32x4   ) self = vaddq_u32(self, other);
-      else  if constexpr( c == category::int16x4    ) self = vadd_s16 (self, other);
-      else  if constexpr( c == category::int16x8    ) self = vaddq_s16(self, other);
-      else  if constexpr( c == category::uint16x4   ) self = vadd_u16 (self, other);
-      else  if constexpr( c == category::uint16x8   ) self = vaddq_u16(self, other);
-      else  if constexpr( c == category::int8x8     ) self = vadd_s8  (self, other);
-      else  if constexpr( c == category::int8x16    ) self = vaddq_s8 (self, other);
-      else  if constexpr( c == category::uint8x8    ) self = vadd_u8  (self, other);
-      else  if constexpr( c == category::uint8x16   ) self = vaddq_u8 (self, other);
-      else  if constexpr( c == category::float32x2  ) self = vadd_f32 (self, other);
-      else  if constexpr( c == category::float32x4  ) self = vaddq_f32(self, other);
-      else if constexpr( current_api >= asimd )
-      {
-              if constexpr( c == category::float64x1 ) self = vadd_f64  (self, other);
-        else  if constexpr( c == category::float64x2 ) self = vaddq_f64 (self, other);
-      }
-    }
-
-    return self;
-  }
-
-  //================================================================================================
   // -=
   //================================================================================================
   template<plain_scalar_value T, value U, typename N>

--- a/include/eve/detail/function/simd/arm/sve/arithmetic_compounds.hpp
+++ b/include/eve/detail/function/simd/arm/sve/arithmetic_compounds.hpp
@@ -15,15 +15,6 @@ namespace eve::detail
 {
 template<plain_scalar_value T, value U, typename N>
 EVE_FORCEINLINE auto&
-self_add(wide<T, N>& self, U const& other) noexcept
-requires(scalar_value<U> || std::same_as<wide<T, N>, U>) && sve_abi<abi_t<T, N>>
-{
-  self = svadd_x(sve_true<T>(), self, other);
-  return self;
-}
-
-template<plain_scalar_value T, value U, typename N>
-EVE_FORCEINLINE auto&
 self_sub(wide<T, N>& self, U const& other) noexcept
 requires(scalar_value<U> || std::same_as<wide<T, N>, U>) && sve_abi<abi_t<T, N>>
 {

--- a/include/eve/detail/function/simd/common/arithmetic_compounds.hpp
+++ b/include/eve/detail/function/simd/common/arithmetic_compounds.hpp
@@ -18,35 +18,6 @@
 namespace eve::detail
 {
   //================================================================================================
-  // +=
-  //================================================================================================
-  template<plain_scalar_value T, value U, typename N>
-  EVE_FORCEINLINE decltype(auto)
-  self_add(wide<T, N> &self,
-           U const &        other) requires(scalar_value<U> || std::same_as<wide<T, N>, U>)
-  {
-    using type = wide<T, N>;
-
-    if constexpr( plain_scalar_value<U> )
-    {
-      return self_add(self, type {other});
-    }
-    else if constexpr( std::same_as<type, U> )
-    {
-      if constexpr( is_emulated_v<abi_t<T, N>> )
-      {
-        apply<N::value>([&](auto... I) { (self.set(I, self.get(I) + other.get(I)), ...); });
-        return self;
-      }
-      else if constexpr( is_aggregated_v<abi_t<T, N>> )
-      {
-        self.storage().for_each( [&](auto& s, auto const& o)  { s += o; }, other );
-        return self;
-      }
-    }
-  }
-
-  //================================================================================================
   // -=
   //================================================================================================
   template<plain_scalar_value T, value U, typename N>

--- a/include/eve/detail/function/simd/ppc/arithmetic_compounds.hpp
+++ b/include/eve/detail/function/simd/ppc/arithmetic_compounds.hpp
@@ -17,27 +17,6 @@
 namespace eve::detail
 {
   //================================================================================================
-  // +=
-  //================================================================================================
-  template<plain_scalar_value T, value U, typename N>
-  EVE_FORCEINLINE decltype(auto) self_add( wide<T, N>& self, U const& other )
-  requires( scalar_value<U> || std::same_as<wide<T, N>, U> ) && ppc_abi<abi_t<T, N>>
-  {
-    using type = wide<T, N>;
-
-    if constexpr( plain_scalar_value<U> )
-    {
-      self = vec_add(self.storage(), type{other}.storage());
-    }
-    else if constexpr( std::same_as<type,U> )
-    {
-      self = vec_add(self.storage(), other.storage());
-    }
-
-    return self;
-  }
-
-  //================================================================================================
   // -=
   //================================================================================================
   template<plain_scalar_value T, value U, typename N>

--- a/include/eve/detail/function/simd/x86/arithmetic_compounds.hpp
+++ b/include/eve/detail/function/simd/x86/arithmetic_compounds.hpp
@@ -16,69 +16,6 @@
 namespace eve::detail
 {
   //================================================================================================
-  // +=
-  //================================================================================================
-  template<plain_scalar_value T, value U, typename N>
-  EVE_FORCEINLINE decltype(auto) self_add(wide<T, N> &self, U const &other) noexcept
-      requires(scalar_value<U> || std::same_as<wide<T, N>, U>) && x86_abi<abi_t<T, N>>
-  {
-    using type = wide<T, N>;
-
-    if constexpr( plain_scalar_value<U> )
-    {
-      return self_add(self, type {other});
-    }
-    else if constexpr( std::same_as<type, U> )
-    {
-      constexpr auto c = categorize<type>();
-
-            if constexpr  ( c == category::float64x8  ) self = _mm512_add_pd(self, other);
-      else  if constexpr  ( c == category::float32x16 ) self = _mm512_add_ps(self, other);
-      else  if constexpr  ( c == category::int64x8    ) self = _mm512_add_epi64(self, other);
-      else  if constexpr  ( c == category::int32x16   ) self = _mm512_add_epi32(self, other);
-      else  if constexpr  ( c == category::int16x32   ) self = _mm512_add_epi16(self, other);
-      else  if constexpr  ( c == category::int8x64    ) self = _mm512_add_epi8(self, other);
-      else  if constexpr  ( c == category::uint64x8   ) self = _mm512_add_epi64(self, other);
-      else  if constexpr  ( c == category::uint32x16  ) self = _mm512_add_epi32(self, other);
-      else  if constexpr  ( c == category::uint16x32  ) self = _mm512_add_epi16(self, other);
-      else  if constexpr  ( c == category::uint8x64   ) self = _mm512_add_epi8(self, other);
-      else  if constexpr  ( c == category::float64x2  ) self = _mm_add_pd(self, other);
-      else  if constexpr  ( c == category::float32x4  ) self = _mm_add_ps(self, other);
-      else  if constexpr  ( c == category::int64x2    ) self = _mm_add_epi64(self, other);
-      else  if constexpr  ( c == category::int32x4    ) self = _mm_add_epi32(self, other);
-      else  if constexpr  ( c == category::int16x8    ) self = _mm_add_epi16(self, other);
-      else  if constexpr  ( c == category::int8x16    ) self = _mm_add_epi8(self, other);
-      else  if constexpr  ( c == category::uint64x2   ) self = _mm_add_epi64(self, other);
-      else  if constexpr  ( c == category::uint32x4   ) self = _mm_add_epi32(self, other);
-      else  if constexpr  ( c == category::uint16x8   ) self = _mm_add_epi16(self, other);
-      else  if constexpr  ( c == category::uint8x16   ) self = _mm_add_epi8(self, other);
-      else  if constexpr  ( c == category::float64x4  ) self = _mm256_add_pd(self, other);
-      else  if constexpr  ( c == category::float32x8  ) self = _mm256_add_ps(self, other);
-      else  if constexpr  ( current_api >= avx2 )
-      {
-              if constexpr  ( c == category::int64x4  ) self = _mm256_add_epi64(self, other);
-        else  if constexpr  ( c == category::uint64x4 ) self = _mm256_add_epi64(self, other);
-        else  if constexpr  ( c == category::int32x8  ) self = _mm256_add_epi32(self, other);
-        else  if constexpr  ( c == category::uint32x8 ) self = _mm256_add_epi32(self, other);
-        else  if constexpr  ( c == category::int16x16 ) self = _mm256_add_epi16(self, other);
-        else  if constexpr  ( c == category::uint16x16) self = _mm256_add_epi16(self, other);
-        else  if constexpr  ( c == category::int8x32  ) self = _mm256_add_epi8(self, other);
-        else  if constexpr  ( c == category::uint8x32 ) self = _mm256_add_epi8(self, other);
-      }
-      else
-      {
-        auto [s1, s2] = self.slice();
-        auto [o1, o2] = other.slice();
-        s1 += o1;
-        s2 += o2;
-        self = type {s1, s2};
-      }
-
-      return self;
-    }
-  }
-
-  //================================================================================================
   // -=
   //================================================================================================
   template<plain_scalar_value T, value U, typename N>

--- a/include/eve/module/core/regular/add.hpp
+++ b/include/eve/module/core/regular/add.hpp
@@ -99,8 +99,16 @@ namespace eve
 
 #include <eve/module/core/regular/impl/add.hpp>
 
+#if defined(EVE_INCLUDE_POWERPC_HEADER)
+#  include <eve/module/core/regular/impl/simd/ppc/add.hpp>
+#endif
+
 #if defined(EVE_INCLUDE_X86_HEADER)
 #  include <eve/module/core/regular/impl/simd/x86/add.hpp>
+#endif
+
+#if defined(EVE_INCLUDE_ARM_HEADER)
+#  include <eve/module/core/regular/impl/simd/arm/neon/add.hpp>
 #endif
 
 #if defined(EVE_INCLUDE_SVE_HEADER)

--- a/include/eve/module/core/regular/impl/add.hpp
+++ b/include/eve/module/core/regular/impl/add.hpp
@@ -40,22 +40,13 @@ namespace eve::detail
         return bit_or(r, bit_mask(is_less(r, a)));
       }
     }
-    else if constexpr (plain_scalar_value<T>)
+    else
     {
+      // The only way to get there is when :
+      //  - a + b is done in scalar
+      //  - emulation occurs and again, a + b is done in scalar
+      //  - a product_type with custom operator+ is used
       return a + b;
-    }
-    else // wide regular case
-    {
-      if constexpr (is_emulated_v<typename T::abi_type>)
-      {
-        apply<cardinal_t<T>::value>([&](auto... I) { (a.set(I, a.get(I) + b.get(I)), ...); });
-        return a;
-      }
-      else if constexpr (is_aggregated_v<typename T::abi_type>)
-      {
-        a.storage().for_each([&](auto& s, auto const& o)  { s += o; }, b);
-        return a;
-      }
     }
   }
 

--- a/include/eve/module/core/regular/impl/add.hpp
+++ b/include/eve/module/core/regular/impl/add.hpp
@@ -21,7 +21,7 @@
 
 namespace eve::detail
 {
-  template<typename T, callable_options O>
+  template<callable_options O, typename T>
   EVE_FORCEINLINE constexpr T add_(EVE_REQUIRES(cpu_), O const&, T a, T b) noexcept
   {
     if constexpr(O::contains(saturated2) && integral_value<T>)

--- a/include/eve/module/core/regular/impl/simd/arm/neon/add.hpp
+++ b/include/eve/module/core/regular/impl/simd/arm/neon/add.hpp
@@ -1,0 +1,47 @@
+//==================================================================================================
+/*
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+*/
+//==================================================================================================
+#pragma once
+
+#include <eve/concept/value.hpp>
+#include <eve/detail/abi.hpp>
+#include <eve/forward.hpp>
+
+namespace eve::detail
+{
+  template<callable_options O, arithmetic_scalar_value T, typename N>
+  EVE_FORCEINLINE wide<T, N> add_(EVE_REQUIRES(neon128_), O const& opts, wide<T, N> v, wide<T, N> w) noexcept
+    requires arm_abi<abi_t<T, N>>
+  {
+    constexpr auto c = categorize<type>();
+
+            if constexpr( c == category::int64x1    ) return vadd_s64 (v, w);
+      else  if constexpr( c == category::int64x2    ) return vaddq_s64(v, w);
+      else  if constexpr( c == category::uint64x1   ) return vadd_u64 (v, w);
+      else  if constexpr( c == category::uint64x2   ) return vaddq_u64(v, w);
+      else  if constexpr( c == category::int32x2    ) return vadd_s32 (v, w);
+      else  if constexpr( c == category::int32x4    ) return vaddq_s32(v, w);
+      else  if constexpr( c == category::uint32x2   ) return vadd_u32 (v, w);
+      else  if constexpr( c == category::uint32x4   ) return vaddq_u32(v, w);
+      else  if constexpr( c == category::int16x4    ) return vadd_s16 (v, w);
+      else  if constexpr( c == category::int16x8    ) return vaddq_s16(v, w);
+      else  if constexpr( c == category::uint16x4   ) return vadd_u16 (v, w);
+      else  if constexpr( c == category::uint16x8   ) return vaddq_u16(v, w);
+      else  if constexpr( c == category::int8x8     ) return vadd_s8  (v, w);
+      else  if constexpr( c == category::int8x16    ) return vaddq_s8 (v, w);
+      else  if constexpr( c == category::uint8x8    ) return vadd_u8  (v, w);
+      else  if constexpr( c == category::uint8x16   ) return vaddq_u8 (v, w);
+      else  if constexpr( c == category::float32x2  ) return vadd_f32 (v, w);
+      else  if constexpr( c == category::float32x4  ) return vaddq_f32(v, w);
+      else if constexpr( current_api >= asimd )
+      {
+              if constexpr( c == category::float64x1 ) return vadd_f64  (v, w);
+        else  if constexpr( c == category::float64x2 ) return vaddq_f64 (v, w);
+      }
+  }
+
+}

--- a/include/eve/module/core/regular/impl/simd/arm/neon/add.hpp
+++ b/include/eve/module/core/regular/impl/simd/arm/neon/add.hpp
@@ -9,6 +9,7 @@
 
 #include <eve/concept/value.hpp>
 #include <eve/detail/abi.hpp>
+#include <eve/detail/category.hpp>
 #include <eve/forward.hpp>
 
 namespace eve::detail
@@ -17,7 +18,7 @@ namespace eve::detail
   EVE_FORCEINLINE wide<T, N> add_(EVE_REQUIRES(neon128_), O const& opts, wide<T, N> v, wide<T, N> w) noexcept
     requires arm_abi<abi_t<T, N>>
   {
-    constexpr auto c = categorize<type>();
+    constexpr auto c = categorize<wide<T, N>>();
 
             if constexpr( c == category::int64x1    ) return vadd_s64 (v, w);
       else  if constexpr( c == category::int64x2    ) return vaddq_s64(v, w);

--- a/include/eve/module/core/regular/impl/simd/arm/neon/add.hpp
+++ b/include/eve/module/core/regular/impl/simd/arm/neon/add.hpp
@@ -18,7 +18,13 @@ namespace eve::detail
   EVE_FORCEINLINE wide<T, N> add_(EVE_REQUIRES(neon128_), O const& opts, wide<T, N> v, wide<T, N> w) noexcept
     requires arm_abi<abi_t<T, N>>
   {
-    constexpr auto c = categorize<wide<T, N>>();
+    if constexpr (O::contains(saturated2) && std::integral<T>)
+    {
+      return add.behavior(cpu_{}, opts, v, w);
+    }
+    else
+    {
+      constexpr auto c = categorize<wide<T, N>>();
 
             if constexpr( c == category::int64x1    ) return vadd_s64 (v, w);
       else  if constexpr( c == category::int64x2    ) return vaddq_s64(v, w);
@@ -43,6 +49,7 @@ namespace eve::detail
               if constexpr( c == category::float64x1 ) return vadd_f64  (v, w);
         else  if constexpr( c == category::float64x2 ) return vaddq_f64 (v, w);
       }
+    }
   }
 
 }

--- a/include/eve/module/core/regular/impl/simd/arm/sve/add.hpp
+++ b/include/eve/module/core/regular/impl/simd/arm/sve/add.hpp
@@ -13,10 +13,9 @@
 
 namespace eve::detail
 {
-  template<arithmetic_scalar_value T, typename N, conditional_expr C, callable_options O>
-  EVE_FORCEINLINE wide<T, N>
-  add_(EVE_REQUIRES(sve_), C const& mask, O const& opts, wide<T, N> v, wide<T, N> w) noexcept
-  requires sve_abi<abi_t<T, N>>
+  template<callable_options O, arithmetic_scalar_value T, typename N, conditional_expr C>
+  EVE_FORCEINLINE wide<T, N> add_(EVE_REQUIRES(sve_), C const& mask, O const& opts, wide<T, N> v, wide<T, N> w) noexcept
+    requires sve_abi<abi_t<T, N>>
   {
     auto const alt = alternative(mask, v, as(v));
 
@@ -40,13 +39,19 @@ namespace eve::detail
     }
   }
 
-  template<arithmetic_scalar_value T, typename N, callable_options O>
-  EVE_FORCEINLINE wide<T, N>
-  add_(EVE_REQUIRES(sve_), O const& opts, wide<T, N> v, wide<T, N> w) noexcept
-  requires sve_abi<abi_t<T, N>>
+  template<callable_options O, arithmetic_scalar_value T, typename N>
+  EVE_FORCEINLINE wide<T, N> add_(EVE_REQUIRES(sve_), O const& opts, wide<T, N> v, wide<T, N> w) noexcept
+    requires sve_abi<abi_t<T, N>>
   {
     // We call the saturated add if required or we just go to the common case of doing v+w
-    if constexpr(O::contains(saturated2) && std::integral<T>) return svqadd(v, w);
-    else                                                      return add.behavior(cpu_{},opts,v,w);
+    if constexpr(O::contains(saturated2) && std::integral<T>)
+    {
+      return svqadd(v, w);
+    }
+    else
+    {
+      return svadd_x(sve_true<T>(), self, other);
+    }
   }
+  
 }

--- a/include/eve/module/core/regular/impl/simd/arm/sve/add.hpp
+++ b/include/eve/module/core/regular/impl/simd/arm/sve/add.hpp
@@ -24,17 +24,17 @@ namespace eve::detail
     else
     {
       //  if saturated on integer, we don't have masked op so we delegate
-      if        constexpr(O::contains(saturated2) && std::integral<T>) return add.behavior(cpu_{},opts,v,w);
+      if        constexpr (O::contains(saturated2) && std::integral<T>) return add.behavior(cpu_{}, opts, v, w);
       //  If not, we can mask if there is no alterative value
-      else  if  constexpr( !C::has_alternative )
+      else  if  constexpr (!C::has_alternative)
       {
-        auto m   = expand_mask(mask, as(v));
+        auto m = expand_mask(mask, as(v));
         return svadd_m(m,v,w);
       }
       // If not, we delegate to the automasking
       else
       {
-        return add.behavior(cpu_{},opts,v,w);
+        return add.behavior(cpu_{}, opts, v, w);
       }
     }
   }
@@ -50,8 +50,8 @@ namespace eve::detail
     }
     else
     {
-      return svadd_x(sve_true<T>(), self, other);
+      return svadd_x(sve_true<T>(), v, w);
     }
   }
-  
+
 }

--- a/include/eve/module/core/regular/impl/simd/arm/sve/add.hpp
+++ b/include/eve/module/core/regular/impl/simd/arm/sve/add.hpp
@@ -40,7 +40,7 @@ namespace eve::detail
   }
 
   template<callable_options O, arithmetic_scalar_value T, typename N>
-  EVE_FORCEINLINE wide<T, N> add_(EVE_REQUIRES(sve_), O const& opts, wide<T, N> v, wide<T, N> w) noexcept
+  EVE_FORCEINLINE wide<T, N> add_(EVE_REQUIRES(sve_), O const&, wide<T, N> v, wide<T, N> w) noexcept
     requires sve_abi<abi_t<T, N>>
   {
     // We call the saturated add if required or we just go to the common case of doing v+w

--- a/include/eve/module/core/regular/impl/simd/ppc/add.hpp
+++ b/include/eve/module/core/regular/impl/simd/ppc/add.hpp
@@ -21,7 +21,7 @@ template<callable_options O, typename T, typename N>
 EVE_FORCEINLINE wide<T, N> add_(EVE_REQUIRES(vmx_), O const& opts, wide<T, N> a, wide<T, N> b)
     requires ppc_abi<abi_t<T, N>>
 {
-    return vec_add(self.storage(), other.storage());
+    return vec_add(a.storage(), b.storage());
 }
 
 }

--- a/include/eve/module/core/regular/impl/simd/ppc/add.hpp
+++ b/include/eve/module/core/regular/impl/simd/ppc/add.hpp
@@ -1,0 +1,27 @@
+//==================================================================================================
+/*
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+*/
+//==================================================================================================
+#pragma once
+
+#include <eve/concept/compatible.hpp>
+#include <eve/concept/value.hpp>
+#include <eve/detail/abi.hpp>
+#include <eve/detail/function/bit_cast.hpp>
+
+#include <concepts>
+
+namespace eve::detail
+{
+
+template<callable_options O, typename T, typename N>
+EVE_FORCEINLINE wide<T, N> add_(EVE_REQUIRES(vmx_), O const& opts, wide<T, N> a, wide<T, N> b)
+    requires ppc_abi<abi_t<T, N>>
+{
+    return vec_add(self.storage(), other.storage());
+}
+
+}

--- a/include/eve/module/core/regular/impl/simd/ppc/add.hpp
+++ b/include/eve/module/core/regular/impl/simd/ppc/add.hpp
@@ -21,7 +21,14 @@ template<callable_options O, typename T, typename N>
 EVE_FORCEINLINE wide<T, N> add_(EVE_REQUIRES(vmx_), O const& opts, wide<T, N> a, wide<T, N> b)
     requires ppc_abi<abi_t<T, N>>
 {
+  if constexpr (O::contains(saturated2) && std::integral<T>)
+  {
+    return add.behavior(cpu_{}, opts, a, b);
+  }
+  else
+  {
     return vec_add(a.storage(), b.storage());
+  }
 }
 
 }

--- a/include/eve/module/core/regular/impl/simd/x86/add.hpp
+++ b/include/eve/module/core/regular/impl/simd/x86/add.hpp
@@ -14,9 +14,9 @@
 
 namespace eve::detail
 {
-template< typename T, typename N, callable_options O>
-EVE_FORCEINLINE
-wide<T, N> add_(EVE_REQUIRES(sse2_), O const& opts, wide<T, N> v, wide<T, N> w) noexcept
+
+template<callable_options O, typename T, typename N>
+EVE_FORCEINLINE wide<T, N> add_(EVE_REQUIRES(sse2_), O const& opts, wide<T, N> v, wide<T, N> w) noexcept
 requires x86_abi<abi_t<T, N>>
 {
   constexpr auto c = categorize<wide<T, N>>();
@@ -41,7 +41,47 @@ requires x86_abi<abi_t<T, N>>
   }
   else
   {
-    return add.behavior(cpu_{}, opts, v, w);
+            if constexpr  ( c == category::float64x8  ) return _mm512_add_pd(v, w);
+      else  if constexpr  ( c == category::float32x16 ) return _mm512_add_ps(v, w);
+      else  if constexpr  ( c == category::int64x8    ) return _mm512_add_epi64(v, w);
+      else  if constexpr  ( c == category::int32x16   ) return _mm512_add_epi32(v, w);
+      else  if constexpr  ( c == category::int16x32   ) return _mm512_add_epi16(v, w);
+      else  if constexpr  ( c == category::int8x64    ) return _mm512_add_epi8(v, w);
+      else  if constexpr  ( c == category::uint64x8   ) return _mm512_add_epi64(v, w);
+      else  if constexpr  ( c == category::uint32x16  ) return _mm512_add_epi32(v, w);
+      else  if constexpr  ( c == category::uint16x32  ) return _mm512_add_epi16(v, w);
+      else  if constexpr  ( c == category::uint8x64   ) return _mm512_add_epi8(v, w);
+      else  if constexpr  ( c == category::float64x2  ) return _mm_add_pd(v, w);
+      else  if constexpr  ( c == category::float32x4  ) return _mm_add_ps(v, w);
+      else  if constexpr  ( c == category::int64x2    ) return _mm_add_epi64(v, w);
+      else  if constexpr  ( c == category::int32x4    ) return _mm_add_epi32(v, w);
+      else  if constexpr  ( c == category::int16x8    ) return _mm_add_epi16(v, w);
+      else  if constexpr  ( c == category::int8x16    ) return _mm_add_epi8(v, w);
+      else  if constexpr  ( c == category::uint64x2   ) return _mm_add_epi64(v, w);
+      else  if constexpr  ( c == category::uint32x4   ) return _mm_add_epi32(v, w);
+      else  if constexpr  ( c == category::uint16x8   ) return _mm_add_epi16(v, w);
+      else  if constexpr  ( c == category::uint8x16   ) return _mm_add_epi8(v, w);
+      else  if constexpr  ( c == category::float64x4  ) return _mm256_add_pd(v, w);
+      else  if constexpr  ( c == category::float32x8  ) return _mm256_add_ps(v, w);
+      else  if constexpr  ( current_api >= avx2 )
+      {
+              if constexpr  ( c == category::int64x4  ) return _mm256_add_epi64(v, w);
+        else  if constexpr  ( c == category::uint64x4 ) return _mm256_add_epi64(v, w);
+        else  if constexpr  ( c == category::int32x8  ) return _mm256_add_epi32(v, w);
+        else  if constexpr  ( c == category::uint32x8 ) return _mm256_add_epi32(v, w);
+        else  if constexpr  ( c == category::int16x16 ) return _mm256_add_epi16(v, w);
+        else  if constexpr  ( c == category::uint16x16) return _mm256_add_epi16(v, w);
+        else  if constexpr  ( c == category::int8x32  ) return _mm256_add_epi8(v, w);
+        else  if constexpr  ( c == category::uint8x32 ) return _mm256_add_epi8(v, w);
+      }
+      else
+      {
+        auto [s1, s2] = v.slice();
+        auto [o1, o2] = w.slice();
+        s1 += o1;
+        s2 += o2;
+        return wide<T, N>{s1, s2};
+      }
   }
 }
 

--- a/include/eve/module/core/regular/impl/simd/x86/add.hpp
+++ b/include/eve/module/core/regular/impl/simd/x86/add.hpp
@@ -17,11 +17,11 @@ namespace eve::detail
 
 template<callable_options O, typename T, typename N>
 EVE_FORCEINLINE wide<T, N> add_(EVE_REQUIRES(sse2_), O const& opts, wide<T, N> v, wide<T, N> w) noexcept
-requires x86_abi<abi_t<T, N>>
+  requires x86_abi<abi_t<T, N>>
 {
   constexpr auto c = categorize<wide<T, N>>();
 
-  if constexpr(O::contains(saturated2))
+  if constexpr(O::contains(saturated2) && std::integral<T>)
   {
     constexpr auto sup_avx2 = current_api >= avx2;
 

--- a/include/eve/traits/common_value.hpp
+++ b/include/eve/traits/common_value.hpp
@@ -14,27 +14,29 @@
 namespace eve::detail
 {
   template<typename T>
-  struct fth {
-    using type = T;
-  };
+  struct fth { using type = T; };
 
   template<scalar_value S0, scalar_value S1>
-  consteval auto operator%(fth<S0>, fth<S1>) noexcept {
-    return fth<decltype((std::declval<S0>() + std::declval<S1>()))>{};
+  consteval fth<decltype((std::declval<S0>() + std::declval<S1>()))> operator%(fth<S0>, fth<S1>) noexcept
+  {
+    return {};
   }
 
   template<typename T, typename N, scalar_value S>
-  consteval auto operator%(fth<wide<T, N>>, fth<S>) noexcept {
+  consteval auto operator%(fth<wide<T, N>>, fth<S>) noexcept
+  {
     return fth<wide<T, N>>{};
   }
 
   template<typename T, typename N, scalar_value S>
-  consteval auto operator%(fth<S>, fth<wide<T, N>>) noexcept {
+  consteval auto operator%(fth<S>, fth<wide<T, N>>) noexcept
+  {
     return fth<wide<T, N>>{};
   }
 
   template<typename T, typename N>
-  consteval auto operator%(fth<wide<T, N>>, fth<wide<T, N>>) noexcept {
+  consteval auto operator%(fth<wide<T, N>>, fth<wide<T, N>>) noexcept
+  {
     return fth<wide<T, N>>{};
   }
 

--- a/include/eve/traits/common_value.hpp
+++ b/include/eve/traits/common_value.hpp
@@ -13,8 +13,33 @@
 
 namespace eve::detail
 {
+  template<typename T>
+  struct fth {
+    using type = T;
+  };
+
+  template<plain_scalar_value S0, plain_scalar_value S1>
+  consteval auto operator%(fth<S0>, fth<S1>) noexcept {
+    return fth<decltype((std::declval<S0>() + std::declval<S1>()))>{};
+  }
+
+  template<typename T, typename N, plain_scalar_value S>
+  consteval auto operator%(fth<wide<T, N>>, fth<S>) noexcept {
+    return fth<wide<T, N>>{};
+  }
+
+  template<typename T, typename N, plain_scalar_value S>
+  consteval auto operator%(fth<S>, fth<wide<T, N>>) noexcept {
+    return fth<wide<T, N>>{};
+  }
+
+  template<typename T, typename N>
+  consteval auto operator%(fth<wide<T, N>>, fth<wide<T, N>>) noexcept {
+    return fth<wide<T, N>>{};
+  }
+
   template<typename... Ts>
-  using find_type = decltype(( std::declval<Ts>() + ... ));
+  using find_type = typename decltype((fth<Ts>{} % ...))::type;
 
   template<typename... Ts>
   requires(!plain_scalar_value<Ts> || ... )
@@ -73,8 +98,8 @@ namespace eve::detail
   };
 
   template<typename T, typename U>
-  requires(!(scalar_value<T> && scalar_value<U>) && requires{ detail::find_common_value<T,U>(); } )
-  struct common_logical_impl<T,U> : as_logical<typename common_value<T,U>::type>
+    requires(!(scalar_value<T> && scalar_value<U>) && requires{ typename common_value<T, U>::type; } )
+  struct common_logical_impl<T, U> : as_logical<typename common_value<T, U>::type>
   {};
 }
 

--- a/include/eve/traits/common_value.hpp
+++ b/include/eve/traits/common_value.hpp
@@ -18,17 +18,17 @@ namespace eve::detail
     using type = T;
   };
 
-  template<plain_scalar_value S0, plain_scalar_value S1>
+  template<scalar_value S0, scalar_value S1>
   consteval auto operator%(fth<S0>, fth<S1>) noexcept {
     return fth<decltype((std::declval<S0>() + std::declval<S1>()))>{};
   }
 
-  template<typename T, typename N, plain_scalar_value S>
+  template<typename T, typename N, scalar_value S>
   consteval auto operator%(fth<wide<T, N>>, fth<S>) noexcept {
     return fth<wide<T, N>>{};
   }
 
-  template<typename T, typename N, plain_scalar_value S>
+  template<typename T, typename N, scalar_value S>
   consteval auto operator%(fth<S>, fth<wide<T, N>>) noexcept {
     return fth<wide<T, N>>{};
   }
@@ -42,11 +42,11 @@ namespace eve::detail
   using find_type = typename decltype((fth<Ts>{} % ...))::type;
 
   template<typename... Ts>
-  requires(!plain_scalar_value<Ts> || ... )
+  requires(!scalar_value<Ts> || ... )
   auto find_common_value() -> find_type<Ts... >;
 
   template<typename T0, typename... Ts>
-  requires(   (plain_scalar_value<T0> && ... && plain_scalar_value<Ts>)
+  requires(   (scalar_value<T0> && ... && scalar_value<Ts>)
           &&  (std::same_as<T0,Ts> && ...)
           )
   T0 find_common_value();


### PR DESCRIPTION
Special note for `common_value`: it no longer relies on `operator+` as it previously did, see commit message.