### PR TITLE
remove self_negate & improve neon unary minus

### DIFF
--- a/include/eve/arch/cpu/wide.hpp
+++ b/include/eve/arch/cpu/wide.hpp
@@ -30,6 +30,7 @@
 #include <eve/module/core/regular/sub.hpp>
 #include <eve/module/core/regular/mul.hpp>
 #include <eve/module/core/regular/div.hpp>
+#include <eve/module/core/regular/minus.hpp>
 #include <eve/memory/soa_ptr.hpp>
 #include <eve/traits/product_type.hpp>
 
@@ -540,11 +541,11 @@ namespace eve
     //! Unary plus operator
     friend EVE_FORCEINLINE wide operator+(wide const& v) noexcept { return v; }
 
-    //! Unary minus operator. See also: eve::unary_minus
+    //! Unary minus operator. See also: eve::minus
     friend EVE_FORCEINLINE wide operator-(wide const& v) noexcept
         requires(!kumi::product_type<Type>)
     {
-      return self_negate(v);
+      return minus(v);
     }
 
     //! @brief Performs the compound addition on all the wide lanes and assign the result

--- a/include/eve/detail/function/simd/arm/sve/friends.hpp
+++ b/include/eve/detail/function/simd/arm/sve/friends.hpp
@@ -12,14 +12,6 @@
 
 namespace eve::detail
 {
-
-template<signed_scalar_value T, typename N>
-EVE_FORCEINLINE auto self_negate(wide<T,N> const& v) noexcept  -> wide<T, N>
-requires sve_abi<abi_t<T, N>>
-{
-  return svneg_x(sve_true<T>(), v);
-}
-
 template<arithmetic_scalar_value T, typename N>
 EVE_FORCEINLINE auto
 self_eq(wide<T, N> v, wide<T, N> w) noexcept -> as_logical_t<wide<T, N>>

--- a/include/eve/detail/function/simd/common/friends.hpp
+++ b/include/eve/detail/function/simd/common/friends.hpp
@@ -29,22 +29,6 @@ namespace eve::detail
 {
   //================================================================================================
   template<arithmetic_scalar_value T, typename N>
-  EVE_FORCEINLINE auto self_negate(wide<T,N> const& v) noexcept
-  {
-    if constexpr(floating_value<T>)
-    {
-      auto that = v;
-      that ^= signmask(eve::as(v));
-      return that;
-    }
-    else
-    {
-      return T{0} - v;
-    }
-  }
-
-  //================================================================================================
-  template<arithmetic_scalar_value T, typename N>
   EVE_FORCEINLINE auto self_bitnot(wide<T,N> const& v) noexcept
   {
     if constexpr(is_native_v<abi_t<T, N>>)

--- a/include/eve/module/core/regular/impl/simd/arm/neon/minus.hpp
+++ b/include/eve/module/core/regular/impl/simd/arm/neon/minus.hpp
@@ -14,26 +14,36 @@
 
 namespace eve::detail
 {
-template<arithmetic_scalar_value T, typename N>
-EVE_FORCEINLINE wide<T, N>
-minus_(EVE_SUPPORTS(neon128_), wide<T, N> const& v) noexcept requires arm_abi<abi_t<T, N>>
-{
-  constexpr auto cat = categorize<wide<T, N>>();
-
-  if constexpr( match(cat, category::unsigned_) ) return zero(eve::as(v)) - v;
-  else if constexpr( match(cat, category::size64_) ) return zero(eve::as(v)) - v;
-  else if constexpr( cat == category::float32x4 ) return vnegq_f32(v);
-  else if constexpr( cat == category::int32x4 ) return vnegq_s32(v);
-  else if constexpr( cat == category::int16x8 ) return vnegq_s16(v);
-  else if constexpr( cat == category::int8x16 ) return vnegq_s8(v);
-  else if constexpr( cat == category::float32x2 ) return vneg_f32(v);
-  else if constexpr( cat == category::int32x2 ) return vneg_s32(v);
-  else if constexpr( cat == category::int16x4 ) return vneg_s16(v);
-  else if constexpr( cat == category::int8x8 ) return vneg_s8(v);
-  else if constexpr( current_api >= asimd )
+  template<callable_options O, arithmetic_scalar_value T, typename N>
+  EVE_FORCEINLINE wide<T, N> minus_(EVE_REQUIRES(neon128_), O const& opts, wide<T, N> v) noexcept
+    requires arm_abi<abi_t<T, N>>
   {
-    if constexpr( cat == category::float64x2 ) return vnegq_f64(v);
-    else if constexpr( cat == category::float64x1 ) return vneg_f64(v);
+    constexpr auto cat = categorize<wide<T, N>>();
+
+    if constexpr (O::contains(saturated2) && std::integral<T>)
+    {
+      return minus.behavior(cpu_{}, opts, v);
+    }
+    else
+    {
+      if constexpr( cat == category::float32x4 )      return vnegq_f32(v);
+      else if constexpr( cat == category::int32x4 )   return vnegq_s32(v);
+      else if constexpr( cat == category::int16x8 )   return vnegq_s16(v);
+      else if constexpr( cat == category::int8x16 )   return vnegq_s8(v);
+      else if constexpr( cat == category::float32x2 ) return vneg_f32(v);
+      else if constexpr( cat == category::int32x2 )   return vneg_s32(v);
+      else if constexpr( cat == category::int16x4 )   return vneg_s16(v);
+      else if constexpr( cat == category::int8x8 )    return vneg_s8(v);
+      else if constexpr( current_api >= asimd )
+      {
+        if constexpr( cat == category::float64x2 )      return vnegq_f64(v);
+        else if constexpr( cat == category::float64x1 ) return vneg_f64(v);
+        else return minus.behavior(cpu_{}, opts, v);
+      }
+      else
+      {
+        return minus.behavior(cpu_{}, opts, v);
+      }
+    }
   }
-}
 }

--- a/include/eve/module/core/regular/impl/simd/arm/sve/minus.hpp
+++ b/include/eve/module/core/regular/impl/simd/arm/sve/minus.hpp
@@ -13,18 +13,18 @@
 
 namespace eve::detail
 {
-  template<signed_scalar_value T, typename N, callable_options O>
-  requires sve_abi<abi_t<T, N>>
+  template<callable_options O, signed_scalar_value T, typename N>
   EVE_FORCEINLINE wide<T, N> minus_(EVE_REQUIRES(sve_), O const& o, wide<T, N> v) noexcept
+    requires sve_abi<abi_t<T, N>>
   {
     // saturated integer has no intrinsic and floating is better by default
-    if constexpr((O::contains(saturated2) && std::integral<T>) || floating_value<T>)  return minus.behavior(cpu_{},o,v);
-    else                                                                              return svneg_x(sve_true<T>(),v);
+    if constexpr((O::contains(saturated2) && std::integral<T>) || floating_value<T>) return minus.behavior(cpu_{},o,v);
+    else                                                                             return svneg_x(sve_true<T>(),v);
   }
 
-  template<conditional_expr C, signed_scalar_value T, typename N, callable_options O>
-  requires sve_abi<abi_t<T, N>>
+  template<callable_options O, conditional_expr C, signed_scalar_value T, typename N>
   EVE_FORCEINLINE wide<T, N> minus_(EVE_REQUIRES(sve_), C const& mask, O const& o, wide<T, N> v) noexcept
+    requires sve_abi<abi_t<T, N>>
   {
     auto const alt = alternative(mask, v, as(v));
 

--- a/include/eve/module/core/regular/minus.hpp
+++ b/include/eve/module/core/regular/minus.hpp
@@ -87,19 +87,26 @@ namespace eve
     template<typename T, callable_options O>
     EVE_FORCEINLINE constexpr T minus_(EVE_REQUIRES(cpu_), O const &, T v) noexcept
     {
-      if      constexpr( floating_value<T> ) return bit_xor(v, signmask(eve::as(v)));
-      else if constexpr(O::contains(saturated2))
+      if      constexpr (floating_value<T>)
+      {
+        return bit_xor(v, signmask(eve::as(v)));
+      }
+      else if constexpr (O::contains(saturated2))
       {
         return if_else(v == valmin(as<T>()), valmax(as<T>()), minus(v));
       }
       else
       {
-        if constexpr( simd_value<T> ) return -v;
-        else                          return T{0} - v;
+        if constexpr (simd_value<T>) return map(minus, v);
+        else                         return T{0} - v;
       }
     }
   }
 }
+
+#if defined(EVE_INCLUDE_ARM_HEADER)
+#  include <eve/module/core/regular/impl/simd/arm/neon/minus.hpp>
+#endif
 
 #if defined(EVE_INCLUDE_SVE_HEADER)
 #  include <eve/module/core/regular/impl/simd/arm/sve/minus.hpp>


### PR DESCRIPTION
Removed `self_negate` from `friends.hpp`.
Also enabled the neon `minus` backend, this allows for more optimal code in certain scenarios.