### PR TITLE
Granularize Boost.Math dependencies in tests

### DIFF
--- a/cmake/config/dependencies.cmake
+++ b/cmake/config/dependencies.cmake
@@ -10,7 +10,6 @@
 find_package(Boost 1.74.0 QUIET)
 
 if(Boost_FOUND)
-  set(EVE_USE_BOOST 1)
   message( STATUS "[eve] Boost found in ${Boost_INCLUDE_DIRS} - Boost dependent tests activated")
 else()
   set(Boost_INCLUDE_DIRS "")

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -85,14 +85,9 @@ add_custom_target(unit.combinatorial.exe         )
 add_dependencies(unit.exe unit.combinatorial.exe )
 glob_unit("unit" ${unit_root} "module/combinatorial/*.cpp" )
 
-if(EVE_USE_BOOST)
 add_custom_target(unit.bessel.exe         )
 add_dependencies(unit.exe unit.bessel.exe )
 glob_unit("unit" ${unit_root} "module/bessel/*.cpp" )
-
-# add_custom_target(unit.complex.exe         )
-# add_dependencies(unit.exe unit.complex.exe )
-# glob_unit("unit" ${unit_root} "module/complex/*.cpp" )
 
 add_custom_target(unit.elliptic.exe         )
 add_dependencies(unit.exe unit.elliptic.exe )
@@ -107,12 +102,6 @@ add_custom_target(unit.polynomial.exe         )
 add_dependencies(unit.exe unit.polynomial.exe )
 glob_unit("unit" ${unit_root} "module/polynomial/*.cpp" )
 
-# add_custom_target(unit.quaternion.exe         )
-# add_dependencies(unit.exe unit.quaternion.exe )
-# glob_unit("unit" ${unit_root} "module/quaternion/*.cpp" )
-
 add_custom_target(unit.special.exe         )
 add_dependencies(unit.exe unit.special.exe )
 glob_unit("unit" ${unit_root} "module/special/*.cpp" )
-
-endif()

--- a/test/unit/module/bessel/airy_ai.cpp
+++ b/test/unit/module/bessel/airy_ai.cpp
@@ -10,8 +10,12 @@
 #include <eve/module/bessel.hpp>
 #include <eve/module/core.hpp>
 
+#if __has_include(<boost/math/special_functions/airy.hpp>)
 #include <boost/math/special_functions/airy.hpp>
+#define EVE_HAS_BOOST
+#endif
 
+#if defined(EVE_HAS_BOOST)
 TTS_CASE_TPL("Check return types of airy_ai", eve::test::simd::ieee_reals)
 <typename T>(tts::type<T>)
 {
@@ -87,3 +91,9 @@ TTS_CASE_WITH("Check behavior of eve::masked(eve::airy_ai)(eve::wide)",
 {
   TTS_IEEE_EQUAL(eve::airy_ai[mask](a0),eve::if_else(mask, eve::airy_ai(a0), a0));
 };
+#else
+TTS_CASE("Check return types of airy_ai")
+{
+  TTS_PASS("SKipping due to no reference available");
+};
+#endif

--- a/test/unit/module/bessel/airy_bi.cpp
+++ b/test/unit/module/bessel/airy_bi.cpp
@@ -6,11 +6,14 @@
 **/
 //==================================================================================================
 #include "test.hpp"
-
 #include <eve/module/bessel.hpp>
 
+#if __has_include(<boost/math/special_functions/airy.hpp>)
 #include <boost/math/special_functions/airy.hpp>
+#define EVE_HAS_BOOST
+#endif
 
+#if defined(EVE_HAS_BOOST)
 TTS_CASE_TPL("Check return types of airy_bi", eve::test::simd::ieee_reals)
 <typename T>(tts::type<T>)
 {
@@ -84,3 +87,10 @@ TTS_CASE_WITH("Check behavior of eve::masked(eve::airy_bi)(eve::wide)",
 {
   TTS_IEEE_EQUAL(eve::airy_bi[mask](a0), eve::if_else(mask, eve::airy_bi(a0), a0));
 };
+#else
+TTS_CASE("Check return types of airy_bi")
+{
+  TTS_PASS("SKipping due to no reference available");
+};
+#endif
+

--- a/test/unit/module/elliptic/ellint_1.cpp
+++ b/test/unit/module/elliptic/ellint_1.cpp
@@ -11,8 +11,12 @@
 #include <eve/module/elliptic.hpp>
 #include <eve/module/math.hpp>
 
+#if __has_include(<boost/math/special_functions/ellint_1.hpp>)
 #include <boost/math/special_functions/ellint_1.hpp>
+#define EVE_HAS_BOOST
+#endif
 
+#if defined(EVE_HAS_BOOST)
 //==================================================================================================
 // Types tests
 //==================================================================================================
@@ -65,3 +69,10 @@ TTS_CASE_WITH("Check behavior of eve::masked(eve::ellint_1)(eve::wide)",
   TTS_IEEE_EQUAL(eve::ellint_1[mask](a0, a1),
             eve::if_else(mask, eve::ellint_1(a0, a1), a0));
 };
+#else
+TTS_CASE("Check return types of ellint_1")
+{
+  TTS_PASS("SKipping due to no reference available");
+};
+#endif
+

--- a/test/unit/module/elliptic/ellint_2.cpp
+++ b/test/unit/module/elliptic/ellint_2.cpp
@@ -11,8 +11,12 @@
 #include <eve/module/elliptic.hpp>
 #include <eve/module/math.hpp>
 
+#if __has_include(<boost/math/special_functions/ellint_2.hpp>)
 #include <boost/math/special_functions/ellint_2.hpp>
+#define EVE_HAS_BOOST
+#endif
 
+#if defined(EVE_HAS_BOOST)
 //==================================================================================================
 // Types tests
 //==================================================================================================
@@ -65,3 +69,9 @@ TTS_CASE_WITH("Check behavior of eve::masked(eve::ellint_2)(eve::wide)",
   TTS_IEEE_EQUAL(eve::ellint_2[mask](a0, a1),
             eve::if_else(mask, eve::ellint_2(a0, a1), a0));
 };
+#else
+TTS_CASE("Check return types of ellint_2")
+{
+  TTS_PASS("SKipping due to no reference available");
+};
+#endif

--- a/test/unit/module/elliptic/ellint_d.cpp
+++ b/test/unit/module/elliptic/ellint_d.cpp
@@ -11,8 +11,12 @@
 #include <eve/module/elliptic.hpp>
 #include <eve/module/math.hpp>
 
+#if __has_include(<boost/math/special_functions/ellint_d.hpp>)
 #include <boost/math/special_functions/ellint_d.hpp>
+#define EVE_HAS_BOOST
+#endif
 
+#if defined(EVE_HAS_BOOST)
 //==================================================================================================
 // Types tests
 //==================================================================================================
@@ -65,3 +69,10 @@ TTS_CASE_WITH("Check behavior of eve::masked(eve::ellint_d)(eve::wide)",
   TTS_IEEE_EQUAL(eve::ellint_d[mask](a0, a1),
             eve::if_else(mask, eve::ellint_d(a0, a1), a0));
 };
+#else
+TTS_CASE("Check return types of ellint_d")
+{
+  TTS_PASS("SKipping due to no reference available");
+};
+#endif
+

--- a/test/unit/module/elliptic/ellint_rc.cpp
+++ b/test/unit/module/elliptic/ellint_rc.cpp
@@ -11,8 +11,12 @@
 #include <eve/module/elliptic.hpp>
 #include <eve/module/math.hpp>
 
+#if __has_include(<boost/math/special_functions/ellint_rc.hpp>)
 #include <boost/math/special_functions/ellint_rc.hpp>
+#define EVE_HAS_BOOST
+#endif
 
+#if defined(EVE_HAS_BOOST)
 //==================================================================================================
 // Types tests
 //==================================================================================================
@@ -59,3 +63,10 @@ TTS_CASE_WITH("Check behavior of eve::masked(eve::ellint_rc)(eve::wide)",
   TTS_IEEE_EQUAL(eve::ellint_rc[mask](a0, a1),
             eve::if_else(mask, eve::ellint_rc(a0, a1), a0));
 };
+#else
+TTS_CASE("Check return types of ellint_rc")
+{
+  TTS_PASS("SKipping due to no reference available");
+};
+#endif
+

--- a/test/unit/module/elliptic/ellint_rd.cpp
+++ b/test/unit/module/elliptic/ellint_rd.cpp
@@ -11,8 +11,12 @@
 #include <eve/module/elliptic.hpp>
 #include <eve/module/math.hpp>
 
+#if __has_include(<boost/math/special_functions/ellint_rd.hpp>)
 #include <boost/math/special_functions/ellint_rd.hpp>
+#define EVE_HAS_BOOST
+#endif
 
+#if defined(EVE_HAS_BOOST)
 //==================================================================================================
 // Types tests
 //==================================================================================================
@@ -66,3 +70,10 @@ TTS_CASE_WITH("Check behavior of eve::masked(eve::ellint_rd)(eve::wide)",
   TTS_IEEE_EQUAL(eve::ellint_rd[mask](a0, a1, a2),
             eve::if_else(mask, eve::ellint_rd(a0, a1, a2), a0));
 };
+#else
+TTS_CASE("Check return types of ellint_rd")
+{
+  TTS_PASS("SKipping due to no reference available");
+};
+#endif
+

--- a/test/unit/module/elliptic/ellint_rf.cpp
+++ b/test/unit/module/elliptic/ellint_rf.cpp
@@ -11,8 +11,12 @@
 #include <eve/module/elliptic.hpp>
 #include <eve/module/math.hpp>
 
+#if __has_include(<boost/math/special_functions/ellint_rf.hpp>)
 #include <boost/math/special_functions/ellint_rf.hpp>
+#define EVE_HAS_BOOST
+#endif
 
+#if defined(EVE_HAS_BOOST)
 //==================================================================================================
 // Types tests
 //==================================================================================================
@@ -66,3 +70,9 @@ TTS_CASE_WITH("Check behavior of eve::masked(eve::ellint_rf)(eve::wide)",
   TTS_IEEE_EQUAL(eve::ellint_rf[mask](a0, a1, a2),
             eve::if_else(mask, eve::ellint_rf(a0, a1, a2), a0));
 };
+#else
+TTS_CASE("Check return types of ellint_rf")
+{
+  TTS_PASS("SKipping due to no reference available");
+};
+#endif

--- a/test/unit/module/elliptic/ellint_rg.cpp
+++ b/test/unit/module/elliptic/ellint_rg.cpp
@@ -11,8 +11,12 @@
 #include <eve/module/elliptic.hpp>
 #include <eve/module/math.hpp>
 
+#if __has_include(<boost/math/special_functions/ellint_rg.hpp>)
 #include <boost/math/special_functions/ellint_rg.hpp>
+#define EVE_HAS_BOOST
+#endif
 
+#if defined(EVE_HAS_BOOST)
 //==================================================================================================
 // Types tests
 //==================================================================================================
@@ -66,3 +70,10 @@ TTS_CASE_WITH("Check behavior of eve::masked(eve::ellint_rg)(eve::wide)",
   TTS_IEEE_EQUAL(eve::ellint_rg[mask](a0, a1, a2),
             eve::if_else(mask, eve::ellint_rg(a0, a1, a2), a0));
 };
+#else
+TTS_CASE("Check return types of ellint_rg")
+{
+  TTS_PASS("SKipping due to no reference available");
+};
+#endif
+

--- a/test/unit/module/elliptic/ellint_rj.cpp
+++ b/test/unit/module/elliptic/ellint_rj.cpp
@@ -13,8 +13,12 @@
 
 #include <cmath>
 
+#if __has_include(<boost/math/special_functions/ellint_rj.hpp>)
 #include <boost/math/special_functions/ellint_rj.hpp>
+#define EVE_HAS_BOOST
+#endif
 
+#if defined(EVE_HAS_BOOST)
 //==================================================================================================
 // Types tests
 //==================================================================================================
@@ -83,3 +87,10 @@ TTS_CASE_WITH("Check behavior of eve::masked(eve::ellint_rj)(eve::wide)",
   TTS_IEEE_EQUAL(eve::ellint_rj[mask](a0, a1, a2, a3),
             eve::if_else(mask, eve::ellint_rj(a0, a1, a2, a3), a0));
 };
+#else
+TTS_CASE("Check return types of ellint_rj")
+{
+  TTS_PASS("SKipping due to no reference available");
+};
+#endif
+

--- a/test/unit/module/polynomial/gegenbauer.cpp
+++ b/test/unit/module/polynomial/gegenbauer.cpp
@@ -9,8 +9,12 @@
 
 #include <eve/module/polynomial.hpp>
 
+#if __has_include(<boost/math/special_functions/gegenbauer.hpp>)
 #include <boost/math/special_functions/gegenbauer.hpp>
+#define EVE_HAS_BOOST
+#endif
 
+#if defined(EVE_HAS_BOOST)
 //==================================================================================================
 //== Types tests
 //==================================================================================================
@@ -63,3 +67,10 @@ TTS_CASE_WITH("Check behavior of gegenbauer on wide",
     }
   }
 };
+#else
+TTS_CASE("Check return types of gegenbauer")
+{
+  TTS_PASS("SKipping due to no reference available");
+};
+#endif
+

--- a/test/unit/module/polynomial/hermite.cpp
+++ b/test/unit/module/polynomial/hermite.cpp
@@ -8,15 +8,19 @@
 #include "test.hpp"
 
 #include <eve/module/polynomial.hpp>
-#if defined(cpp_lib_math_special_functions)
-#include <cmath>
-#define NAMESPACE std
+
+#if defined(__cpp_lib_math_special_functions)
+# define NAMESPACE std
+# define EVE_HAS_MATH
 #else
-#include <boost/math/special_functions/hermite.hpp>
-#define NAMESPACE boost::math
+# if __has_include(<boost/math/special_functions/hermite.hpp>)
+#   include <boost/math/special_functions/hermite.hpp>
+#   define EVE_HAS_MATH
+#   define NAMESPACE boost::math
+# endif
 #endif
 
-
+#if defined(EVE_HAS_MATH)
 //==================================================================================================
 //== Types tests
 //==================================================================================================
@@ -65,3 +69,10 @@ TTS_CASE_WITH("Check behavior of hermite on wide",
     }
   }
 };
+#else
+TTS_CASE("Check return types of hermite")
+{
+  TTS_PASS("SKipping due to no reference available");
+};
+#endif
+

--- a/test/unit/module/polynomial/jacobi.cpp
+++ b/test/unit/module/polynomial/jacobi.cpp
@@ -9,9 +9,12 @@
 
 #include <eve/module/polynomial.hpp>
 
+#if __has_include(<boost/math/special_functions/jacobi.hpp>)
 #include <boost/math/special_functions/jacobi.hpp>
+#define EVE_HAS_BOOST
+#endif
 
-
+#if defined(EVE_HAS_BOOST)
 //==================================================================================================
 // Types tests
 //==================================================================================================
@@ -41,3 +44,10 @@ TTS_CASE_WITH( "Check behavior of diff jacobi on wide"
   auto bdt1 = [&](auto i, auto e, auto f,  auto g){return boost::math::jacobi(i, e, f, g); };
   TTS_ULP_EQUAL(dt, eve::detail::map(bdt1, i0, a0, a1, a2), 1000);
 };
+#else
+TTS_CASE("Check return types of jacobi")
+{
+  TTS_PASS("SKipping due to no reference available");
+};
+#endif
+

--- a/test/unit/module/polynomial/laguerre.cpp
+++ b/test/unit/module/polynomial/laguerre.cpp
@@ -10,12 +10,17 @@
 #include <eve/module/polynomial.hpp>
 
 #if defined(__cpp_lib_math_special_functions)
-#define NAMESPACE std
+# define NAMESPACE std
+# define EVE_HAS_MATH
 #else
-#include <boost/math/special_functions/laguerre.hpp>
-#define NAMESPACE boost::math
+# if __has_include(<boost/math/special_functions/laguerre.hpp>)
+#   include <boost/math/special_functions/laguerre.hpp>
+#   define EVE_HAS_MATH
+#   define NAMESPACE boost::math
+# endif
 #endif
 
+#if defined(EVE_HAS_MATH)
 //==================================================================================================
 //== Types tests
 //==================================================================================================
@@ -66,3 +71,10 @@ TTS_CASE_WITH("Check behavior of laguerre on wide",
     }
   }
 };
+#else
+TTS_CASE("Check return types of laguerre")
+{
+  TTS_PASS("SKipping due to no reference available");
+};
+#endif
+

--- a/test/unit/module/polynomial/tchebytchev.cpp
+++ b/test/unit/module/polynomial/tchebytchev.cpp
@@ -6,11 +6,14 @@
 **/
 //==================================================================================================
 #include "test.hpp"
-
 #include <eve/module/polynomial.hpp>
 
+#if __has_include(<boost/math/special_functions/chebyshev.hpp>)
 #include <boost/math/special_functions/chebyshev.hpp>
+#define EVE_HAS_BOOST
+#endif
 
+#if defined(EVE_HAS_BOOST)
 //==================================================================================================
 //== Types tests
 //==================================================================================================
@@ -73,3 +76,11 @@ TTS_CASE_WITH("Check behavior of successor(tchebytchev)",
   auto u5 = eve::tchebytchev[kind_2](5, a0);
   TTS_ULP_EQUAL(eve::tchebytchev[eve::successor](a0, u4, u3), u5, 300);
 };
+#else
+TTS_CASE("Check return types of tchebytchev")
+{
+  TTS_PASS("SKipping due to no reference available");
+};
+#endif
+
+

--- a/test/unit/module/special/double_factorial.cpp
+++ b/test/unit/module/special/double_factorial.cpp
@@ -9,8 +9,12 @@
 
 #include <eve/module/special.hpp>
 
+#if __has_include(<boost/math/special_functions/factorials.hpp>)
 #include <boost/math/special_functions/factorials.hpp>
+#define EVE_HAS_BOOST
+#endif
 
+#if defined(EVE_HAS_BOOST)
 //==================================================================================================
 // Types tests
 //==================================================================================================
@@ -46,3 +50,9 @@ TTS_CASE_TPL("Check corner-cases behavior of eve::double_factorial on wide",
     TTS_ULP_EQUAL(eve::double_factorial(T(302)), eve::inf(eve::as<d_t>()), 0);
   }
 };
+#else
+TTS_CASE("Check return types of double_factorial")
+{
+  TTS_PASS("SKipping due to no reference available");
+};
+#endif

--- a/test/unit/module/special/erf_inv.cpp
+++ b/test/unit/module/special/erf_inv.cpp
@@ -10,8 +10,12 @@
 #include <eve/module/core.hpp>
 #include <eve/module/special.hpp>
 
+#if __has_include(<boost/math/special_functions/erf.hpp>)
 #include <boost/math/special_functions/erf.hpp>
+#define EVE_HAS_BOOST
+#endif
 
+#if defined(EVE_HAS_BOOST)
 //==================================================================================================
 // Types tests
 //==================================================================================================
@@ -85,3 +89,10 @@ TTS_CASE_WITH("Check behavior of eve::masked(eve::erf_inv)(eve::wide)",
   TTS_IEEE_EQUAL(eve::erf_inv[mask](a0),
             eve::if_else(mask, eve::erf_inv(a0), a0));
 };
+#else
+TTS_CASE("Check return types of erf_inv")
+{
+  TTS_PASS("SKipping due to no reference available");
+};
+#endif
+

--- a/test/unit/module/special/erfc_inv.cpp
+++ b/test/unit/module/special/erfc_inv.cpp
@@ -12,11 +12,15 @@
 #include <eve/module/special.hpp>
 #include <eve/arch/platform.hpp>
 
+#include <type_traits>
 #include <cmath>
 
+#if __has_include(<boost/math/special_functions/erf.hpp>)
 #include <boost/math/special_functions/erf.hpp>
-#include <type_traits>
+#define EVE_HAS_BOOST
+#endif
 
+#if defined(EVE_HAS_BOOST)
 //==================================================================================================
 // Types tests
 //==================================================================================================
@@ -87,3 +91,10 @@ TTS_CASE_WITH("Check behavior of eve::masked(eve::erfc_inv)(eve::wide)",
   TTS_IEEE_EQUAL(eve::erfc_inv[mask](a0),
             eve::if_else(mask, eve::erfc_inv(a0), a0));
 };
+#else
+TTS_CASE("Check return types of erfc_inv")
+{
+  TTS_PASS("SKipping due to no reference available");
+};
+#endif
+

--- a/test/unit/module/special/exp_int.cpp
+++ b/test/unit/module/special/exp_int.cpp
@@ -9,11 +9,14 @@
 
 #include <eve/module/core.hpp>
 #include <eve/module/special.hpp>
-
 #include <cmath>
 
+#if __has_include(<boost/math/special_functions/expint.hpp>)
 #include <boost/math/special_functions/expint.hpp>
+#define EVE_HAS_BOOST
+#endif
 
+#if defined(EVE_HAS_BOOST)
 //==================================================================================================
 // Types tests
 //==================================================================================================
@@ -73,3 +76,9 @@ TTS_CASE_WITH("Check behavior of exp_int on wide",
   TTS_ULP_EQUAL(
       exp_int(elt_t(6000), elt_t(0.5)), (boost::math::expint(elt_t(6000), elt_t(0.5))), 4.0);
 };
+#else
+TTS_CASE("Check return types of expint")
+{
+  TTS_PASS("SKipping due to no reference available");
+};
+#endif

--- a/test/unit/module/special/gamma_p.cpp
+++ b/test/unit/module/special/gamma_p.cpp
@@ -9,11 +9,14 @@
 
 #include <eve/module/core.hpp>
 #include <eve/module/special.hpp>
-
 #include <cmath>
 
+#if __has_include(<boost/math/special_functions/gamma.hpp>)
 #include <boost/math/special_functions/gamma.hpp>
+#define EVE_HAS_BOOST
+#endif
 
+#if defined(EVE_HAS_BOOST)
 //==================================================================================================
 // Types tests
 //==================================================================================================
@@ -82,3 +85,10 @@ TTS_CASE_WITH("Check behavior of eve::masked(eve::gamma_p)(eve::wide)",
   TTS_IEEE_EQUAL(eve::gamma_p[mask](a0, a1),
             eve::if_else(mask, eve::gamma_p(a0, a1), a0));
 };
+#else
+TTS_CASE("Check return types of gamma_p")
+{
+  TTS_PASS("SKipping due to no reference available");
+};
+#endif
+

--- a/test/unit/module/special/gamma_p_inv.cpp
+++ b/test/unit/module/special/gamma_p_inv.cpp
@@ -9,11 +9,14 @@
 
 #include <eve/module/core.hpp>
 #include <eve/module/special.hpp>
-
 #include <cmath>
 
+#if __has_include(<boost/math/special_functions/gamma.hpp>)
 #include <boost/math/special_functions/gamma.hpp>
+#define EVE_HAS_BOOST
+#endif
 
+#if defined(EVE_HAS_BOOST)
 //==================================================================================================
 // Types tests
 //==================================================================================================
@@ -76,3 +79,10 @@ TTS_CASE_WITH("Check behavior of eve::masked(eve::gamma_p_inv)(eve::wide)",
   TTS_IEEE_EQUAL(eve::gamma_p_inv[mask](a0, a1),
             eve::if_else(mask, eve::gamma_p_inv(a0, a1), a0));
 };
+#else
+TTS_CASE("Check return types of gamma_p_inv")
+{
+  TTS_PASS("SKipping due to no reference available");
+};
+#endif
+

--- a/test/unit/module/special/lambert.cpp
+++ b/test/unit/module/special/lambert.cpp
@@ -9,8 +9,13 @@
 
 #include <eve/module/core.hpp>
 #include <eve/module/special.hpp>
-#include <boost/math/special_functions/lambert_w.hpp>
 
+#if __has_include(<boost/math/special_functions/lambert_w.hpp>)
+#include <boost/math/special_functions/lambert_w.hpp>
+#define EVE_HAS_BOOST
+#endif
+
+#if defined(EVE_HAS_BOOST)
 //==================================================================================================
 // Types tests
 //==================================================================================================
@@ -160,3 +165,9 @@ TTS_CASE_WITH("Check behavior of lambert on wide",
     }
   }
 };
+#else
+TTS_CASE("Check return types of lambert")
+{
+  TTS_PASS("SKipping due to no reference available");
+};
+#endif


### PR DESCRIPTION
Prevent large swath of code not to be compiled when Boost.Math is unavailable for tests