### PR TITLE
RISCV bit_cast

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -147,9 +147,9 @@ jobs:
           mkdir build && cd build
           cmake .. -G Ninja -DEVE_OPTIONS="${{ matrix.cfg.opts }}" -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchain/${{ matrix.cfg.comp }}.${{ matrix.cfg.arch }}.cmake
       - name: Compiling Unit Tests
-        run:  cd build && ninja unit.meta.exe unit.arch.exe -j 5
+        run:  cd build && ninja unit.meta.exe unit.arch.exe  unit.core.bit_cast.exe -j 5
       - name: Running Unit Tests
-        run:  cd build && ctest --output-on-failure -j 4  -R "^unit.meta.*.exe|^unit.arch.*.exe"
+        run:  cd build && ctest --output-on-failure -j 4  -R "^unit.meta.*.exe|^unit.arch.*.exe|unit.core.bit_cast.exe"
 
   ##################################################################################################
   ## Mac OS X Targets

--- a/test/unit/module/core/bit_cast.cpp
+++ b/test/unit/module/core/bit_cast.cpp
@@ -10,18 +10,39 @@
 //==================================================================================================
 // Types tests
 //==================================================================================================
+
+// We use sizeof(Wide) to get real occupied size, so if we divide it to the sizeof(Scalar),
+// we get the number of Scalar elements that we need to occupy the same size.
+template<eve::arithmetic_simd_value Wide, typename Scalar>
+using same_size_of =
+    eve::wide<Scalar, eve::fixed<std::max<size_t>(1, sizeof(Wide) / sizeof(Scalar))>>;
+
 TTS_CASE_TPL("Check return types of bit_cast", eve::test::simd::all_types)
 <typename T>(tts::type<T>)
 {
   using ut_t = eve::as_integer_t<T, unsigned>;
   using it_t = eve::as_integer_t<T, signed>;
-  using v_t  = eve::element_type_t<T>;
-  using u8_t = eve::as_wide_t<std::int8_t, eve::fixed<eve::cardinal_v<T> * sizeof(v_t)>>;
+  using u8_t  = same_size_of<T, std::int8_t>;
+  using u16_t = same_size_of<T, std::int16_t>;
+  using u32_t = same_size_of<T, std::int32_t>;
+  using u64_t = same_size_of<T, std::int64_t>;
+  using f32_t = same_size_of<T, float>;
+  using f64_t = same_size_of<T, double>;
   // regular
   TTS_EXPR_IS(eve::bit_cast(T(), eve::as<it_t>()), it_t);
   TTS_EXPR_IS(eve::bit_cast(T(), eve::as<ut_t>()), ut_t);
   TTS_EXPR_IS(eve::bit_cast(T(), eve::as<T>()), T);
   TTS_EXPR_IS(eve::bit_cast(T(), eve::as<u8_t>()), u8_t);
+  if constexpr( sizeof(T) == sizeof(u16_t) )
+    TTS_EXPR_IS(eve::bit_cast(T(), eve::as<u16_t>()), u16_t);
+  if constexpr( sizeof(T) == sizeof(u32_t) )
+    TTS_EXPR_IS(eve::bit_cast(T(), eve::as<u32_t>()), u32_t);
+  if constexpr( sizeof(T) == sizeof(f32_t) )
+    TTS_EXPR_IS(eve::bit_cast(T(), eve::as<f32_t>()), f32_t);
+  if constexpr( sizeof(T) == sizeof(u64_t) )
+    TTS_EXPR_IS(eve::bit_cast(T(), eve::as<u64_t>()), u64_t);
+  if constexpr( sizeof(T) == sizeof(f64_t) )
+    TTS_EXPR_IS(eve::bit_cast(T(), eve::as<f64_t>()), f64_t);
 };
 
 //==================================================================================================


### PR DESCRIPTION
Hi

This patch improves `bit_cast` support for RISC-V `Wide` types. Now instead of using `std::bit_cast`, that could lead to `std::memcpy`, we use pseudo intrinsics, that will result in no real code.

Also I've added some tests for `bit_cast` to check that expected combination of types will be supported.