### PR TITLE
Add RISC-V support for simd_cast

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -147,9 +147,9 @@ jobs:
           mkdir build && cd build
           cmake .. -G Ninja -DEVE_OPTIONS="${{ matrix.cfg.opts }}" -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchain/${{ matrix.cfg.comp }}.${{ matrix.cfg.arch }}.cmake
       - name: Compiling Unit Tests
-        run:  cd build && ninja unit.meta.exe unit.arch.exe  unit.core.bit_cast.exe -j 5
+        run:  cd build && ninja unit.meta.exe unit.arch.exe  unit.core.bit_cast.exe unit.api.regular.wide.exe unit.core.simd_cast.exe -j 5
       - name: Running Unit Tests
-        run:  cd build && ctest --output-on-failure -j 4  -R "^unit.meta.*.exe|^unit.arch.*.exe|unit.core.bit_cast.exe"
+        run:  cd build && ctest --output-on-failure -j 4  -R "^unit.meta.*.exe|^unit.arch.*.exe|unit.core.bit_cast.exe|unit.api.regular.wide.exe|unit.core.simd_cast.exe"
 
   ##################################################################################################
   ## Mac OS X Targets

--- a/cmake/toolchain/clang.riscv.cmake
+++ b/cmake/toolchain/clang.riscv.cmake
@@ -9,5 +9,5 @@ set(CMAKE_SYSTEM_PROCESSOR  riscv64)
 set(CMAKE_C_COMPILER    /opt/llvm/bin/clang)
 set(CMAKE_CXX_COMPILER  /opt/llvm/bin/clang++)
 
-set(CMAKE_CXX_FLAGS "-march=rv64gcv --static --target=riscv64-unknown-linux-gnu ${EVE_OPTIONS}" )
+set(CMAKE_CXX_FLAGS "-march=rv64gcv --static -fbracket-depth=512 --target=riscv64-unknown-linux-gnu ${EVE_OPTIONS}" )
 set(CMAKE_CROSSCOMPILING_CMD ${PROJECT_SOURCE_DIR}/cmake/toolchain/run_rvv128.sh )

--- a/include/eve/detail/function/simd/riscv/combine.hpp
+++ b/include/eve/detail/function/simd/riscv/combine.hpp
@@ -8,20 +8,17 @@
 #pragma once
 
 #include <eve/arch.hpp>
-#include <eve/arch/riscv/rvv_common_masks.hpp>
 #include <eve/detail/abi.hpp>
-#include <eve/module/core/regular/if_else.hpp>
 
 namespace eve::detail
 {
 template<typename T, typename N>
-EVE_FORCEINLINE auto
-combine(rvv_ const&, wide<T, N> l, wide<T, N> h) noexcept
+EVE_FORCEINLINE wide<T, typename N::combined_type>
+                combine(rvv_ const&, wide<T, N> l, wide<T, N> h) noexcept
 requires rvv_abi<abi_t<T, N>>
 {
   using that_t = wide<T, typename N::combined_type>;
 
-  constexpr size_t combined_vl = N::combined_type::value;
   if constexpr( eve::has_aggregated_abi_v<that_t> )
   {
     that_t that;
@@ -33,10 +30,11 @@ requires rvv_abi<abi_t<T, N>>
     auto           wider_l        = simd_cast(l, as<that_t> {});
     auto           wider_h        = simd_cast(h, as<that_t> {});
     constexpr auto shift_size     = N::value;
+    constexpr size_t combined_vl    = N::combined_type::value;
     that_t         wider_h_placed = __riscv_vslideup(wider_h, wider_h, shift_size, combined_vl);
-    auto           mask_all_ones  = rvv_true<T, N>();
-    auto           wider_mask     = simd_cast(mask_all_ones, as<logical<that_t>> {});
-    return if_else(wider_mask, wider_l, wider_h_placed);
+    // TODO: can be optimized when simd_cast will support conversions wide<->logical
+    logical<that_t> mask([shift_size](auto i, auto) { return i < shift_size; });
+    return __riscv_vmerge(wider_h_placed, wider_l, mask, combined_vl);
   }
 }
 
@@ -45,9 +43,7 @@ EVE_FORCEINLINE auto
 combine(rvv_ const&, logical<wide<T, N>> l, logical<wide<T, N>> h) noexcept
 requires rvv_abi<abi_t<T, N>>
 {
-  constexpr size_t combined_vl = N::combined_type::value;
-  using that_t                 = logical<wide<T, typename N::combined_type>>;
-
+  using that_t = logical<wide<T, typename N::combined_type>>;
   if constexpr( eve::has_aggregated_abi_v<that_t> )
   {
     that_t that;

--- a/include/eve/detail/function/simd/riscv/slice.hpp
+++ b/include/eve/detail/function/simd/riscv/slice.hpp
@@ -15,95 +15,6 @@
 
 namespace eve::detail
 {
-// TODO: move this to `simd_cast`
-template<plain_scalar_value T, typename N>
-EVE_FORCEINLINE wide<T, typename N::split_type>
-                riscv_lmul_trunc(wide<T, N> a) noexcept
-requires rvv_abi<abi_t<T, N>>
-{
-  constexpr auto c        = categorize<wide<T, typename N::split_type>>();
-  constexpr auto out_lmul = rvv_lmul_v<T, typename N::split_type>;
-  constexpr auto in_lmul  = rvv_lmul_v<T, N>;
-  if constexpr( out_lmul == in_lmul ) return a.storage();
-  else
-  {
-    static_assert(in_lmul > out_lmul);
-
-    if constexpr( match(c, category::float64) )
-    {
-      if constexpr( out_lmul == 1 ) return __riscv_vlmul_trunc_f64m1(a);
-      else if constexpr( out_lmul == 2 ) return __riscv_vlmul_trunc_f64m2(a);
-      else if constexpr( out_lmul == 4 ) return __riscv_vlmul_trunc_f64m4(a);
-    }
-    else if constexpr( match(c, category::int64) )
-    {
-      if constexpr( out_lmul == 1 ) return __riscv_vlmul_trunc_i64m1(a);
-      else if constexpr( out_lmul == 2 ) return __riscv_vlmul_trunc_i64m2(a);
-      else if constexpr( out_lmul == 4 ) return __riscv_vlmul_trunc_i64m4(a);
-    }
-    else if constexpr( match(c, category::uint64) )
-    {
-      if constexpr( out_lmul == 1 ) return __riscv_vlmul_trunc_u64m1(a);
-      else if constexpr( out_lmul == 2 ) return __riscv_vlmul_trunc_u64m2(a);
-      else if constexpr( out_lmul == 4 ) return __riscv_vlmul_trunc_u64m4(a);
-    }
-    else if constexpr( match(c, category::float32) )
-    {
-      if constexpr( out_lmul == -2 ) return __riscv_vlmul_trunc_f32mf2(a);
-      else if constexpr( out_lmul == 1 ) return __riscv_vlmul_trunc_f32m1(a);
-      else if constexpr( out_lmul == 2 ) return __riscv_vlmul_trunc_f32m2(a);
-      else if constexpr( out_lmul == 4 ) return __riscv_vlmul_trunc_f32m4(a);
-    }
-    else if constexpr( match(c, category::int32) )
-    {
-      if constexpr( out_lmul == -2 ) return __riscv_vlmul_trunc_i32mf2(a);
-      else if constexpr( out_lmul == 1 ) return __riscv_vlmul_trunc_i32m1(a);
-      else if constexpr( out_lmul == 2 ) return __riscv_vlmul_trunc_i32m2(a);
-      else if constexpr( out_lmul == 4 ) return __riscv_vlmul_trunc_i32m4(a);
-    }
-    else if constexpr( match(c, category::uint32) )
-    {
-      if constexpr( out_lmul == -2 ) return __riscv_vlmul_trunc_u32mf2(a);
-      else if constexpr( out_lmul == 1 ) return __riscv_vlmul_trunc_u32m1(a);
-      else if constexpr( out_lmul == 2 ) return __riscv_vlmul_trunc_u32m2(a);
-      else if constexpr( out_lmul == 4 ) return __riscv_vlmul_trunc_u32m4(a);
-    }
-    else if constexpr( match(c, category::int16) )
-    {
-      if constexpr( out_lmul == -4 ) return __riscv_vlmul_trunc_i16mf4(a);
-      else if constexpr( out_lmul == -2 ) return __riscv_vlmul_trunc_i16mf2(a);
-      else if constexpr( out_lmul == 1 ) return __riscv_vlmul_trunc_i16m1(a);
-      else if constexpr( out_lmul == 2 ) return __riscv_vlmul_trunc_i16m2(a);
-      else if constexpr( out_lmul == 4 ) return __riscv_vlmul_trunc_i16m4(a);
-    }
-    else if constexpr( match(c, category::uint16) )
-    {
-      if constexpr( out_lmul == -4 ) return __riscv_vlmul_trunc_u16mf4(a);
-      else if constexpr( out_lmul == -2 ) return __riscv_vlmul_trunc_u16mf2(a);
-      else if constexpr( out_lmul == 1 ) return __riscv_vlmul_trunc_u16m1(a);
-      else if constexpr( out_lmul == 2 ) return __riscv_vlmul_trunc_u16m2(a);
-      else if constexpr( out_lmul == 4 ) return __riscv_vlmul_trunc_u16m4(a);
-    }
-    else if constexpr( match(c, category::int8) )
-    {
-      if constexpr( out_lmul == -8 ) return __riscv_vlmul_trunc_i8mf8(a);
-      else if constexpr( out_lmul == -4 ) return __riscv_vlmul_trunc_i8mf4(a);
-      else if constexpr( out_lmul == -2 ) return __riscv_vlmul_trunc_i8mf2(a);
-      else if constexpr( out_lmul == 1 ) return __riscv_vlmul_trunc_i8m1(a);
-      else if constexpr( out_lmul == 2 ) return __riscv_vlmul_trunc_i8m2(a);
-      else if constexpr( out_lmul == 4 ) return __riscv_vlmul_trunc_i8m4(a);
-    }
-    else if constexpr( match(c, category::uint8) )
-    {
-      if constexpr( out_lmul == -8 ) return __riscv_vlmul_trunc_u8mf8(a);
-      else if constexpr( out_lmul == -4 ) return __riscv_vlmul_trunc_u8mf4(a);
-      else if constexpr( out_lmul == -2 ) return __riscv_vlmul_trunc_u8mf2(a);
-      else if constexpr( out_lmul == 1 ) return __riscv_vlmul_trunc_u8m1(a);
-      else if constexpr( out_lmul == 2 ) return __riscv_vlmul_trunc_u8m2(a);
-      else if constexpr( out_lmul == 4 ) return __riscv_vlmul_trunc_u8m4(a);
-    }
-  }
-}
 
 //================================================================================================
 // Single slice
@@ -117,11 +28,7 @@ requires rvv_abi<abi_t<T, N>>
   constexpr auto in_lmul  = rvv_lmul_v<T, N>;
   constexpr auto out_lmul = rvv_lmul_v<T, typename N::split_type>;
   if constexpr( in_lmul == out_lmul ) return a.storage();
-  else
-  {
-    // we need to lower lmul - call lmul trunc.
-    return riscv_lmul_trunc(a);
-  }
+  else { return simd_cast(a, as<wide<T, typename N::split_type>> {}); }
 }
 
 template<callable_options O, typename T, typename N>
@@ -137,7 +44,7 @@ requires rvv_abi<abi_t<T, N>>
   else
   {
     // we need to lower lmul - call lmul trunc.
-    return riscv_lmul_trunc(res);
+    return simd_cast(res, as<wide<T, typename N::split_type>> {});
   }
 }
 

--- a/test/tts/tts.hpp
+++ b/test/tts/tts.hpp
@@ -432,6 +432,19 @@ namespace tts
   };
   template<typename... Ls> struct concatenate { using type = decltype( (Ls{} + ...) ); };
   template<typename... Ls> using concatenate_t = typename concatenate<Ls...>::type;
+  // filter types with predicate
+  template<template<typename> typename Pred, typename Type> struct filter
+  {
+    template<typename... Ls> static constexpr types<Ls...> tuple_to_types(const std::tuple<Ls...>&);
+    template<typename T>
+    static constexpr std::conditional_t<Pred<T>::value, std::tuple<T>, std::tuple<>> filter_type();
+
+    template<typename... Ls> static constexpr auto filter_impl(types<Ls...>)
+    {
+      return tuple_to_types(std::tuple_cat(filter_type<Ls>()...));
+    }
+    using type = decltype(filter_impl(Type {}));
+  };
   template<typename T> struct type {};
   using real_types        = types < double,float>;
   using int_types         = types < std::int64_t , std::int32_t , std::int16_t , std::int8_t>;

--- a/test/unit/module/core/simd_cast.cpp
+++ b/test/unit/module/core/simd_cast.cpp
@@ -57,11 +57,12 @@ simd_cast_test_one_way()
 
   U actual = eve::simd_cast(x, eve::as<U> {});
 
-  // the bit nature of logicals on avx512 (rvv probably too)
+  // the bit nature of logicals on avx512 and rvv
   // makes the byte level comparisons not work,
   // because part of the byte be garbage we need to ignore.
   // That doesn't happen on other platfroms.
-  if constexpr( eve::logical_simd_value<T> && eve::current_api >= eve::avx512 )
+  if constexpr( eve::logical_simd_value<T>
+                && (eve::current_api >= eve::avx512 || eve::current_api >= eve::rvv) )
   {
     std::ptrdiff_t min_len = std::min(T::size(), U::size());
     for( std::ptrdiff_t i = 0; i != min_len; ++i ) { TTS_EQUAL(x.get(i), actual.get(i)); }


### PR DESCRIPTION
Hi

This patches add extends support for `simd_cast` for RISC-V. Also I'm fixing `combine` and `to_logical` functions for RISC-V and turn on wide api test, to be sure that `combine` and `slice` works fine.

Cast from logical to wide still prohibited.