### PR TITLE
Remove the bit_compatible family of concepts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,7 @@ endif()
 ## Test and Benchmarks target
 ## =================================================================================================
 if( EVE_BUILD_TEST )
+  set(CTEST_COVERAGE_EXTRA_FLAGS "--long-file-names --hash-filenames")
   include(CTest)
   include(config/dependencies)
   include(config/compiler)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,6 @@ endif()
 ## Test and Benchmarks target
 ## =================================================================================================
 if( EVE_BUILD_TEST )
-  set(CTEST_COVERAGE_EXTRA_FLAGS "--long-file-names --hash-filenames")
   include(CTest)
   include(config/dependencies)
   include(config/compiler)

--- a/doc/internals/semantic.md
+++ b/doc/internals/semantic.md
@@ -98,26 +98,6 @@ In a less formal way, **EVE** @ref glossary_arithmetic generalizes the notion of
 arithmetic operations. By construction, a large majority of @ref glossary_arithmetic are _de facto_
 @ref glossary_elementwise.
 
-@subsection glossary_bitwise Bitwise Functions
-
-For any [values](@ref eve::value) `x1`, ..., `xn` of types `T1`, ..., `Tn`so that the expression
-`eve::bit_compatible_values<T1,...,Tn>` evaluates to `true`, a Callable Object `f` is said to be
-a **Bitwise Function** if the expression `T1 r = f(x1, ..., xn)` is semantically equivalent to:
-
-  - if `T1` models eve::simd_value:
-    @code{.cpp}
-    T1 r = [](auto i, auto) { return f(get(x1,i), ..., get(eve::bit_cast(xn, eve::as(x1)),i); };
-    @endcode
-
-  - if `T1` models eve::scalar_value:
-    @code{.cpp}
-    T1 r = f(x1,...eve::bit_cast(xn,eve::as(x1)));
-    @endcode
-
-In a less formal way, **EVE** @ref glossary_bitwise can be applied to any pair of types, the first
-acting as the value type and the second as a type-less source of bits. By construction, a large
-majority of @ref glossary_bitwise are _de facto_ @ref glossary_elementwise.
-
 @subsection glossary_logical Logical Functions
 
 **EVE** @ref glossary_logical are @ref glossary_arithmetic that can only be applied to

--- a/include/eve/arch/cpu/wide.hpp
+++ b/include/eve/arch/cpu/wide.hpp
@@ -401,9 +401,9 @@ namespace eve
     //! @brief Performs a compound bitwise and on all the wide lanes and assign the result to the current
     //! one
     template<value V>
-    friend EVE_FORCEINLINE bit_value_t<wide, V>& operator&=(wide& w, V o) noexcept
+    friend EVE_FORCEINLINE wide& operator&=(wide& w, V o) noexcept
 #if !defined(EVE_DOXYGEN_INVOKED)
-        requires (!kumi::product_type<Type>)
+        requires (!kumi::product_type<Type> && supports_bitwise_call<wide, V>)
 #endif
     {
       return detail::self_bitand(w, o);
@@ -412,9 +412,9 @@ namespace eve
     //! @brief Performs a bitwise and between all lanes of two wide instances.
     //! Do not participate to overload resolution if both wide doesnot have the same `sizeof`
     template<scalar_value U, typename M>
-    friend EVE_FORCEINLINE bit_value_t<wide, wide<U, M>> operator&(wide const& v, wide<U, M> const& w) noexcept
+    friend EVE_FORCEINLINE wide operator&(wide const& v, wide<U, M> const& w) noexcept
 #if !defined(EVE_DOXYGEN_INVOKED)
-        requires (!kumi::product_type<Type>)
+        requires (!kumi::product_type<Type> && supports_bitwise_call<wide, wide<U, M>>)
 #endif
     {
       auto that = v;
@@ -424,9 +424,9 @@ namespace eve
     //! @brief Performs a bitwise and between all lanes of a eve::wide and a scalar
     //! Do not participate to overload resolution if `sizeof(Type) != sizeof(S)`
     template<scalar_value S>
-    friend EVE_FORCEINLINE bit_value_t<wide, S> operator&(wide const& v, S w) noexcept
+    friend EVE_FORCEINLINE wide operator&(wide const& v, S w) noexcept
 #if !defined(EVE_DOXYGEN_INVOKED)
-        requires(!kumi::product_type<Type>)
+        requires(!kumi::product_type<Type> && supports_bitwise_call<wide, S>)
 #endif
     {
       auto that = v;
@@ -436,9 +436,9 @@ namespace eve
     //! @brief Performs a bitwise and between all lanes of a scalar and a eve::wide
     //! Do not participate to overload resolution if `sizeof(Type) != sizeof(S)`
     template<scalar_value S>
-    friend EVE_FORCEINLINE bit_value_t<S, wide> operator&(S v, wide const& w) noexcept
+    friend EVE_FORCEINLINE wide<S, Cardinal> operator&(S v, wide const& w) noexcept
 #if !defined(EVE_DOXYGEN_INVOKED)
-        requires(!kumi::product_type<Type>)
+        requires(!kumi::product_type<Type> && supports_bitwise_call<wide, S>)
 #endif
     {
       auto u = bit_cast(w, as<typename wide::template rebind<S, Cardinal>>());

--- a/include/eve/arch/cpu/wide.hpp
+++ b/include/eve/arch/cpu/wide.hpp
@@ -401,9 +401,9 @@ namespace eve
     //! @brief Performs a compound bitwise and on all the wide lanes and assign the result to the current
     //! one
     template<value V>
-    friend EVE_FORCEINLINE auto operator&=(wide& w, V o) noexcept
+    friend EVE_FORCEINLINE bit_value_t<wide, V> operator&=(wide& w, V o) noexcept
 #if !defined(EVE_DOXYGEN_INVOKED)
-        requires(!kumi::product_type<Type> && bit_compatible_values<wide, V>)
+        requires (!kumi::product_type<Type>)
 #endif
     {
       return detail::self_bitand(w, o);
@@ -412,9 +412,9 @@ namespace eve
     //! @brief Performs a bitwise and between all lanes of two wide instances.
     //! Do not participate to overload resolution if both wide doesnot have the same `sizeof`
     template<scalar_value U, typename M>
-    friend EVE_FORCEINLINE auto operator&(wide const& v, wide<U, M> const& w) noexcept
+    friend EVE_FORCEINLINE bit_value_t<wide, wide<U, M>> operator&(wide const& v, wide<U, M> const& w) noexcept
 #if !defined(EVE_DOXYGEN_INVOKED)
-        requires(!kumi::product_type<Type> && bit_compatible_values<wide, wide<U, M>>)
+        requires (!kumi::product_type<Type>)
 #endif
     {
       auto that = v;
@@ -424,9 +424,9 @@ namespace eve
     //! @brief Performs a bitwise and between all lanes of a eve::wide and a scalar
     //! Do not participate to overload resolution if `sizeof(Type) != sizeof(S)`
     template<scalar_value S>
-    friend EVE_FORCEINLINE auto operator&(wide const& v, S w) noexcept
+    friend EVE_FORCEINLINE bit_value_t<wide, S> operator&(wide const& v, S w) noexcept
 #if !defined(EVE_DOXYGEN_INVOKED)
-        requires(!kumi::product_type<Type> && bit_compatible_values<wide, S>)
+        requires(!kumi::product_type<Type>)
 #endif
     {
       auto that = v;
@@ -436,9 +436,9 @@ namespace eve
     //! @brief Performs a bitwise and between all lanes of a scalar and a eve::wide
     //! Do not participate to overload resolution if `sizeof(Type) != sizeof(S)`
     template<scalar_value S>
-    friend EVE_FORCEINLINE auto operator&(S v, wide const& w) noexcept
+    friend EVE_FORCEINLINE bit_value_t<S, wide> operator&(S v, wide const& w) noexcept
 #if !defined(EVE_DOXYGEN_INVOKED)
-        requires(!kumi::product_type<Type> && bit_compatible_values<wide, S>)
+        requires(!kumi::product_type<Type>)
 #endif
     {
       auto u = bit_cast(w, as<typename wide::template rebind<S, Cardinal>>());
@@ -448,9 +448,9 @@ namespace eve
     //! @brief Performs a Compound bitwise or on all the wide lanes and assign the result to the current
     //! one
     template<value V>
-    friend EVE_FORCEINLINE auto operator|=(wide& w, V o) noexcept
+    friend EVE_FORCEINLINE bit_value_t<wide, V> operator|=(wide& w, V o) noexcept
 #if !defined(EVE_DOXYGEN_INVOKED)
-        requires(!kumi::product_type<Type> && bit_compatible_values<wide, V>)
+        requires(!kumi::product_type<Type>)
 #endif
     {
       return detail::self_bitor(w, o);
@@ -459,9 +459,9 @@ namespace eve
     //! @brief Performs a bitwise or between all lanes of two wide instances.
     //! Do not participate to overload resolution if both wide doesn't has the same `sizeof`
     template<scalar_value U, typename M>
-    friend EVE_FORCEINLINE auto operator|(wide const& v, wide<U, M> const& w) noexcept
+    friend EVE_FORCEINLINE bit_value_t<wide, wide<U, M>> operator|(wide const& v, wide<U, M> const& w) noexcept
 #if !defined(EVE_DOXYGEN_INVOKED)
-        requires(!kumi::product_type<Type> && bit_compatible_values<wide, wide<U, M>>)
+        requires(!kumi::product_type<Type>)
 #endif
     {
       wide that = v;
@@ -471,9 +471,9 @@ namespace eve
     //! @brief Performs a bitwise or between all lanes of a scalar and a eve::wide
     //! Do not participate to overload resolution if `sizeof(Type) != sizeof(S)`
     template<scalar_value S>
-    friend EVE_FORCEINLINE auto operator|(wide const& v, S w) noexcept
+    friend EVE_FORCEINLINE bit_value_t<wide, S> operator|(wide const& v, S w) noexcept
 #if !defined(EVE_DOXYGEN_INVOKED)
-        requires(!kumi::product_type<Type> && bit_compatible_values<wide, S>)
+        requires(!kumi::product_type<Type>)
 #endif
     {
       auto that = v;
@@ -483,9 +483,9 @@ namespace eve
     //! @brief Performs a bitwise or between all lanes of a scalar and a eve::wide
     //! Do not participate to overload resolution if `sizeof(Type) != sizeof(S)`
     template<scalar_value S>
-    friend EVE_FORCEINLINE auto operator|(S v, wide const& w) noexcept
+    friend EVE_FORCEINLINE bit_value_t<S, wide> operator|(S v, wide const& w) noexcept
 #if !defined(EVE_DOXYGEN_INVOKED)
-        requires(!kumi::product_type<Type> && bit_compatible_values<wide, S>)
+        requires(!kumi::product_type<Type>)
 #endif
     {
       auto u = bit_cast(w, as<typename wide::template rebind<S, Cardinal>>());
@@ -494,9 +494,9 @@ namespace eve
 
     //! @brief Performs a bitwise xor on all the wide lanes and assign the result to the current one
     template<value V>
-    friend EVE_FORCEINLINE auto operator^=(wide& w, V o) noexcept
+    friend EVE_FORCEINLINE bit_value_t<wide, V> operator^=(wide& w, V o) noexcept
 #if !defined(EVE_DOXYGEN_INVOKED)
-        requires(!kumi::product_type<Type> && bit_compatible_values<wide, V>)
+        requires(!kumi::product_type<Type>)
 #endif
     {
       return detail::self_bitxor(w, o);
@@ -505,9 +505,9 @@ namespace eve
     //! @brief Performs a bitwise xor between all lanes of two wide instances.
     //! Do not participate to overload resolution if both wide doesn't has the same `sizeof`
     template<scalar_value U, typename M>
-    friend EVE_FORCEINLINE auto operator^(wide const& v, wide<U, M> const& w) noexcept
+    friend EVE_FORCEINLINE bit_value_t<wide, wide<U, M>> operator^(wide const& v, wide<U, M> const& w) noexcept
 #if !defined(EVE_DOXYGEN_INVOKED)
-        requires(!kumi::product_type<Type> && bit_compatible_values<wide, wide<U, M>>)
+        requires(!kumi::product_type<Type>)
 #endif
     {
       auto that = v;
@@ -517,9 +517,9 @@ namespace eve
     //! @brief Performs a bitwise xor between all lanes of a scalar and a eve::wide
     //! Do not participate to overload resolution if `sizeof(Type) != sizeof(S)`
     template<scalar_value S>
-    friend EVE_FORCEINLINE auto operator^(wide const& v, S w) noexcept
+    friend EVE_FORCEINLINE bit_value_t<wide, S> operator^(wide const& v, S w) noexcept
 #if !defined(EVE_DOXYGEN_INVOKED)
-        requires(!kumi::product_type<Type> && bit_compatible_values<wide, S>)
+        requires(!kumi::product_type<Type>)
 #endif
     {
       auto that = v;
@@ -529,9 +529,9 @@ namespace eve
     //! @brief Performs a bitwise xor between all lanes of a scalar and a eve::wide
     //! Do not participate to overload resolution if `sizeof(Type) != sizeof(S)`
     template<scalar_value S>
-    friend EVE_FORCEINLINE auto operator^(S v, wide const& w) noexcept
+    friend EVE_FORCEINLINE bit_value_t<S, wide> operator^(S v, wide const& w) noexcept
 #if !defined(EVE_DOXYGEN_INVOKED)
-        requires(!kumi::product_type<Type> && bit_compatible_values<wide, S>)
+        requires(!kumi::product_type<Type>)
 #endif
     {
       auto u = bit_cast(w, as<typename wide::template rebind<S, Cardinal>>());

--- a/include/eve/arch/cpu/wide.hpp
+++ b/include/eve/arch/cpu/wide.hpp
@@ -438,7 +438,7 @@ namespace eve
     template<scalar_value S>
     friend EVE_FORCEINLINE wide<S, Cardinal> operator&(S v, wide const& w) noexcept
 #if !defined(EVE_DOXYGEN_INVOKED)
-        requires(!kumi::product_type<Type> && supports_bitwise_call<wide, S>)
+        requires(!kumi::product_type<Type> && supports_bitwise_call<S, wide>)
 #endif
     {
       auto u = bit_cast(w, as<typename wide::template rebind<S, Cardinal>>());
@@ -448,9 +448,9 @@ namespace eve
     //! @brief Performs a Compound bitwise or on all the wide lanes and assign the result to the current
     //! one
     template<value V>
-    friend EVE_FORCEINLINE bit_value_t<wide, V>& operator|=(wide& w, V o) noexcept
+    friend EVE_FORCEINLINE wide& operator|=(wide& w, V o) noexcept
 #if !defined(EVE_DOXYGEN_INVOKED)
-        requires(!kumi::product_type<Type>)
+        requires(!kumi::product_type<Type> && supports_bitwise_call<wide, V>)
 #endif
     {
       return detail::self_bitor(w, o);
@@ -459,9 +459,9 @@ namespace eve
     //! @brief Performs a bitwise or between all lanes of two wide instances.
     //! Do not participate to overload resolution if both wide doesn't has the same `sizeof`
     template<scalar_value U, typename M>
-    friend EVE_FORCEINLINE bit_value_t<wide, wide<U, M>> operator|(wide const& v, wide<U, M> const& w) noexcept
+    friend EVE_FORCEINLINE wide operator|(wide const& v, wide<U, M> const& w) noexcept
 #if !defined(EVE_DOXYGEN_INVOKED)
-        requires(!kumi::product_type<Type>)
+        requires(!kumi::product_type<Type> && supports_bitwise_call<wide, wide<U, M>>)
 #endif
     {
       wide that = v;
@@ -471,9 +471,9 @@ namespace eve
     //! @brief Performs a bitwise or between all lanes of a scalar and a eve::wide
     //! Do not participate to overload resolution if `sizeof(Type) != sizeof(S)`
     template<scalar_value S>
-    friend EVE_FORCEINLINE bit_value_t<wide, S> operator|(wide const& v, S w) noexcept
+    friend EVE_FORCEINLINE wide operator|(wide const& v, S w) noexcept
 #if !defined(EVE_DOXYGEN_INVOKED)
-        requires(!kumi::product_type<Type>)
+        requires(!kumi::product_type<Type> && supports_bitwise_call<wide, S>)
 #endif
     {
       auto that = v;
@@ -483,9 +483,9 @@ namespace eve
     //! @brief Performs a bitwise or between all lanes of a scalar and a eve::wide
     //! Do not participate to overload resolution if `sizeof(Type) != sizeof(S)`
     template<scalar_value S>
-    friend EVE_FORCEINLINE bit_value_t<S, wide> operator|(S v, wide const& w) noexcept
+    friend EVE_FORCEINLINE wide<S, Cardinal> operator|(S v, wide const& w) noexcept
 #if !defined(EVE_DOXYGEN_INVOKED)
-        requires(!kumi::product_type<Type>)
+        requires(!kumi::product_type<Type> && supports_bitwise_call<S, wide>)
 #endif
     {
       auto u = bit_cast(w, as<typename wide::template rebind<S, Cardinal>>());
@@ -494,9 +494,9 @@ namespace eve
 
     //! @brief Performs a bitwise xor on all the wide lanes and assign the result to the current one
     template<value V>
-    friend EVE_FORCEINLINE bit_value_t<wide, V>& operator^=(wide& w, V o) noexcept
+    friend EVE_FORCEINLINE wide& operator^=(wide& w, V o) noexcept
 #if !defined(EVE_DOXYGEN_INVOKED)
-        requires(!kumi::product_type<Type>)
+        requires(!kumi::product_type<Type> && supports_bitwise_call<wide, V>)
 #endif
     {
       return detail::self_bitxor(w, o);
@@ -505,9 +505,9 @@ namespace eve
     //! @brief Performs a bitwise xor between all lanes of two wide instances.
     //! Do not participate to overload resolution if both wide doesn't has the same `sizeof`
     template<scalar_value U, typename M>
-    friend EVE_FORCEINLINE bit_value_t<wide, wide<U, M>> operator^(wide const& v, wide<U, M> const& w) noexcept
+    friend EVE_FORCEINLINE wide operator^(wide const& v, wide<U, M> const& w) noexcept
 #if !defined(EVE_DOXYGEN_INVOKED)
-        requires(!kumi::product_type<Type>)
+        requires(!kumi::product_type<Type> && supports_bitwise_call<wide, wide<U, M>>)
 #endif
     {
       auto that = v;
@@ -517,9 +517,9 @@ namespace eve
     //! @brief Performs a bitwise xor between all lanes of a scalar and a eve::wide
     //! Do not participate to overload resolution if `sizeof(Type) != sizeof(S)`
     template<scalar_value S>
-    friend EVE_FORCEINLINE bit_value_t<wide, S> operator^(wide const& v, S w) noexcept
+    friend EVE_FORCEINLINE wide operator^(wide const& v, S w) noexcept
 #if !defined(EVE_DOXYGEN_INVOKED)
-        requires(!kumi::product_type<Type>)
+        requires(!kumi::product_type<Type> && supports_bitwise_call<wide, S>)
 #endif
     {
       auto that = v;
@@ -529,9 +529,9 @@ namespace eve
     //! @brief Performs a bitwise xor between all lanes of a scalar and a eve::wide
     //! Do not participate to overload resolution if `sizeof(Type) != sizeof(S)`
     template<scalar_value S>
-    friend EVE_FORCEINLINE bit_value_t<S, wide> operator^(S v, wide const& w) noexcept
+    friend EVE_FORCEINLINE wide<S, Cardinal> operator^(S v, wide const& w) noexcept
 #if !defined(EVE_DOXYGEN_INVOKED)
-        requires(!kumi::product_type<Type>)
+        requires(!kumi::product_type<Type> && supports_bitwise_call<S, wide>)
 #endif
     {
       auto u = bit_cast(w, as<typename wide::template rebind<S, Cardinal>>());

--- a/include/eve/arch/cpu/wide.hpp
+++ b/include/eve/arch/cpu/wide.hpp
@@ -401,7 +401,7 @@ namespace eve
     //! @brief Performs a compound bitwise and on all the wide lanes and assign the result to the current
     //! one
     template<value V>
-    friend EVE_FORCEINLINE bit_value_t<wide, V> operator&=(wide& w, V o) noexcept
+    friend EVE_FORCEINLINE bit_value_t<wide, V>& operator&=(wide& w, V o) noexcept
 #if !defined(EVE_DOXYGEN_INVOKED)
         requires (!kumi::product_type<Type>)
 #endif
@@ -448,7 +448,7 @@ namespace eve
     //! @brief Performs a Compound bitwise or on all the wide lanes and assign the result to the current
     //! one
     template<value V>
-    friend EVE_FORCEINLINE bit_value_t<wide, V> operator|=(wide& w, V o) noexcept
+    friend EVE_FORCEINLINE bit_value_t<wide, V>& operator|=(wide& w, V o) noexcept
 #if !defined(EVE_DOXYGEN_INVOKED)
         requires(!kumi::product_type<Type>)
 #endif
@@ -494,7 +494,7 @@ namespace eve
 
     //! @brief Performs a bitwise xor on all the wide lanes and assign the result to the current one
     template<value V>
-    friend EVE_FORCEINLINE bit_value_t<wide, V> operator^=(wide& w, V o) noexcept
+    friend EVE_FORCEINLINE bit_value_t<wide, V>& operator^=(wide& w, V o) noexcept
 #if !defined(EVE_DOXYGEN_INVOKED)
         requires(!kumi::product_type<Type>)
 #endif

--- a/include/eve/concept/compatible.hpp
+++ b/include/eve/concept/compatible.hpp
@@ -24,16 +24,6 @@ namespace eve
                            || std::same_as<std::remove_cvref_t<T>,std::remove_cvref_t<U>>;
 
   template<typename T, typename U>
-  concept element_bit_compatible_to = scalar_value<T>
-                                   && simd_value<U>
-                                   && (sizeof(T) == sizeof(element_type_t<U>));
-
-  template<typename T, typename U>
-  concept bit_compatible_values = (sizeof(T) == sizeof(U))
-                               || element_bit_compatible_to<T, U>
-                               || element_bit_compatible_to<U, T>;
-
-  template<typename T, typename U>
   concept size_compatible_to = scalar_value<T>
                             || std::same_as<cardinal_t<T>, cardinal_t<U>>;
 

--- a/include/eve/detail/function/simd/arm/neon/bit_compounds.hpp
+++ b/include/eve/detail/function/simd/arm/neon/bit_compounds.hpp
@@ -138,17 +138,12 @@ namespace eve::detail
   // &=
   //================================================================================================
   template<scalar_value T, value U, typename N>
-  EVE_FORCEINLINE decltype(auto) self_bitand(wide<T, N> &self, U const &other) noexcept
+  EVE_FORCEINLINE bit_value_t<wide<T, N>, U> self_bitand(wide<T, N> &self, U const &other) noexcept
       requires((sizeof(wide<T, N>) == sizeof(U)) || (sizeof(T) == sizeof(U))) && arm_abi<abi_t<T, N>>
   {
     using type = wide<T, N>;
 
-    if constexpr( element_bit_compatible_to<U, type> )
-    {
-      auto bit_other = eve::bit_cast(other, as<T> {});
-      self           = self_bitand(self, type {bit_other});
-    }
-    else if constexpr( simd_value<U> && sizeof(self) == sizeof(other) )
+    if constexpr( simd_value<U> && sizeof(self) == sizeof(other) )
     {
       auto bit_other = eve::bit_cast(other, as<type> {});
       constexpr auto c = categorize<type>();
@@ -201,6 +196,11 @@ namespace eve::detail
         }
       }
     }
+    else
+    {
+      auto bit_other = eve::bit_cast(other, as<T> {});
+      self           = self_bitand(self, type {bit_other});
+    }
 
     return self;
   }
@@ -209,17 +209,12 @@ namespace eve::detail
   // |=
   //================================================================================================
   template<scalar_value T, value U, typename N>
-  EVE_FORCEINLINE decltype(auto) self_bitor(wide<T, N> &self, U const &other) noexcept
+  EVE_FORCEINLINE bit_value_t<wide<T, N>, U> self_bitor(wide<T, N> &self, U const &other) noexcept
       requires((sizeof(wide<T, N>) == sizeof(U)) || (sizeof(T) == sizeof(U))) && arm_abi<abi_t<T, N>>
   {
     using type = wide<T, N>;
 
-    if constexpr( element_bit_compatible_to<U, type> )
-    {
-      auto bit_other = eve::bit_cast(other, as<T> {});
-      self           = self_bitor(self, type {bit_other});
-    }
-    else if constexpr( simd_value<U> && sizeof(self) == sizeof(other) )
+    if constexpr( simd_value<U> && sizeof(self) == sizeof(other) )
     {
       auto bit_other = eve::bit_cast(other, as<type> {});
       constexpr auto c = categorize<type>();
@@ -272,6 +267,11 @@ namespace eve::detail
         }
       }
     }
+    else
+    {
+      auto bit_other = eve::bit_cast(other, as<T> {});
+      self           = self_bitor(self, type {bit_other});
+    }
 
     return self;
   }
@@ -280,17 +280,12 @@ namespace eve::detail
   // ^=
   //================================================================================================
   template<scalar_value T, value U, typename N>
-  EVE_FORCEINLINE decltype(auto) self_bitxor(wide<T, N> &self, U const &other) noexcept
+  EVE_FORCEINLINE bit_value_t<wide<T, N>, U> self_bitxor(wide<T, N> &self, U const &other) noexcept
       requires((sizeof(wide<T, N>) == sizeof(U)) || (sizeof(T) == sizeof(U))) && arm_abi<abi_t<T, N>>
   {
     using type = wide<T, N>;
 
-    if constexpr( element_bit_compatible_to<U, type> )
-    {
-      auto bit_other = eve::bit_cast(other, as<T> {});
-      self           = self_bitxor(self, type {bit_other});
-    }
-    else if constexpr( simd_value<U> && sizeof(self) == sizeof(other) )
+    if constexpr( simd_value<U> && sizeof(self) == sizeof(other) )
     {
       auto bit_other = eve::bit_cast(other, as<type> {});
       constexpr auto c = categorize<type>();
@@ -342,6 +337,11 @@ namespace eve::detail
                                       );
         }
       }
+    }
+    else
+    {
+      auto bit_other = eve::bit_cast(other, as<T> {});
+      self           = self_bitxor(self, type {bit_other});
     }
 
     return self;

--- a/include/eve/detail/function/simd/arm/neon/bit_compounds.hpp
+++ b/include/eve/detail/function/simd/arm/neon/bit_compounds.hpp
@@ -138,7 +138,7 @@ namespace eve::detail
   // &=
   //================================================================================================
   template<scalar_value T, value U, typename N>
-  EVE_FORCEINLINE bit_value_t<wide<T, N>, U> self_bitand(wide<T, N> &self, U const &other) noexcept
+  EVE_FORCEINLINE bit_value_t<wide<T, N>, U>& self_bitand(wide<T, N> &self, U const &other) noexcept
       requires((sizeof(wide<T, N>) == sizeof(U)) || (sizeof(T) == sizeof(U))) && arm_abi<abi_t<T, N>>
   {
     using type = wide<T, N>;
@@ -209,7 +209,7 @@ namespace eve::detail
   // |=
   //================================================================================================
   template<scalar_value T, value U, typename N>
-  EVE_FORCEINLINE bit_value_t<wide<T, N>, U> self_bitor(wide<T, N> &self, U const &other) noexcept
+  EVE_FORCEINLINE bit_value_t<wide<T, N>, U>& self_bitor(wide<T, N> &self, U const &other) noexcept
       requires((sizeof(wide<T, N>) == sizeof(U)) || (sizeof(T) == sizeof(U))) && arm_abi<abi_t<T, N>>
   {
     using type = wide<T, N>;
@@ -280,7 +280,7 @@ namespace eve::detail
   // ^=
   //================================================================================================
   template<scalar_value T, value U, typename N>
-  EVE_FORCEINLINE bit_value_t<wide<T, N>, U> self_bitxor(wide<T, N> &self, U const &other) noexcept
+  EVE_FORCEINLINE bit_value_t<wide<T, N>, U>& self_bitxor(wide<T, N> &self, U const &other) noexcept
       requires((sizeof(wide<T, N>) == sizeof(U)) || (sizeof(T) == sizeof(U))) && arm_abi<abi_t<T, N>>
   {
     using type = wide<T, N>;

--- a/include/eve/detail/function/simd/arm/sve/bit_compounds.hpp
+++ b/include/eve/detail/function/simd/arm/sve/bit_compounds.hpp
@@ -114,16 +114,15 @@ requires((sizeof(wide<T, N>) == sizeof(U)) || (sizeof(T) == sizeof(U))) && sve_a
 
   if constexpr( simd_value<U> )
   {
-    auto bit_other = eve::bit_cast(other, as<T> {});
-    self           = self_bitand(self, type {bit_other});
-  }
-  else
-  {
     using i_t = typename type::template rebind <as_integer_t<T, signed>,N>;
     constexpr auto tgt = as<i_t>();
     self = bit_cast ( i_t(svand_x(sve_true<T>(), bit_cast(self,tgt), bit_cast(other,tgt)))
                     , as(self)
                     );
+  }
+  else
+  {
+    self = self_bitand(self, eve::bit_cast(other, as<type>{}));
   }
 
   return self;
@@ -135,18 +134,18 @@ self_bitor(wide<T, N>& self, U const& other) noexcept
 requires((sizeof(wide<T, N>) == sizeof(U)) || (sizeof(T) == sizeof(U))) && sve_abi<abi_t<T, N>>
 {
   using type = wide<T, N>;
+
   if constexpr( simd_value<U> )
-  {
-    auto bit_other = eve::bit_cast(other, as<T> {});
-    self           = self_bitor(self, type {bit_other});
-  }
-  else
   {
     using i_t = typename type::template rebind <as_integer_t<T, signed>,N>;
     constexpr auto tgt = as<i_t>();
     self = bit_cast ( i_t(svorr_x(sve_true<T>(), bit_cast(self,tgt), bit_cast(other,tgt)))
                     , as(self)
                     );
+  }
+  else
+  {
+    self = self_bitor(self, eve::bit_cast(other, as<type>{}));
   }
 
   return self;
@@ -159,16 +158,15 @@ requires((sizeof(wide<T, N>) == sizeof(U)) || (sizeof(T) == sizeof(U))) && sve_a
   using type = wide<T, N>;
   if constexpr( simd_value<U> )
   {
-    auto bit_other = eve::bit_cast(other, as<T> {});
-    self           = self_bitxor(self, type {bit_other});
-  }
-  else
-  {
     using i_t = typename type::template rebind <as_integer_t<T, signed>,N>;
     constexpr auto tgt = as<i_t>();
     self = bit_cast ( i_t(sveor_x(sve_true<T>(), bit_cast(self,tgt), bit_cast(other,tgt)))
                     , as(self)
                     );
+  }
+  else
+  {
+    self = self_bitxor(self, eve::bit_cast(other, as<type>{}));
   }
 
   return self;

--- a/include/eve/detail/function/simd/arm/sve/bit_compounds.hpp
+++ b/include/eve/detail/function/simd/arm/sve/bit_compounds.hpp
@@ -106,12 +106,13 @@ requires sve_abi<abi_t<T, N>>
 }
 
 template<scalar_value T, value U, typename N>
-EVE_FORCEINLINE auto&
+EVE_FORCEINLINE bit_value_t<wide<T, N>, U>&
 self_bitand(wide<T, N>& self, U const& other) noexcept
 requires((sizeof(wide<T, N>) == sizeof(U)) || (sizeof(T) == sizeof(U))) && sve_abi<abi_t<T, N>>
 {
   using type = wide<T, N>;
-  if constexpr( element_bit_compatible_to<U, type> )
+
+  if constexpr( simd_value<U> )
   {
     auto bit_other = eve::bit_cast(other, as<T> {});
     self           = self_bitand(self, type {bit_other});
@@ -129,12 +130,12 @@ requires((sizeof(wide<T, N>) == sizeof(U)) || (sizeof(T) == sizeof(U))) && sve_a
 }
 
 template<scalar_value T, value U, typename N>
-EVE_FORCEINLINE auto&
+EVE_FORCEINLINE bit_value_t<wide<T, N>, U>&
 self_bitor(wide<T, N>& self, U const& other) noexcept
 requires((sizeof(wide<T, N>) == sizeof(U)) || (sizeof(T) == sizeof(U))) && sve_abi<abi_t<T, N>>
 {
   using type = wide<T, N>;
-  if constexpr( element_bit_compatible_to<U, type> )
+  if constexpr( simd_value<U> )
   {
     auto bit_other = eve::bit_cast(other, as<T> {});
     self           = self_bitor(self, type {bit_other});
@@ -151,12 +152,12 @@ requires((sizeof(wide<T, N>) == sizeof(U)) || (sizeof(T) == sizeof(U))) && sve_a
   return self;
 }
 template<scalar_value T, value U, typename N>
-EVE_FORCEINLINE auto&
+EVE_FORCEINLINE bit_value_t<wide<T, N>, U>&
 self_bitxor(wide<T, N>& self, U const& other) noexcept
 requires((sizeof(wide<T, N>) == sizeof(U)) || (sizeof(T) == sizeof(U))) && sve_abi<abi_t<T, N>>
 {
   using type = wide<T, N>;
-  if constexpr( element_bit_compatible_to<U, type> )
+  if constexpr( simd_value<U> )
   {
     auto bit_other = eve::bit_cast(other, as<T> {});
     self           = self_bitxor(self, type {bit_other});

--- a/include/eve/detail/function/simd/arm/sve/bit_compounds.hpp
+++ b/include/eve/detail/function/simd/arm/sve/bit_compounds.hpp
@@ -122,7 +122,7 @@ requires((sizeof(wide<T, N>) == sizeof(U)) || (sizeof(T) == sizeof(U))) && sve_a
   }
   else
   {
-    self = self_bitand(self, eve::bit_cast(other, as<type>{}));
+    self = self_bitand(self, type{eve::bit_cast(other, as<T>{})});
   }
 
   return self;
@@ -145,7 +145,7 @@ requires((sizeof(wide<T, N>) == sizeof(U)) || (sizeof(T) == sizeof(U))) && sve_a
   }
   else
   {
-    self = self_bitor(self, eve::bit_cast(other, as<type>{}));
+    self = self_bitor(self, type{eve::bit_cast(other, as<T>{})});
   }
 
   return self;
@@ -166,7 +166,7 @@ requires((sizeof(wide<T, N>) == sizeof(U)) || (sizeof(T) == sizeof(U))) && sve_a
   }
   else
   {
-    self = self_bitxor(self, eve::bit_cast(other, as<type>{}));
+    self = self_bitxor(self, type{eve::bit_cast(other, as<T>{})});
   }
 
   return self;

--- a/include/eve/detail/function/simd/common/bit_compounds.hpp
+++ b/include/eve/detail/function/simd/common/bit_compounds.hpp
@@ -54,7 +54,7 @@ namespace eve::detail
   // >>=
   //================================================================================================
   template<integral_scalar_value T, typename N, integral_scalar_value U>
-  EVE_FORCEINLINE decltype(auto) self_shr(wide<T,N>& v, wide<U,N> s) noexcept
+  EVE_FORCEINLINE bit_value_t<wide<T, N>, U>& self_shr(wide<T,N>& v, wide<U,N> s) noexcept
   {
     auto ss = []<typename V>(V a, auto b) { return static_cast<V>(a >> b); };
 
@@ -87,7 +87,7 @@ namespace eve::detail
   // &=
   //================================================================================================
   template<scalar_value T, value U, typename N>
-  EVE_FORCEINLINE decltype(auto) self_bitand(wide<T, N> &self, U const &other) noexcept
+  EVE_FORCEINLINE bit_value_t<wide<T, N>, U>& self_bitand(wide<T, N> &self, U const &other) noexcept
   requires((sizeof(wide<T, N>) == sizeof(U)) || (sizeof(T) == sizeof(U))) && non_native_abi<abi_t<T, N>>
   {
     using type = wide<T, N>;
@@ -122,7 +122,7 @@ namespace eve::detail
   // |=
   //================================================================================================
   template<scalar_value T, value U, typename N>
-  EVE_FORCEINLINE decltype(auto)
+  EVE_FORCEINLINE bit_value_t<wide<T, N>, U>&
   self_bitor(wide<T, N> &self, U const &other) requires((sizeof(wide<T, N>) == sizeof(U))
                                                              || (sizeof(T) == sizeof(U))) && non_native_abi<abi_t<T, N>>
   {
@@ -158,7 +158,7 @@ namespace eve::detail
   // ^=
   //================================================================================================
   template<scalar_value T, value U, typename N>
-  EVE_FORCEINLINE decltype(auto)
+  EVE_FORCEINLINE bit_value_t<wide<T, N>, U>&
   self_bitxor(wide<T, N> &self, U const &other) requires((sizeof(wide<T, N>) == sizeof(U))
                                                               || (sizeof(T) == sizeof(U))) && non_native_abi<abi_t<T, N>>
   {

--- a/include/eve/detail/function/simd/ppc/bit_compounds.hpp
+++ b/include/eve/detail/function/simd/ppc/bit_compounds.hpp
@@ -65,19 +65,19 @@ namespace eve::detail
   // &=
   //================================================================================================
   template<scalar_value T, value U, typename N>
-  EVE_FORCEINLINE decltype(auto) self_bitand( wide<T,N>& self, U const& other )
+  EVE_FORCEINLINE bit_value_t<wide<T, N>, U> self_bitand( wide<T,N>& self, U const& other )
     requires( (sizeof(wide<T,N>) == sizeof(U)) || (sizeof(T) == sizeof(U)) ) && ppc_abi<abi_t<T, N>>
   {
     using type = wide<T,N>;
 
-    if constexpr( element_bit_compatible_to<U,type> )
+    if constexpr( simd_value<U> && sizeof(self) == sizeof(other) )
+    {
+      self = vec_and(self.storage(), (typename type::storage_type)(other.storage()) );
+    }
+    else
     {
       auto bit_other = bit_cast(other , as<T>{});
       self = vec_and(self.storage(), type{bit_other}.storage());
-    }
-    else if constexpr( simd_value<U> && sizeof(self) == sizeof(other) )
-    {
-      self = vec_and(self.storage(), (typename type::storage_type)(other.storage()) );
     }
 
     return self;
@@ -87,19 +87,19 @@ namespace eve::detail
   // |=
   //================================================================================================
   template<scalar_value T, value U, typename N>
-  EVE_FORCEINLINE decltype(auto) self_bitor( wide<T,N>& self, U const& other )
+  EVE_FORCEINLINE bit_value_t<wide<T, N>, U> self_bitor( wide<T,N>& self, U const& other )
   requires( (sizeof(wide<T,N>) == sizeof(U)) || (sizeof(T) == sizeof(U)) ) && ppc_abi<abi_t<T, N>>
   {
     using type = wide<T,N>;
 
-    if constexpr( element_bit_compatible_to<U,type> )
+    if constexpr( simd_value<U> && sizeof(self) == sizeof(other) )
+    {
+      self = vec_or(self.storage(), (typename type::storage_type)(other.storage()) );
+    }
+    else
     {
       auto bit_other = bit_cast(other , as<T>{});
       self = vec_or(self.storage(), type{bit_other}.storage());
-    }
-    else if constexpr( simd_value<U> && sizeof(self) == sizeof(other) )
-    {
-      self = vec_or(self.storage(), (typename type::storage_type)(other.storage()) );
     }
 
     return self;
@@ -109,19 +109,19 @@ namespace eve::detail
   // ^=
   //================================================================================================
   template<scalar_value T, value U, typename N>
-  EVE_FORCEINLINE decltype(auto) self_bitxor( wide<T,N>& self, U const& other )
+  EVE_FORCEINLINE bit_value_t<wide<T, N>, U> self_bitxor( wide<T,N>& self, U const& other )
   requires( (sizeof(wide<T,N>) == sizeof(U)) || (sizeof(T) == sizeof(U)) ) && ppc_abi<abi_t<T, N>>
   {
     using type = wide<T,N>;
 
-    if constexpr( element_bit_compatible_to<U,type> )
+    if constexpr( simd_value<U> && sizeof(self) == sizeof(other) )
+    {
+      self = vec_xor(self.storage(), (typename type::storage_type)(other.storage()) );
+    }
+    else
     {
       auto bit_other = bit_cast(other , as<T>{});
       self = vec_xor(self.storage(), type{bit_other}.storage());
-    }
-    else if constexpr( simd_value<U> && sizeof(self) == sizeof(other) )
-    {
-      self = vec_xor(self.storage(), (typename type::storage_type)(other.storage()) );
     }
 
     return self;

--- a/include/eve/detail/function/simd/ppc/bit_compounds.hpp
+++ b/include/eve/detail/function/simd/ppc/bit_compounds.hpp
@@ -65,7 +65,7 @@ namespace eve::detail
   // &=
   //================================================================================================
   template<scalar_value T, value U, typename N>
-  EVE_FORCEINLINE bit_value_t<wide<T, N>, U> self_bitand( wide<T,N>& self, U const& other )
+  EVE_FORCEINLINE bit_value_t<wide<T, N>, U>& self_bitand( wide<T,N>& self, U const& other )
     requires( (sizeof(wide<T,N>) == sizeof(U)) || (sizeof(T) == sizeof(U)) ) && ppc_abi<abi_t<T, N>>
   {
     using type = wide<T,N>;
@@ -87,7 +87,7 @@ namespace eve::detail
   // |=
   //================================================================================================
   template<scalar_value T, value U, typename N>
-  EVE_FORCEINLINE bit_value_t<wide<T, N>, U> self_bitor( wide<T,N>& self, U const& other )
+  EVE_FORCEINLINE bit_value_t<wide<T, N>, U>& self_bitor( wide<T,N>& self, U const& other )
   requires( (sizeof(wide<T,N>) == sizeof(U)) || (sizeof(T) == sizeof(U)) ) && ppc_abi<abi_t<T, N>>
   {
     using type = wide<T,N>;
@@ -109,7 +109,7 @@ namespace eve::detail
   // ^=
   //================================================================================================
   template<scalar_value T, value U, typename N>
-  EVE_FORCEINLINE bit_value_t<wide<T, N>, U> self_bitxor( wide<T,N>& self, U const& other )
+  EVE_FORCEINLINE bit_value_t<wide<T, N>, U>& self_bitxor( wide<T,N>& self, U const& other )
   requires( (sizeof(wide<T,N>) == sizeof(U)) || (sizeof(T) == sizeof(U)) ) && ppc_abi<abi_t<T, N>>
   {
     using type = wide<T,N>;

--- a/include/eve/detail/function/simd/x86/bit_compounds.hpp
+++ b/include/eve/detail/function/simd/x86/bit_compounds.hpp
@@ -204,7 +204,7 @@ namespace eve::detail
   // &=
   //================================================================================================
   template<scalar_value T, value U, typename N>
-  EVE_FORCEINLINE decltype(auto) self_bitand(wide<T, N> &self, U const &other) noexcept
+  EVE_FORCEINLINE bit_value_t<wide<T, N>, U>& self_bitand(wide<T, N> &self, U const &other) noexcept
   requires((sizeof(wide<T, N>) == sizeof(U)) || (sizeof(T) == sizeof(U))) && x86_abi<abi_t<T, N>>
   {
     using type = wide<T, N>;
@@ -245,7 +245,7 @@ namespace eve::detail
   // |=
   //================================================================================================
   template<scalar_value T, value U, typename N>
-  EVE_FORCEINLINE decltype(auto) self_bitor(wide<T, N> &self, U const &other) noexcept
+  EVE_FORCEINLINE bit_value_t<wide<T, N>, U>& self_bitor(wide<T, N> &self, U const &other) noexcept
       requires((sizeof(wide<T, N>) == sizeof(U)) || (sizeof(T) == sizeof(U))) && x86_abi<abi_t<T, N>>
   {
     using type = wide<T, N>;
@@ -287,7 +287,7 @@ namespace eve::detail
   // ^=
   //================================================================================================
   template<scalar_value T, value U, typename N>
-  EVE_FORCEINLINE decltype(auto) self_bitxor(wide<T, N> &self, U const &other) noexcept
+  EVE_FORCEINLINE bit_value_t<wide<T, N>, U>& self_bitxor(wide<T, N> &self, U const &other) noexcept
       requires((sizeof(wide<T, N>) == sizeof(U)) || (sizeof(T) == sizeof(U))) && x86_abi<abi_t<T, N>>
   {
     using type = wide<T, N>;

--- a/include/eve/detail/skeleton_calls.hpp
+++ b/include/eve/detail/skeleton_calls.hpp
@@ -53,10 +53,10 @@ namespace eve::detail
    // -----------------------------------------------------------------------------------------------
   // binary bit operators scheme
   template<typename Obj, value T, value U>
-  EVE_FORCEINLINE auto bit_call(Obj op
+  EVE_FORCEINLINE bit_value_t<T, U> bit_call(Obj op
                                , T const &a
                                , U const &b) noexcept
-  requires bit_compatible_values<T, U>  && (!std::same_as<U,T>)
+  requires (!std::same_as<U,T>)
   {
     using vt_t = element_type_t<T>;
     using vt_u = element_type_t<U>;
@@ -87,11 +87,11 @@ namespace eve::detail
   }
 
   template<typename Obj, value T, value U, value V>
-  EVE_FORCEINLINE auto bit_call(Obj op
+  EVE_FORCEINLINE bit_value_t<T, U, V> bit_call(Obj op
                                , T const &a
                                , U const &b
                                , V const &c) noexcept
-  requires bit_compatible_values<T, U> && bit_compatible_values<T, V> && bit_compatible_values<U, V>  && (!(std::same_as<U,T> && std::same_as<T,V>))
+  requires (!(std::same_as<U,T> && std::same_as<T,V>))
   {
     using vt_u = element_type_t<U>;
     if constexpr(simd_value<T> && simd_value<U> && simd_value<V>)    //all three are simd so of the same bit size

--- a/include/eve/module/core/regular/impl/simd/x86/popcount.hpp
+++ b/include/eve/module/core/regular/impl/simd/x86/popcount.hpp
@@ -26,98 +26,87 @@ namespace eve::detail
   EVE_FORCEINLINE auto putcounts( wide<T, N> in)
   {
     using i8_t = typename wide<T,N>::template rebind<std::uint8_t>;
+    
     const i8_t pattern_2bit(0x55);
     const i8_t pattern_4bit(0x33);
     const i8_t pattern_16bit(0x0f);
     auto xx = bit_cast(in, as<i8_t>()); // put
+
     xx -= bit_shr(xx, 1) & pattern_2bit; // put
     xx  = (xx & pattern_4bit) + (bit_shr(xx, 2) & pattern_4bit);
     xx  = (xx + bit_shr(xx, 4)) & pattern_16bit; // put count of each 8 bits into those 8 bits
+
     return bit_cast(xx,as(in));
   };
 
   template<unsigned_scalar_value T, typename N, callable_options O>
-  EVE_FORCEINLINE auto popcount_(EVE_REQUIRES(sse2_), O const&, wide<T, N> x) noexcept
+  EVE_FORCEINLINE auto popcount_(EVE_REQUIRES(sse2_), O const& opts, wide<T, N> x) noexcept
   requires std::same_as<abi_t<T, N>, x86_128_>
   {
-    using r_t = wide<T, N>;
-    if constexpr( sizeof(T) == 8 || sizeof(T) == 1 )
+    if constexpr ((sizeof(T) == 8) || (sizeof(T) == 1))
     {
-      using i16_t = typename wide<T,N>::template rebind<std::uint16_t>;
-      auto xx     = bit_cast(x, as<i16_t>());
-      if constexpr( sizeof(T) == 8 )
+      using r_t = wide<T, N>;
+      using u16_t = typename wide<T,N>::template rebind<std::uint16_t>;
+
+      auto xx     = bit_cast(x, as<u16_t>());
+
+      if constexpr (sizeof(T) == 8)
       {
         return bit_cast(_mm_sad_epu8(putcounts(xx), _mm_setzero_si128()), as<r_t>());
       }
-      else if constexpr( sizeof(T) == 1 )
+      else if constexpr (sizeof(T) == 1)
       {
-        const i16_t masklow(0xff);
+        const u16_t masklow(0xff);
         return bit_cast(popcount(xx & masklow) + (popcount(bit_shr(xx, 8) & masklow) << 8), as<r_t>());
       }
     }
-    else if constexpr( sizeof(T) == 4 || sizeof(T) == 2 )
+    else
     {
-      using i8_t = typename wide<T,N>::template rebind<std::uint8_t>;
-      const i8_t pattern_2bit(0x55);
-      const i8_t pattern_4bit(0x33);
-      const i8_t pattern_16bit(0x0f);
-      const r_t  mask(0x7f);
-
-      x = putcounts(x);
-      if constexpr( sizeof(T) >= 2 ) x += bit_shr(x,  8); // put count of each 16 bits into their lowest 8 bits
-      if constexpr( sizeof(T) >= 4 ) x += bit_shr(x, 16); // put count of each 32 bits into their lowest 8 bits
-      return bit_cast(x & mask, as(mask));
+      return popcount.behavior(cpu_{}, opts, x); 
     }
   }
 
   /////////////////////////////////////////////////////////////////////////////
   // 256 bits
   template<unsigned_scalar_value T, typename N, callable_options O>
-  EVE_FORCEINLINE auto
-  popcount_(EVE_REQUIRES(avx_), O const& o, wide<T, N> x) noexcept
-  requires std::same_as<abi_t<T, N>, x86_256_>
+  EVE_FORCEINLINE auto popcount_(EVE_REQUIRES(avx_), O const& o, wide<T, N> x) noexcept
+    requires std::same_as<abi_t<T, N>, x86_256_>
   {
     using r_t = wide<T, N>;
-    if constexpr( current_api >= avx2 )
+
+    if constexpr (current_api >= avx2)
     {
-      if constexpr( sizeof(T) == 8 || sizeof(T) == 1 )
+      if constexpr ((sizeof(T) == 8) || (sizeof(T) == 1))
       {
-        using N16   = fixed<(sizeof(T) < 8) ? 16 : sizeof(T) * 2>;
-        using i16_t = wide<uint16_t, N16>;
-        auto xx     = bit_cast(x, as<i16_t>());
-        if constexpr( sizeof(T) == 8 )
+        using u16_t = typename wide<T,N>::template rebind<std::uint16_t>;
+        auto xx     = bit_cast(x, as<u16_t>());
+
+        if constexpr (sizeof(T) == 8)
         {
           xx = putcounts(xx);
           return bit_cast(_mm256_sad_epu8(xx, _mm256_setzero_si256()), as<r_t>());
         }
-        else if constexpr( sizeof(T) == 1 )
+        else if constexpr (sizeof(T) == 1)
         {
-          const i16_t masklow(0xff);
-          return bit_cast(popcount(xx & masklow) + (popcount(bit_shr(xx, 8) & masklow) << 8),
-                          as<r_t>());
+          const u16_t masklow(0xff);
+          return bit_cast(popcount(xx & masklow) + (popcount(bit_shr(xx, 8) & masklow) << 8), as<r_t>());
         }
       }
-      else if constexpr( sizeof(T) == 4 || sizeof(T) == 2 )
+      else
       {
-        x = putcounts(x);
-        if constexpr( sizeof(T) >= 2 )
-          x += bit_shr(x, 8); // put count of each 16 bits into their lowest 8 bits
-        if constexpr( sizeof(T) >= 4 )
-          x += bit_shr(x, 16); // put count of each 32 bits into their lowest 8 bits
-        if constexpr( sizeof(T) >= 8 )
-          x += bit_shr(x, 32); // put count of each 64 bits into their lowest 8 bits
-        const r_t mask(0x7f);
-        return bit_cast(x & mask, as<r_t>());
+        return popcount.behavior(cpu_{}, o, x);
       }
     }
     else
     {
-      if constexpr( sizeof(T) >= 8 )
+      if constexpr (sizeof(T) >= 8)
+      {
         return popcount.behavior(cpu_{}, o, x);
+      }
       else
       {
         auto [lo, hi] = x.slice();
-        return r_t(popcount(lo), popcount(hi));
+        return r_t{popcount(lo), popcount(hi)};
       }
     }
   }

--- a/include/eve/traits/bit_value.hpp
+++ b/include/eve/traits/bit_value.hpp
@@ -104,4 +104,7 @@ namespace eve
 
   template<typename... Ts>
   using bit_value_t = typename bit_value<Ts...>::type;
+
+  template<typename... Ts>
+  concept supports_bitwise_call = requires { typename bit_value<Ts...>::type; };
 }

--- a/test/unit/api/regular/arithmetic.cpp
+++ b/test/unit/api/regular/arithmetic.cpp
@@ -34,6 +34,19 @@ TTS_CASE_TPL( "Check return types of arithmetic operators on wide", eve::test::s
     TTS_EXPR_IS( v_t()% T(), T);
     TTS_EXPR_IS( T() % v_t(), T);
   }
+
+  // assigning operators
+  auto v = T{};
+
+  TTS_EXPR_IS(v += v, T&);
+  TTS_EXPR_IS(v -= v, T&);
+  TTS_EXPR_IS(v *= v, T&);
+  TTS_EXPR_IS(v /= v, T&);
+
+  if constexpr( eve::integral_value<T> )
+  {
+    TTS_EXPR_IS(v %= v, T&);
+  }
 };
 
 //==================================================================================================
@@ -126,4 +139,16 @@ TTS_CASE_WITH( "Check behavior of arithmetic operators on wide and scalar"
     TTS_EQUAL( (a0 % s), T([&](auto i, auto) { return a0.get(i) % s; }));
     TTS_EQUAL( (s % a1), T([&](auto i, auto) { return s % a1.get(i); }));
   }
+
+  auto cpy = a0; (cpy += s);
+  TTS_EQUAL(cpy, T([&](auto i, auto) { return a0.get(i) + s; }));
+
+  cpy = a0; (cpy -= s);
+  TTS_EQUAL(cpy, T([&](auto i, auto) { return a0.get(i) - s; }));
+
+  cpy = a0; (cpy *= s);
+  TTS_EQUAL(cpy, T([&](auto i, auto) { return a0.get(i) * s; }));
+
+  cpy = a0; (cpy /= s);
+  TTS_ULP_EQUAL(cpy, T([&](auto i, auto) { return a0.get(i) / s; }), 1);
 };

--- a/test/unit/api/regular/arithmetic.cpp
+++ b/test/unit/api/regular/arithmetic.cpp
@@ -140,15 +140,19 @@ TTS_CASE_WITH( "Check behavior of arithmetic operators on wide and scalar"
     TTS_EQUAL( (s % a1), T([&](auto i, auto) { return s % a1.get(i); }));
   }
 
-  auto cpy = a0; (cpy += s);
+  auto cpy = a0;
+  (cpy += s);
   TTS_EQUAL(cpy, T([&](auto i, auto) { return a0.get(i) + s; }));
 
-  cpy = a0; (cpy -= s);
+  cpy = a0;
+  (cpy -= s);
   TTS_EQUAL(cpy, T([&](auto i, auto) { return a0.get(i) - s; }));
 
-  cpy = a0; (cpy *= s);
+  cpy = a0;
+  (cpy *= s);
   TTS_EQUAL(cpy, T([&](auto i, auto) { return a0.get(i) * s; }));
 
-  cpy = a0; (cpy /= s);
+  cpy = a0;
+  (cpy /= s);
   TTS_ULP_EQUAL(cpy, T([&](auto i, auto) { return a0.get(i) / s; }), 1);
 };

--- a/test/unit/api/regular/bitwise.cpp
+++ b/test/unit/api/regular/bitwise.cpp
@@ -72,12 +72,15 @@ TTS_CASE_WITH( "Check behavior of bitwise operators on wide and scalar"
   TTS_IEEE_EQUAL( (v_t(1) | a0), T([&](auto i, auto) { return eve::bit_or (v_t(1), a0.get(i)); }));
   TTS_IEEE_EQUAL( (v_t(1) ^ a0), T([&](auto i, auto) { return eve::bit_xor(v_t(1), a0.get(i)); }));
 
-  auto cpy = a0; (cpy &= v_t(1));
+  auto cpy = a0;
+  (cpy &= v_t(1));
   TTS_IEEE_EQUAL(cpy, T([&](auto i, auto) { return eve::bit_and(a0.get(i), v_t(1)); }));
 
-  cpy = a0; (cpy |= v_t(1));
+  cpy = a0;
+  (cpy |= v_t(1));
   TTS_IEEE_EQUAL(cpy, T([&](auto i, auto) { return eve::bit_or(a0.get(i), v_t(1)); }));
 
-  cpy = a0; (cpy ^= v_t(1));
+  cpy = a0;
+  (cpy ^= v_t(1));
   TTS_IEEE_EQUAL(cpy, T([&](auto i, auto) { return eve::bit_xor(a0.get(i), v_t(1)); }));
 };

--- a/test/unit/api/regular/bitwise.cpp
+++ b/test/unit/api/regular/bitwise.cpp
@@ -16,6 +16,7 @@ TTS_CASE_TPL( "Check return types of bitwise operators on wide", eve::test::simd
 {
   using v_t = eve::element_type_t<T>;
 
+
   TTS_EXPR_IS( T()    & T()   , T);
   TTS_EXPR_IS( T()    & v_t() , T);
   TTS_EXPR_IS( v_t()  & T()   , T);
@@ -26,6 +27,13 @@ TTS_CASE_TPL( "Check return types of bitwise operators on wide", eve::test::simd
   TTS_EXPR_IS( T()    ^ v_t() , T);
   TTS_EXPR_IS( v_t()  ^ T()   , T);
   TTS_EXPR_IS( ~T()           , T);
+
+  // assigning operators
+  auto v = T{};
+
+  TTS_EXPR_IS(v &= v, T&);
+  TTS_EXPR_IS(v |= v, T&);
+  TTS_EXPR_IS(v ^= v, T&);
 };
 
 //==================================================================================================
@@ -63,4 +71,13 @@ TTS_CASE_WITH( "Check behavior of bitwise operators on wide and scalar"
   TTS_IEEE_EQUAL( (v_t(1) & a0), T([&](auto i, auto) { return eve::bit_and(v_t(1), a0.get(i)); }));
   TTS_IEEE_EQUAL( (v_t(1) | a0), T([&](auto i, auto) { return eve::bit_or (v_t(1), a0.get(i)); }));
   TTS_IEEE_EQUAL( (v_t(1) ^ a0), T([&](auto i, auto) { return eve::bit_xor(v_t(1), a0.get(i)); }));
+
+  auto cpy = a0; (cpy &= v_t(1));
+  TTS_IEEE_EQUAL(cpy, T([&](auto i, auto) { return eve::bit_and(a0.get(i), v_t(1)); }));
+
+  cpy = a0; (cpy |= v_t(1));
+  TTS_IEEE_EQUAL(cpy, T([&](auto i, auto) { return eve::bit_or(a0.get(i), v_t(1)); }));
+
+  cpy = a0; (cpy ^= v_t(1));
+  TTS_IEEE_EQUAL(cpy, T([&](auto i, auto) { return eve::bit_xor(a0.get(i), v_t(1)); }));
 };


### PR DESCRIPTION
In preparation of moving all `bit_compound` function to proper callables, we found out that the current callable versions of these functions accepted a more relaxed set of parameters, by using `bit_value_t` as a guard instead of `bit_compatible_value`.

The goal of this PR is to see if it would be possible to completly scrap the `bit_compatible_*` family of concepts, as they might not be needed when moving all `bit_compound` functions into their callables counterparts.