### PR TITLE
removed reference to eve::detail::map from the unit tests

### DIFF
--- a/include/eve/traits/cardinal.hpp
+++ b/include/eve/traits/cardinal.hpp
@@ -65,8 +65,8 @@ namespace eve
   };
 
   template<typename Type>
-  using cardinal_t = typename cardinal<Type>::type;
+  using cardinal_t = typename cardinal<std::remove_cvref_t<Type>>::type;
 
   template<typename Type>
-  inline constexpr auto cardinal_v = cardinal<Type>::value;
+  inline constexpr auto cardinal_v = cardinal<std::remove_cvref_t<Type>>::value;
 }

--- a/test/doc/core/rotate.cpp
+++ b/test/doc/core/rotate.cpp
@@ -13,6 +13,6 @@ int main()
             << "-> rotate(x, eve::index<1>) = " << eve::rotate(x, eve::index<1>) << '\n'
             << "-> rotate(x, eve::index<2>) = " << eve::rotate(x, eve::index<2>) << '\n'
             << "-> rotate(x, eve::index<3>) = " << eve::rotate(x, eve::index<3>) << '\n'
-            << "-> rotate(x, eve::index<4>) = " << eve::rotate(x, eve::index<4>) << '\n';;
+            << "-> rotate(x, eve::index<4>) = " << eve::rotate(x, eve::index<4>) << '\n';
 
 }

--- a/test/doc/elliptic/ellint_1.cpp
+++ b/test/doc/elliptic/ellint_1.cpp
@@ -2,7 +2,7 @@
 #include <eve/module/elliptic.hpp>
 #include <iostream>
 
-eve::wide wf{1.0, 0.0, 0.75, 0.5};;
+eve::wide wf{1.0, 0.0, 0.75, 0.5};
 eve::wide wphi{1.0, 1.0e-30, 0.5, 0.0};
 
 int main(){

--- a/test/doc/elliptic/ellint_2.cpp
+++ b/test/doc/elliptic/ellint_2.cpp
@@ -2,7 +2,7 @@
 #include <eve/module/elliptic.hpp>
 #include <iostream>
 
-eve::wide wf{1.0, 0.0, 0.75, 0.5};;
+eve::wide wf{1.0, 0.0, 0.75, 0.5};
 eve::wide wphi{1.0, 1.0e-30, 0.5, 0.0};
 
 int main(){

--- a/test/doc/elliptic/ellint_d.cpp
+++ b/test/doc/elliptic/ellint_d.cpp
@@ -2,7 +2,7 @@
 #include <eve/module/elliptic.hpp>
 #include <iostream>
 
-eve::wide wf{1.0, 0.0, 0.75, 0.5};;
+eve::wide wf{1.0, 0.0, 0.75, 0.5};
 eve::wide wphi{1.0, 1.0e-30, 0.5, 0.0};
 
 int main(){

--- a/test/doc/math/geommean.cpp
+++ b/test/doc/math/geommean.cpp
@@ -5,8 +5,8 @@
 int main()
 {
   eve::wide pf = {3.0, -1.0, -3.0, 10.0};
-  eve::wide qf = {4.0, 1.0, 1.0, 15.0};;
-  eve::wide rf = {-1.0, 2.0, 3.0, 1.5};;
+  eve::wide qf = {4.0, 1.0, 1.0, 15.0};
+  eve::wide rf = {-1.0, 2.0, 3.0, 1.5};
   kumi::tuple wt{pf, qf, rf};
 
   std::cout << "<- pf                              = " << pf << "\n";

--- a/test/doc/math/regular/geommean.cpp
+++ b/test/doc/math/regular/geommean.cpp
@@ -21,7 +21,7 @@ int main()
             << " yi                  = " << yi << '\n'
             << " -> geommean(xi, yi) = " << eve::geommean(xi, yi) << '\n';
 
-  w_t pf = {3, 1, -3, -10}, qf = {4, 1, 1, 15};;
+  w_t pf = {3, 1, -3, -10}, qf = {4, 1, 1, 15};
   std::cout << "---- multi" << '\n'
             << " <- pf                             = " << pf << '\n'
             << " <- qf                             = " << qf << '\n'

--- a/test/test.hpp
+++ b/test/test.hpp
@@ -423,6 +423,14 @@ namespace tts
       }
     }();
   }
+  
+  template<typename Fn, typename Wm, typename... Args>
+  auto map(Fn&& f, Wm&& wm, Args&&... args) -> eve::as_wide_t<decltype(f(eve::detail::get_at(wm, 0), eve::detail::get_at(args, 0)...)), eve::cardinal_t<Wm>>
+  {
+    using r_t = eve::as_wide_t<decltype(f(eve::detail::get_at(wm, 0), eve::detail::get_at(args, 0)...)), eve::cardinal_t<Wm>>;
+    auto call_f = [&](auto idx) { return f(eve::detail::get_at(wm, idx), eve::detail::get_at(args, idx)...); };
+    return eve::detail::apply<eve::cardinal_v<Wm>>([&](auto... I) { return r_t{call_f(I)...}; });
+  }
 }
 
 //==================================================================================================

--- a/test/unit/module/bessel/cyl_bessel_i0.cpp
+++ b/test/unit/module/bessel/cyl_bessel_i0.cpp
@@ -34,9 +34,9 @@ TTS_CASE_WITH ( "Check behavior of cyl_bessel_i0 on wide"
 
 #if defined(__cpp_lib_math_special_functions)
   auto std_cyl_bessel_i0 = [](auto x) -> v_t { return std::cyl_bessel_i(v_t(0), x); };
-  TTS_ULP_EQUAL(eve::cyl_bessel_i0(a0), eve::detail::map(std_cyl_bessel_i0, a0), 16.0);
-  TTS_ULP_EQUAL(eve::cyl_bessel_i0(a1), eve::detail::map(std_cyl_bessel_i0, a1), 16.0);
-  TTS_ULP_EQUAL(eve::cyl_bessel_i0(a2), eve::detail::map(std_cyl_bessel_i0, a2), 16.0);
+  TTS_ULP_EQUAL(eve::cyl_bessel_i0(a0), tts::map(std_cyl_bessel_i0, a0), 16.0);
+  TTS_ULP_EQUAL(eve::cyl_bessel_i0(a1), tts::map(std_cyl_bessel_i0, a1), 16.0);
+  TTS_ULP_EQUAL(eve::cyl_bessel_i0(a2), tts::map(std_cyl_bessel_i0, a2), 16.0);
 #else
   TTS_PASS("No support for std::cyl_bessel_i");
 #endif

--- a/test/unit/module/bessel/cyl_bessel_i1.cpp
+++ b/test/unit/module/bessel/cyl_bessel_i1.cpp
@@ -34,9 +34,9 @@ TTS_CASE_WITH ( "Check behavior of cyl_bessel_i1 on wide"
 
 #if defined(__cpp_lib_math_special_functions)
   auto std_cyl_bessel_i1 = [](auto x) -> v_t { return std::cyl_bessel_i(v_t(1), x); };
-  TTS_ULP_EQUAL(eve::cyl_bessel_i1(a0), eve::detail::map(std_cyl_bessel_i1, a0), 16.0);
-  TTS_ULP_EQUAL(eve::cyl_bessel_i1(a1), eve::detail::map(std_cyl_bessel_i1, a1), 16.0);
-  TTS_ULP_EQUAL(eve::cyl_bessel_i1(a2), eve::detail::map(std_cyl_bessel_i1, a2), 16.0);
+  TTS_ULP_EQUAL(eve::cyl_bessel_i1(a0), tts::map(std_cyl_bessel_i1, a0), 16.0);
+  TTS_ULP_EQUAL(eve::cyl_bessel_i1(a1), tts::map(std_cyl_bessel_i1, a1), 16.0);
+  TTS_ULP_EQUAL(eve::cyl_bessel_i1(a2), tts::map(std_cyl_bessel_i1, a2), 16.0);
 #else
   TTS_PASS("No support for std::cyl_bessel_i");
 #endif

--- a/test/unit/module/bessel/cyl_bessel_in.cpp
+++ b/test/unit/module/bessel/cyl_bessel_in.cpp
@@ -69,8 +69,8 @@ TTS_CASE_WITH ( "Check behavior of cyl_bessel_in on wide"
 
 #if defined(__cpp_lib_math_special_functions)
   auto std_cyl_bessel_in = [](auto a, auto b) -> v_t { return std::cyl_bessel_i(a,b); };
-  TTS_RELATIVE_EQUAL(eve::cyl_bessel_in( a0,a1) , eve::detail::map(std_cyl_bessel_in, a0, a1), 1.5e-4);
-  TTS_RELATIVE_EQUAL(eve::cyl_bessel_in( ia0,a1), eve::detail::map(std_cyl_bessel_in,ia0, a1), 1.5e-4);
+  TTS_RELATIVE_EQUAL(eve::cyl_bessel_in( a0,a1) , tts::map(std_cyl_bessel_in, a0, a1), 1.5e-4);
+  TTS_RELATIVE_EQUAL(eve::cyl_bessel_in( ia0,a1), tts::map(std_cyl_bessel_in,ia0, a1), 1.5e-4);
 #else
   TTS_PASS("No support for std::cyl_bessel_i");
 #endif

--- a/test/unit/module/bessel/cyl_bessel_j0.cpp
+++ b/test/unit/module/bessel/cyl_bessel_j0.cpp
@@ -40,10 +40,10 @@ TTS_CASE_WITH ( "Check behavior of cyl_bessel_j0 on wide"
 
 #if defined(__cpp_lib_math_special_functions)
   auto std_cyl_bessel_j0 = [](auto x) -> v_t { return std::cyl_bessel_j(v_t(0), x); };
-  TTS_RELATIVE_EQUAL(eve::cyl_bessel_j0(a0), eve::detail::map(std_cyl_bessel_j0, a0), 1e-4);
-  TTS_RELATIVE_EQUAL(eve::cyl_bessel_j0(a1), eve::detail::map(std_cyl_bessel_j0, a1), 1e-4);
-  TTS_RELATIVE_EQUAL(eve::cyl_bessel_j0(a2), eve::detail::map(std_cyl_bessel_j0, a2), 1e-4);
-  TTS_RELATIVE_EQUAL(eve::cyl_bessel_j0(a3), eve::detail::map(std_cyl_bessel_j0, a3), 2e-2);
+  TTS_RELATIVE_EQUAL(eve::cyl_bessel_j0(a0), tts::map(std_cyl_bessel_j0, a0), 1e-4);
+  TTS_RELATIVE_EQUAL(eve::cyl_bessel_j0(a1), tts::map(std_cyl_bessel_j0, a1), 1e-4);
+  TTS_RELATIVE_EQUAL(eve::cyl_bessel_j0(a2), tts::map(std_cyl_bessel_j0, a2), 1e-4);
+  TTS_RELATIVE_EQUAL(eve::cyl_bessel_j0(a3), tts::map(std_cyl_bessel_j0, a3), 2e-2);
 #else
   TTS_PASS("No support for std::cyl_bessel_j");
 #endif

--- a/test/unit/module/bessel/cyl_bessel_j1.cpp
+++ b/test/unit/module/bessel/cyl_bessel_j1.cpp
@@ -40,10 +40,10 @@ TTS_CASE_WITH ( "Check behavior of cyl_bessel_j1 on wide"
 
 #if defined(__cpp_lib_math_special_functions)
   auto std_cyl_bessel_j1 = [](auto x) -> v_t { return std::cyl_bessel_j(v_t(1), x); };
-  TTS_RELATIVE_EQUAL(eve::cyl_bessel_j1(a0), eve::detail::map(std_cyl_bessel_j1, a0), 1e-4);
-  TTS_RELATIVE_EQUAL(eve::cyl_bessel_j1(a1), eve::detail::map(std_cyl_bessel_j1, a1), 1e-4);
-  TTS_RELATIVE_EQUAL(eve::cyl_bessel_j1(a2), eve::detail::map(std_cyl_bessel_j1, a2), 1e-4);
-  TTS_RELATIVE_EQUAL(eve::cyl_bessel_j1(a3), eve::detail::map(std_cyl_bessel_j1, a3), 2e-2);
+  TTS_RELATIVE_EQUAL(eve::cyl_bessel_j1(a0), tts::map(std_cyl_bessel_j1, a0), 1e-4);
+  TTS_RELATIVE_EQUAL(eve::cyl_bessel_j1(a1), tts::map(std_cyl_bessel_j1, a1), 1e-4);
+  TTS_RELATIVE_EQUAL(eve::cyl_bessel_j1(a2), tts::map(std_cyl_bessel_j1, a2), 1e-4);
+  TTS_RELATIVE_EQUAL(eve::cyl_bessel_j1(a3), tts::map(std_cyl_bessel_j1, a3), 2e-2);
 #else
   TTS_PASS("No support for std::cyl_bessel_j");
 #endif

--- a/test/unit/module/bessel/cyl_bessel_jn.cpp
+++ b/test/unit/module/bessel/cyl_bessel_jn.cpp
@@ -93,7 +93,7 @@ TTS_CASE_WITH("Check behavior of cyl_bessel_jn on wide with integral order",
   TTS_ULP_EQUAL(eve::cyl_bessel_jn(I_t(10), T(8)), T(std_cyl_bessel_jn(10, v_t(8))), 20000.0);
   TTS_ULP_EQUAL(eve::cyl_bessel_jn(I_t(10), T(8)), T(std_cyl_bessel_jn(10, v_t(8))), 20000.0);
 
-  TTS_RELATIVE_EQUAL(eve::cyl_bessel_jn(n, a0), map(std_cyl_bessel_jn, n, a0), 0.0025);
+  TTS_RELATIVE_EQUAL(eve::cyl_bessel_jn(n, a0), tts::map(std_cyl_bessel_jn, n, a0), 0.0025);
 #else
   TTS_PASS("No support for std::cyl_bessel_j");
 #endif
@@ -149,7 +149,7 @@ TTS_CASE_WITH("Check behavior of cyl_bessel_jn on wide with non integral order",
   TTS_ULP_EQUAL(eve::cyl_bessel_jn(T(10.5), T(8)), T(std_cyl_bessel_jn(v_t(10.5), v_t(8))), 20000.0);
   TTS_ULP_EQUAL(eve::cyl_bessel_jn(T(10.5), T(8)), T(std_cyl_bessel_jn(v_t(10.5), v_t(8))), 20000.0);
 
-  TTS_RELATIVE_EQUAL(eve::cyl_bessel_jn(n, a0),   map(std_cyl_bessel_jn, n, a0)   , 0.001);
+  TTS_RELATIVE_EQUAL(eve::cyl_bessel_jn(n, a0),   tts::map(std_cyl_bessel_jn, n, a0)   , 0.001);
 #else
   TTS_PASS("No support for std::cyl_bessel_j");
 #endif

--- a/test/unit/module/bessel/cyl_bessel_k0.cpp
+++ b/test/unit/module/bessel/cyl_bessel_k0.cpp
@@ -40,10 +40,10 @@ TTS_CASE_WITH ( "Check behavior of cyl_bessel_k0 on wide"
 
 #if defined(__cpp_lib_math_special_functions)
   auto std_cyl_bessel_k0 = [](auto x) -> v_t { return std::cyl_bessel_k(v_t(0), x); };
-  TTS_RELATIVE_EQUAL(eve::cyl_bessel_k0(a0), eve::detail::map(std_cyl_bessel_k0, a0), 1e-4);
-  TTS_RELATIVE_EQUAL(eve::cyl_bessel_k0(a1), eve::detail::map(std_cyl_bessel_k0, a1), 1e-4);
-  TTS_RELATIVE_EQUAL(eve::cyl_bessel_k0(a2), eve::detail::map(std_cyl_bessel_k0, a2), 1e-4);
-  TTS_RELATIVE_EQUAL(eve::cyl_bessel_k0(a3), eve::detail::map(std_cyl_bessel_k0, a3), 2e-2);
+  TTS_RELATIVE_EQUAL(eve::cyl_bessel_k0(a0), tts::map(std_cyl_bessel_k0, a0), 1e-4);
+  TTS_RELATIVE_EQUAL(eve::cyl_bessel_k0(a1), tts::map(std_cyl_bessel_k0, a1), 1e-4);
+  TTS_RELATIVE_EQUAL(eve::cyl_bessel_k0(a2), tts::map(std_cyl_bessel_k0, a2), 1e-4);
+  TTS_RELATIVE_EQUAL(eve::cyl_bessel_k0(a3), tts::map(std_cyl_bessel_k0, a3), 2e-2);
 #else
   TTS_PASS("No support for std::cyl_bessel_k");
 #endif

--- a/test/unit/module/bessel/cyl_bessel_k1.cpp
+++ b/test/unit/module/bessel/cyl_bessel_k1.cpp
@@ -40,10 +40,10 @@ TTS_CASE_WITH ( "Check behavior of cyl_bessel_k1 on wide"
 
 #if defined(__cpp_lib_math_special_functions)
   auto std_cyl_bessel_k1 = [](auto x) -> v_t { return std::cyl_bessel_k(v_t(1), x); };
-  TTS_RELATIVE_EQUAL(eve::cyl_bessel_k1(a0), eve::detail::map(std_cyl_bessel_k1, a0), 1e-4);
-  TTS_RELATIVE_EQUAL(eve::cyl_bessel_k1(a1), eve::detail::map(std_cyl_bessel_k1, a1), 1e-4);
-  TTS_RELATIVE_EQUAL(eve::cyl_bessel_k1(a2), eve::detail::map(std_cyl_bessel_k1, a2), 1e-4);
-  TTS_RELATIVE_EQUAL(eve::cyl_bessel_k1(a3), eve::detail::map(std_cyl_bessel_k1, a3), 2e-2);
+  TTS_RELATIVE_EQUAL(eve::cyl_bessel_k1(a0), tts::map(std_cyl_bessel_k1, a0), 1e-4);
+  TTS_RELATIVE_EQUAL(eve::cyl_bessel_k1(a1), tts::map(std_cyl_bessel_k1, a1), 1e-4);
+  TTS_RELATIVE_EQUAL(eve::cyl_bessel_k1(a2), tts::map(std_cyl_bessel_k1, a2), 1e-4);
+  TTS_RELATIVE_EQUAL(eve::cyl_bessel_k1(a3), tts::map(std_cyl_bessel_k1, a3), 2e-2);
 #else
   TTS_PASS("No support for std::cyl_bessel_k");
 #endif

--- a/test/unit/module/bessel/cyl_bessel_kn.cpp
+++ b/test/unit/module/bessel/cyl_bessel_kn.cpp
@@ -106,7 +106,7 @@ TTS_CASE_WITH("Check behavior of cyl_bessel_kn on wide with integral order",
   TTS_ULP_EQUAL(eve::cyl_bessel_kn(I_t(10), T(8)), T(std_cyl_bessel_kn(10, v_t(8))), 5.0);
   TTS_ULP_EQUAL(eve::cyl_bessel_kn(I_t(20), T(8)), T(std_cyl_bessel_kn(20, v_t(8))), 5.0);
 
-  TTS_RELATIVE_EQUAL(eve::cyl_bessel_kn(n, a0), map(std_cyl_bessel_kn, n, a0), 1.0e-4);
+  TTS_RELATIVE_EQUAL(eve::cyl_bessel_kn(n, a0), tts::map(std_cyl_bessel_kn, n, a0), 1.0e-4);
 #else
   TTS_PASS("No support for std::cyl_bessel_k");
 #endif
@@ -152,7 +152,7 @@ TTS_CASE_WITH( "Check behavior of cyl_bessel_kn on wide with non integral order"
   TTS_ULP_EQUAL(eve::cyl_bessel_kn(T(10.5), T(8)), T(std_cyl_bessel_kn(v_t(10.5), v_t(8))), 10.0);
   TTS_ULP_EQUAL(eve::cyl_bessel_kn(T(10.5), T(8)), T(std_cyl_bessel_kn(v_t(10.5), v_t(8))), 10.0);
 
-  TTS_RELATIVE_EQUAL(eve::cyl_bessel_kn(n, a0), map(std_cyl_bessel_kn, n, a0), 1.0e-3);
+  TTS_RELATIVE_EQUAL(eve::cyl_bessel_kn(n, a0), tts::map(std_cyl_bessel_kn, n, a0), 1.0e-3);
 #else
   TTS_PASS("No support for std::cyl_bessel_k");
 #endif

--- a/test/unit/module/bessel/cyl_bessel_y0.cpp
+++ b/test/unit/module/bessel/cyl_bessel_y0.cpp
@@ -37,7 +37,7 @@ TTS_CASE_WITH ( "Check behavior of cyl_bessel_y0 on wide"
 
 #if defined(__cpp_lib_math_special_functions)
   auto std_cyl_bessel_y0 = [](auto x) -> v_t { return std::cyl_neumann(v_t(0), x); };
-  TTS_RELATIVE_EQUAL(eve::cyl_bessel_y0(a0), eve::detail::map(std_cyl_bessel_y0, a0), 7e-3);
+  TTS_RELATIVE_EQUAL(eve::cyl_bessel_y0(a0), tts::map(std_cyl_bessel_y0, a0), 7e-3);
 #else
   TTS_PASS("No support for std::cyl_bessel_y");
 #endif

--- a/test/unit/module/bessel/cyl_bessel_y1.cpp
+++ b/test/unit/module/bessel/cyl_bessel_y1.cpp
@@ -37,7 +37,7 @@ TTS_CASE_WITH ( "Check behavior of cyl_bessel_y1 on wide"
 
 #if defined(__cpp_lib_math_special_functions)
   auto std_cyl_bessel_y1 = [](auto x) -> v_t { return std::cyl_neumann(v_t(1), x); };
-  TTS_RELATIVE_EQUAL(eve::cyl_bessel_y1(a0), eve::detail::map(std_cyl_bessel_y1, a0), 7e-3);
+  TTS_RELATIVE_EQUAL(eve::cyl_bessel_y1(a0), tts::map(std_cyl_bessel_y1, a0), 7e-3);
 #else
   TTS_PASS("No support for std::cyl_bessel_y");
 #endif

--- a/test/unit/module/bessel/cyl_bessel_yn.cpp
+++ b/test/unit/module/bessel/cyl_bessel_yn.cpp
@@ -97,7 +97,7 @@ TTS_CASE_WITH("Check behavior of cyl_bessel_yn on wide with integral order",
   TTS_ULP_EQUAL(eve::cyl_bessel_yn(I_t(10), T(8)), T(std_cyl_bessel_yn(10, v_t(8))), 20000.0);
   TTS_ULP_EQUAL(eve::cyl_bessel_yn(I_t(10), T(8)), T(std_cyl_bessel_yn(10, v_t(8))), 20000.0);
 
-  TTS_ULP_EQUAL(eve::cyl_bessel_yn(n, a0), eve::detail::map(std_cyl_bessel_yn, n, a0), 100000.0);
+  TTS_ULP_EQUAL(eve::cyl_bessel_yn(n, a0), tts::map(std_cyl_bessel_yn, n, a0), 100000.0);
 #else
   TTS_PASS("No support for std::cyl_neumann");
 #endif
@@ -130,7 +130,7 @@ TTS_CASE_WITH("Check behavior of cyl_bessel_yn on wide with non integral order",
   TTS_ULP_EQUAL(eve::cyl_bessel_yn(T(10.5), T(8)), T(std_cyl_bessel_yn(v_t(10.5), v_t(8))), 20000.0);
   TTS_ULP_EQUAL(eve::cyl_bessel_yn(T(10.5), T(8)), T(std_cyl_bessel_yn(v_t(10.5), v_t(8))), 20000.0);
 
-  TTS_RELATIVE_EQUAL(eve::cyl_bessel_yn(n, a0), eve::detail::map(std_cyl_bessel_yn, n, a0), 0.22);
+  TTS_RELATIVE_EQUAL(eve::cyl_bessel_yn(n, a0), tts::map(std_cyl_bessel_yn, n, a0), 0.22);
 #else
   TTS_PASS("No support for std::cyl_neumann");
 #endif

--- a/test/unit/module/bessel/sph_bessel_j0.cpp
+++ b/test/unit/module/bessel/sph_bessel_j0.cpp
@@ -54,9 +54,9 @@ TTS_CASE_WITH("Check behavior of eve::sph_bessel_j0 on wide",
   TTS_ULP_EQUAL(eve::sph_bessel_j0(T(1)), T(std_sph_bessel_j0(v_t(1))), 5000.0);
   TTS_ULP_EQUAL(eve::sph_bessel_j0(T(0)), eve::one(eve::as<T>()), 0.0);
 
-  TTS_ULP_EQUAL(eve::sph_bessel_j0(a0), map(std_sph_bessel_j0, a0), 2048.0);
-  TTS_ULP_EQUAL(eve::sph_bessel_j0(a1), map(std_sph_bessel_j0, a1), 2048.0);
-  TTS_ULP_EQUAL(eve::sph_bessel_j0(a2), map(std_sph_bessel_j0, a2), 2048.0);
+  TTS_ULP_EQUAL(eve::sph_bessel_j0(a0), tts::map(std_sph_bessel_j0, a0), 2048.0);
+  TTS_ULP_EQUAL(eve::sph_bessel_j0(a1), tts::map(std_sph_bessel_j0, a1), 2048.0);
+  TTS_ULP_EQUAL(eve::sph_bessel_j0(a2), tts::map(std_sph_bessel_j0, a2), 2048.0);
 #else
   TTS_PASS("No support for std::sph_bessel");
 #endif

--- a/test/unit/module/bessel/sph_bessel_j1.cpp
+++ b/test/unit/module/bessel/sph_bessel_j1.cpp
@@ -56,9 +56,9 @@ TTS_CASE_TPL("Check return types of sph_bessel_j1", eve::test::simd::ieee_reals)
   TTS_ULP_EQUAL(eve::sph_bessel_j1(T(1)), T(std_sph_bessel_j1(v_t(1))), 5000.0);
   TTS_ULP_EQUAL(eve::sph_bessel_j1(T(0)), eve::zero(eve::as<T>()), 0.0);
 
-  TTS_ULP_EQUAL(eve::sph_bessel_j1(a0), eve::detail::map(std_sph_bessel_j1, a0), 1390.0);
-  TTS_ULP_EQUAL(eve::sph_bessel_j1(a1), eve::detail::map(std_sph_bessel_j1, a1), 390.0);
-  TTS_ULP_EQUAL(eve::sph_bessel_j1(a2), eve::detail::map(std_sph_bessel_j1, a2), 10700.0);
+  TTS_ULP_EQUAL(eve::sph_bessel_j1(a0), tts::map(std_sph_bessel_j1, a0), 1390.0);
+  TTS_ULP_EQUAL(eve::sph_bessel_j1(a1), tts::map(std_sph_bessel_j1, a1), 390.0);
+  TTS_ULP_EQUAL(eve::sph_bessel_j1(a2), tts::map(std_sph_bessel_j1, a2), 10700.0);
 #else
   TTS_PASS("No support for std::sph_bessel");
 #endif

--- a/test/unit/module/bessel/sph_bessel_jn.cpp
+++ b/test/unit/module/bessel/sph_bessel_jn.cpp
@@ -101,7 +101,7 @@ TTS_CASE_WITH( "Check behavior of sph_bessel_jn on wide with integral order"
   TTS_ULP_EQUAL(eve::sph_bessel_jn(I_t(10), T(8)), T(std_sph_bessel_jn(10u, v_t(8))), 500000.0);
   TTS_ULP_EQUAL(eve::sph_bessel_jn(I_t(10), T(8)), T(std_sph_bessel_jn(10u, v_t(8))), 500000.0);
 
-  TTS_RELATIVE_EQUAL(eve::sph_bessel_jn(n, a0), map(std_sph_bessel_jn, n, a0), 0.005);
+  TTS_RELATIVE_EQUAL(eve::sph_bessel_jn(n, a0), tts::map(std_sph_bessel_jn, n, a0), 0.005);
 #else
   TTS_PASS("No support for std::sph_bessel");
 #endif

--- a/test/unit/module/bessel/sph_bessel_y0.cpp
+++ b/test/unit/module/bessel/sph_bessel_y0.cpp
@@ -55,9 +55,9 @@ TTS_CASE_WITH("Check behavior of sph_bessel_y0 on wide",
   TTS_ULP_EQUAL(eve::sph_bessel_y0(T(1)), T(std_sph_bessel_y0(v_t(1))), 1024.0);
   TTS_ULP_EQUAL(eve::sph_bessel_y0(T(0)), eve::minf(eve::as<T>()), 0.0);
 
-  TTS_ULP_EQUAL(eve::sph_bessel_y0(a0), map(std_sph_bessel_y0, a0), 1024.0);
-  TTS_ULP_EQUAL(eve::sph_bessel_y0(a1), map(std_sph_bessel_y0, a1), 1024.0);
-  TTS_ULP_EQUAL(eve::sph_bessel_y0(a2), map(std_sph_bessel_y0, a2), 10000.0);
+  TTS_ULP_EQUAL(eve::sph_bessel_y0(a0), tts::map(std_sph_bessel_y0, a0), 1024.0);
+  TTS_ULP_EQUAL(eve::sph_bessel_y0(a1), tts::map(std_sph_bessel_y0, a1), 1024.0);
+  TTS_ULP_EQUAL(eve::sph_bessel_y0(a2), tts::map(std_sph_bessel_y0, a2), 10000.0);
 #else
   TTS_PASS("No support for std::sph_neumann");
 #endif

--- a/test/unit/module/bessel/sph_bessel_y1.cpp
+++ b/test/unit/module/bessel/sph_bessel_y1.cpp
@@ -57,10 +57,10 @@ TTS_CASE_WITH("Check behavior of sph_bessel_y1 on wide",
   TTS_ULP_EQUAL(eve::sph_bessel_y1(T(1)), T(std_sph_bessel_y1(v_t(1))), 5000.0);
   TTS_ULP_EQUAL(eve::sph_bessel_y1(T(0)), eve::minf(eve::as<T>()), 0.0);
 
-  TTS_ULP_EQUAL(eve::sph_bessel_y1(a0), map(std_sph_bessel_y1, a0), 32.0);
-  TTS_ULP_EQUAL(eve::sph_bessel_y1(a1), map(std_sph_bessel_y1, a1), 32.0);
-  TTS_ULP_EQUAL(eve::sph_bessel_y1(a2), map(std_sph_bessel_y1, a2), 64.0);
-  TTS_ULP_EQUAL(eve::sph_bessel_y1(a3), map(std_sph_bessel_y1, a3), 10000.0);
+  TTS_ULP_EQUAL(eve::sph_bessel_y1(a0), tts::map(std_sph_bessel_y1, a0), 32.0);
+  TTS_ULP_EQUAL(eve::sph_bessel_y1(a1), tts::map(std_sph_bessel_y1, a1), 32.0);
+  TTS_ULP_EQUAL(eve::sph_bessel_y1(a2), tts::map(std_sph_bessel_y1, a2), 64.0);
+  TTS_ULP_EQUAL(eve::sph_bessel_y1(a3), tts::map(std_sph_bessel_y1, a3), 10000.0);
 #else
   TTS_PASS("No support for std::sph_neumann");
 #endif

--- a/test/unit/module/bessel/sph_bessel_yn.cpp
+++ b/test/unit/module/bessel/sph_bessel_yn.cpp
@@ -100,7 +100,7 @@ TTS_CASE_WITH( "Check behavior of sph_bessel_yn on wide with integral order"
   TTS_ULP_EQUAL(eve::sph_bessel_yn(I_t(10), T(8)), T(std_sph_bessel_yn(10u, v_t(8))), 10000.0);
   TTS_ULP_EQUAL(eve::sph_bessel_yn(I_t(10), T(8)), T(std_sph_bessel_yn(10u, v_t(8))), 10000.0);
 
-  TTS_RELATIVE_EQUAL(eve::sph_bessel_yn(n, a0), map(std_sph_bessel_yn, n, a0), 0.005);
+  TTS_RELATIVE_EQUAL(eve::sph_bessel_yn(n, a0), tts::map(std_sph_bessel_yn, n, a0), 0.005);
 #else
   TTS_PASS("No support for std::sph_neumann");
 #endif

--- a/test/unit/module/combinatorial/gcd.cpp
+++ b/test/unit/module/combinatorial/gcd.cpp
@@ -29,9 +29,8 @@ TTS_CASE_WITH("Check corner-cases behavior of eve::gcd on wide",
               tts::generate(tts::randoms(mini, eve::valmax), tts::randoms(mini, eve::valmax)))
 <typename T>(const T& a0, const T& a1)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
-  TTS_EQUAL(eve::gcd(a0, a1), map([](auto e, auto f) -> v_t { return std::gcd(e, f); }, a0, a1));
+  TTS_EQUAL(eve::gcd(a0, a1), tts::map([](auto e, auto f) -> v_t { return std::gcd(e, f); }, a0, a1));
 };
 
 //==================================================================================================

--- a/test/unit/module/combinatorial/lcm.cpp
+++ b/test/unit/module/combinatorial/lcm.cpp
@@ -25,10 +25,9 @@ TTS_CASE_WITH("Check corner-cases behavior of eve::lcm on wide",
               tts::generate(tts::randoms(1, maxi), tts::randoms(1, maxi)))
 <typename T>(const T& a0, const T& a1)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
-  TTS_EQUAL(eve::lcm(a0, a1), map([](auto e, auto f) -> v_t { return std::lcm(e, f); }, a0, a1));
+  TTS_EQUAL(eve::lcm(a0, a1), tts::map([](auto e, auto f) -> v_t { return std::lcm(e, f); }, a0, a1));
 };
 
 //==================================================================================================

--- a/test/unit/module/core/abs.cpp
+++ b/test/unit/module/core/abs.cpp
@@ -56,10 +56,9 @@ TTS_CASE_WITH("Check behavior of eve::abs(eve::wide)",
               tts::generate(tts::randoms(-10, +10), tts::logicals(0, 3)))
 <typename T, typename M>(T const& a0, M const& mask)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
-  TTS_EQUAL(eve::abs(a0), map([](auto e) -> v_t { return e > 0 ? e : -e; }, a0));
+  TTS_EQUAL(eve::abs(a0), tts::map([](auto e) -> v_t { return e > 0 ? e : -e; }, a0));
   TTS_EQUAL(eve::abs[mask](a0), eve::if_else(mask, eve::abs(a0), a0));
 };
 
@@ -72,12 +71,11 @@ TTS_CASE_WITH("Check behavior of eve::abs[eve::saturated](eve::wide)",
 <typename T, typename M>(T const& a0, M const& mask)
 {
   using v_t = eve::element_type_t<T>;
-  using eve::detail::map;
 
   if constexpr( std::is_signed_v<v_t> )
   {
     TTS_EQUAL(eve::abs[eve::saturated](a0),
-              map([](auto e)
+              tts::map([](auto e)
                   { return e == eve::valmin(eve::as(e)) ? eve::valmax(eve::as(e)) : eve::abs(e); },
                   a0));
   }

--- a/test/unit/module/core/absmax.cpp
+++ b/test/unit/module/core/absmax.cpp
@@ -49,18 +49,17 @@ TTS_CASE_WITH("Check behavior of absmax on all types full range",
 {
   using eve::abs;
   using eve::absmax;
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
   auto m    = [](auto a, auto b, auto c) -> v_t { return eve::abs(eve::max(a, b, c)); };
 
-  TTS_ULP_EQUAL(absmax(a0, a1, a2), map(m, a0, a1, a2), 2);
-  TTS_ULP_EQUAL(absmax[eve::pedantic](a0, a1, a2), map(m, a0, a1, a2), 2);
-  TTS_ULP_EQUAL(absmax[eve::numeric](a0, a1, a2), map(m, a0, a1, a2), 2);
-  TTS_ULP_EQUAL(absmax[eve::saturated](a0, a1, a2), map(m, a0, a1, a2), 2);
-  TTS_ULP_EQUAL(absmax(kumi::tuple{a0, a1, a2}), map(m, a0, a1, a2), 2);
-  TTS_ULP_EQUAL(absmax[eve::pedantic](kumi::tuple{a0, a1, a2}), map(m, a0, a1, a2), 2);
-  TTS_ULP_EQUAL(absmax[eve::numeric](kumi::tuple{a0, a1, a2}), map(m, a0, a1, a2), 2);
-  TTS_ULP_EQUAL(absmax[eve::saturated](kumi::tuple{a0, a1, a2}), map(m, a0, a1, a2), 2);
+  TTS_ULP_EQUAL(absmax(a0, a1, a2), tts::map(m, a0, a1, a2), 2);
+  TTS_ULP_EQUAL(absmax[eve::pedantic](a0, a1, a2), tts::map(m, a0, a1, a2), 2);
+  TTS_ULP_EQUAL(absmax[eve::numeric](a0, a1, a2), tts::map(m, a0, a1, a2), 2);
+  TTS_ULP_EQUAL(absmax[eve::saturated](a0, a1, a2), tts::map(m, a0, a1, a2), 2);
+  TTS_ULP_EQUAL(absmax(kumi::tuple{a0, a1, a2}), tts::map(m, a0, a1, a2), 2);
+  TTS_ULP_EQUAL(absmax[eve::pedantic](kumi::tuple{a0, a1, a2}), tts::map(m, a0, a1, a2), 2);
+  TTS_ULP_EQUAL(absmax[eve::numeric](kumi::tuple{a0, a1, a2}), tts::map(m, a0, a1, a2), 2);
+  TTS_ULP_EQUAL(absmax[eve::saturated](kumi::tuple{a0, a1, a2}), tts::map(m, a0, a1, a2), 2);
 
   TTS_IEEE_EQUAL(absmax[t](a0, a1), eve::if_else(t, absmax(a0, a1), a0));
 };

--- a/test/unit/module/core/absmin.cpp
+++ b/test/unit/module/core/absmin.cpp
@@ -57,18 +57,17 @@ TTS_CASE_WITH("Check behavior of absmin on all types full range",
 {
   using eve::abs;
   using eve::absmin;
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
   auto m = [](auto a, auto b, auto c) -> v_t { return eve::abs(eve::min(a, b, c)); };
-   TTS_ULP_EQUAL(absmin((a0), (a1), (a2)), map(m, a0, a1, a2), 2) << a0 << " --- " << a1 << " --- " << a2 << '\n';
-  TTS_ULP_EQUAL(eve::absmin[eve::pedantic]((a0), (a1), (a2)), map(m, a0, a1, a2), 2);
-  TTS_ULP_EQUAL(eve::absmin[eve::numeric]((a0), (a1), (a2)), map(m, a0, a1, a2), 2);
-  TTS_ULP_EQUAL(eve::absmin[eve::saturated]((a0), (a1), (a2)), map(m, a0, a1, a2), 2);
-  TTS_ULP_EQUAL(eve::absmin(kumi::tuple{(a0), (a1), (a2)}), map(m, a0, a1, a2), 2);
-  TTS_ULP_EQUAL(eve::absmin[eve::pedantic](kumi::tuple{(a0), (a1), (a2)}), map(m, a0, a1, a2), 2);
-  TTS_ULP_EQUAL(eve::absmin[eve::numeric](kumi::tuple{(a0), (a1), (a2)}), map(m, a0, a1, a2), 2);
-  TTS_ULP_EQUAL(eve::absmin[eve::saturated](kumi::tuple{(a0), (a1), (a2)}), map(m, a0, a1, a2), 2);
+   TTS_ULP_EQUAL(absmin((a0), (a1), (a2)), tts::map(m, a0, a1, a2), 2) << a0 << " --- " << a1 << " --- " << a2 << '\n';
+  TTS_ULP_EQUAL(eve::absmin[eve::pedantic]((a0), (a1), (a2)), tts::map(m, a0, a1, a2), 2);
+  TTS_ULP_EQUAL(eve::absmin[eve::numeric]((a0), (a1), (a2)), tts::map(m, a0, a1, a2), 2);
+  TTS_ULP_EQUAL(eve::absmin[eve::saturated]((a0), (a1), (a2)), tts::map(m, a0, a1, a2), 2);
+  TTS_ULP_EQUAL(eve::absmin(kumi::tuple{(a0), (a1), (a2)}), tts::map(m, a0, a1, a2), 2);
+  TTS_ULP_EQUAL(eve::absmin[eve::pedantic](kumi::tuple{(a0), (a1), (a2)}), tts::map(m, a0, a1, a2), 2);
+  TTS_ULP_EQUAL(eve::absmin[eve::numeric](kumi::tuple{(a0), (a1), (a2)}), tts::map(m, a0, a1, a2), 2);
+  TTS_ULP_EQUAL(eve::absmin[eve::saturated](kumi::tuple{(a0), (a1), (a2)}), tts::map(m, a0, a1, a2), 2);
 
   TTS_IEEE_EQUAL(absmin[t](a0, a1), eve::if_else(t, absmin(a0, a1), a0));
 };

--- a/test/unit/module/core/add.cpp
+++ b/test/unit/module/core/add.cpp
@@ -79,20 +79,19 @@ TTS_CASE_WITH("Check behavior of add on wide",
   using eve::lower;
   using eve::upper;
   using eve::strict;
-  using eve::detail::map;
 
-  TTS_ULP_EQUAL( add(a0, a2), map([](auto e, auto f) { return add(e, f); }, a0, a2), 0.5);
-  TTS_ULP_EQUAL( add[saturated](a0, a2), map([&](auto e, auto f) { return add[saturated](e, f); }, a0, a2), 0.5);
-  TTS_ULP_EQUAL( add(a0, a1, a2), map([&](auto e, auto f, auto g) { return add(add(e, f), g); }, a0, a1, a2), 0.5);
-  TTS_ULP_EQUAL( add[saturated](a0, a1, a2), map([&](auto e, auto f, auto g) { return add[saturated](add[saturated](e, f), g); }, a0, a1, a2), 0.5);
-  TTS_ULP_EQUAL( add(kumi::tuple{a0, a2}), map([](auto e, auto f) { return add(e, f); }, a0, a2), 0.5);
-  TTS_ULP_EQUAL( add[saturated](kumi::tuple{a0, a2}), map([&](auto e, auto f) { return add[saturated](e, f); }, a0, a2), 0.5);
-  TTS_ULP_EQUAL( add(kumi::tuple{a0, a1, a2}), map([&](auto e, auto f, auto g) { return add(add(e, f), g); }, a0, a1, a2), 0.5);
-  TTS_ULP_EQUAL( add[saturated](kumi::tuple{a0, a1, a2}), map([&](auto e, auto f, auto g) { return add[saturated](add[saturated](e, f), g); }, a0, a1, a2), 0.5);
+  TTS_ULP_EQUAL( add(a0, a2), tts::map([](auto e, auto f) { return add(e, f); }, a0, a2), 0.5);
+  TTS_ULP_EQUAL( add[saturated](a0, a2), tts::map([&](auto e, auto f) { return add[saturated](e, f); }, a0, a2), 0.5);
+  TTS_ULP_EQUAL( add(a0, a1, a2), tts::map([&](auto e, auto f, auto g) { return add(add(e, f), g); }, a0, a1, a2), 0.5);
+  TTS_ULP_EQUAL( add[saturated](a0, a1, a2), tts::map([&](auto e, auto f, auto g) { return add[saturated](add[saturated](e, f), g); }, a0, a1, a2), 0.5);
+  TTS_ULP_EQUAL( add(kumi::tuple{a0, a2}), tts::map([](auto e, auto f) { return add(e, f); }, a0, a2), 0.5);
+  TTS_ULP_EQUAL( add[saturated](kumi::tuple{a0, a2}), tts::map([&](auto e, auto f) { return add[saturated](e, f); }, a0, a2), 0.5);
+  TTS_ULP_EQUAL( add(kumi::tuple{a0, a1, a2}), tts::map([&](auto e, auto f, auto g) { return add(add(e, f), g); }, a0, a1, a2), 0.5);
+  TTS_ULP_EQUAL( add[saturated](kumi::tuple{a0, a1, a2}), tts::map([&](auto e, auto f, auto g) { return add[saturated](add[saturated](e, f), g); }, a0, a1, a2), 0.5);
   if constexpr (eve::floating_value<T> && sizeof(eve::element_type_t<T>) == 4)
   {
-    TTS_ULP_EQUAL( add[lower](kumi::tuple{a0, a1, a2}), map([&](auto e, auto f, auto g) { return add[lower](add[lower](e, f), g); }, a0, a1, a2), 1.0);
-    TTS_ULP_EQUAL( add[upper](kumi::tuple{a0, a1, a2}), map([&](auto e, auto f, auto g) { return add[upper](add[upper](e, f), g); }, a0, a1, a2), 1.0);
+    TTS_ULP_EQUAL( add[lower](kumi::tuple{a0, a1, a2}), tts::map([&](auto e, auto f, auto g) { return add[lower](add[lower](e, f), g); }, a0, a1, a2), 1.0);
+    TTS_ULP_EQUAL( add[upper](kumi::tuple{a0, a1, a2}), tts::map([&](auto e, auto f, auto g) { return add[upper](add[upper](e, f), g); }, a0, a1, a2), 1.0);
     TTS_EXPECT(eve::all(add[upper](a0, a1, a2) >=  add[lower](a0, a1, a2)));
     T w0(1);
     T w1(eve::smallestposval(eve::as<T>()));
@@ -120,17 +119,16 @@ TTS_CASE_WITH("Check behavior of add on signed types",
 {
   using eve::add;
   using eve::saturated;
-  using eve::detail::map;
 
   auto e0 = a2.get(0);
 
   TTS_EQUAL(add[e0 > T(64)](a0, a1),
-            map([e0](auto e, auto f) { return e0 > 64 ? add(e, f) : e; }, a0, a1));
+            tts::map([e0](auto e, auto f) { return e0 > 64 ? add(e, f) : e; }, a0, a1));
   TTS_EQUAL(add[a2 > T(64)](a0, a1),
-            map([](auto e, auto f, auto g) { return g > 64 ? add(e, f) : e; }, a0, a1, a2));
+            tts::map([](auto e, auto f, auto g) { return g > 64 ? add(e, f) : e; }, a0, a1, a2));
   TTS_EQUAL(
       add[saturated][a2 > T(64)](a0, a1),
-      map([](auto e, auto f, auto g) { return g > 64 ? add[saturated](e, f) : e; }, a0, a1, a2));
+      tts::map([](auto e, auto f, auto g) { return g > 64 ? add[saturated](e, f) : e; }, a0, a1, a2));
 };
 
 

--- a/test/unit/module/core/agm.cpp
+++ b/test/unit/module/core/agm.cpp
@@ -33,7 +33,6 @@ TTS_CASE_WITH("Check behavior of agm(wide)",
 <typename T>(T const& a0, T const& a1)
 {
   using eve::agm;
-  using eve::detail::map;
   TTS_RELATIVE_EQUAL(agm(a0, a1),
                      ((a0 + a1) / eve::ellint_1((a0 - a1) / (a0 + a1))) * eve::pio_4(eve::as(a0)),
                      0.5);
@@ -48,10 +47,9 @@ TTS_CASE_WITH("Check behavior of  agm[cond](wide)",
 <typename T>(T const& a0, T const& a1, T const& a2)
 {
   using eve::agm;
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
   TTS_ULP_EQUAL(agm[a2 > T(64)](a0, a1),
-                map([](auto e, auto f, auto g) { return g > v_t(64) ? agm(e, f) : e; }, a0, a1, a2),
+                tts::map([](auto e, auto f, auto g) { return g > v_t(64) ? agm(e, f) : e; }, a0, a1, a2),
                 5);
 };
 

--- a/test/unit/module/core/average.cpp
+++ b/test/unit/module/core/average.cpp
@@ -53,13 +53,12 @@ TTS_CASE_WITH("Check behavior of average(wide)",
 <typename T>(T const& a0, T const& a1, T const& a2)
 {
   using eve::average;
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
-  TTS_ULP_EQUAL(average(a0, a1), map([](auto e, auto f) -> v_t { return std::midpoint(e, f); }, a0, a1), 2);
+  TTS_ULP_EQUAL(average(a0, a1), tts::map([](auto e, auto f) -> v_t { return std::midpoint(e, f); }, a0, a1), 2);
   if constexpr( eve::floating_value<T> )
   {
     TTS_ULP_EQUAL(average(a0, a1, a2),
-                  map([](auto e, auto f, auto g) { return (g + f + e) / 3; }, a0, a1, a2),
+                  tts::map([](auto e, auto f, auto g) { return (g + f + e) / 3; }, a0, a1, a2),
                   48);
   }
 };
@@ -71,9 +70,8 @@ TTS_CASE_WITH("Check behavior of average(wide)",
 <typename T>(T const& a0, T const& a1)
 {
   using eve::average;
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
-  TTS_ULP_EQUAL(average(a0, a1), map([](auto e, auto f) -> v_t { return std::midpoint(e, f); }, a0, a1), 2);
+  TTS_ULP_EQUAL(average(a0, a1), tts::map([](auto e, auto f) -> v_t { return std::midpoint(e, f); }, a0, a1), 2);
 };
 
 //==================================================================================================
@@ -85,13 +83,12 @@ TTS_CASE_WITH("Check behavior of  average[cond](wide)",
 <typename T>(T const& a0, T const& a1, T const& a2)
 {
   using eve::average;
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
   // values can differ by one on integral types from scalar to simd implementations (intrinsics may
   // be at work)
   TTS_ULP_EQUAL(
       average[a2 > T(64)](a0, a1),
-      map([](auto e, auto f, auto g) { return g > v_t(64) ? average(e, f) : e; }, a0, a1, a2),
+      tts::map([](auto e, auto f, auto g) { return g > v_t(64) ? average(e, f) : e; }, a0, a1, a2),
       2);
 };
 

--- a/test/unit/module/core/bit_and.cpp
+++ b/test/unit/module/core/bit_and.cpp
@@ -47,12 +47,11 @@ TTS_CASE_WITH("Check behavior of bit_and on integral types",
 {
   using eve::as;
   using eve::bit_and;
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
-  TTS_EQUAL(bit_and(a0, a1), map([](auto e, auto f) -> v_t { return e & f; }, a0, a1));
+  TTS_EQUAL(bit_and(a0, a1), tts::map([](auto e, auto f) -> v_t { return e & f; }, a0, a1));
   TTS_EQUAL(bit_and[test](a0, a1), eve::if_else(test, eve::bit_and(a0, a1), a0));
   TTS_EQUAL(bit_and[test](a0, a1, a2), eve::if_else(test, eve::bit_and(a0, a1, a2), a0));
-  TTS_EQUAL(bit_and(kumi::tuple{a0, a1}), map([](auto e, auto f) -> v_t { return e & f; }, a0, a1));
+  TTS_EQUAL(bit_and(kumi::tuple{a0, a1}), tts::map([](auto e, auto f) -> v_t { return e & f; }, a0, a1));
   TTS_EQUAL(bit_and[test](kumi::tuple{a0, a1}), eve::if_else(test, eve::bit_and(a0, a1), a0));
   TTS_EQUAL(bit_and[test](kumi::tuple{a0, a1, a2}), eve::if_else(test, eve::bit_and(a0, a1, a2), a0));
 };
@@ -68,12 +67,11 @@ TTS_CASE_WITH("Check behavior of bit_and on floating types",
   using eve::as;
   using eve::bit_and;
   using eve::bit_cast;
-  using eve::detail::map;
   using i_t = eve::as_integer_t<eve::element_type_t<T>, signed>;
   using v_t = eve::element_type_t<T>;
   TTS_IEEE_EQUAL(
       bit_and(a0, a1),
-      map([](auto e, auto f) -> v_t
+      tts::map([](auto e, auto f) -> v_t
           { return bit_cast(bit_cast(e, as(i_t())) & bit_cast(f, as(i_t())), as(v_t())); },
           a0,
           a1));

--- a/test/unit/module/core/bit_andnot.cpp
+++ b/test/unit/module/core/bit_andnot.cpp
@@ -47,12 +47,11 @@ TTS_CASE_WITH("Check behavior of bit_andnot on integral types",
 {
   using eve::as;
   using eve::bit_andnot;
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
-  TTS_EQUAL(bit_andnot(a0, a1), map([](auto e, auto f) -> v_t { return e & ~f; }, a0, a1));
+  TTS_EQUAL(bit_andnot(a0, a1), tts::map([](auto e, auto f) -> v_t { return e & ~f; }, a0, a1));
   TTS_EQUAL(bit_andnot[test](a0, a1), eve::if_else(test, eve::bit_andnot(a0, a1), a0));
   TTS_EQUAL(bit_andnot[test](a0, a1, a2), eve::if_else(test, eve::bit_andnot(a0, eve::bit_or(a1, a2)), a0));
-  TTS_EQUAL(bit_andnot(kumi::tuple{a0, a1}), map([](auto e, auto f) -> v_t { return e & ~f; }, a0, a1));
+  TTS_EQUAL(bit_andnot(kumi::tuple{a0, a1}), tts::map([](auto e, auto f) -> v_t { return e & ~f; }, a0, a1));
   TTS_EQUAL(bit_andnot[test](kumi::tuple{a0, a1}), eve::if_else(test, eve::bit_andnot(a0, a1), a0));
   TTS_EQUAL(bit_andnot[test](kumi::tuple{a0, a1, a2}), eve::if_else(test, eve::bit_andnot(a0, eve::bit_or(a1, a2)), a0));
 };
@@ -68,12 +67,11 @@ TTS_CASE_WITH("Check behavior of bit_andnot on floating types",
   using eve::as;
   using eve::bit_andnot;
   using eve::bit_cast;
-  using eve::detail::map;
   using i_t = eve::as_integer_t<eve::element_type_t<T>, signed>;
   using v_t = eve::element_type_t<T>;
   TTS_IEEE_EQUAL(
     bit_andnot(a0, a1),
-    map([](auto e, auto f) -> v_t
+    tts::map([](auto e, auto f) -> v_t
         { return bit_cast(bit_cast(e, as(i_t())) & ~bit_cast(f, as(i_t())), as(v_t())); },
         a0,
         a1));

--- a/test/unit/module/core/bit_cast.cpp
+++ b/test/unit/module/core/bit_cast.cpp
@@ -55,7 +55,6 @@ TTS_CASE_WITH("Check behavior of bit_cast(simd) on integral types",
 {
   using eve::as;
   using eve::bit_cast;
-  using eve::detail::map;
   using elt_t = eve::element_type_t<T>;
   using ut_t  = eve::as_integer_t<T, unsigned>;
   using it_t  = eve::as_integer_t<T, signed>;
@@ -64,13 +63,13 @@ TTS_CASE_WITH("Check behavior of bit_cast(simd) on integral types",
 
   TTS_EQUAL(
       bit_cast(a0, eve::as<T>()),
-      map([](auto e, auto) -> elt_t { return bit_cast(e, eve::as<elt_t>()); }, a0, eve::as<T>()));
+      tts::map([](auto e, auto) -> elt_t { return bit_cast(e, eve::as<elt_t>()); }, a0, eve::as<T>()));
   TTS_EQUAL(bit_cast(a0, eve::as<ut_t>()),
-            map([](auto e, auto) -> vut_t { return bit_cast(e, eve::as<vut_t>()); },
+            tts::map([](auto e, auto) -> vut_t { return bit_cast(e, eve::as<vut_t>()); },
                 a0,
                 eve::as<ut_t>()));
   TTS_EQUAL(bit_cast(a0, eve::as<it_t>()),
-            map([](auto e, auto) -> vit_t { return bit_cast(e, eve::as<vit_t>()); },
+            tts::map([](auto e, auto) -> vit_t { return bit_cast(e, eve::as<vit_t>()); },
                 a0,
                 eve::as<it_t>()));
   //== more tests to write when std::bit_cast will be available

--- a/test/unit/module/core/bit_ceil.cpp
+++ b/test/unit/module/core/bit_ceil.cpp
@@ -39,9 +39,8 @@ TTS_CASE_WITH("Check behavior of bit_ceil(wide) on integral types",
 {
   using v_t = eve::element_type_t<T>;
   using u_t = eve::as_integer_t<v_t, unsigned>;
-  using eve::detail::map;
   TTS_EQUAL(eve::bit_ceil(a0),
-            map([](auto e) { return v_t(eve::bit_ceil(u_t((e > 0) ? e : 0))); }, a0));
+            tts::map([](auto e) { return v_t(eve::bit_ceil(u_t((e > 0) ? e : 0))); }, a0));
   TTS_EQUAL(eve::bit_ceil[t](a0), eve::if_else(t, eve::bit_ceil(a0), a0));
 };
 
@@ -53,9 +52,8 @@ TTS_CASE_WITH("Check behavior of bit_ceil(wide) on floating",
   using v_t = eve::element_type_t<T>;
   using eve::exponent;
   using eve::ldexp;
-  using eve::detail::map;
   TTS_EQUAL(eve::bit_ceil(a0),
-            map(
+            tts::map(
                 [](auto x)
                 {
                   auto v = x;

--- a/test/unit/module/core/bit_flip.cpp
+++ b/test/unit/module/core/bit_flip.cpp
@@ -19,7 +19,6 @@ TTS_CASE_WITH("Check behavior of bit_flip(simd) on integral types",
 {
   using v_t = eve::element_type_t<T>;
   using eve::bit_flip;
-  using eve::detail::map;
-  TTS_EQUAL(bit_flip(a0, 0u), map([](auto e) -> v_t { return eve::bit_flip(e, 0u); }, a0));
+  TTS_EQUAL(bit_flip(a0, 0u), tts::map([](auto e) -> v_t { return eve::bit_flip(e, 0u); }, a0));
   TTS_EQUAL(eve::bit_flip[t](a0, 0u), eve::if_else(t, eve::bit_flip(a0, 0u), a0));
 };

--- a/test/unit/module/core/bit_floor.cpp
+++ b/test/unit/module/core/bit_floor.cpp
@@ -32,7 +32,7 @@ TTS_CASE_WITH("Check behavior of bit_floor(wide) on unsigned integral types",
 <typename T, typename U>(T const& a0, U const& t)
 {
   using v_t = eve::element_type_t<T>;
-  TTS_EQUAL(eve::bit_floor(a0), map([](auto e) { return v_t(std::bit_floor(e)); }, a0));
+  TTS_EQUAL(eve::bit_floor(a0), tts::map([](auto e) { return v_t(std::bit_floor(e)); }, a0));
   TTS_EQUAL(eve::bit_floor[t](a0), eve::if_else(t, eve::bit_floor(a0), a0));
 };
 

--- a/test/unit/module/core/bit_mask.cpp
+++ b/test/unit/module/core/bit_mask.cpp
@@ -31,9 +31,8 @@ TTS_CASE_WITH("Check behavior of bit_mask(simd) on all types",
 {
   using v_t = eve::element_type_t<T>;
   using eve::bit_mask;
-  using eve::detail::map;
   TTS_IEEE_EQUAL(
       bit_mask(a0),
-      map([](auto v) -> v_t { return v ? eve::allbits(eve::as(v)) : eve::zero(eve::as(v)); }, a0));
+      tts::map([](auto v) -> v_t { return v ? eve::allbits(eve::as(v)) : eve::zero(eve::as(v)); }, a0));
   TTS_IEEE_EQUAL(eve::bit_mask[t](a0), eve::if_else(t, eve::bit_mask(a0), a0));
 };

--- a/test/unit/module/core/bit_not.cpp
+++ b/test/unit/module/core/bit_not.cpp
@@ -35,8 +35,7 @@ TTS_CASE_WITH("Check behavior of bit_not(simd) on integral types",
 {
   using v_t = eve::element_type_t<T>;
   using eve::bit_not;
-  using eve::detail::map;
-  TTS_EQUAL(bit_not(a0), map([](auto e) -> v_t { return ~e; }, a0));
+  TTS_EQUAL(bit_not(a0), tts::map([](auto e) -> v_t { return ~e; }, a0));
   TTS_EQUAL(eve::bit_not[t](a0), eve::if_else(t, eve::bit_not(a0), a0));
 };
 
@@ -48,11 +47,10 @@ TTS_CASE_WITH("Check behavior of bit_not(simd) on floating types",
   using eve::as;
   using eve::bit_cast;
   using eve::bit_not;
-  using eve::detail::map;
   using i_t = eve::as_integer_t<eve::element_type_t<T>, signed>;
   using v_t = eve::element_type_t<T>;
   TTS_IEEE_EQUAL(bit_not(a0),
-                 map([](auto e) { return bit_cast(~bit_cast(e, as(i_t())), as(v_t())); }, a0));
+                 tts::map([](auto e) { return bit_cast(~bit_cast(e, as(i_t())), as(v_t())); }, a0));
   TTS_IEEE_EQUAL(eve::bit_not[t](a0), eve::if_else(t, eve::bit_not(a0), a0));
 };
 

--- a/test/unit/module/core/bit_notand.cpp
+++ b/test/unit/module/core/bit_notand.cpp
@@ -47,13 +47,12 @@ TTS_CASE_WITH("Check behavior of bit_notand on integral types",
 {
   using eve::as;
   using eve::bit_notand;
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
-  TTS_EQUAL(bit_notand(a0, a1), map([](auto e, auto f) -> v_t { return ~e & f; }, a0, a1));
+  TTS_EQUAL(bit_notand(a0, a1), tts::map([](auto e, auto f) -> v_t { return ~e & f; }, a0, a1));
   auto test = a3 > eve::average(eve::valmin(as<T>()), eve::valmax(as<T>()));
   TTS_EQUAL(bit_notand[test](a0, a1), eve::if_else(test, eve::bit_notand(a0, a1), a0));
   TTS_EQUAL(bit_notand[test](a0, a1, a2), eve::if_else(test, eve::bit_notand(a0, eve::bit_and(a1, a2)), a0));
-  TTS_EQUAL(bit_notand(kumi::tuple{a0, a1}), map([](auto e, auto f) -> v_t { return ~e & f; }, a0, a1));
+  TTS_EQUAL(bit_notand(kumi::tuple{a0, a1}), tts::map([](auto e, auto f) -> v_t { return ~e & f; }, a0, a1));
   TTS_EQUAL(bit_notand[test](kumi::tuple{a0, a1}), eve::if_else(test, eve::bit_notand(a0, a1), a0));
   TTS_EQUAL(bit_notand[test](kumi::tuple{a0, a1, a2}), eve::if_else(test, eve::bit_notand(a0, eve::bit_and(a1, a2)), a0));
 };
@@ -69,12 +68,11 @@ TTS_CASE_WITH("Check behavior of bit_notand on floating types",
   using eve::as;
   using eve::bit_cast;
   using eve::bit_notand;
-  using eve::detail::map;
   using i_t = eve::as_integer_t<eve::element_type_t<T>, signed>;
   using v_t = eve::element_type_t<T>;
   TTS_IEEE_EQUAL(
       bit_notand(a0, a1),
-      map([](auto e, auto f) -> v_t
+      tts::map([](auto e, auto f) -> v_t
           { return bit_cast(~bit_cast(e, as(i_t())) & bit_cast(f, as(i_t())), as(v_t())); },
           a0,
           a1));

--- a/test/unit/module/core/bit_notor.cpp
+++ b/test/unit/module/core/bit_notor.cpp
@@ -47,14 +47,13 @@ TTS_CASE_WITH("Check behavior of bit_notor on integral types",
 {
   using eve::as;
   using eve::bit_notor;
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
-  TTS_EQUAL(bit_notor(a0, a1), map([](auto e, auto f) -> v_t { return ~e | f; }, a0, a1));
+  TTS_EQUAL(bit_notor(a0, a1), tts::map([](auto e, auto f) -> v_t { return ~e | f; }, a0, a1));
   auto test = a3 > eve::average(eve::valmin(as<T>()), eve::valmax(as<T>()));
   TTS_EQUAL(bit_notor[test](a0, a1), eve::if_else(test, eve::bit_notor(a0, a1), a0));
   TTS_EQUAL(bit_notor[test](a0, a1, a2),
             eve::if_else(test, eve::bit_notor(a0, eve::bit_or(a1, a2)), a0));
-  TTS_EQUAL(bit_notor(kumi::tuple{a0, a1}), map([](auto e, auto f) -> v_t { return ~e | f; }, a0, a1));
+  TTS_EQUAL(bit_notor(kumi::tuple{a0, a1}), tts::map([](auto e, auto f) -> v_t { return ~e | f; }, a0, a1));
   TTS_EQUAL(bit_notor[test](kumi::tuple{a0, a1}), eve::if_else(test, eve::bit_notor(a0, a1), a0));
   TTS_EQUAL(bit_notor[test](kumi::tuple{a0, a1, a2}), eve::if_else(test, eve::bit_notor(a0, eve::bit_or(a1, a2)), a0));
 };
@@ -70,12 +69,11 @@ TTS_CASE_WITH("Check behavior of bit_notor on floating types",
   using eve::as;
   using eve::bit_cast;
   using eve::bit_notor;
-  using eve::detail::map;
   using i_t = eve::as_integer_t<eve::element_type_t<T>, signed>;
   using v_t = eve::element_type_t<T>;
   TTS_IEEE_EQUAL(
       bit_notor(a0, a1),
-      map([](auto e, auto f) -> v_t
+      tts::map([](auto e, auto f) -> v_t
           { return bit_cast(~bit_cast(e, as(i_t())) | bit_cast(f, as(i_t())), as(v_t())); },
           a0,
           a1));

--- a/test/unit/module/core/bit_or.cpp
+++ b/test/unit/module/core/bit_or.cpp
@@ -47,13 +47,12 @@ TTS_CASE_WITH("Check behavior of bit_or on integral types",
 {
   using eve::as;
   using eve::bit_or;
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
-  TTS_EQUAL(bit_or(a0, a1), map([](auto e, auto f) -> v_t { return e | f; }, a0, a1));
+  TTS_EQUAL(bit_or(a0, a1), tts::map([](auto e, auto f) -> v_t { return e | f; }, a0, a1));
   auto test = a3 > eve::average(eve::valmin(as<T>()), eve::valmax(as<T>()));
   TTS_EQUAL(bit_or[test](a0, a1), eve::if_else(test, eve::bit_or(a0, a1), a0));
   TTS_EQUAL(bit_or[test](a0, a1, a2), eve::if_else(test, eve::bit_or(a0, a1, a2), a0));
-  TTS_EQUAL(bit_or(kumi::tuple{a0, a1}), map([](auto e, auto f) -> v_t { return e | f; }, a0, a1));
+  TTS_EQUAL(bit_or(kumi::tuple{a0, a1}), tts::map([](auto e, auto f) -> v_t { return e | f; }, a0, a1));
   TTS_EQUAL(bit_or[test](kumi::tuple{a0, a1}), eve::if_else(test, eve::bit_or(a0, a1), a0));
   TTS_EQUAL(bit_or[test](kumi::tuple{a0, a1, a2}), eve::if_else(test, eve::bit_or(a0, a1, a2), a0));
 };
@@ -69,12 +68,11 @@ TTS_CASE_WITH("Check behavior of bit_or on floating types",
   using eve::as;
   using eve::bit_cast;
   using eve::bit_or;
-  using eve::detail::map;
   using i_t = eve::as_integer_t<eve::element_type_t<T>, signed>;
   using v_t = eve::element_type_t<T>;
   TTS_IEEE_EQUAL(
       bit_or(a0, a1),
-      map([](auto e, auto f) -> v_t
+      tts::map([](auto e, auto f) -> v_t
           { return bit_cast(bit_cast(e, as(i_t())) | bit_cast(f, as(i_t())), as(v_t())); },
           a0,
           a1));

--- a/test/unit/module/core/bit_ornot.cpp
+++ b/test/unit/module/core/bit_ornot.cpp
@@ -47,14 +47,13 @@ TTS_CASE_WITH("Check behavior of bit_ornot on integral types",
 {
   using eve::as;
   using eve::bit_ornot;
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
-  TTS_EQUAL(bit_ornot(a0, a1), map([](auto e, auto f) -> v_t { return e | ~f; }, a0, a1));
+  TTS_EQUAL(bit_ornot(a0, a1), tts::map([](auto e, auto f) -> v_t { return e | ~f; }, a0, a1));
   auto test = a3 > eve::average(eve::valmin(as<T>()), eve::valmax(as<T>()));
   TTS_EQUAL(bit_ornot[test](a0, a1), eve::if_else(test, eve::bit_ornot(a0, a1), a0));
   TTS_EQUAL(bit_ornot[test](a0, a1, a2),
             eve::if_else(test, eve::bit_ornot(a0, eve::bit_and(a1, a2)), a0));
-  TTS_EQUAL(bit_ornot(kumi::tuple{a0, a1}), map([](auto e, auto f) -> v_t { return e | ~f; }, a0, a1));
+  TTS_EQUAL(bit_ornot(kumi::tuple{a0, a1}), tts::map([](auto e, auto f) -> v_t { return e | ~f; }, a0, a1));
   TTS_EQUAL(bit_ornot[test](kumi::tuple{a0, a1}), eve::if_else(test, eve::bit_ornot(a0, a1), a0));
   TTS_EQUAL(bit_ornot[test](kumi::tuple{a0, a1, a2}), eve::if_else(test, eve::bit_ornot(a0, eve::bit_and(a1, a2)), a0));
 };
@@ -70,12 +69,11 @@ TTS_CASE_WITH("Check behavior of bit_ornot on floating types",
   using eve::as;
   using eve::bit_cast;
   using eve::bit_ornot;
-  using eve::detail::map;
   using i_t = eve::as_integer_t<eve::element_type_t<T>, signed>;
   using v_t = eve::element_type_t<T>;
   TTS_IEEE_EQUAL(
       bit_ornot(a0, a1),
-      map([](auto e, auto f) -> v_t
+      tts::map([](auto e, auto f) -> v_t
           { return bit_cast(bit_cast(e, as(i_t())) | ~bit_cast(f, as(i_t())), as(v_t())); },
           a0,
           a1));

--- a/test/unit/module/core/bit_reverse.cpp
+++ b/test/unit/module/core/bit_reverse.cpp
@@ -31,9 +31,8 @@ TTS_CASE_WITH("Check behavior of bit_reverse(simd) on integral types",
 {
   using v_t = eve::element_type_t<T>;
   using eve::bit_reverse;
-  using eve::detail::map;
-  TTS_EQUAL(bit_reverse(a0), map([](auto e) -> v_t { return bit_reverse(e); }, a0));
+  TTS_EQUAL(bit_reverse(a0), tts::map([](auto e) -> v_t { return bit_reverse(e); }, a0));
   TTS_EQUAL(eve::bit_reverse[t](a0), eve::if_else(t, eve::bit_reverse(a0), a0));
-  TTS_EQUAL(bit_reverse(a0, 2), map([](auto e) -> v_t { return bit_reverse(e, 2); }, a0));
+  TTS_EQUAL(bit_reverse(a0, 2), tts::map([](auto e) -> v_t { return bit_reverse(e, 2); }, a0));
   TTS_EQUAL(eve::bit_reverse[t](a0, 2), eve::if_else(t, eve::bit_reverse(a0, 2), a0));
 };

--- a/test/unit/module/core/bit_select.cpp
+++ b/test/unit/module/core/bit_select.cpp
@@ -36,7 +36,6 @@ TTS_CASE_WITH("Check behavior of bit_select(simd) on integers",
 {
   using v_t = eve::element_type_t<T>;
   using eve::bit_select;
-  using eve::detail::map;
   TTS_EQUAL(bit_select(a0, a1, a2),
-            map([](auto x, auto y, auto z) -> v_t { return (y & x) | (z & ~x); }, a0, a1, a2));
+            tts::map([](auto x, auto y, auto z) -> v_t { return (y & x) | (z & ~x); }, a0, a1, a2));
 };

--- a/test/unit/module/core/bit_set.cpp
+++ b/test/unit/module/core/bit_set.cpp
@@ -19,7 +19,6 @@ TTS_CASE_WITH("Check behavior of bit_set(simd) on integral types",
 {
   using v_t = eve::element_type_t<T>;
   using eve::bit_set;
-  using eve::detail::map;
-  TTS_EQUAL(bit_set(a0, 0u), map([](auto e) -> v_t { return eve::bit_set(e, 0u); }, a0));
+  TTS_EQUAL(bit_set(a0, 0u), tts::map([](auto e) -> v_t { return eve::bit_set(e, 0u); }, a0));
   TTS_EQUAL(eve::bit_set[t](a0, 0u), eve::if_else(t, eve::bit_set(a0, 0u), a0));
 };

--- a/test/unit/module/core/bit_shl.cpp
+++ b/test/unit/module/core/bit_shl.cpp
@@ -43,9 +43,8 @@ TTS_CASE_WITH("Check behavior of bit_shl(wide, wide)",
 <typename T, typename I, typename L>(T a0, I a1, L test)
 {
   using eve::bit_shl;
-  using eve::detail::map;
   using v_t = typename T::value_type;
-  TTS_EQUAL(bit_shl(a0, a1), map([](auto e, auto s) -> v_t { return e << s; }, a0, a1));
+  TTS_EQUAL(bit_shl(a0, a1), tts::map([](auto e, auto s) -> v_t { return e << s; }, a0, a1));
   TTS_EQUAL(bit_shl[test](a0, a1), eve::if_else(test, eve::bit_shl(a0, a1), a0));
 };
 
@@ -55,10 +54,9 @@ TTS_CASE_WITH("Check behavior of bit_shl(wide, scalar)",
 <typename T, typename I, typename L>(T a0, I s, L test)
 {
   using eve::bit_shl;
-  using eve::detail::map;
   auto val  = s.get(0);
   using v_t = typename T::value_type;
-  TTS_EQUAL(bit_shl(a0, val), map([&](auto e) -> v_t { return e << val; }, a0));
+  TTS_EQUAL(bit_shl(a0, val), tts::map([&](auto e) -> v_t { return e << val; }, a0));
   TTS_EQUAL(bit_shl[test](a0, val), eve::if_else(test, eve::bit_shl(a0, val), a0));
 };
 
@@ -68,9 +66,8 @@ TTS_CASE_WITH("Check behavior of bit_shl(wide, integral constant)",
 <typename T, typename L>(T a0, L test)
 {
   using eve::bit_shl;
-  using eve::detail::map;
   using v_t = typename T::value_type;
-  TTS_EQUAL(bit_shl(a0, eve::index<1>), map([&](auto e) -> v_t { return e << 1; }, a0));
+  TTS_EQUAL(bit_shl(a0, eve::index<1>), tts::map([&](auto e) -> v_t { return e << 1; }, a0));
   TTS_EQUAL(bit_shl[test](a0, eve::index<1>), eve::if_else(test, eve::bit_shl(a0, eve::index<1>), a0));
 };
 

--- a/test/unit/module/core/bit_shr.cpp
+++ b/test/unit/module/core/bit_shr.cpp
@@ -44,10 +44,9 @@ TTS_CASE_WITH("Check behavior of shr(wide, wide)",
 <typename T, typename I, typename L>(T a0, I a1, L test)
 {
   using eve::bit_shr;
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
   using u_t = eve::as_integer_t<v_t, unsigned>;
-  TTS_EQUAL(bit_shr(a0, a1), map([](auto e, auto s) -> v_t { return v_t(u_t(e) >> s); }, a0, a1));
+  TTS_EQUAL(bit_shr(a0, a1), tts::map([](auto e, auto s) -> v_t { return v_t(u_t(e) >> s); }, a0, a1));
   TTS_EQUAL(bit_shr[test](a0, a1), eve::if_else(test, eve::bit_shr(a0, a1), a0));
 };
 
@@ -57,9 +56,8 @@ TTS_CASE_WITH("Check behavior of bit_shr(wide, integral constant)",
 <typename T, typename L>(T a0, L test)
 {
   using eve::bit_shr;
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
-  TTS_EQUAL(bit_shr(a0, eve::index<1>), map([&](auto e) -> v_t { return eve::bit_shr(e, eve::index<1>); }, a0));
+  TTS_EQUAL(bit_shr(a0, eve::index<1>), tts::map([&](auto e) -> v_t { return eve::bit_shr(e, eve::index<1>); }, a0));
   TTS_EQUAL(bit_shr[test](a0, eve::index<1>), eve::if_else(test, eve::bit_shr(a0, eve::index<1>), a0));
 };
 
@@ -69,11 +67,10 @@ TTS_CASE_WITH("Check behavior of shift(wide, scalar)",
 <typename T, typename I, typename L>(T a0, I s, L test)
 {
   using eve::bit_shr;
-  using eve::detail::map;
   auto val  = s.get(0);
   using v_t = eve::element_type_t<T>;
   using u_t = eve::as_integer_t<v_t, unsigned>;
-  TTS_EQUAL(bit_shr(a0, val), map([&](auto e) -> v_t { return v_t(u_t(e) >> val); }, a0));
+  TTS_EQUAL(bit_shr(a0, val), tts::map([&](auto e) -> v_t { return v_t(u_t(e) >> val); }, a0));
   TTS_EQUAL(bit_shr[test](a0, val), eve::if_else(test, eve::bit_shr(a0, val), a0));
 };
 

--- a/test/unit/module/core/bit_swap_adjacent.cpp
+++ b/test/unit/module/core/bit_swap_adjacent.cpp
@@ -31,35 +31,35 @@ TTS_CASE_WITH("Check behavior of bit_swap_adjacent(simd) on unsigned types",
   using eve::bit_swap_adjacent;
   {
     int n = 1;
-    TTS_EQUAL(bit_swap_adjacent(a0, n), map([n](auto e) -> v_t { return bit_swap_adjacent(e, n); }, a0));
+    TTS_EQUAL(bit_swap_adjacent(a0, n), tts::map([n](auto e) -> v_t { return bit_swap_adjacent(e, n); }, a0));
     TTS_EQUAL(eve::bit_swap_adjacent[t](a0, n), eve::if_else(t, eve::bit_swap_adjacent(a0, n), a0));
   }
   {
     int n = 2;
-    TTS_EQUAL(bit_swap_adjacent(a0, n), map([n](auto e) -> v_t { return bit_swap_adjacent(e, n); }, a0));
+    TTS_EQUAL(bit_swap_adjacent(a0, n), tts::map([n](auto e) -> v_t { return bit_swap_adjacent(e, n); }, a0));
     TTS_EQUAL(eve::bit_swap_adjacent[t](a0, n), eve::if_else(t, eve::bit_swap_adjacent(a0, n), a0));
   }
   {
     int n = 4;
-    TTS_EQUAL(bit_swap_adjacent(a0, n), map([n](auto e) -> v_t { return bit_swap_adjacent(e, n); }, a0));
+    TTS_EQUAL(bit_swap_adjacent(a0, n), tts::map([n](auto e) -> v_t { return bit_swap_adjacent(e, n); }, a0));
     TTS_EQUAL(eve::bit_swap_adjacent[t](a0, n), eve::if_else(t, eve::bit_swap_adjacent(a0, n), a0));
   }
   if constexpr(sizeof(v_t) >= 2)
   {
     int n = 8;
-    TTS_EQUAL(bit_swap_adjacent(a0, n), map([n](auto e) -> v_t { return bit_swap_adjacent(e, n); }, a0));
+    TTS_EQUAL(bit_swap_adjacent(a0, n), tts::map([n](auto e) -> v_t { return bit_swap_adjacent(e, n); }, a0));
     TTS_EQUAL(eve::bit_swap_adjacent[t](a0, n), eve::if_else(t, eve::bit_swap_adjacent(a0, n), a0));
   }
   if constexpr(sizeof(v_t) >= 4)
   {
     int n = 16;
-    TTS_EQUAL(bit_swap_adjacent(a0, n), map([n](auto e) -> v_t { return bit_swap_adjacent(e, n); }, a0));
+    TTS_EQUAL(bit_swap_adjacent(a0, n), tts::map([n](auto e) -> v_t { return bit_swap_adjacent(e, n); }, a0));
     TTS_EQUAL(eve::bit_swap_adjacent[t](a0, n), eve::if_else(t, eve::bit_swap_adjacent(a0, n), a0));
   }
   if constexpr(sizeof(v_t) == 8)
   {
     int n = 32;
-    TTS_EQUAL(bit_swap_adjacent(a0, n), map([n](auto e) -> v_t { return bit_swap_adjacent(e, n); }, a0));
+    TTS_EQUAL(bit_swap_adjacent(a0, n), tts::map([n](auto e) -> v_t { return bit_swap_adjacent(e, n); }, a0));
     TTS_EQUAL(eve::bit_swap_adjacent[t](a0, n), eve::if_else(t, eve::bit_swap_adjacent(a0, n), a0));
   }
 };

--- a/test/unit/module/core/bit_swap_pairs.cpp
+++ b/test/unit/module/core/bit_swap_pairs.cpp
@@ -19,9 +19,8 @@ TTS_CASE_WITH("Check behavior of bit_swap_pairs(simd) on integral types",
 {
   using v_t = eve::element_type_t<T>;
   using eve::bit_swap_pairs;
-  using eve::detail::map;
 
-  TTS_EQUAL(bit_swap_pairs(a0, 0u, 7u), map([](auto e) -> v_t { return eve::bit_swap_pairs(e, 0u, 7u); }, a0)) << a0 << '\n';
+  TTS_EQUAL(bit_swap_pairs(a0, 0u, 7u), tts::map([](auto e) -> v_t { return eve::bit_swap_pairs(e, 0u, 7u); }, a0)) << a0 << '\n';
   TTS_EQUAL(eve::bit_swap_pairs[t](a0, 0u, 7u), eve::if_else(t, eve::bit_swap_pairs(a0, 0u, 7u), a0));
 
   eve::wide<int, typename T::cardinal_type> wn{[](auto i, auto) { return -i; }};

--- a/test/unit/module/core/bit_unset.cpp
+++ b/test/unit/module/core/bit_unset.cpp
@@ -19,7 +19,6 @@ TTS_CASE_WITH("Check behavior of bit_unset(simd) on integral types",
 {
   using v_t = eve::element_type_t<T>;
   using eve::bit_unset;
-  using eve::detail::map;
-  TTS_EQUAL(bit_unset(a0, 0u), map([](auto e) -> v_t { return eve::bit_unset(e, 0u); }, a0)) << a0 << '\n';
+  TTS_EQUAL(bit_unset(a0, 0u), tts::map([](auto e) -> v_t { return eve::bit_unset(e, 0u); }, a0)) << a0 << '\n';
   TTS_EQUAL(eve::bit_unset[t](a0, 0u), eve::if_else(t, eve::bit_unset(a0, 0u), a0));
 };

--- a/test/unit/module/core/bit_width.cpp
+++ b/test/unit/module/core/bit_width.cpp
@@ -31,9 +31,8 @@ TTS_CASE_WITH("Check behavior of bit_width(wide) on unsigned integrals",
               tts::generate(tts::randoms(eve::valmin, eve::valmax), tts::logicals(0, 3)))
 <typename T, typename U>(T const& a0, U const& t)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
-  TTS_EQUAL(eve::bit_width(a0), map([](auto e) -> v_t { return std::bit_width(e); }, a0));
+  TTS_EQUAL(eve::bit_width(a0), tts::map([](auto e) -> v_t { return std::bit_width(e); }, a0));
   TTS_EQUAL(eve::bit_width[t](a0), eve::if_else(t, eve::bit_width(a0), a0));
 };
 
@@ -45,7 +44,6 @@ TTS_CASE_WITH("Check behavior of bit_width(wide) on unsigned integrals",
               tts::generate(tts::randoms(eve::valmin, eve::valmax)))
 <typename T>(T const& a0)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
   for( int i = 0; i != T::size(); ++i )
   {

--- a/test/unit/module/core/bit_xor.cpp
+++ b/test/unit/module/core/bit_xor.cpp
@@ -47,13 +47,12 @@ TTS_CASE_WITH("Check behavior of bit_xor on integral types",
 {
   using eve::as;
   using eve::bit_xor;
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
-  TTS_EQUAL(bit_xor(a0, a1), map([](auto e, auto f) -> v_t { return e ^ f; }, a0, a1));
+  TTS_EQUAL(bit_xor(a0, a1), tts::map([](auto e, auto f) -> v_t { return e ^ f; }, a0, a1));
   auto test = a3 > eve::average(eve::valmin(as<T>()), eve::valmax(as<T>()));
   TTS_EQUAL(bit_xor[test](a0, a1), eve::if_else(test, eve::bit_xor(a0, a1), a0));
   TTS_EQUAL(bit_xor[test](a0, a1, a2), eve::if_else(test, eve::bit_xor(a0, a1, a2), a0));
-  TTS_EQUAL(bit_xor(kumi::tuple{a0, a1}), map([](auto e, auto f) -> v_t { return e ^ f; }, a0, a1));
+  TTS_EQUAL(bit_xor(kumi::tuple{a0, a1}), tts::map([](auto e, auto f) -> v_t { return e ^ f; }, a0, a1));
   TTS_EQUAL(bit_xor[test](kumi::tuple{a0, a1}), eve::if_else(test, eve::bit_xor(a0, a1), a0));
   TTS_EQUAL(bit_xor[test](kumi::tuple{a0, a1, a2}), eve::if_else(test, eve::bit_xor(a0, a1, a2), a0));
 };
@@ -69,12 +68,11 @@ TTS_CASE_WITH("Check behavior of bit_xor on floating types",
   using eve::as;
   using eve::bit_cast;
   using eve::bit_xor;
-  using eve::detail::map;
   using i_t = eve::as_integer_t<eve::element_type_t<T>, signed>;
   using v_t = eve::element_type_t<T>;
   TTS_IEEE_EQUAL(
       bit_xor(a0, a1),
-      map([](auto e, auto f) -> v_t
+      tts::map([](auto e, auto f) -> v_t
           { return bit_cast(bit_cast(e, as(i_t())) ^ bit_cast(f, as(i_t())), as(v_t())); },
           a0,
           a1));

--- a/test/unit/module/core/bitofsign.cpp
+++ b/test/unit/module/core/bitofsign.cpp
@@ -36,9 +36,8 @@ TTS_CASE_WITH("Check behavior of bitofsign(wide)",
               tts::generate(tts::randoms(eve::valmin, eve::valmax)))
 <typename T>(T const& a0)
 {
-  using eve::detail::map;
   TTS_EQUAL(eve::bitofsign(a0),
-            map([&](auto e) { return eve::bit_and(e, eve::signmask(eve::as(e))); }, a0));
+            tts::map([&](auto e) { return eve::bit_and(e, eve::signmask(eve::as(e))); }, a0));
 };
 
 //==================================================================================================
@@ -51,8 +50,7 @@ TTS_CASE_WITH("Check behavior of bitofsign(wide)",
 {
   using v_t = eve::element_type_t<T>;
   auto val  = eve::unsigned_value<v_t> ? (eve::valmax(eve::as<v_t>()) / 2) : 0;
-  using eve::detail::map;
   TTS_EQUAL(
       eve::bitofsign[a0 < val](a0),
-      map([&](auto e) { return (e < val) ? eve::bit_and(e, eve::signmask(eve::as(e))) : e; }, a0));
+      tts::map([&](auto e) { return (e < val) ? eve::bit_and(e, eve::signmask(eve::as(e))) : e; }, a0));
 };

--- a/test/unit/module/core/byte_reverse.cpp
+++ b/test/unit/module/core/byte_reverse.cpp
@@ -30,8 +30,8 @@ TTS_CASE_WITH("Check behavior of byte_reverse(simd) on integral types",
   if constexpr(sizeof(v_t) == 8)
   {
     using eve::byte_reverse;
-    using eve::detail::map;
-    TTS_EQUAL(byte_reverse(a0), map([](auto e) -> v_t { return byte_reverse(e); }, a0));
+    ;
+    TTS_EQUAL(byte_reverse(a0), tts::map([](auto e) -> v_t { return byte_reverse(e); }, a0));
     TTS_EQUAL(eve::byte_reverse[t](a0), eve::if_else(t, eve::byte_reverse(a0), a0));
   }
 };

--- a/test/unit/module/core/byte_swap_adjacent.cpp
+++ b/test/unit/module/core/byte_swap_adjacent.cpp
@@ -31,23 +31,22 @@ TTS_CASE_WITH("Check behavior of byte_swap_adjacent(simd) on unsigned types",
   using v_t = eve::element_type_t<T>;
   using eve::byte_swap_adjacent;
   using eve::bit_swap_adjacent;
-  using eve::detail::map;
  if constexpr(sizeof(v_t) >= 2)
  {
     int n= 1;
-    TTS_EQUAL(byte_swap_adjacent(a0, n), map([n](auto e) -> v_t { return byte_swap_adjacent(e, n); }, a0)) << a0 << '\n';
+    TTS_EQUAL(byte_swap_adjacent(a0, n), tts::map([n](auto e) -> v_t { return byte_swap_adjacent(e, n); }, a0)) << a0 << '\n';
     TTS_EQUAL(eve::byte_swap_adjacent[t](a0, n), eve::if_else(t, eve::byte_swap_adjacent(a0, n), a0));
   }
   if constexpr(sizeof(v_t) >= 4)
   {
     int n= 2;
-    TTS_EQUAL(byte_swap_adjacent(a0, n), map([n](auto e) -> v_t { return byte_swap_adjacent(e, n); }, a0)) << a0 << '\n';
+    TTS_EQUAL(byte_swap_adjacent(a0, n), tts::map([n](auto e) -> v_t { return byte_swap_adjacent(e, n); }, a0)) << a0 << '\n';
     TTS_EQUAL(eve::byte_swap_adjacent[t](a0, n), eve::if_else(t, eve::byte_swap_adjacent(a0, n), a0));
   }
   if constexpr(sizeof(v_t) >= 8)
   {
     int n= 4;
-    TTS_EQUAL(byte_swap_adjacent(a0, n), map([n](auto e) -> v_t { return byte_swap_adjacent(e, n); }, a0)) << a0 << '\n';
+    TTS_EQUAL(byte_swap_adjacent(a0, n), tts::map([n](auto e) -> v_t { return byte_swap_adjacent(e, n); }, a0)) << a0 << '\n';
     TTS_EQUAL(eve::byte_swap_adjacent[t](a0, n), eve::if_else(t, eve::byte_swap_adjacent(a0, n), a0));
   }
 };

--- a/test/unit/module/core/byte_swap_pairs.cpp
+++ b/test/unit/module/core/byte_swap_pairs.cpp
@@ -23,9 +23,8 @@ TTS_CASE_WITH("Check behavior of byte_swap_pairs(simd) on integral types",
  constexpr auto _S = eve::index_t<S-1>();
  constexpr auto _H = eve::index_t<S/2>();
   using eve::byte_swap_pairs;
-  using eve::detail::map;
-  TTS_EQUAL(byte_swap_pairs(a0, _0, _S), map([_0, _S](auto e) -> v_t { return eve::byte_swap_pairs(e, _0, _S); }, a0));
+  TTS_EQUAL(byte_swap_pairs(a0, _0, _S), tts::map([_0, _S](auto e) -> v_t { return eve::byte_swap_pairs(e, _0, _S); }, a0));
   TTS_EQUAL(eve::byte_swap_pairs[t](a0, _0, _S), eve::if_else(t, eve::byte_swap_pairs(a0, _0, _S), a0));
-  TTS_EQUAL(byte_swap_pairs(a0, _0, _H), map([_0, _H](auto e) -> v_t { return eve::byte_swap_pairs(e, _0, _H); }, a0));
+  TTS_EQUAL(byte_swap_pairs(a0, _0, _H), tts::map([_0, _H](auto e) -> v_t { return eve::byte_swap_pairs(e, _0, _H); }, a0));
   TTS_EQUAL(eve::byte_swap_pairs[t](a0, _0, _H), eve::if_else(t, eve::byte_swap_pairs(a0, _0, _H), a0));
 };

--- a/test/unit/module/core/ceil.cpp
+++ b/test/unit/module/core/ceil.cpp
@@ -82,7 +82,6 @@ TTS_CASE_WITH("Check behavior of ceil(wide))",
               tts::generate(tts::randoms(min, +50)))
 <typename T>(T const& a0)
 {
-  using eve::detail::map;
   using wi_t  = eve::as_integer_t<T>;
   using uwi_t = eve::as_integer_t<T, unsigned>;
   using v_t   = eve::element_type_t<T>;
@@ -90,7 +89,7 @@ TTS_CASE_WITH("Check behavior of ceil(wide))",
   using ui_t  = eve::as_integer_t<v_t, unsigned>;
   if constexpr( eve::floating_value<T> )
   {
-    TTS_EQUAL(eve::ceil(a0), map([&](auto e) -> v_t { return v_t(std::ceil(e)); }, a0));
+    TTS_EQUAL(eve::ceil(a0), tts::map([&](auto e) -> v_t { return v_t(std::ceil(e)); }, a0));
 
     TTS_EQUAL(eve::ceil(a0, eve::as<int>()),
               wi_t([&](auto i, auto) { return i_t(std::ceil(a0.get(i))); }));

--- a/test/unit/module/core/chi.cpp
+++ b/test/unit/module/core/chi.cpp
@@ -43,13 +43,13 @@ TTS_CASE_WITH("Check behavior of chi(wide) and diff  on all types",
   using v_t = eve::element_type_t<T>;
 
   TTS_EQUAL(chi(a0, a1, a2),
-             map([&](auto e, auto f, auto g) -> v_t { return e >= f && e < g; }, a0, a1, a2));
+             tts::map([&](auto e, auto f, auto g) -> v_t { return e >= f && e < g; }, a0, a1, a2));
 
   auto b = [a1, a2](auto x){return (x <  a1) || (x >= a2); };
   TTS_EQUAL(chi(a0, b),
-             map([](auto e, auto f, auto g) -> v_t { return (e < f || e >=  g); }, a0, a1, a2));
+             tts::map([](auto e, auto f, auto g) -> v_t { return (e < f || e >=  g); }, a0, a1, a2));
   TTS_EQUAL(chi(a0, a1, 2),
-            map([&](auto e, auto f) -> v_t { return e >= f && e < 2; }, a0, a1));
+            tts::map([&](auto e, auto f) -> v_t { return e >= f && e < 2; }, a0, a1));
 
 };
 

--- a/test/unit/module/core/clamp.cpp
+++ b/test/unit/module/core/clamp.cpp
@@ -52,7 +52,7 @@ TTS_CASE_WITH("Check behavior of clamp(wide) and diff  on all types",
   using v_t = eve::element_type_t<T>;
 
   TTS_EQUAL(clamp(a0, a1, a2),
-            map([&](auto e, auto f, auto g) -> v_t { return std::clamp(e, f, g); }, a0, a1, a2));
+            tts::map([&](auto e, auto f, auto g) -> v_t { return std::clamp(e, f, g); }, a0, a1, a2));
 };
 
 

--- a/test/unit/module/core/copysign.cpp
+++ b/test/unit/module/core/copysign.cpp
@@ -34,15 +34,14 @@ TTS_CASE_WITH("Check behavior of copysign on wide and scalar",
                             tts::randoms(eve::valmin, eve::valmax)))
 <typename T>(T const& a0, T const& a1)
 {
-  using eve::detail::map;
   auto val1 = a1.get(0);
   auto val0 = a0.get(0);
   TTS_EQUAL(eve::copysign(a0, a1),
-            map([&](auto e, auto f) { return eve::abs(e) * eve::sign(f); }, a0, a1));
+            tts::map([&](auto e, auto f) { return eve::abs(e) * eve::sign(f); }, a0, a1));
   TTS_EQUAL(eve::copysign(val0, a1),
-            map([&](auto f) { return eve::abs(val0) * eve::sign(f); }, a1));
+            tts::map([&](auto f) { return eve::abs(val0) * eve::sign(f); }, a1));
   TTS_EQUAL(eve::copysign(a0, val1),
-            map([&](auto e) { return eve::abs(e) * eve::sign(val1); }, a0));
+            tts::map([&](auto e) { return eve::abs(e) * eve::sign(val1); }, a0));
 };
 
 

--- a/test/unit/module/core/countl_one.cpp
+++ b/test/unit/module/core/countl_one.cpp
@@ -32,6 +32,6 @@ TTS_CASE_WITH("Check behavior of countl_one(wide) on unsigned integral ",
 <typename T, typename M>(T const& a0, const M t)
 {
   using v_t = eve::element_type_t<T>;
-  TTS_EQUAL(eve::countl_one(a0), map([](auto e) -> v_t { return std::countl_one(e); }, a0));
+  TTS_EQUAL(eve::countl_one(a0), tts::map([](auto e) -> v_t { return std::countl_one(e); }, a0));
   TTS_EQUAL(eve::countl_one[t](a0), eve::if_else(t, eve::countl_one(a0), a0));
 };

--- a/test/unit/module/core/countl_zero.cpp
+++ b/test/unit/module/core/countl_zero.cpp
@@ -32,11 +32,11 @@ TTS_CASE_WITH("Check behavior of countl_zero(wide) on unsigned integral ",
 <typename T, typename M>(T const& a0, const M t)
 {
   using v_t = eve::element_type_t<T>;
-  TTS_EQUAL(eve::countl_zero(a0), map([](auto e) -> v_t { return std::countl_zero(e); }, a0));
+  TTS_EQUAL(eve::countl_zero(a0), tts::map([](auto e) -> v_t { return std::countl_zero(e); }, a0));
   TTS_EQUAL(eve::countl_zero[t](a0), eve::if_else(t, eve::countl_zero(a0), a0));
   for( v_t i = 0; i < sizeof(v_t) * 8 - 1; ++i )
   {
     auto j = T(v_t(1) << i);
-    TTS_EQUAL(eve::countl_zero(j), map([](auto e) -> v_t { return std::countl_zero(e); }, j));
+    TTS_EQUAL(eve::countl_zero(j), tts::map([](auto e) -> v_t { return std::countl_zero(e); }, j));
   }
 };

--- a/test/unit/module/core/countr_one.cpp
+++ b/test/unit/module/core/countr_one.cpp
@@ -32,6 +32,6 @@ TTS_CASE_WITH("Check behavior of countr_one(wide) on unsigned integral ",
 <typename T, typename M>(T const& a0, const M t)
 {
   using v_t = eve::element_type_t<T>;
-  TTS_EQUAL(eve::countr_one(a0), map([](auto e) -> v_t { return std::countr_one(e); }, a0));
+  TTS_EQUAL(eve::countr_one(a0), tts::map([](auto e) -> v_t { return std::countr_one(e); }, a0));
   TTS_EQUAL(eve::countr_one[t](a0), eve::if_else(t, eve::countr_one(a0), a0));
 };

--- a/test/unit/module/core/countr_zero.cpp
+++ b/test/unit/module/core/countr_zero.cpp
@@ -32,6 +32,6 @@ TTS_CASE_WITH("Check behavior of countr_zero(wide) on unsigned integral ",
 <typename T, typename M>(T const& a0, const M t)
 {
   using v_t = eve::element_type_t<T>;
-  TTS_EQUAL(eve::countr_zero(a0), map([](auto e) -> v_t { return std::countr_zero(e); }, a0));
+  TTS_EQUAL(eve::countr_zero(a0), tts::map([](auto e) -> v_t { return std::countr_zero(e); }, a0));
   TTS_EQUAL(eve::countr_zero[t](a0), eve::if_else(t, eve::countr_zero(a0), a0));
 };

--- a/test/unit/module/core/dec.cpp
+++ b/test/unit/module/core/dec.cpp
@@ -50,11 +50,11 @@ TTS_CASE_WITH("Check behavior of dec(wide) and dec[cond](wide)",
 {
   using v_t = eve::element_type_t<T>;
 
-  TTS_EQUAL(eve::dec(a0), map([](auto e) -> v_t { return v_t(e - 1); }, a0));
+  TTS_EQUAL(eve::dec(a0), tts::map([](auto e) -> v_t { return v_t(e - 1); }, a0));
   TTS_EQUAL(eve::dec[a0 > 64](a0),
-            map([](auto e) -> v_t { return v_t((e > 64) ? e - 1 : e); }, a0));
+            tts::map([](auto e) -> v_t { return v_t((e > 64) ? e - 1 : e); }, a0));
   bool z = (a0.get(0) > 64);
-  TTS_EQUAL(eve::dec[z](a0), map([&](auto e) -> v_t { return v_t((z) ? e - 1 : e); }, a0));
+  TTS_EQUAL(eve::dec[z](a0), tts::map([&](auto e) -> v_t { return v_t((z) ? e - 1 : e); }, a0));
   if constexpr(eve::floating_value<T>)
   {
     TTS_EXPECT(eve::all(eve::dec[eve::lower](a0) <= eve::dec(a0)));
@@ -71,15 +71,15 @@ TTS_CASE_WITH("Check behavior of dec[saturated](wide) on integral types",
 {
   using v_t = eve::element_type_t<T>;
   TTS_EQUAL(eve::dec[eve::saturated](a0),
-            map([](auto e) -> v_t { return v_t(e == eve::valmin(eve::as(e)) ? e : e - 1); }, a0));
+            tts::map([](auto e) -> v_t { return v_t(e == eve::valmin(eve::as(e)) ? e : e - 1); }, a0));
   TTS_EQUAL(eve::dec[eve::saturated][a0 > 64](a0),
-            map([](auto e) -> v_t
+            tts::map([](auto e) -> v_t
                 { return v_t((e > 64 && e != eve::valmin(eve::as(e)) ? e - 1 : e)); },
                 a0));
   bool z = (a0.get(0) > 64);
   TTS_EQUAL(
       eve::dec[eve::saturated][z](a0),
-      map([&](auto e) -> v_t { return v_t((z && e != eve::valmin(eve::as(e)) ? e - 1 : e)); }, a0));
+      tts::map([&](auto e) -> v_t { return v_t((z && e != eve::valmin(eve::as(e)) ? e - 1 : e)); }, a0));
 };
 
 TTS_CASE_WITH("Check behavior of dec[saturated](wide) on integral types",

--- a/test/unit/module/core/decorated.div.cpp
+++ b/test/unit/module/core/decorated.div.cpp
@@ -62,13 +62,12 @@ TTS_CASE_WITH("Check behavior of div on wide",
   using eve::downward;
   using eve::to_nearest;
   using eve::upward;
-  using eve::detail::map;
   a2 = eve::if_else(eve::is_eqz(a2), eve::one, a2);
 
-  TTS_EQUAL(eve::div(a0, a2), map([](auto e, auto f) { return eve::div(e, f); }, a0, a2));
-  TTS_EQUAL(div[downward](a0, a2), map([&](auto e, auto f) { return div[downward](e, f); }, a0, a2));
-  TTS_EQUAL(div[upward](a0, a2), map([&](auto e, auto f) { return div[upward](e, f); }, a0, a2));
-  TTS_EQUAL(div[to_nearest](a0, a2),  map([&](auto e, auto f) { return div[to_nearest](e, f); }, a0, a2));
+  TTS_EQUAL(eve::div(a0, a2), tts::map([](auto e, auto f) { return eve::div(e, f); }, a0, a2));
+  TTS_EQUAL(div[downward](a0, a2), tts::map([&](auto e, auto f) { return div[downward](e, f); }, a0, a2));
+  TTS_EQUAL(div[upward](a0, a2), tts::map([&](auto e, auto f) { return div[upward](e, f); }, a0, a2));
+  TTS_EQUAL(div[to_nearest](a0, a2),  tts::map([&](auto e, auto f) { return div[to_nearest](e, f); }, a0, a2));
 };
 
 //==================================================================================================
@@ -216,19 +215,18 @@ TTS_CASE_WITH("Check behavior of div on signed types",
   using eve::is_nez;
   using eve::to_nearest;
   using eve::upward;
-  using eve::detail::map;
   TTS_ULP_EQUAL(div[downward][is_nez(a2)](a0, a2),
-                map([](auto e, auto f) { return is_nez(f) ? div[downward](e, f) : e; }, a0, a2),
+                tts::map([](auto e, auto f) { return is_nez(f) ? div[downward](e, f) : e; }, a0, a2),
                 2.5);
   TTS_ULP_EQUAL(div[upward][is_nez(a2)](a0, a2),
-                map([](auto e, auto f) { return is_nez(f) ? div[upward](e, f) : e; }, a0, a2),
+                tts::map([](auto e, auto f) { return is_nez(f) ? div[upward](e, f) : e; }, a0, a2),
                 2.5);
   TTS_ULP_EQUAL(div[to_nearest][is_nez(a2)](a0, a2),
-                map([](auto e, auto f) { return is_nez(f) ? div[to_nearest](e, f) : e; }, a0, a2),
+                tts::map([](auto e, auto f) { return is_nez(f) ? div[to_nearest](e, f) : e; }, a0, a2),
                 2.5);
 
   a1 = eve::if_else(eve::is_eqz(a1), eve::one, a1);
-  TTS_EQUAL(div[downward][a2 > T(64)](a0, a1), map([](auto e, auto f, auto g) { return g > 64 ? div[downward](e, f) : e; }, a0, a1, a2));
-  TTS_EQUAL(div[upward][a2 > T(64)](a0, a1), map([](auto e, auto f, auto g) { return g > 64 ? div[upward](e, f) : e; }, a0, a1, a2));
-  TTS_EQUAL(div[to_nearest][a2 > T(64)](a0, a1), map([](auto e, auto f, auto g) { return g > 64 ? div[to_nearest](e, f) : e; }, a0, a1, a2));
+  TTS_EQUAL(div[downward][a2 > T(64)](a0, a1), tts::map([](auto e, auto f, auto g) { return g > 64 ? div[downward](e, f) : e; }, a0, a1, a2));
+  TTS_EQUAL(div[upward][a2 > T(64)](a0, a1), tts::map([](auto e, auto f, auto g) { return g > 64 ? div[upward](e, f) : e; }, a0, a1, a2));
+  TTS_EQUAL(div[to_nearest][a2 > T(64)](a0, a1), tts::map([](auto e, auto f, auto g) { return g > 64 ? div[to_nearest](e, f) : e; }, a0, a1, a2));
 };

--- a/test/unit/module/core/decorated.rem.cpp
+++ b/test/unit/module/core/decorated.rem.cpp
@@ -55,13 +55,12 @@ TTS_CASE_WITH("Check behavior of rem on wide",
   using eve::rem;
   using eve::to_nearest;
   using eve::upward;
-  using eve::detail::map;
   a2 = eve::if_else(eve::is_eqz(a2), eve::one, a2);
 
-  TTS_EQUAL(eve::rem(a0, a2), map([](auto e, auto f) { return eve::rem(e, f); }, a0, a2));
-  TTS_EQUAL(rem[downward](a0, a2),  map([&](auto e, auto f) { return rem[downward](e, f); }, a0, a2));
-  TTS_EQUAL(rem[upward](a0, a2), map([&](auto e, auto f) { return rem[upward](e, f); }, a0, a2));
-  TTS_EQUAL(rem[to_nearest](a0, a2), map([&](auto e, auto f) { return rem[to_nearest](e, f); }, a0, a2));
+  TTS_EQUAL(eve::rem(a0, a2), tts::map([](auto e, auto f) { return eve::rem(e, f); }, a0, a2));
+  TTS_EQUAL(rem[downward](a0, a2),  tts::map([&](auto e, auto f) { return rem[downward](e, f); }, a0, a2));
+  TTS_EQUAL(rem[upward](a0, a2), tts::map([&](auto e, auto f) { return rem[upward](e, f); }, a0, a2));
+  TTS_EQUAL(rem[to_nearest](a0, a2), tts::map([&](auto e, auto f) { return rem[to_nearest](e, f); }, a0, a2));
 };
 
 //==================================================================================================
@@ -178,14 +177,13 @@ TTS_CASE_WITH("Check behavior of rem on signed types",
   using eve::rem;
   using eve::to_nearest;
   using eve::upward;
-  using eve::detail::map;
 
-  TTS_RELATIVE_EQUAL( rem[is_nez(a2)][downward](a0, a2), map([](auto e, auto f) { return is_nez(f) ? rem[downward](e, f) : e; }, a0, a2),  4e-4);
-  TTS_RELATIVE_EQUAL(rem[is_nez(a2)][upward](a0, a2), map([](auto e, auto f) { return is_nez(f) ? rem[upward](e, f) : e; }, a0, a2),       4e-4);
-  TTS_RELATIVE_EQUAL(rem[is_nez(a2)][to_nearest](a0, a2), map([](auto e, auto f) { return is_nez(f) ? rem[to_nearest](e, f) : e; }, a0, a2), 4e-4);
+  TTS_RELATIVE_EQUAL( rem[is_nez(a2)][downward](a0, a2), tts::map([](auto e, auto f) { return is_nez(f) ? rem[downward](e, f) : e; }, a0, a2),  4e-4);
+  TTS_RELATIVE_EQUAL(rem[is_nez(a2)][upward](a0, a2), tts::map([](auto e, auto f) { return is_nez(f) ? rem[upward](e, f) : e; }, a0, a2),       4e-4);
+  TTS_RELATIVE_EQUAL(rem[is_nez(a2)][to_nearest](a0, a2), tts::map([](auto e, auto f) { return is_nez(f) ? rem[to_nearest](e, f) : e; }, a0, a2), 4e-4);
 
   a1 = eve::if_else(eve::is_eqz(a1), eve::one, a1);
-  TTS_RELATIVE_EQUAL(rem[a2 > T(64)][downward](a0, a1), map([](auto e, auto f, auto g) { return g > 64 ? rem[downward](e, f) : e; }, a0, a1, a2), 4e-4);
-  TTS_RELATIVE_EQUAL(rem[a2 > T(64)][upward](a0, a1),   map([](auto e, auto f, auto g) { return g > 64 ? rem[upward](e, f) : e; }, a0, a1, a2),   4e-4);
-  TTS_RELATIVE_EQUAL(rem[a2 > T(64)][to_nearest](a0, a1), map([](auto e, auto f, auto g) { return g > 64 ? rem[to_nearest](e, f) : e; }, a0, a1, a2), 4e-4);
+  TTS_RELATIVE_EQUAL(rem[a2 > T(64)][downward](a0, a1), tts::map([](auto e, auto f, auto g) { return g > 64 ? rem[downward](e, f) : e; }, a0, a1, a2), 4e-4);
+  TTS_RELATIVE_EQUAL(rem[a2 > T(64)][upward](a0, a1),   tts::map([](auto e, auto f, auto g) { return g > 64 ? rem[upward](e, f) : e; }, a0, a1, a2),   4e-4);
+  TTS_RELATIVE_EQUAL(rem[a2 > T(64)][to_nearest](a0, a1), tts::map([](auto e, auto f, auto g) { return g > 64 ? rem[to_nearest](e, f) : e; }, a0, a1, a2), 4e-4);
 };

--- a/test/unit/module/core/diff_of_prod.cpp
+++ b/test/unit/module/core/diff_of_prod.cpp
@@ -82,7 +82,6 @@ TTS_CASE_WITH("Check behavior of diff_of_prod upper lower on all types",
 {
   using eve::as;
   using eve::diff_of_prod;
-  using eve::detail::map;
   using eve::lower;
   using eve::upper;
   using eve::strict;

--- a/test/unit/module/core/dist.cpp
+++ b/test/unit/module/core/dist.cpp
@@ -43,7 +43,6 @@ TTS_CASE_WITH("Check behavior of dist(wide)",
 <typename T>(T a0, T a1)
 {
   using eve::dist;
-  using eve::detail::map;
   TTS_ULP_EQUAL(dist(a0, a1), eve::max(a0, a1) - eve::min(a0, a1), 2);
   TTS_ULP_EQUAL(dist[eve::saturated](a0, a1), [](auto a, auto b){
                   auto d = eve::dist(a, b);
@@ -81,13 +80,12 @@ TTS_CASE_WITH("Check behavior of dist(wide)",
 <typename T>(T const& a0, T const& a1)
 {
   using eve::dist;
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
   TTS_ULP_EQUAL(dist(a0, a1),
-                map([](auto e, auto f) -> v_t { return std::max(e, f) - std::min(f, e); }, a0, a1),
+                tts::map([](auto e, auto f) -> v_t { return std::max(e, f) - std::min(f, e); }, a0, a1),
                 2);
   TTS_ULP_EQUAL(dist[eve::saturated](a0, a1),
-                map(
+                tts::map(
                     [](auto e, auto f) -> v_t
                     {
                       v_t d = eve::max(e, f) - eve::min(f, e);

--- a/test/unit/module/core/div.cpp
+++ b/test/unit/module/core/div.cpp
@@ -78,19 +78,18 @@ TTS_CASE_WITH("Check behavior of div on wide",
   using eve::upper;
   using eve::lower;
   using eve::strict;
-  using eve::detail::map;
-  TTS_ULP_EQUAL(eve::div(a0, a2), map([](auto e, auto f) { return eve::div(e, f); }, a0, a2), 1);
-  TTS_ULP_EQUAL(eve::div[saturated](a0, a2), map([&](auto e, auto f) { return div[saturated](e, f); }, a0, a2), 1);
-  TTS_ULP_EQUAL(div(a0, a1, a2), map([&](auto e, auto f, auto g) { return div(e, mul(f, g)); }, a0, a1, a2), 1);
-  TTS_ULP_EQUAL(div[saturated](a0, a1, a2), map([&](auto e, auto f, auto g) { return div[saturated](e, mul[saturated](f, g)); }, a0, a1, a2),1);
-  TTS_ULP_EQUAL(eve::div(kumi::tuple{a0, a2}), map([](auto e, auto f) { return eve::div(e, f); }, a0, a2), 1);
-  TTS_ULP_EQUAL(div[saturated](kumi::tuple{a0, a2}), map([&](auto e, auto f) { return div[saturated](e, f); }, a0, a2), 1);
-  TTS_ULP_EQUAL(div(kumi::tuple{a0, a1, a2}), map([&](auto e, auto f, auto g) { return div(e, mul(f, g)); }, a0, a1, a2), 1);
-  TTS_ULP_EQUAL(div[saturated](kumi::tuple{a0, a1, a2}), map([&](auto e, auto f, auto g) { return div[saturated](e, mul[saturated](f, g)); }, a0, a1, a2), 1);
+  TTS_ULP_EQUAL(eve::div(a0, a2), tts::map([](auto e, auto f) { return eve::div(e, f); }, a0, a2), 1);
+  TTS_ULP_EQUAL(eve::div[saturated](a0, a2), tts::map([&](auto e, auto f) { return div[saturated](e, f); }, a0, a2), 1);
+  TTS_ULP_EQUAL(div(a0, a1, a2), tts::map([&](auto e, auto f, auto g) { return div(e, mul(f, g)); }, a0, a1, a2), 1);
+  TTS_ULP_EQUAL(div[saturated](a0, a1, a2), tts::map([&](auto e, auto f, auto g) { return div[saturated](e, mul[saturated](f, g)); }, a0, a1, a2),1);
+  TTS_ULP_EQUAL(eve::div(kumi::tuple{a0, a2}), tts::map([](auto e, auto f) { return eve::div(e, f); }, a0, a2), 1);
+  TTS_ULP_EQUAL(div[saturated](kumi::tuple{a0, a2}), tts::map([&](auto e, auto f) { return div[saturated](e, f); }, a0, a2), 1);
+  TTS_ULP_EQUAL(div(kumi::tuple{a0, a1, a2}), tts::map([&](auto e, auto f, auto g) { return div(e, mul(f, g)); }, a0, a1, a2), 1);
+  TTS_ULP_EQUAL(div[saturated](kumi::tuple{a0, a1, a2}), tts::map([&](auto e, auto f, auto g) { return div[saturated](e, mul[saturated](f, g)); }, a0, a1, a2), 1);
   if constexpr (eve::floating_value<T>)
   {
-    TTS_ULP_EQUAL( div[lower](kumi::tuple{a0, a1, a2}), map([&](auto e, auto f, auto g) { return div[lower](div[lower](e, f), g); }, a0, a1, a2), 2.0);
-    TTS_ULP_EQUAL( div[upper](kumi::tuple{a0, a1, a2}), map([&](auto e, auto f, auto g) { return div[upper](div[upper](e, f), g); }, a0, a1, a2), 2.0);
+    TTS_ULP_EQUAL( div[lower](kumi::tuple{a0, a1, a2}), tts::map([&](auto e, auto f, auto g) { return div[lower](div[lower](e, f), g); }, a0, a1, a2), 2.0);
+    TTS_ULP_EQUAL( div[upper](kumi::tuple{a0, a1, a2}), tts::map([&](auto e, auto f, auto g) { return div[upper](div[upper](e, f), g); }, a0, a1, a2), 2.0);
     TTS_EXPECT(eve::all(div[upper](a0, a1, a2) >=  div[lower](a0, a1, a2)));
     TTS_EXPECT(eve::all(div[upper](a0, a1)     >=  div[lower](a0, a1)));
     T w0(T(0.12345));
@@ -136,23 +135,22 @@ TTS_CASE_WITH("Check behavior of div on signed types",
   using eve::div;
   using eve::is_nez;
   using eve::saturated;
-  using eve::detail::map;
   using elt_t = eve::element_type_t<T>;
   a2 = eve::if_else(a2 > 0, eve::zero, a2);
   TTS_ULP_EQUAL(div[is_nez(a2)](a0, a2),
-                map([](auto e, auto f) { return eve::is_eqz(f) ? e : elt_t(e/f); }, a0, a2),
+                tts::map([](auto e, auto f) { return eve::is_eqz(f) ? e : elt_t(e/f); }, a0, a2),
                 2.5);
   TTS_ULP_EQUAL(
       div[saturated][is_nez(a0) && is_nez(a2)](a0, a2),
-      map([](auto e, auto f) { return is_nez(e) && is_nez(f) ? div[saturated](e, f) : e; }, a0, a2),
+      tts::map([](auto e, auto f) { return is_nez(e) && is_nez(f) ? div[saturated](e, f) : e; }, a0, a2),
       2.5);
 
   a1 = eve::if_else(eve::is_eqz(a1), eve::one, a1);
   TTS_ULP_EQUAL(div[a2 > T(64)](a0, a1),
-                map([](auto e, auto f, auto g) { return g > 64 ? div(e, f) : e; }, a0, a1, a2),
+                tts::map([](auto e, auto f, auto g) { return g > 64 ? div(e, f) : e; }, a0, a1, a2),
                 0.5);
   TTS_ULP_EQUAL(
       div[saturated][a2 > T(64)](a0, a1),
-      map([](auto e, auto f, auto g) { return g > 64 ? div[saturated](e, f) : e; }, a0, a1, a2),
+      tts::map([](auto e, auto f, auto g) { return g > 64 ? div[saturated](e, f) : e; }, a0, a1, a2),
       0.5);
 };

--- a/test/unit/module/core/epsilon.cpp
+++ b/test/unit/module/core/epsilon.cpp
@@ -30,7 +30,6 @@ TTS_CASE_WITH("Check behavior of eve::epsilon(simd)",
               tts::generate(tts::ramp(1)))
 <typename T>(T const& a0)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
   using eve::as;
   if constexpr( eve::floating_value<T> )
@@ -51,7 +50,7 @@ TTS_CASE_WITH("Check behavior of eve::epsilon(simd)",
     TTS_ULP_EQUAL(eve::epsilon(T(2)), 2 * eve::eps(as<T>()), 0.5);
     TTS_ULP_EQUAL(eve::epsilon(T(1.5)), eve::eps(as<T>()), 0.5);
     TTS_ULP_EQUAL(eve::epsilon(a0),
-                  map([](auto e) -> v_t { return eve::bit_floor(e) * eve::eps(as<v_t>()); }, a0),
+                  tts::map([](auto e) -> v_t { return eve::bit_floor(e) * eve::eps(as<v_t>()); }, a0),
                   2);
     TTS_ULP_EQUAL(eve::epsilon[eve::downward](T(1)), eve::eps(as<T>())/2, 0.5);
     TTS_ULP_EQUAL(eve::epsilon[eve::downward](T(0)), eve::mindenormal(as<T>()), 0.5);

--- a/test/unit/module/core/exponent.cpp
+++ b/test/unit/module/core/exponent.cpp
@@ -32,12 +32,11 @@ TTS_CASE_WITH("Check behavior of eve::exponent(simd)",
               tts::generate(tts::between(-1.0, 1.0), tts::logicals(0, 3)))
 <typename T, typename M>(T const& a0, M const& t)
 {
-  using eve::detail::map;
   using i_t  = eve::as_integer_t<T>;
   using vi_t = eve::element_type_t<i_t>;
 
   TTS_EQUAL(eve::exponent(a0),
-            map(
+            tts::map(
                 [](auto e) -> vi_t
                 {
                   int ee;

--- a/test/unit/module/core/fam.cpp
+++ b/test/unit/module/core/fam.cpp
@@ -52,11 +52,10 @@ TTS_CASE_WITH("Check precision behavior of fam on real types",
 <typename T>(T const& a0, T const& a1)
 {
   using eve::fam;
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
   TTS_ULP_EQUAL(
       eve::fam[eve::pedantic](a0, a1, -eve::one(eve::as<T>())),
-      map([&](auto e, auto f) -> v_t { return eve::fam[eve::pedantic](e, f, v_t(-1)); }, a0, a1),
+      tts::map([&](auto e, auto f) -> v_t { return eve::fam[eve::pedantic](e, f, v_t(-1)); }, a0, a1),
       2);
 };
 
@@ -71,11 +70,10 @@ TTS_CASE_WITH("Check precision behavior of fam on real types",
 <typename T>(T const& a0, T const& a1)
 {
   using eve::fam;
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
   TTS_ULP_EQUAL(
       eve::fam[eve::pedantic](a0, a1, -eve::one(eve::as<T>())),
-      map([&](auto e, auto f) -> v_t { return eve::fam[eve::pedantic](e, f, v_t(-1)); }, a0, a1),
+      tts::map([&](auto e, auto f) -> v_t { return eve::fam[eve::pedantic](e, f, v_t(-1)); }, a0, a1),
       2);
 };
 
@@ -92,7 +90,6 @@ TTS_CASE_WITH("Check behavior of fam upper lower on all types",
 {
   using eve::as;
   using eve::fam;
-  using eve::detail::map;
   using eve::lower;
   using eve::upper;
   using eve::strict;
@@ -116,7 +113,6 @@ TTS_CASE_WITH("Check behavior of fam[promote] on all types",
   using eve::as;
   using eve::fam;
   using eve::promote;
-  using eve::detail::map;
 
   constexpr int N = eve::cardinal_v<T>;
   eve::wide<float, eve::fixed<N>> fa([](auto i,  auto){return float(i)/2; });

--- a/test/unit/module/core/fanm.cpp
+++ b/test/unit/module/core/fanm.cpp
@@ -52,11 +52,10 @@ TTS_CASE_WITH("Check precision behavior of fanm on real types",
 <typename T>(T const& a0, T const& a1)
 {
   using eve::fanm;
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
   TTS_ULP_EQUAL(
       eve::fanm[eve::pedantic](a0, a1, -eve::one(eve::as<T>())),
-      map([&](auto e, auto f) -> v_t { return eve::fanm[eve::pedantic](e, f, v_t(-1)); }, a0, a1),
+      tts::map([&](auto e, auto f) -> v_t { return eve::fanm[eve::pedantic](e, f, v_t(-1)); }, a0, a1),
       2);
 };
 
@@ -75,7 +74,6 @@ TTS_CASE_WITH("Check behavior of fanm lower upper on real types",
   using eve::as;
   using eve::fanm;
   using eve::promote;
-  using eve::detail::map;
   using eve::lower;
   using eve::upper;
   using eve::strict;
@@ -97,11 +95,10 @@ TTS_CASE_WITH("Check precision behavior of fanm on real types",
 <typename T>(T const& a0, T const& a1)
 {
   using eve::fanm;
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
   TTS_ULP_EQUAL(
       eve::fanm[eve::pedantic](a0, a1, -eve::one(eve::as<T>())),
-      map([&](auto e, auto f) -> v_t { return eve::fanm[eve::pedantic](e, f, v_t(-1)); }, a0, a1),
+      tts::map([&](auto e, auto f) -> v_t { return eve::fanm[eve::pedantic](e, f, v_t(-1)); }, a0, a1),
       2);
 };
 
@@ -117,7 +114,6 @@ TTS_CASE_WITH("Check behavior of fanm[promote] on all types",
   using eve::as;
   using eve::fanm;
   using eve::promote;
-  using eve::detail::map;
 
   constexpr int N = eve::cardinal_v<T>;
   eve::wide<float, eve::fixed<N>> fa([](auto i,  auto){return float(i)/2; });

--- a/test/unit/module/core/fdim.cpp
+++ b/test/unit/module/core/fdim.cpp
@@ -31,11 +31,10 @@ TTS_CASE_WITH("Check behavior of eve::fdim(simd) floating",
 <typename T>(T const& a0, T const& a1)
 {
   using eve::as;
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
   TTS_EQUAL(eve::fdim(a0, a1),
-            map([](auto e, auto f) -> v_t { return (e >= f) ? e - f : eve::zero(as(e)); }, a0, a1));
+            tts::map([](auto e, auto f) -> v_t { return (e >= f) ? e - f : eve::zero(as(e)); }, a0, a1));
 };
 
 auto maxi =
@@ -49,10 +48,9 @@ TTS_CASE_WITH("Check behavior of eve::fdim(simd) integral",
 <typename T>(T const& a0, T const& a1)
 {
   using eve::as;
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
   TTS_EQUAL(eve::fdim(a0, a1),
-            map([](auto e, auto f) -> v_t
+            tts::map([](auto e, auto f) -> v_t
                 { return (e >= f) ? v_t(e - f) : eve::zero(eve::as<v_t>()); },
                 a0,
                 a1));

--- a/test/unit/module/core/firstbitset.cpp
+++ b/test/unit/module/core/firstbitset.cpp
@@ -28,9 +28,8 @@ TTS_CASE_WITH("Check behavior of eve::firstbitset(simd)",
               tts::generate(tts::ramp(0), tts::logicals(0, 3)))
 <typename T, typename M>(T const& a0, const M t)
 {
-  using eve::detail::map;
   using vi_t = eve::element_type_t<T>;
 
-  TTS_EQUAL(eve::firstbitset(a0), map([](auto e) -> vi_t { return eve::firstbitset(e); }, a0));
+  TTS_EQUAL(eve::firstbitset(a0), tts::map([](auto e) -> vi_t { return eve::firstbitset(e); }, a0));
   TTS_EQUAL(eve::firstbitset[t](a0), eve::if_else(t, eve::firstbitset(a0), a0));
 };

--- a/test/unit/module/core/firstbitunset.cpp
+++ b/test/unit/module/core/firstbitunset.cpp
@@ -28,9 +28,8 @@ TTS_CASE_WITH("Check behavior of eve::firstbitunset(simd)",
               tts::generate(tts::ramp(0), tts::logicals(0, 3)))
 <typename T, typename M>(T const& a0, const M t)
 {
-  using eve::detail::map;
   using vi_t = eve::element_type_t<T>;
 
-  TTS_EQUAL(eve::firstbitunset(a0), map([](auto e) -> vi_t { return eve::firstbitunset(e); }, a0));
+  TTS_EQUAL(eve::firstbitunset(a0), tts::map([](auto e) -> vi_t { return eve::firstbitunset(e); }, a0));
   TTS_EQUAL(eve::firstbitunset[t](a0), eve::if_else(t, eve::firstbitunset(a0), a0));
 };

--- a/test/unit/module/core/floor.cpp
+++ b/test/unit/module/core/floor.cpp
@@ -101,7 +101,6 @@ TTS_CASE_WITH("Check behavior of floor(wide)",
               tts::generate(tts::randoms(mini, +50)))
 <typename T>(T const& a0)
 {
-  using eve::detail::map;
   using wi_t  = eve::as_integer_t<T>;
   using uwi_t = eve::as_integer_t<T, unsigned>;
   using v_t   = eve::element_type_t<T>;
@@ -109,7 +108,7 @@ TTS_CASE_WITH("Check behavior of floor(wide)",
   using ui_t  = eve::as_integer_t<v_t, unsigned>;
   if constexpr( eve::floating_value<T> )
   {
-    TTS_EQUAL(eve::floor(a0), map([&](auto e) -> v_t { return v_t(std::floor(e)); }, a0));
+    TTS_EQUAL(eve::floor(a0), tts::map([&](auto e) -> v_t { return v_t(std::floor(e)); }, a0));
 
     TTS_EQUAL(eve::floor(a0, eve::as<int>()),
               wi_t([&](auto i, auto) { return i_t(std::floor(a0.get(i))); }));

--- a/test/unit/module/core/fma.cpp
+++ b/test/unit/module/core/fma.cpp
@@ -53,11 +53,10 @@ TTS_CASE_WITH("Check precision behavior of fma on real types",
 <typename T>(T const& a0, T const& a1)
 {
   using eve::fma;
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
   TTS_ULP_EQUAL(
       eve::fma[eve::pedantic](a0, a1, -eve::one(eve::as<T>())),
-      map([&](auto e, auto f) -> v_t { return eve::fma[eve::pedantic](e, f, v_t(-1)); }, a0, a1),
+      tts::map([&](auto e, auto f) -> v_t { return eve::fma[eve::pedantic](e, f, v_t(-1)); }, a0, a1),
       2);
 };
 
@@ -72,11 +71,10 @@ TTS_CASE_WITH("Check precision behavior of fma on real types",
 <typename T>(T const& a0, T const& a1)
 {
   using eve::fma;
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
   TTS_ULP_EQUAL(
       eve::fma[eve::pedantic](a0, a1, -eve::one(eve::as<T>())),
-      map([&](auto e, auto f) -> v_t { return eve::fma[eve::pedantic](e, f, v_t(-1)); }, a0, a1),
+      tts::map([&](auto e, auto f) -> v_t { return eve::fma[eve::pedantic](e, f, v_t(-1)); }, a0, a1),
       2);
 };
 
@@ -93,7 +91,6 @@ TTS_CASE_WITH("Check behavior of fma[promote] on all types",
 {
   using eve::as;
   using eve::fma;
-  using eve::detail::map;
   using eve::lower;
   using eve::upper;
   using eve::strict;
@@ -117,7 +114,6 @@ TTS_CASE_WITH("Check behavior of fma[promote] on all types",
   using eve::as;
   using eve::fma;
   using eve::promote;
-  using eve::detail::map;
 
   constexpr int N = eve::cardinal_v<T>;
   eve::wide<float, eve::fixed<N>> fa([](auto i,  auto){return float(i)/2; });

--- a/test/unit/module/core/fmod.cpp
+++ b/test/unit/module/core/fmod.cpp
@@ -48,11 +48,10 @@ TTS_CASE_WITH("Check behavior of fmod on wide",
 <typename T>(T a0, T a1)
 {
   using eve::fmod;
-  using eve::detail::map;
 
   auto thrs = std::same_as<eve::element_type_t<T>, float> ? 5e-3 : 5e-12;
   a1 = eve::if_else(eve::is_eqz(a1), eve::one, a1);
-  TTS_RELATIVE_EQUAL(fmod(a0, a1), map([](auto e, auto f) { return std::fmod(e, f); }, a0, a1), thrs);
+  TTS_RELATIVE_EQUAL(fmod(a0, a1), tts::map([](auto e, auto f) { return std::fmod(e, f); }, a0, a1), thrs);
 };
 
 TTS_CASE_TPL("Check corner-cases behavior of eve::fmod",

--- a/test/unit/module/core/fms.cpp
+++ b/test/unit/module/core/fms.cpp
@@ -52,11 +52,10 @@ TTS_CASE_WITH("Check precision behavior of fms on real types",
 <typename T>(T const& a0, T const& a1)
 {
   using eve::fms;
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
   TTS_ULP_EQUAL(
       eve::fms[eve::pedantic](a0, a1, -eve::one(eve::as<T>())),
-      map([&](auto e, auto f) -> v_t { return eve::fms[eve::pedantic](e, f, v_t(-1)); }, a0, a1),
+      tts::map([&](auto e, auto f) -> v_t { return eve::fms[eve::pedantic](e, f, v_t(-1)); }, a0, a1),
       2);
 };
 
@@ -71,11 +70,10 @@ TTS_CASE_WITH("Check precision behavior of fms on real types",
 <typename T>(T const& a0, T const& a1)
 {
   using eve::fms;
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
   TTS_ULP_EQUAL(
       eve::fms[eve::pedantic](a0, a1, -eve::one(eve::as<T>())),
-      map([&](auto e, auto f) -> v_t { return eve::fms[eve::pedantic](e, f, v_t(-1)); }, a0, a1),
+      tts::map([&](auto e, auto f) -> v_t { return eve::fms[eve::pedantic](e, f, v_t(-1)); }, a0, a1),
       2);
 };
 
@@ -93,7 +91,6 @@ TTS_CASE_WITH("Check behavior of fms[promote] on all types",
   using eve::as;
   using eve::fms;
   using eve::promote;
-  using eve::detail::map;
   using eve::lower;
   using eve::upper;
   using eve::strict;
@@ -117,7 +114,6 @@ TTS_CASE_WITH("Check behavior of fms[promote] on all types",
   using eve::as;
   using eve::fms;
   using eve::promote;
-  using eve::detail::map;
 
   constexpr int N = eve::cardinal_v<T>;
   eve::wide<float, eve::fixed<N>> fa([](auto i,  auto){return float(i)/2; });

--- a/test/unit/module/core/fnma.cpp
+++ b/test/unit/module/core/fnma.cpp
@@ -55,11 +55,10 @@ TTS_CASE_WITH("Check precision behavior of fnma on real types",
 <typename T>(T const& a0, T const& a1)
 {
   using eve::fnma;
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
   TTS_ULP_EQUAL(
       fnma[eve::pedantic](a0, a1, eve::one(eve::as<T>())),
-      map([&](auto e, auto f) -> v_t { return fnma[eve::pedantic](e, f, v_t(1)); }, a0, a1),
+      tts::map([&](auto e, auto f) -> v_t { return fnma[eve::pedantic](e, f, v_t(1)); }, a0, a1),
       2);
 };
 
@@ -99,7 +98,6 @@ TTS_CASE_WITH("Check behavior of fnma on all types full range",
 {
   using eve::as;
   using eve::fnma;
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
   if( eve::all(
@@ -107,7 +105,7 @@ TTS_CASE_WITH("Check behavior of fnma on all types full range",
           == eve::fnma[eve::pedantic](onemmileps(eve::as(a0)), onepmileps(eve::as(a0)), T(1))) )
   {
     TTS_ULP_EQUAL(fnma((a0), (a1), (a2)),
-                  map([&](auto e, auto f, auto g) -> v_t { return fnma[eve::pedantic](e, f, g); },
+                  tts::map([&](auto e, auto f, auto g) -> v_t { return fnma[eve::pedantic](e, f, g); },
                       a0,
                       a1,
                       a2),
@@ -116,12 +114,12 @@ TTS_CASE_WITH("Check behavior of fnma on all types full range",
   else
   {
     TTS_ULP_EQUAL(fnma((a0), (a1), (a2)),
-                  map([&](auto e, auto f, auto g) -> v_t { return -e * f + g; }, a0, a1, a2),
+                  tts::map([&](auto e, auto f, auto g) -> v_t { return -e * f + g; }, a0, a1, a2),
                   2);
   }
   TTS_ULP_EQUAL(
       fnma[eve::pedantic]((a0), (a1), (a2)),
-      map([&](auto e, auto f, auto g) -> v_t { return fnma[eve::pedantic](e, f, g); }, a0, a1, a2),
+      tts::map([&](auto e, auto f, auto g) -> v_t { return fnma[eve::pedantic](e, f, g); }, a0, a1, a2),
       2);
  };
 
@@ -137,7 +135,6 @@ TTS_CASE_WITH("Check behavior of promote(fnma) on all types",
   using eve::as;
   using eve::fnma;
   using eve::promote;
-  using eve::detail::map;
 
   constexpr int N = eve::cardinal_v<T>;
   eve::wide<float, eve::fixed<N>> fa([](auto i,  auto){return float(i)/2; });

--- a/test/unit/module/core/fnms.cpp
+++ b/test/unit/module/core/fnms.cpp
@@ -52,11 +52,10 @@ TTS_CASE_WITH("Check precision behavior of fnms on real types",
 <typename T>(T const& a0, T const& a1)
 {
   using eve::fnms;
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
   TTS_ULP_EQUAL(
       eve::fnms[eve::pedantic](a0, a1, -eve::one(eve::as<T>())),
-      map([&](auto e, auto f) -> v_t { return eve::fnms[eve::pedantic](e, f, v_t(-1)); }, a0, a1),
+      tts::map([&](auto e, auto f) -> v_t { return eve::fnms[eve::pedantic](e, f, v_t(-1)); }, a0, a1),
       2);
 };
 
@@ -71,11 +70,10 @@ TTS_CASE_WITH("Check precision behavior of fnms on real types",
 <typename T>(T const& a0, T const& a1)
 {
   using eve::fnms;
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
   TTS_ULP_EQUAL(
       eve::fnms[eve::pedantic](a0, a1, -eve::one(eve::as<T>())),
-      map([&](auto e, auto f) -> v_t { return eve::fnms[eve::pedantic](e, f, v_t(-1)); }, a0, a1),
+      tts::map([&](auto e, auto f) -> v_t { return eve::fnms[eve::pedantic](e, f, v_t(-1)); }, a0, a1),
       2);
 };
 
@@ -92,7 +90,6 @@ TTS_CASE_WITH("Check behavior of fsnm lower upper on real types",
 {
   using eve::as;
   using eve::fnms;
-  using eve::detail::map;
   using eve::lower;
   using eve::upper;
   using eve::strict;
@@ -116,7 +113,6 @@ TTS_CASE_WITH("Check behavior of fnms[promote] on all types",
   using eve::as;
   using eve::fnms;
   using eve::promote;
-  using eve::detail::map;
 
   constexpr int N = eve::cardinal_v<T>;
   eve::wide<float, eve::fixed<N>> fa([](auto i,  auto){return float(i)/2; });

--- a/test/unit/module/core/frac.cpp
+++ b/test/unit/module/core/frac.cpp
@@ -31,10 +31,9 @@ TTS_CASE_WITH("Check behavior of eve::frac(simd)",
               tts::generate(tts::between(-1.0, 1.0)))
 <typename T>(T const& a0)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
-  TTS_EQUAL(eve::frac(a0), map([](auto e) -> v_t { return e - std::trunc(e); }, a0));
+  TTS_EQUAL(eve::frac(a0), tts::map([](auto e) -> v_t { return e - std::trunc(e); }, a0));
   TTS_EXPECT(eve::all(eve::is_negative(eve::frac(eve::mzero(eve::as(a0))))));
 };
 

--- a/test/unit/module/core/fracscale.cpp
+++ b/test/unit/module/core/fracscale.cpp
@@ -33,16 +33,15 @@ TTS_CASE_WITH("Check behavior of fracscale(wide) and diff on  floating types",
               tts::generate(tts::randoms(-100.0, 100.0)))
 <typename T>(T const& a0)
 {
-  using eve::detail::map;
 
   using eve::rec;
   using eve::sqr;
   TTS_ULP_EQUAL(eve::fracscale(a0, 4),
-                map([&](auto e) { return e - eve::ldexp(eve::nearest(eve::ldexp(e, 4)), -4); }, a0),
+                tts::map([&](auto e) { return e - eve::ldexp(eve::nearest(eve::ldexp(e, 4)), -4); }, a0),
                 2);
   TTS_ULP_EQUAL(
       eve::fracscale(a0, 10),
-      map([&](auto e) { return e - eve::ldexp(eve::nearest(eve::ldexp(e, 10)), -10); }, a0),
+      tts::map([&](auto e) { return e - eve::ldexp(eve::nearest(eve::ldexp(e, 10)), -10); }, a0),
       2);
 };
 

--- a/test/unit/module/core/frexp.cpp
+++ b/test/unit/module/core/frexp.cpp
@@ -31,12 +31,11 @@ TTS_CASE_WITH("Check behavior of eve::frexp(simd)",
               tts::generate(tts::randoms(eve::valmin, eve::valmax)))
 <typename T>(T const& a0)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
   {
     auto [x, n] = eve::frexp(a0);
     TTS_EQUAL(x,
-              map(
+              tts::map(
                   [](auto e) -> v_t
                   {
                     int ee;
@@ -44,7 +43,7 @@ TTS_CASE_WITH("Check behavior of eve::frexp(simd)",
                   },
                   a0));
     TTS_EQUAL(n,
-              map(
+              tts::map(
                   [](auto e) -> v_t
                   {
                     int ee;
@@ -56,7 +55,7 @@ TTS_CASE_WITH("Check behavior of eve::frexp(simd)",
   {
     auto [x, n] = eve::frexp[eve::pedantic](a0);
     TTS_EQUAL(x,
-              map(
+              tts::map(
                   [](auto e) -> v_t
                   {
                     int ee;
@@ -64,7 +63,7 @@ TTS_CASE_WITH("Check behavior of eve::frexp(simd)",
                   },
                   a0));
     TTS_EQUAL(n,
-              map(
+              tts::map(
                   [](auto e) -> v_t
                   {
                     int ee;

--- a/test/unit/module/core/fsm.cpp
+++ b/test/unit/module/core/fsm.cpp
@@ -52,11 +52,10 @@ TTS_CASE_WITH("Check precision behavior of fsm on real types",
 <typename T>(T const& a0, T const& a1)
 {
   using eve::fsm;
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
   TTS_ULP_EQUAL(
       eve::fsm[eve::pedantic](a0, a1, -eve::one(eve::as<T>())),
-      map([&](auto e, auto f) -> v_t { return eve::fsm[eve::pedantic](e, f, v_t(-1)); }, a0, a1),
+      tts::map([&](auto e, auto f) -> v_t { return eve::fsm[eve::pedantic](e, f, v_t(-1)); }, a0, a1),
       2);
 };
 
@@ -71,11 +70,10 @@ TTS_CASE_WITH("Check precision behavior of fsm on real types",
 <typename T>(T const& a0, T const& a1)
 {
   using eve::fsm;
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
   TTS_ULP_EQUAL(
       eve::fsm[eve::pedantic](a0, a1, -eve::one(eve::as<T>())),
-      map([&](auto e, auto f) -> v_t { return eve::fsm[eve::pedantic](e, f, v_t(-1)); }, a0, a1),
+      tts::map([&](auto e, auto f) -> v_t { return eve::fsm[eve::pedantic](e, f, v_t(-1)); }, a0, a1),
       2);
 };
 
@@ -115,7 +113,6 @@ TTS_CASE_WITH("Check behavior of fsm[promote] on all types",
   using eve::as;
   using eve::fsm;
   using eve::promote;
-  using eve::detail::map;
 
   constexpr int N = eve::cardinal_v<T>;
   eve::wide<float, eve::fixed<N>> fa([](auto i,  auto){return float(i)/2; });

--- a/test/unit/module/core/fsnm.cpp
+++ b/test/unit/module/core/fsnm.cpp
@@ -52,11 +52,10 @@ TTS_CASE_WITH("Check precision behavior of fsnm on real types",
 <typename T>(T const& a0, T const& a1)
 {
   using eve::fsnm;
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
   TTS_ULP_EQUAL(
       eve::fsnm[eve::pedantic](a0, a1, -eve::one(eve::as<T>())),
-      map([&](auto e, auto f) -> v_t { return eve::fsnm[eve::pedantic](e, f, v_t(-1)); }, a0, a1),
+      tts::map([&](auto e, auto f) -> v_t { return eve::fsnm[eve::pedantic](e, f, v_t(-1)); }, a0, a1),
       2);
 };
 
@@ -71,11 +70,10 @@ TTS_CASE_WITH("Check precision behavior of fsnm on real types",
 <typename T>(T const& a0, T const& a1)
 {
   using eve::fsnm;
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
   TTS_ULP_EQUAL(
       eve::fsnm[eve::pedantic](a0, a1, -eve::one(eve::as<T>())),
-      map([&](auto e, auto f) -> v_t { return eve::fsnm[eve::pedantic](e, f, v_t(-1)); }, a0, a1),
+      tts::map([&](auto e, auto f) -> v_t { return eve::fsnm[eve::pedantic](e, f, v_t(-1)); }, a0, a1),
       2);
 };
 
@@ -92,7 +90,6 @@ TTS_CASE_WITH("Check behavior of fsnm lower upper on real types",
 {
   using eve::as;
   using eve::fsnm;
-  using eve::detail::map;
   using eve::lower;
   using eve::upper;
   using eve::strict;
@@ -116,7 +113,6 @@ TTS_CASE_WITH("Check behavior of fsnm[promote] on all types",
   using eve::as;
   using eve::fsnm;
   using eve::promote;
-  using eve::detail::map;
 
   constexpr int N = eve::cardinal_v<T>;
   eve::wide<float, eve::fixed<N>> fa([](auto i,  auto){return float(i)/2; });

--- a/test/unit/module/core/has_single_bit.cpp
+++ b/test/unit/module/core/has_single_bit.cpp
@@ -34,7 +34,7 @@ TTS_CASE_WITH("Check behavior of has_single_bit(wide) on unsigned integral ",
   using v_t = eve::element_type_t<T>;
   using f_t = eve::as_floating_point_t<v_t>;
   TTS_EQUAL(eve::has_single_bit(a0),
-            map([](auto e) -> eve::logical<v_t>
+            tts::map([](auto e) -> eve::logical<v_t>
                 { return std::exp2(std::trunc(std::log2(f_t(e)))) == f_t(e); },
                 a0));
 };

--- a/test/unit/module/core/heaviside.cpp
+++ b/test/unit/module/core/heaviside.cpp
@@ -41,9 +41,9 @@ TTS_CASE_WITH("Check behavior of heaviside(wide) on all types",
   using v_t = eve::element_type_t<T>;
 
   TTS_EQUAL(heaviside(a0, a1),
-            map([&](auto e, auto f) -> v_t { return e > f; }, a0, a1));
+            tts::map([&](auto e, auto f) -> v_t { return e > f; }, a0, a1));
   TTS_EQUAL(heaviside(a0),
-            map([&](auto e) -> v_t { return e > 0; }, a0));
+            tts::map([&](auto e) -> v_t { return e > 0; }, a0));
 };
 
 

--- a/test/unit/module/core/hi.cpp
+++ b/test/unit/module/core/hi.cpp
@@ -37,10 +37,10 @@ TTS_CASE_WITH("Check behavior of hi(wide) on unsigned integral ",
   constexpr int s = sizeof(v_t) * 4;
   if constexpr( s == 4 )
   {
-    TTS_EQUAL(eve::hi(a0), map([&](auto e) -> v_t { return d_t(eve::shr(e, s)); }, a0));
+    TTS_EQUAL(eve::hi(a0), tts::map([&](auto e) -> v_t { return d_t(eve::shr(e, s)); }, a0));
   }
   else
   {
-    TTS_EQUAL(eve::hi(a0), map([&](auto e) -> d_t { return d_t(eve::shr(e, s)); }, a0));
+    TTS_EQUAL(eve::hi(a0), tts::map([&](auto e) -> d_t { return d_t(eve::shr(e, s)); }, a0));
   }
 };

--- a/test/unit/module/core/if_else.cpp
+++ b/test/unit/module/core/if_else.cpp
@@ -76,57 +76,56 @@ TTS_CASE_WITH(
   using eve::nan;
   using eve::one;
   using eve::zero;
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
-  TTS_EQUAL(if_else(m0, m1, m2), map([](auto e, auto f, auto g) { return e ? f : g; }, m0, m1, m2));
-  TTS_EQUAL(if_else(m0, a1, a2), map([](auto e, auto f, auto g) { return e ? f : g; }, m0, a1, a2));
-  TTS_EQUAL(if_else(m0, a1, one), map([](auto e, auto f) { return e ? f : v_t(1); }, m0, a1));
-  TTS_EQUAL(if_else(m0, a1, zero), map([](auto e, auto f) { return e ? f : v_t(0); }, m0, a1));
+  TTS_EQUAL(if_else(m0, m1, m2), tts::map([](auto e, auto f, auto g) { return e ? f : g; }, m0, m1, m2));
+  TTS_EQUAL(if_else(m0, a1, a2), tts::map([](auto e, auto f, auto g) { return e ? f : g; }, m0, a1, a2));
+  TTS_EQUAL(if_else(m0, a1, one), tts::map([](auto e, auto f) { return e ? f : v_t(1); }, m0, a1));
+  TTS_EQUAL(if_else(m0, a1, zero), tts::map([](auto e, auto f) { return e ? f : v_t(0); }, m0, a1));
   if constexpr( eve::signed_value<T> )
-    TTS_EQUAL(if_else(m0, a1, mone), map([](auto e, auto f) { return e ? f : v_t(-1); }, m0, a1));
+    TTS_EQUAL(if_else(m0, a1, mone), tts::map([](auto e, auto f) { return e ? f : v_t(-1); }, m0, a1));
   else
     TTS_EQUAL(if_else(m0, a1, allbits),
-              map([](auto e, auto f) { return e ? f : allbits(as<v_t>()); }, m0, a1));
+              tts::map([](auto e, auto f) { return e ? f : allbits(as<v_t>()); }, m0, a1));
   if constexpr( eve::floating_value<T> )
     TTS_IEEE_EQUAL(if_else(m0, a1, allbits),
-                   map([](auto e, auto f) { return e ? f : nan(as<v_t>()); }, m0, a1));
-  TTS_EQUAL(if_else(true, m1, m2), map([](auto f) { return f; }, m1));
-  TTS_EQUAL(if_else(false, a1, a2), map([](auto g) { return g; }, a2));
+                   tts::map([](auto e, auto f) { return e ? f : nan(as<v_t>()); }, m0, a1));
+  TTS_EQUAL(if_else(true, m1, m2), tts::map([](auto f) { return f; }, m1));
+  TTS_EQUAL(if_else(false, a1, a2), tts::map([](auto g) { return g; }, a2));
 
   using d_t = eve::logical<eve::downgrade_t<eve::element_type_t<T>>>;
   auto dm0  = eve::convert(m0, as<d_t>());
 
   TTS_EQUAL(if_else(dm0, m1, m2),
-            map([](auto e, auto f, auto g) { return e ? f : g; }, dm0, m1, m2));
+            tts::map([](auto e, auto f, auto g) { return e ? f : g; }, dm0, m1, m2));
   TTS_EQUAL(if_else(dm0, a1, a2),
-            map([](auto e, auto f, auto g) { return e ? f : g; }, dm0, a1, a2));
-  TTS_EQUAL(if_else(dm0, a1, one), map([](auto e, auto f) { return e ? f : v_t(1); }, dm0, a1));
-  TTS_EQUAL(if_else(dm0, a1, zero), map([](auto e, auto f) { return e ? f : v_t(0); }, dm0, a1));
+            tts::map([](auto e, auto f, auto g) { return e ? f : g; }, dm0, a1, a2));
+  TTS_EQUAL(if_else(dm0, a1, one), tts::map([](auto e, auto f) { return e ? f : v_t(1); }, dm0, a1));
+  TTS_EQUAL(if_else(dm0, a1, zero), tts::map([](auto e, auto f) { return e ? f : v_t(0); }, dm0, a1));
   if constexpr( eve::signed_value<T> )
-    TTS_EQUAL(if_else(dm0, a1, mone), map([](auto e, auto f) { return e ? f : v_t(-1); }, dm0, a1));
+    TTS_EQUAL(if_else(dm0, a1, mone), tts::map([](auto e, auto f) { return e ? f : v_t(-1); }, dm0, a1));
   else
     TTS_EQUAL(if_else(dm0, a1, allbits),
-              map([](auto e, auto f) { return e ? f : allbits(as<v_t>()); }, dm0, a1));
+              tts::map([](auto e, auto f) { return e ? f : allbits(as<v_t>()); }, dm0, a1));
   if constexpr( eve::floating_value<T> )
     TTS_IEEE_EQUAL(if_else(dm0, a1, allbits),
-                   map([](auto e, auto f) { return e ? f : nan(as<v_t>()); }, dm0, a1));
+                   tts::map([](auto e, auto f) { return e ? f : nan(as<v_t>()); }, dm0, a1));
 
   using u_t = eve::logical<eve::upgrade_t<eve::element_type_t<T>>>;
   auto um0  = eve::convert(m0, as<u_t>());
   TTS_EQUAL(if_else(um0, m1, m2),
-            map([](auto e, auto f, auto g) { return e ? f : g; }, um0, m1, m2));
+            tts::map([](auto e, auto f, auto g) { return e ? f : g; }, um0, m1, m2));
   TTS_EQUAL(if_else(um0, a1, a2),
-            map([](auto e, auto f, auto g) { return e ? f : g; }, um0, a1, a2));
-  TTS_EQUAL(if_else(um0, a1, one), map([](auto e, auto f) { return e ? f : v_t(1); }, um0, a1));
-  TTS_EQUAL(if_else(um0, a1, zero), map([](auto e, auto f) { return e ? f : v_t(0); }, um0, a1));
+            tts::map([](auto e, auto f, auto g) { return e ? f : g; }, um0, a1, a2));
+  TTS_EQUAL(if_else(um0, a1, one), tts::map([](auto e, auto f) { return e ? f : v_t(1); }, um0, a1));
+  TTS_EQUAL(if_else(um0, a1, zero), tts::map([](auto e, auto f) { return e ? f : v_t(0); }, um0, a1));
   if constexpr( eve::signed_value<T> )
-    TTS_EQUAL(if_else(um0, a1, mone), map([](auto e, auto f) { return e ? f : v_t(-1); }, um0, a1));
+    TTS_EQUAL(if_else(um0, a1, mone), tts::map([](auto e, auto f) { return e ? f : v_t(-1); }, um0, a1));
   else
     TTS_EQUAL(if_else(um0, a1, allbits),
-              map([](auto e, auto f) { return e ? f : allbits(as<v_t>()); }, um0, a1));
+              tts::map([](auto e, auto f) { return e ? f : allbits(as<v_t>()); }, um0, a1));
   if constexpr( eve::floating_value<T> )
     TTS_IEEE_EQUAL(if_else(um0, a1, allbits),
-                   map([](auto e, auto f) { return e ? f : nan(as<v_t>()); }, um0, a1));
+                   tts::map([](auto e, auto f) { return e ? f : nan(as<v_t>()); }, um0, a1));
 };
 
 TTS_CASE_WITH("Check behavior of eve::if_else(conditional, a, b)",

--- a/test/unit/module/core/inc.cpp
+++ b/test/unit/module/core/inc.cpp
@@ -48,10 +48,10 @@ TTS_CASE_WITH("Check behavior of inc(wide) and inc[cond](wide)",
 {
   using v_t = eve::element_type_t<T>;
 
-  TTS_EQUAL( eve::inc(a0), map([](auto e) ->v_t{ return v_t(e+1); }, a0));
-  TTS_EQUAL( eve::inc[a0 > 64](a0), map([](auto e) ->v_t{ return v_t((e > 64) ?e+1 : e); }, a0));
+  TTS_EQUAL( eve::inc(a0), tts::map([](auto e) ->v_t{ return v_t(e+1); }, a0));
+  TTS_EQUAL( eve::inc[a0 > 64](a0), tts::map([](auto e) ->v_t{ return v_t((e > 64) ?e+1 : e); }, a0));
   bool z = (a0.get(0) > 64);
-  TTS_EQUAL(eve::inc[z](a0), map([&](auto e) -> v_t { return v_t((z) ? e + 1 : e); }, a0));
+  TTS_EQUAL(eve::inc[z](a0), tts::map([&](auto e) -> v_t { return v_t((z) ? e + 1 : e); }, a0));
   if constexpr(eve::floating_value<T>)
   {
     TTS_EXPECT(eve::all(eve::dec[eve::lower](a0) <= eve::inc(a0)));
@@ -68,15 +68,15 @@ TTS_CASE_WITH("Check behavior of inc[saturated](wide) on integral types",
 {
   using v_t = eve::element_type_t<T>;
   TTS_EQUAL(eve::inc[eve::saturated](a0),
-            map([](auto e) -> v_t { return v_t(e == eve::valmax(eve::as(e)) ? e : e + 1); }, a0));
+            tts::map([](auto e) -> v_t { return v_t(e == eve::valmax(eve::as(e)) ? e : e + 1); }, a0));
   TTS_EQUAL(eve::inc[eve::saturated][a0 > 64](a0),
-            map([](auto e) -> v_t
+            tts::map([](auto e) -> v_t
                 { return v_t((e > 64 && e != eve::valmin(eve::as(e)) ? e + 1 : e)); },
                 a0));
   bool z = (a0.get(0) > 64);
   TTS_EQUAL(
       eve::inc[eve::saturated][z](a0),
-      map([&](auto e) -> v_t { return v_t((z && e != eve::valmin(eve::as(e)) ? e + 1 : e)); }, a0));
+      tts::map([&](auto e) -> v_t { return v_t((z && e != eve::valmin(eve::as(e)) ? e + 1 : e)); }, a0));
 };
 
 TTS_CASE_WITH("Check behavior of inc[saturated](wide) on integral types",

--- a/test/unit/module/core/is_bit_equal.cpp
+++ b/test/unit/module/core/is_bit_equal.cpp
@@ -36,18 +36,17 @@ TTS_CASE_WITH(
     tts::generate(tts::ramp(0), tts::reverse_ramp(4, 2), tts::logicals(0, 3), tts::logicals(1, 2)))
 <typename T, typename M>(T const& a0, T const& a1, M const& l0, M const& l1)
 {
-  using eve::detail::map;
   using eve::as;
   using eve::bit_cast;
   using v_t = eve::element_type_t<T>;
   using vi_t= eve::as_integer_t<v_t, unsigned>;
   using bi_t= eve::as_integer_t<T, unsigned>;
   TTS_EQUAL(eve::is_bit_equal(a0, a1),
-            map([](auto e, auto f) -> eve::logical<vi_t> { return bit_cast(e, as<vi_t>())== bit_cast(f, as<vi_t>()); }, a0, a1));
+            tts::map([](auto e, auto f) -> eve::logical<vi_t> { return bit_cast(e, as<vi_t>())== bit_cast(f, as<vi_t>()); }, a0, a1));
   TTS_EQUAL(eve::is_bit_equal(a0, a0),
-            map([](auto e, auto f) -> eve::logical<vi_t> { return bit_cast(e, as<vi_t>())== bit_cast(f, as<vi_t>()); }, a0, a0));
+            tts::map([](auto e, auto f) -> eve::logical<vi_t> { return bit_cast(e, as<vi_t>())== bit_cast(f, as<vi_t>()); }, a0, a0));
   TTS_EQUAL(eve::is_bit_equal(l0, l1),
-             map([](auto e, auto f) { return e == f; }, l0, l1));
+             tts::map([](auto e, auto f) { return e == f; }, l0, l1));
   TTS_EQUAL(eve::is_bit_equal[l0](a0, a1),
             eve::if_else(l0, eve::is_bit_equal(a0, a1), eve::false_(eve::as<bi_t>())));
 };

--- a/test/unit/module/core/is_eqmz.cpp
+++ b/test/unit/module/core/is_eqmz.cpp
@@ -30,9 +30,8 @@ TTS_CASE_WITH("Check behavior of eve::is_eqmz(simd)",
               tts::generate(tts::ramp(0), tts::logicals(0, 3)))
 <typename T, typename M>(T const& a0, M const& t)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
-  TTS_EQUAL(eve::is_eqmz(a0), map([](auto e) -> eve::logical<v_t> { return e == 0 && eve::is_negative(e); }, a0));
+  TTS_EQUAL(eve::is_eqmz(a0), tts::map([](auto e) -> eve::logical<v_t> { return e == 0 && eve::is_negative(e); }, a0));
   TTS_EQUAL(eve::is_eqmz[t](a0), eve::if_else(t, eve::is_eqmz(a0), eve::false_(eve::as(a0))));
 };

--- a/test/unit/module/core/is_eqpz.cpp
+++ b/test/unit/module/core/is_eqpz.cpp
@@ -30,9 +30,8 @@ TTS_CASE_WITH("Check behavior of eve::is_eqpz(simd)",
               tts::generate(tts::ramp(0), tts::logicals(0, 3)))
 <typename T, typename M>(T const& a0, M const& t)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
-  TTS_EQUAL(eve::is_eqpz(a0), map([](auto e) -> eve::logical<v_t> { return e == 0 && eve::is_positive(e); }, a0));
+  TTS_EQUAL(eve::is_eqpz(a0), tts::map([](auto e) -> eve::logical<v_t> { return e == 0 && eve::is_positive(e); }, a0));
   TTS_EQUAL(eve::is_eqpz[t](a0), eve::if_else(t, eve::is_eqpz(a0), eve::false_(eve::as(a0))));
 };

--- a/test/unit/module/core/is_equal.cpp
+++ b/test/unit/module/core/is_equal.cpp
@@ -46,19 +46,18 @@ TTS_CASE_WITH(
     tts::generate(tts::ramp(0), tts::reverse_ramp(4, 2), tts::logicals(0, 3), tts::logicals(1, 2)))
 <typename T, typename M>(T const& a0, T const& a1, M const& l0, M const& l1)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
   TTS_EQUAL(eve::is_equal(a0, a1),
-            map([](auto e, auto f) -> eve::logical<v_t> { return e == f; }, a0, a1));
+            tts::map([](auto e, auto f) -> eve::logical<v_t> { return e == f; }, a0, a1));
   TTS_EQUAL(eve::is_equal(a0, a0),
-            map([](auto e, auto f) -> eve::logical<v_t> { return e == f; }, a0, a0));
+            tts::map([](auto e, auto f) -> eve::logical<v_t> { return e == f; }, a0, a0));
   TTS_EQUAL(eve::is_equal(a0, v_t(1)),
-            map([](auto e) -> eve::logical<v_t> { return e == v_t(1); }, a0));
+            tts::map([](auto e) -> eve::logical<v_t> { return e == v_t(1); }, a0));
   TTS_EQUAL(eve::is_equal(v_t(14), a1),
-            map([](auto e) -> eve::logical<v_t> { return e == v_t(14); }, a1));
+            tts::map([](auto e) -> eve::logical<v_t> { return e == v_t(14); }, a1));
   TTS_EQUAL(eve::is_equal(l0, l1),
-            map([](auto e, auto f) -> eve::logical<v_t> { return e == f; }, l0, l1));
+            tts::map([](auto e, auto f) -> eve::logical<v_t> { return e == f; }, l0, l1));
   TTS_EQUAL(eve::is_equal[l0](a0, a1),
             eve::if_else(l0, eve::is_equal(a0, a1), eve::false_(eve::as(a0))));
 };
@@ -70,7 +69,6 @@ TTS_CASE_TPL("Check behavior of eve::is_equal(simd)", eve::test::simd::ieee_real
 <typename T>(tts::type<T> const& tgt)
 {
   using eve::as;
-  using eve::detail::map;
   using v_t  = eve::element_type_t<T>;
   using ui_t = eve::as_integer_t<v_t, unsigned>;
 

--- a/test/unit/module/core/is_eqz.cpp
+++ b/test/unit/module/core/is_eqz.cpp
@@ -30,9 +30,8 @@ TTS_CASE_WITH("Check behavior of eve::is_eqz(simd)",
               tts::generate(tts::ramp(0), tts::logicals(0, 3)))
 <typename T, typename M>(T const& a0, M const& t)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
-  TTS_EQUAL(eve::is_eqz(a0), map([](auto e) -> eve::logical<v_t> { return e == 0; }, a0));
+  TTS_EQUAL(eve::is_eqz(a0), tts::map([](auto e) -> eve::logical<v_t> { return e == 0; }, a0));
   TTS_EQUAL(eve::is_eqz[t](a0), eve::if_else(t, eve::is_eqz(a0), eve::false_(eve::as(a0))));
 };

--- a/test/unit/module/core/is_even.cpp
+++ b/test/unit/module/core/is_even.cpp
@@ -31,11 +31,10 @@ TTS_CASE_WITH("Check behavior of eve::is_even(simd)",
               tts::generate(tts::ramp(0), tts::logicals(0, 3)))
 <typename T, typename M>(T const& a0, M const& t)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
   TTS_EQUAL(eve::is_even(a0),
-            map([](auto e) -> eve::logical<v_t> { return (std::trunc(e / 2) * 2) == e; }, a0));
+            tts::map([](auto e) -> eve::logical<v_t> { return (std::trunc(e / 2) * 2) == e; }, a0));
   TTS_EQUAL(eve::is_even[t](a0), eve::if_else(t, eve::is_even(a0), eve::false_(eve::as(a0))));
 };
 
@@ -44,9 +43,8 @@ TTS_CASE_WITH("Check behavior of eve::is_even(simd)",
               tts::generate(tts::ramp(0), tts::logicals(0, 3)))
 <typename T, typename M>(T const& a0, M const& t)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
-  TTS_EQUAL(eve::is_even(a0), map([](auto e) -> eve::logical<v_t> { return (e & 1) == 0; }, a0));
+  TTS_EQUAL(eve::is_even(a0), tts::map([](auto e) -> eve::logical<v_t> { return (e & 1) == 0; }, a0));
   TTS_EQUAL(eve::is_even[t](a0), eve::if_else(t, eve::is_even(a0), eve::false_(eve::as(a0))));
 };

--- a/test/unit/module/core/is_finite.cpp
+++ b/test/unit/module/core/is_finite.cpp
@@ -29,10 +29,9 @@ TTS_CASE_WITH("Check behavior of eve::is_finite(simd) for IEEE",
               tts::generate(tts::ramp(0), tts::logicals(0, 3)))
 <typename T, typename M>(T a0, M const& t)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
   a0        = eve::if_else(eve::is_eqz(a0), eve::inf(eve::as<v_t>()), eve::zero);
-  TTS_EQUAL(eve::is_finite(a0), map([](auto e) -> eve::logical<v_t> { return e - e == 0; }, a0));
+  TTS_EQUAL(eve::is_finite(a0), tts::map([](auto e) -> eve::logical<v_t> { return e - e == 0; }, a0));
   TTS_EQUAL(eve::is_finite[t](a0), eve::if_else(t, eve::is_finite(a0), eve::false_(eve::as(a0))));
 };
 
@@ -41,7 +40,6 @@ TTS_CASE_WITH("Check behavior of eve::is_finite(simd) for integer",
               tts::generate(tts::ramp(0), tts::logicals(0, 3)))
 <typename T, typename M>(T a0, M const& t)
 {
-  using eve::detail::map;
   TTS_EQUAL(eve::is_finite(a0), eve::true_(eve::as(a0)));
   TTS_EQUAL(eve::is_finite[t](a0), eve::if_else(t, eve::is_finite(a0), eve::false_(eve::as(a0))));
 };

--- a/test/unit/module/core/is_flint.cpp
+++ b/test/unit/module/core/is_flint.cpp
@@ -35,14 +35,13 @@ TTS_CASE_WITH("Check behavior of eve::is_flint(simd)",
                             tts::logicals(0, 3)))
 <typename T, typename M>(T const& a0, T const& a1, M const& t)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
   auto aa0  = eve::trunc(a0) / 2;
   auto aa1  = eve::trunc(a1) / 2;
   TTS_EQUAL(eve::is_flint(aa0),
-            map([](auto e) -> eve::logical<v_t> { return e == std::trunc(e); }, aa0));
+            tts::map([](auto e) -> eve::logical<v_t> { return e == std::trunc(e); }, aa0));
   TTS_EQUAL(eve::is_flint[eve::pedantic](aa1),
-            map([](auto e) -> eve::logical<v_t>
+            tts::map([](auto e) -> eve::logical<v_t>
                 { return (e == std::trunc(e)) && (e <= eve::maxflint(eve::as(e))); },
                 aa1));
   TTS_EQUAL(eve::is_flint[t](a0), eve::if_else(t, eve::is_flint(a0), eve::false_(eve::as(a0))));

--- a/test/unit/module/core/is_gez.cpp
+++ b/test/unit/module/core/is_gez.cpp
@@ -30,10 +30,9 @@ TTS_CASE_WITH("Check behavior of eve::is_gez(simd)",
               tts::generate(tts::ramp(-1.0), tts::ramp(1.0, -1.0), tts::logicals(0, 3)))
 <typename T, typename M>(T const& a0, T const& a1, M const& t)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
-  TTS_EQUAL(eve::is_gez(a0), map([](auto e) -> eve::logical<v_t> { return e >= v_t(0); }, a0));
-  TTS_EQUAL(eve::is_gez(a1), map([](auto e) -> eve::logical<v_t> { return e >= v_t(0); }, a1));
+  TTS_EQUAL(eve::is_gez(a0), tts::map([](auto e) -> eve::logical<v_t> { return e >= v_t(0); }, a0));
+  TTS_EQUAL(eve::is_gez(a1), tts::map([](auto e) -> eve::logical<v_t> { return e >= v_t(0); }, a1));
   TTS_EQUAL(eve::is_gez[t](a0), eve::if_else(t, eve::is_gez(a0), eve::false_(eve::as(a0))));
 };

--- a/test/unit/module/core/is_greater.cpp
+++ b/test/unit/module/core/is_greater.cpp
@@ -39,15 +39,14 @@ TTS_CASE_WITH("Check behavior of eve::is_greater(simd)",
               tts::generate(tts::ramp(0), tts::reverse_ramp(4, 2), tts::logicals(0, 3)))
 <typename T, typename M>(T const& a0, T const& a1, M const& t)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
   TTS_EQUAL(eve::is_greater(a0, a1),
-            map([](auto e, auto f) -> eve::logical<v_t> { return e > f; }, a0, a1));
+            tts::map([](auto e, auto f) -> eve::logical<v_t> { return e > f; }, a0, a1));
   TTS_EQUAL(eve::is_greater(a0, a0),
-            map([](auto e, auto f) -> eve::logical<v_t> { return e > f; }, a0, a0));
+            tts::map([](auto e, auto f) -> eve::logical<v_t> { return e > f; }, a0, a0));
   TTS_EQUAL(eve::is_greater(a0, v_t(1)),
-            map([](auto e) -> eve::logical<v_t> { return e > v_t(1); }, a0));
+            tts::map([](auto e) -> eve::logical<v_t> { return e > v_t(1); }, a0));
   TTS_EQUAL(eve::is_greater[t](a0, a1),
             eve::if_else(t, eve::is_greater(a0, a1), eve::false_(eve::as(a0))));
 };
@@ -59,7 +58,6 @@ TTS_CASE_TPL("Check behavior of eve::is_greater(simd)", eve::test::simd::ieee_re
 <typename T>(tts::type<T>)
 {
   using eve::as;
-  using eve::detail::map;
   using v_t  = eve::element_type_t<T>;
   using ui_t = eve::as_integer_t<v_t, unsigned>;
 

--- a/test/unit/module/core/is_greater_equal.cpp
+++ b/test/unit/module/core/is_greater_equal.cpp
@@ -48,15 +48,14 @@ TTS_CASE_WITH("Check behavior of eve::is_greater_equal(simd)",
               tts::generate(tts::ramp(0), tts::reverse_ramp(4, 2), tts::logicals(0, 3)))
 <typename T, typename M>(T const& a0, T const& a1, M const& t)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
   TTS_EQUAL(eve::is_greater_equal(a0, a1),
-            map([](auto e, auto f) -> eve::logical<v_t> { return e >= f; }, a0, a1));
+            tts::map([](auto e, auto f) -> eve::logical<v_t> { return e >= f; }, a0, a1));
   TTS_EQUAL(eve::is_greater_equal(a0, a0),
-            map([](auto e, auto f) -> eve::logical<v_t> { return e >= f; }, a0, a0));
+            tts::map([](auto e, auto f) -> eve::logical<v_t> { return e >= f; }, a0, a0));
   TTS_EQUAL(eve::is_greater_equal(a0, v_t(1)),
-            map([](auto e) -> eve::logical<v_t> { return e >= v_t(1); }, a0));
+            tts::map([](auto e) -> eve::logical<v_t> { return e >= v_t(1); }, a0));
   TTS_EQUAL(eve::is_greater_equal[t](a0, a1),
             eve::if_else(t, eve::is_greater_equal(a0, a1), eve::false_(eve::as(a0))));
 };
@@ -69,7 +68,6 @@ TTS_CASE_TPL("Check behavior of eve::is_greater_equal(simd)", eve::test::simd::i
 {
   using eve::as;
   using eve::logical;
-  using eve::detail::map;
   using v_t  = eve::element_type_t<T>;
 
   TTS_EQUAL(eve::is_greater_equal[eve::almost](T(1), T(1)), eve::true_(eve::as<T>()));

--- a/test/unit/module/core/is_gtz.cpp
+++ b/test/unit/module/core/is_gtz.cpp
@@ -30,10 +30,9 @@ TTS_CASE_WITH("Check behavior of eve::is_gtz(simd)",
               tts::generate(tts::ramp(-1.0), tts::ramp(1.0, -1.0), tts::logicals(0, 3)))
 <typename T, typename M>(T const& a0, T const& a1, M const& t)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
-  TTS_EQUAL(eve::is_gtz(a0), map([](auto e) -> eve::logical<v_t> { return e > v_t(0); }, a0));
-  TTS_EQUAL(eve::is_gtz(a1), map([](auto e) -> eve::logical<v_t> { return e > v_t(0); }, a1));
+  TTS_EQUAL(eve::is_gtz(a0), tts::map([](auto e) -> eve::logical<v_t> { return e > v_t(0); }, a0));
+  TTS_EQUAL(eve::is_gtz(a1), tts::map([](auto e) -> eve::logical<v_t> { return e > v_t(0); }, a1));
   TTS_EQUAL(eve::is_gtz[t](a0), eve::if_else(t, eve::is_gtz(a0), eve::false_(eve::as(a0))));
 };

--- a/test/unit/module/core/is_infinite.cpp
+++ b/test/unit/module/core/is_infinite.cpp
@@ -29,7 +29,6 @@ TTS_CASE_WITH("Check behavior of eve::is_infinite(simd) integrals",
               tts::generate(tts::ramp(0), tts::logicals(0, 3)))
 <typename T, typename M>(T a0, M const& t)
 {
-  using eve::detail::map;
   TTS_EQUAL(eve::is_infinite(a0), eve::false_(eve::as(a0)));
   TTS_EQUAL(eve::is_infinite[t](a0),
             eve::if_else(t, eve::is_infinite(a0), eve::false_(eve::as(a0))));
@@ -40,11 +39,10 @@ TTS_CASE_WITH("Check behavior of eve::is_infinite(simd) IEEE",
               tts::generate(tts::ramp(0), tts::logicals(0, 3)))
 <typename T, typename M>(T a0, M const& t)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
   a0        = eve::if_else(eve::is_eqz(a0), eve::inf(eve::as<v_t>()), eve::zero);
   TTS_EQUAL(eve::is_infinite(a0),
-            map([](auto e) -> eve::logical<v_t> { return e - e != 0 && e == e; }, a0));
+            tts::map([](auto e) -> eve::logical<v_t> { return e - e != 0 && e == e; }, a0));
   TTS_EQUAL(eve::is_infinite[t](a0),
             eve::if_else(t, eve::is_infinite(a0), eve::false_(eve::as(a0))));
 };

--- a/test/unit/module/core/is_less.cpp
+++ b/test/unit/module/core/is_less.cpp
@@ -39,15 +39,14 @@ TTS_CASE_WITH("Check behavior of eve::is_less(simd)",
               tts::generate(tts::ramp(0), tts::reverse_ramp(4, 2), tts::logicals(0, 3)))
 <typename T, typename M>(T const& a0, T const& a1, M const& t)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
   TTS_EQUAL(eve::is_less(a0, a1),
-            map([](auto e, auto f) -> eve::logical<v_t> { return e < f; }, a0, a1));
+            tts::map([](auto e, auto f) -> eve::logical<v_t> { return e < f; }, a0, a1));
   TTS_EQUAL(eve::is_less(a0, a0),
-            map([](auto e, auto f) -> eve::logical<v_t> { return e < f; }, a0, a0));
+            tts::map([](auto e, auto f) -> eve::logical<v_t> { return e < f; }, a0, a0));
   TTS_EQUAL(eve::is_less(a0, v_t(1)),
-            map([](auto e) -> eve::logical<v_t> { return e < v_t(1); }, a0));
+            tts::map([](auto e) -> eve::logical<v_t> { return e < v_t(1); }, a0));
   TTS_EQUAL(eve::is_less[t](a0, a1),
             eve::if_else(t, eve::is_less(a0, a1), eve::false_(eve::as(a0))));
 };

--- a/test/unit/module/core/is_less_equal.cpp
+++ b/test/unit/module/core/is_less_equal.cpp
@@ -48,15 +48,14 @@ TTS_CASE_WITH("Check behavior of eve::is_less_equal(simd)",
               tts::generate(tts::ramp(0), tts::reverse_ramp(4, 2), tts::logicals(0, 3)))
 <typename T, typename M>(T const& a0, T const& a1, M const& t)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
   TTS_EQUAL(eve::is_less_equal(a0, a1),
-            map([](auto e, auto f) -> eve::logical<v_t> { return e <= f; }, a0, a1));
+            tts::map([](auto e, auto f) -> eve::logical<v_t> { return e <= f; }, a0, a1));
   TTS_EQUAL(eve::is_less_equal(a0, a0),
-            map([](auto e, auto f) -> eve::logical<v_t> { return e <= f; }, a0, a0));
+            tts::map([](auto e, auto f) -> eve::logical<v_t> { return e <= f; }, a0, a0));
   TTS_EQUAL(eve::is_less_equal(a0, v_t(1)),
-            map([](auto e) -> eve::logical<v_t> { return e <= v_t(1); }, a0));
+            tts::map([](auto e) -> eve::logical<v_t> { return e <= v_t(1); }, a0));
   TTS_EQUAL(eve::is_less_equal[t](a0, a1),
             eve::if_else(t, eve::is_less_equal(a0, a1), eve::false_(eve::as(a0))));
 };

--- a/test/unit/module/core/is_lessgreater.cpp
+++ b/test/unit/module/core/is_lessgreater.cpp
@@ -31,15 +31,14 @@ TTS_CASE_WITH("Check behavior of eve::is_lessgreater(simd)",
               tts::generate(tts::ramp(0), tts::reverse_ramp(4, 2), tts::logicals(0, 3)))
 <typename T, typename M>(T const& a0, T const& a1, M const& t)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
   TTS_EQUAL(eve::is_lessgreater(a0, a1),
-            map([](auto e, auto f) -> eve::logical<v_t> { return (e < f) || (e > f); }, a0, a1));
+            tts::map([](auto e, auto f) -> eve::logical<v_t> { return (e < f) || (e > f); }, a0, a1));
   TTS_EQUAL(eve::is_lessgreater(a0, a0),
-            map([](auto e, auto f) -> eve::logical<v_t> { return (e < f) || (e > f); }, a0, a0));
+            tts::map([](auto e, auto f) -> eve::logical<v_t> { return (e < f) || (e > f); }, a0, a0));
   TTS_EQUAL(eve::is_lessgreater(a0, v_t(1)),
-            map([](auto e) -> eve::logical<v_t> { return (e < v_t(1)) || (e > v_t(1)); }, a0));
+            tts::map([](auto e) -> eve::logical<v_t> { return (e < v_t(1)) || (e > v_t(1)); }, a0));
   TTS_EQUAL(eve::is_lessgreater[t](a0, a1),
             eve::if_else(t, eve::is_lessgreater(a0, a1), eve::false_(eve::as(a0))));
 };

--- a/test/unit/module/core/is_lez.cpp
+++ b/test/unit/module/core/is_lez.cpp
@@ -30,10 +30,9 @@ TTS_CASE_WITH("Check behavior of eve::is_lez(simd)",
               tts::generate(tts::ramp(-1.0), tts::ramp(1.0, -1.0), tts::logicals(0, 3)))
 <typename T, typename M>(T const& a0, T const& a1, M const& t)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
-  TTS_EQUAL(eve::is_lez(a0), map([](auto e) -> eve::logical<v_t> { return e <= v_t(0); }, a0));
-  TTS_EQUAL(eve::is_lez(a1), map([](auto e) -> eve::logical<v_t> { return e <= v_t(0); }, a1));
+  TTS_EQUAL(eve::is_lez(a0), tts::map([](auto e) -> eve::logical<v_t> { return e <= v_t(0); }, a0));
+  TTS_EQUAL(eve::is_lez(a1), tts::map([](auto e) -> eve::logical<v_t> { return e <= v_t(0); }, a1));
   TTS_EQUAL(eve::is_lez[t](a0), eve::if_else(t, eve::is_lez(a0), eve::false_(eve::as(a0))));
 };

--- a/test/unit/module/core/is_ltz.cpp
+++ b/test/unit/module/core/is_ltz.cpp
@@ -31,10 +31,9 @@ TTS_CASE_WITH("Check behavior of eve::is_ltz(simd)",
 <typename T, typename M>(T const& a0, T const& a1, M const& t)
 
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
-  TTS_EQUAL(eve::is_ltz(a0), map([](auto e) -> eve::logical<v_t> { return e < v_t(0); }, a0));
-  TTS_EQUAL(eve::is_ltz(a1), map([](auto e) -> eve::logical<v_t> { return e < v_t(0); }, a1));
+  TTS_EQUAL(eve::is_ltz(a0), tts::map([](auto e) -> eve::logical<v_t> { return e < v_t(0); }, a0));
+  TTS_EQUAL(eve::is_ltz(a1), tts::map([](auto e) -> eve::logical<v_t> { return e < v_t(0); }, a1));
   TTS_EQUAL(eve::is_ltz[t](a0), eve::if_else(t, eve::is_ltz(a0), eve::false_(eve::as(a0))));
 };

--- a/test/unit/module/core/is_minf.cpp
+++ b/test/unit/module/core/is_minf.cpp
@@ -29,7 +29,6 @@ TTS_CASE_WITH("Check behavior of eve::is_minf(simd) integrals",
               tts::generate(tts::ramp(0), tts::logicals(0, 3)))
 <typename T, typename M>(T a0, M const& t)
 {
-  using eve::detail::map;
   TTS_EQUAL(eve::is_minf(a0), eve::false_(eve::as(a0)));
   TTS_EQUAL(eve::is_minf[t](a0),
             eve::if_else(t, eve::is_minf(a0), eve::false_(eve::as(a0))));
@@ -40,11 +39,10 @@ TTS_CASE_WITH("Check behavior of eve::is_minf(simd) IEEE",
               tts::generate(tts::ramp(0), tts::logicals(0, 3)))
 <typename T, typename M>(T a0, M const& t)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
   a0        = eve::if_else(eve::is_eqz(a0), eve::inf(eve::as<v_t>()), eve::zero);
   TTS_EQUAL(eve::is_minf(a0),
-            map([](auto e) -> eve::logical<v_t> { return e - e != 0 && e < 0; }, a0));
+            tts::map([](auto e) -> eve::logical<v_t> { return e - e != 0 && e < 0; }, a0));
   TTS_EQUAL(eve::is_minf[t](a0),
             eve::if_else(t, eve::is_minf(a0), eve::false_(eve::as(a0))));
 };

--- a/test/unit/module/core/is_nan.cpp
+++ b/test/unit/module/core/is_nan.cpp
@@ -30,10 +30,9 @@ TTS_CASE_WITH("Check behavior of eve::is_nan(simd)",
               tts::generate(tts::ramp(0), tts::logicals(0, 3)))
 <typename T, typename M>(T a0, M const& t)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
-  TTS_EQUAL(eve::is_nan(a0), map([](auto e) -> eve::logical<v_t> { return (e != e); }, a0));
+  TTS_EQUAL(eve::is_nan(a0), tts::map([](auto e) -> eve::logical<v_t> { return (e != e); }, a0));
   TTS_EQUAL(eve::is_nan[t](a0), eve::if_else(t, eve::is_nan(a0), eve::false_(eve::as(a0))));
 };
 

--- a/test/unit/module/core/is_negative.cpp
+++ b/test/unit/module/core/is_negative.cpp
@@ -34,15 +34,14 @@ TTS_CASE_WITH("Check behavior of eve::is_negative(simd)",
   using eve::bit_or;
   using eve::bitofsign;
   using eve::one;
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
   TTS_EQUAL(eve::is_negative(a0),
-            map([](auto e) -> eve::logical<v_t>
+            tts::map([](auto e) -> eve::logical<v_t>
                 { return bit_or(bitofsign(e), one(as(e))) < v_t(0); },
                 a0));
   TTS_EQUAL(eve::is_negative(-a0),
-            map([](auto e) -> eve::logical<v_t>
+            tts::map([](auto e) -> eve::logical<v_t>
                 { return bit_or(bitofsign(e), one(as(e))) < v_t(0); },
                 -a0));
   TTS_EQUAL(eve::is_negative[t](a0),

--- a/test/unit/module/core/is_nemz.cpp
+++ b/test/unit/module/core/is_nemz.cpp
@@ -30,9 +30,8 @@ TTS_CASE_WITH("Check behavior of eve::is_nemz(simd)",
               tts::generate(tts::ramp(0), tts::logicals(0, 3)))
 <typename T, typename M>(T const& a0, M const& t)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
-  TTS_EQUAL(eve::is_nemz(a0), map([](auto e) -> eve::logical<v_t> { return eve::is_ltz(e) || eve::is_positive(e); }, a0));
+  TTS_EQUAL(eve::is_nemz(a0), tts::map([](auto e) -> eve::logical<v_t> { return eve::is_ltz(e) || eve::is_positive(e); }, a0));
   TTS_EQUAL(eve::is_nemz[t](a0), eve::if_else(t, eve::is_nemz(a0), eve::false_(eve::as(a0))));
 };

--- a/test/unit/module/core/is_nepz.cpp
+++ b/test/unit/module/core/is_nepz.cpp
@@ -30,9 +30,8 @@ TTS_CASE_WITH("Check behavior of eve::is_nepz(simd)",
               tts::generate(tts::ramp(0), tts::logicals(0, 3)))
 <typename T, typename M>(T const& a0, M const& t)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
-  TTS_EQUAL(eve::is_nepz(a0), map([](auto e) -> eve::logical<v_t> { return eve::is_gtz(e) || eve::is_negative(e); }, a0));
+  TTS_EQUAL(eve::is_nepz(a0), tts::map([](auto e) -> eve::logical<v_t> { return eve::is_gtz(e) || eve::is_negative(e); }, a0));
   TTS_EQUAL(eve::is_nepz[t](a0), eve::if_else(t, eve::is_nepz(a0), eve::false_(eve::as(a0))));
 };

--- a/test/unit/module/core/is_nez.cpp
+++ b/test/unit/module/core/is_nez.cpp
@@ -30,9 +30,8 @@ TTS_CASE_WITH("Check behavior of eve::is_nez(simd)",
               tts::generate(tts::ramp(0), tts::logicals(0, 3)))
 <typename T, typename M>(T a0, M const& t)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
-  TTS_EQUAL(eve::is_nez(a0), map([](auto e) -> eve::logical<v_t> { return e != 0; }, a0));
+  TTS_EQUAL(eve::is_nez(a0), tts::map([](auto e) -> eve::logical<v_t> { return e != 0; }, a0));
   TTS_EQUAL(eve::is_nez[t](a0), eve::if_else(t, eve::is_nez(a0), eve::false_(eve::as(a0))));
 };

--- a/test/unit/module/core/is_ngez.cpp
+++ b/test/unit/module/core/is_ngez.cpp
@@ -30,10 +30,9 @@ TTS_CASE_WITH("Check behavior of eve::is_ngez(simd)",
               tts::generate(tts::ramp(-1.0), tts::ramp(1.0, -1.0), tts::logicals(0, 3)))
 <typename T, typename M>(T const& a0, T const& a1, M const& t)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
-  TTS_EQUAL(eve::is_ngez(a0), map([](auto e) -> eve::logical<v_t> { return !(e >= v_t(0)); }, a0));
-  TTS_EQUAL(eve::is_ngez(a1), map([](auto e) -> eve::logical<v_t> { return !(e >= v_t(0)); }, a1));
+  TTS_EQUAL(eve::is_ngez(a0), tts::map([](auto e) -> eve::logical<v_t> { return !(e >= v_t(0)); }, a0));
+  TTS_EQUAL(eve::is_ngez(a1), tts::map([](auto e) -> eve::logical<v_t> { return !(e >= v_t(0)); }, a1));
   TTS_EQUAL(eve::is_ngez[t](a0), eve::if_else(t, eve::is_ngez(a0), eve::false_(eve::as(a0))));
 };

--- a/test/unit/module/core/is_ngtz.cpp
+++ b/test/unit/module/core/is_ngtz.cpp
@@ -30,10 +30,9 @@ TTS_CASE_WITH("Check behavior of eve::is_ngtz(simd)",
               tts::generate(tts::ramp(-1.0), tts::ramp(1.0, -1.0), tts::logicals(0, 3)))
 <typename T, typename M>(T const& a0, T const& a1, M const& t)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
-  TTS_EQUAL(eve::is_ngtz(a0), map([](auto e) -> eve::logical<v_t> { return !(e > v_t(0)); }, a0));
-  TTS_EQUAL(eve::is_ngtz(a1), map([](auto e) -> eve::logical<v_t> { return !(e > v_t(0)); }, a1));
+  TTS_EQUAL(eve::is_ngtz(a0), tts::map([](auto e) -> eve::logical<v_t> { return !(e > v_t(0)); }, a0));
+  TTS_EQUAL(eve::is_ngtz(a1), tts::map([](auto e) -> eve::logical<v_t> { return !(e > v_t(0)); }, a1));
   TTS_EQUAL(eve::is_ngtz[t](a0), eve::if_else(t, eve::is_ngtz(a0), eve::false_(eve::as(a0))));
 };

--- a/test/unit/module/core/is_nlez.cpp
+++ b/test/unit/module/core/is_nlez.cpp
@@ -30,10 +30,9 @@ TTS_CASE_WITH("Check behavior of eve::is_nlez(simd)",
               tts::generate(tts::ramp(-1.0), tts::ramp(1.0, -1.0), tts::logicals(0, 3)))
 <typename T, typename M>(T const& a0, T const& a1, M const& t)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
-  TTS_EQUAL(eve::is_nlez(a0), map([](auto e) -> eve::logical<v_t> { return !(e <= v_t(0)); }, a0));
-  TTS_EQUAL(eve::is_nlez(a1), map([](auto e) -> eve::logical<v_t> { return !(e <= v_t(0)); }, a1));
+  TTS_EQUAL(eve::is_nlez(a0), tts::map([](auto e) -> eve::logical<v_t> { return !(e <= v_t(0)); }, a0));
+  TTS_EQUAL(eve::is_nlez(a1), tts::map([](auto e) -> eve::logical<v_t> { return !(e <= v_t(0)); }, a1));
   TTS_EQUAL(eve::is_nlez[t](a0), eve::if_else(t, eve::is_nlez(a0), eve::false_(eve::as(a0))));
 };

--- a/test/unit/module/core/is_nltz.cpp
+++ b/test/unit/module/core/is_nltz.cpp
@@ -30,10 +30,9 @@ TTS_CASE_WITH("Check behavior of eve::is_nltz(simd)",
               tts::generate(tts::ramp(-1.0), tts::ramp(1.0, -1.0), tts::logicals(0, 3)))
 <typename T, typename M>(T const& a0, T const& a1, M const& t)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
-  TTS_EQUAL(eve::is_nltz(a0), map([](auto e) -> eve::logical<v_t> { return !(e < v_t(0)); }, a0));
-  TTS_EQUAL(eve::is_nltz(a1), map([](auto e) -> eve::logical<v_t> { return !(e < v_t(0)); }, a1));
+  TTS_EQUAL(eve::is_nltz(a0), tts::map([](auto e) -> eve::logical<v_t> { return !(e < v_t(0)); }, a0));
+  TTS_EQUAL(eve::is_nltz(a1), tts::map([](auto e) -> eve::logical<v_t> { return !(e < v_t(0)); }, a1));
   TTS_EQUAL(eve::is_nltz[t](a0), eve::if_else(t, eve::is_nltz(a0), eve::false_(eve::as(a0))));
 };

--- a/test/unit/module/core/is_normal.cpp
+++ b/test/unit/module/core/is_normal.cpp
@@ -36,14 +36,13 @@ TTS_CASE_WITH("Check behavior of eve::is_normal(simd)",
                             tts::logicals(0, 3)))
 <typename T, typename M>(T const& a0, T const& a1, T const& a2, M const& t)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
   TTS_EQUAL(eve::is_normal(a0),
-            map([](auto e) -> eve::logical<v_t> { return std::fpclassify(e) == FP_NORMAL; }, a0));
+            tts::map([](auto e) -> eve::logical<v_t> { return std::fpclassify(e) == FP_NORMAL; }, a0));
   TTS_EQUAL(eve::is_normal(a1),
-            map([](auto e) -> eve::logical<v_t> { return std::fpclassify(e) == FP_NORMAL; }, a1));
+            tts::map([](auto e) -> eve::logical<v_t> { return std::fpclassify(e) == FP_NORMAL; }, a1));
   TTS_EQUAL(eve::is_normal(a2),
-            map([](auto e) -> eve::logical<v_t> { return std::fpclassify(e) == FP_NORMAL; }, a2));
+            tts::map([](auto e) -> eve::logical<v_t> { return std::fpclassify(e) == FP_NORMAL; }, a2));
   TTS_EQUAL(eve::is_normal[t](a0), eve::if_else(t, eve::is_normal(a0), eve::false_(eve::as(a0))));
 };

--- a/test/unit/module/core/is_not_equal.cpp
+++ b/test/unit/module/core/is_not_equal.cpp
@@ -47,19 +47,18 @@ TTS_CASE_WITH(
     tts::generate(tts::ramp(0), tts::reverse_ramp(4, 2), tts::logicals(0, 3), tts::logicals(1, 2)))
 <typename T, typename M>(T const& a0, T const& a1, M const& l0, M const& l1)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
   TTS_EQUAL(eve::is_not_equal(a0, a1),
-            map([](auto e, auto f) -> eve::logical<v_t> { return e != f; }, a0, a1));
+            tts::map([](auto e, auto f) -> eve::logical<v_t> { return e != f; }, a0, a1));
   TTS_EQUAL(eve::is_not_equal(a0, a0),
-            map([](auto e, auto f) -> eve::logical<v_t> { return e != f; }, a0, a0));
+            tts::map([](auto e, auto f) -> eve::logical<v_t> { return e != f; }, a0, a0));
   TTS_EQUAL(eve::is_not_equal(a0, v_t(1)),
-            map([](auto e) -> eve::logical<v_t> { return e != v_t(1); }, a0));
+            tts::map([](auto e) -> eve::logical<v_t> { return e != v_t(1); }, a0));
   TTS_EQUAL(eve::is_not_equal(v_t(14), a1),
-            map([](auto e) -> eve::logical<v_t> { return e != v_t(14); }, a1));
+            tts::map([](auto e) -> eve::logical<v_t> { return e != v_t(14); }, a1));
   TTS_EQUAL(eve::is_not_equal(l0, l1),
-            map([](auto e, auto f) -> eve::logical<v_t> { return e != f; }, l0, l1));
+            tts::map([](auto e, auto f) -> eve::logical<v_t> { return e != f; }, l0, l1));
   TTS_EQUAL(eve::is_not_equal[l0](a0, a1),
             eve::if_else(l0, eve::is_not_equal(a0, a1), eve::false_(eve::as(a0))));
 };
@@ -71,7 +70,6 @@ TTS_CASE_TPL("Check behavior of eve::is_not_equal(simd)", eve::test::simd::ieee_
 <typename T>(tts::type<T>)
 {
   using eve::as;
-  using eve::detail::map;
   using v_t  = eve::element_type_t<T>;
   using ui_t = eve::as_integer_t<v_t, unsigned>;
 

--- a/test/unit/module/core/is_not_finite.cpp
+++ b/test/unit/module/core/is_not_finite.cpp
@@ -26,11 +26,10 @@ TTS_CASE_WITH("Check behavior of eve::is_not_finite(simd)",
               tts::generate(tts::ramp(0), tts::logicals(0, 3)))
 <typename T, typename M>(T const& a0, M const& t)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
   TTS_EQUAL(eve::is_not_finite(a0),
-            map([](auto e) -> eve::logical<v_t> { return e - e != 0; }, a0));
+            tts::map([](auto e) -> eve::logical<v_t> { return e - e != 0; }, a0));
   TTS_EQUAL(eve::is_not_finite[t](a0),
             eve::if_else(t, eve::is_not_finite(a0), eve::false_(eve::as(a0))));
 };

--- a/test/unit/module/core/is_not_flint.cpp
+++ b/test/unit/module/core/is_not_flint.cpp
@@ -37,14 +37,13 @@ TTS_CASE_WITH("Check behavior of eve::is_not_flint(simd)",
                             tts::logicals(0, 3)))
 <typename T, typename M>(T const& a0, T const& a1, M const& t)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
   auto aa0  = eve::trunc(a0) / 2;
   auto aa1  = eve::trunc(a1) / 2;
   TTS_EQUAL(eve::is_not_flint(aa0),
-            map([](auto e) -> eve::logical<v_t> { return e != std::trunc(e); }, aa0));
+            tts::map([](auto e) -> eve::logical<v_t> { return e != std::trunc(e); }, aa0));
   TTS_EQUAL(eve::is_not_flint[eve::pedantic](aa1),
-            map([](auto e) -> eve::logical<v_t>
+            tts::map([](auto e) -> eve::logical<v_t>
                 { return (e != std::trunc(e)) || (e > eve::maxflint(eve::as(e))); },
                 aa1));
   TTS_EQUAL(eve::is_not_flint[t](a0),

--- a/test/unit/module/core/is_not_greater.cpp
+++ b/test/unit/module/core/is_not_greater.cpp
@@ -48,15 +48,14 @@ TTS_CASE_WITH("Check behavior of eve::is_not_greater(simd)",
               tts::generate(tts::ramp(0), tts::reverse_ramp(4, 2), tts::logicals(0, 3)))
 <typename T, typename M>(T const& a0, T const& a1, M const& t)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
   TTS_EQUAL(eve::is_not_greater(a0, a1),
-            map([](auto e, auto f) -> eve::logical<v_t> { return e <= f; }, a0, a1));
+            tts::map([](auto e, auto f) -> eve::logical<v_t> { return e <= f; }, a0, a1));
   TTS_EQUAL(eve::is_not_greater(a0, a0),
-            map([](auto e, auto f) -> eve::logical<v_t> { return e <= f; }, a0, a0));
+            tts::map([](auto e, auto f) -> eve::logical<v_t> { return e <= f; }, a0, a0));
   TTS_EQUAL(eve::is_not_greater(a0, v_t(1)),
-            map([](auto e) -> eve::logical<v_t> { return e <= v_t(1); }, a0));
+            tts::map([](auto e) -> eve::logical<v_t> { return e <= v_t(1); }, a0));
   TTS_EQUAL(eve::is_not_greater[t](a0, a1),
             eve::if_else(t, eve::is_not_greater(a0, a1), eve::false_(eve::as(a0))));
 };

--- a/test/unit/module/core/is_not_greater_equal.cpp
+++ b/test/unit/module/core/is_not_greater_equal.cpp
@@ -39,15 +39,14 @@ TTS_CASE_WITH("Check behavior of eve::is_not_greater_equal(simd)",
               tts::generate(tts::ramp(0), tts::reverse_ramp(4, 2), tts::logicals(0, 3)))
 <typename T, typename M>(T const& a0, T const& a1, M const& t)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
   TTS_EQUAL(eve::is_not_greater_equal(a0, a1),
-            map([](auto e, auto f) -> eve::logical<v_t> { return e < f; }, a0, a1));
+            tts::map([](auto e, auto f) -> eve::logical<v_t> { return e < f; }, a0, a1));
   TTS_EQUAL(eve::is_not_greater_equal(a0, a0),
-            map([](auto e, auto f) -> eve::logical<v_t> { return e < f; }, a0, a0));
+            tts::map([](auto e, auto f) -> eve::logical<v_t> { return e < f; }, a0, a0));
   TTS_EQUAL(eve::is_not_greater_equal(a0, v_t(1)),
-            map([](auto e) -> eve::logical<v_t> { return e < v_t(1); }, a0));
+            tts::map([](auto e) -> eve::logical<v_t> { return e < v_t(1); }, a0));
   TTS_EQUAL(eve::is_not_greater_equal[t](a0, a1),
             eve::if_else(t, eve::is_not_greater_equal(a0, a1), eve::false_(eve::as(a0))));
 };

--- a/test/unit/module/core/is_not_infinite.cpp
+++ b/test/unit/module/core/is_not_infinite.cpp
@@ -26,11 +26,10 @@ TTS_CASE_WITH("Check behavior of eve::is_not_infinite(simd)",
               tts::generate(tts::ramp(0), tts::logicals(0, 3)))
 <typename T, typename M>(T const& a0, M const& t)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
   TTS_EQUAL(eve::is_not_infinite(a0),
-            map([](auto e) -> eve::logical<v_t> { return e - e == 0 || e != e; }, a0));
+            tts::map([](auto e) -> eve::logical<v_t> { return e - e == 0 || e != e; }, a0));
   TTS_EQUAL(eve::is_not_infinite[t](a0),
             eve::if_else(t, eve::is_not_infinite(a0), eve::false_(eve::as(a0))));
 };

--- a/test/unit/module/core/is_not_less.cpp
+++ b/test/unit/module/core/is_not_less.cpp
@@ -48,15 +48,14 @@ TTS_CASE_WITH("Check behavior of eve::is_not_less(simd)",
               tts::generate(tts::ramp(0), tts::reverse_ramp(4, 2), tts::logicals(0, 3)))
 <typename T, typename M>(T const& a0, T const& a1, M const& t)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
   TTS_EQUAL(eve::is_not_less(a0, a1),
-            map([](auto e, auto f) -> eve::logical<v_t> { return e >= f; }, a0, a1));
+            tts::map([](auto e, auto f) -> eve::logical<v_t> { return e >= f; }, a0, a1));
   TTS_EQUAL(eve::is_not_less(a0, a0),
-            map([](auto e, auto f) -> eve::logical<v_t> { return e >= f; }, a0, a0));
+            tts::map([](auto e, auto f) -> eve::logical<v_t> { return e >= f; }, a0, a0));
   TTS_EQUAL(eve::is_not_less(a0, v_t(1)),
-            map([](auto e) -> eve::logical<v_t> { return e >= v_t(1); }, a0));
+            tts::map([](auto e) -> eve::logical<v_t> { return e >= v_t(1); }, a0));
   TTS_EQUAL(eve::is_not_less[t](a0, a1),
             eve::if_else(t, eve::is_not_less(a0, a1), eve::false_(eve::as(a0))));
 };

--- a/test/unit/module/core/is_not_less_equal.cpp
+++ b/test/unit/module/core/is_not_less_equal.cpp
@@ -39,15 +39,14 @@ TTS_CASE_WITH("Check behavior of eve::is_not_less_equal(simd)",
               tts::generate(tts::ramp(0), tts::reverse_ramp(4, 2), tts::logicals(0, 3)))
 <typename T, typename M>(T const& a0, T const& a1, M const& t)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
   TTS_EQUAL(eve::is_not_less_equal(a0, a1),
-            map([](auto e, auto f) -> eve::logical<v_t> { return e > f; }, a0, a1));
+            tts::map([](auto e, auto f) -> eve::logical<v_t> { return e > f; }, a0, a1));
   TTS_EQUAL(eve::is_not_less_equal(a0, a0),
-            map([](auto e, auto f) -> eve::logical<v_t> { return e > f; }, a0, a0));
+            tts::map([](auto e, auto f) -> eve::logical<v_t> { return e > f; }, a0, a0));
   TTS_EQUAL(eve::is_not_less_equal(a0, v_t(1)),
-            map([](auto e) -> eve::logical<v_t> { return e > v_t(1); }, a0));
+            tts::map([](auto e) -> eve::logical<v_t> { return e > v_t(1); }, a0));
   TTS_EQUAL(eve::is_not_less_equal[t](a0, a1),
             eve::if_else(t, eve::is_not_less_equal(a0, a1), eve::false_(eve::as(a0))));
 };

--- a/test/unit/module/core/is_not_nan.cpp
+++ b/test/unit/module/core/is_not_nan.cpp
@@ -29,10 +29,9 @@ TTS_CASE_WITH("Check behavior of eve::is_not_nan(simd)",
               tts::generate(tts::ramp(0), tts::logicals(0, 3)))
 <typename T, typename M>(T const& a0, M const& t)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
-  TTS_EQUAL(eve::is_not_nan(a0), map([](auto e) -> eve::logical<v_t> { return (e == e); }, a0));
+  TTS_EQUAL(eve::is_not_nan(a0), tts::map([](auto e) -> eve::logical<v_t> { return (e == e); }, a0));
   TTS_EQUAL(eve::is_not_nan[t](a0), eve::if_else(t, eve::is_not_nan(a0), eve::false_(eve::as(a0))));
 };
 

--- a/test/unit/module/core/is_odd.cpp
+++ b/test/unit/module/core/is_odd.cpp
@@ -31,11 +31,10 @@ TTS_CASE_WITH("Check behavior of eve::is_odd(simd) for IEEE ",
               tts::generate(tts::ramp(0), tts::logicals(0, 3)))
 <typename T, typename M>(T const& a0, M const& t)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
   TTS_EQUAL(eve::is_odd(a0),
-            map([](auto e) -> eve::logical<v_t> { return (std::trunc(e / 2) * 2) == e - 1; }, a0));
+            tts::map([](auto e) -> eve::logical<v_t> { return (std::trunc(e / 2) * 2) == e - 1; }, a0));
   TTS_EQUAL(eve::is_odd[t](a0), eve::if_else(t, eve::is_odd(a0), eve::false_(eve::as(a0))));
 };
 
@@ -44,9 +43,8 @@ TTS_CASE_WITH("Check behavior of eve::is_odd(simd) for IEEE ",
               tts::generate(tts::ramp(0), tts::logicals(0, 3)))
 <typename T, typename M>(T const& a0, M const& t)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
-  TTS_EQUAL(eve::is_odd(a0), map([](auto e) -> eve::logical<v_t> { return (e & 1) != 0; }, a0));
+  TTS_EQUAL(eve::is_odd(a0), tts::map([](auto e) -> eve::logical<v_t> { return (e & 1) != 0; }, a0));
   TTS_EQUAL(eve::is_odd[t](a0), eve::if_else(t, eve::is_odd(a0), eve::false_(eve::as(a0))));
 };

--- a/test/unit/module/core/is_ordered.cpp
+++ b/test/unit/module/core/is_ordered.cpp
@@ -31,15 +31,14 @@ TTS_CASE_WITH("Check behavior of eve::is_ordered(simd)",
               tts::generate(tts::ramp(0), tts::reverse_ramp(4, 2), tts::logicals(0, 3)))
 <typename T, typename M>(T a0, T const& a1, M const& t)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
   a0.set(0, eve::nan(eve::as<v_t>()));
   TTS_EQUAL(eve::is_ordered(a0, a1),
-            map([](auto e, auto f) -> eve::logical<v_t> { return (e == e) && (f == f); }, a0, a1));
+            tts::map([](auto e, auto f) -> eve::logical<v_t> { return (e == e) && (f == f); }, a0, a1));
   TTS_EQUAL(eve::is_ordered(a0, v_t(1)),
-            map([](auto e) -> eve::logical<v_t> { return (e == e); }, a0));
+            tts::map([](auto e) -> eve::logical<v_t> { return (e == e); }, a0));
   TTS_EQUAL(eve::is_ordered(v_t(14), a1),
-            map([](auto e) -> eve::logical<v_t> { return (e == e); }, a1));
+            tts::map([](auto e) -> eve::logical<v_t> { return (e == e); }, a1));
   TTS_EQUAL(eve::is_ordered[t](a0, a1),
             eve::if_else(t, eve::is_ordered(a0, a1), eve::false_(eve::as(a0))));
 };
@@ -52,7 +51,6 @@ TTS_CASE_TPL("Check behavior of eve::is_ordered(simd)", eve::test::simd::ieee_re
 {
   using v_t = eve::element_type_t<T>;
   using eve::as;
-  using eve::detail::map;
 
   auto cases = tts::limits(tgt);
 

--- a/test/unit/module/core/is_pinf.cpp
+++ b/test/unit/module/core/is_pinf.cpp
@@ -29,7 +29,6 @@ TTS_CASE_WITH("Check behavior of eve::is_pinf(simd) integrals",
               tts::generate(tts::ramp(0), tts::logicals(0, 3)))
 <typename T, typename M>(T a0, M const& t)
 {
-  using eve::detail::map;
   TTS_EQUAL(eve::is_pinf(a0), eve::false_(eve::as(a0)));
   TTS_EQUAL(eve::is_pinf[t](a0),
             eve::if_else(t, eve::is_pinf(a0), eve::false_(eve::as(a0))));
@@ -40,11 +39,10 @@ TTS_CASE_WITH("Check behavior of eve::is_pinf(simd) IEEE",
               tts::generate(tts::ramp(0), tts::logicals(0, 3)))
 <typename T, typename M>(T a0, M const& t)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
   a0        = eve::if_else(eve::is_eqz(a0), eve::inf(eve::as<v_t>()), eve::zero);
   TTS_EQUAL(eve::is_pinf(a0),
-            map([](auto e) -> eve::logical<v_t> { return e - e != 0 && e >  0; }, a0));
+            tts::map([](auto e) -> eve::logical<v_t> { return e - e != 0 && e >  0; }, a0));
   TTS_EQUAL(eve::is_pinf[t](a0),
             eve::if_else(t, eve::is_pinf(a0), eve::false_(eve::as(a0))));
 };

--- a/test/unit/module/core/is_positive.cpp
+++ b/test/unit/module/core/is_positive.cpp
@@ -34,15 +34,14 @@ TTS_CASE_WITH("Check behavior of eve::is_positive(simd)",
   using eve::bit_or;
   using eve::bitofsign;
   using eve::one;
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
   TTS_EQUAL(eve::is_positive(a0),
-            map([](auto e) -> eve::logical<v_t>
+            tts::map([](auto e) -> eve::logical<v_t>
                 { return bit_or(bitofsign(e), one(as(e))) > v_t(0); },
                 a0));
   TTS_EQUAL(eve::is_positive(-a0),
-            map([](auto e) -> eve::logical<v_t>
+            tts::map([](auto e) -> eve::logical<v_t>
                 { return bit_or(bitofsign(e), one(as(e))) > v_t(0); },
                 -a0));
 };

--- a/test/unit/module/core/is_pow2.cpp
+++ b/test/unit/module/core/is_pow2.cpp
@@ -34,7 +34,7 @@ TTS_CASE_WITH("Check behavior of is_pow2(wide) on unsigned integral ",
   using v_t = eve::element_type_t<T>;
   using f_t = eve::as_floating_point_t<v_t>;
   TTS_EQUAL(eve::is_pow2(a0),
-            map([](auto e) -> eve::logical<v_t>
+            tts::map([](auto e) -> eve::logical<v_t>
                 { return std::exp2(std::trunc(std::log2(f_t(e)))) == f_t(e); },
                 a0));
 };

--- a/test/unit/module/core/is_unit.cpp
+++ b/test/unit/module/core/is_unit.cpp
@@ -30,9 +30,8 @@ TTS_CASE_WITH("Check behavior of eve::is_unit(simd)",
               tts::generate(tts::ramp(0), tts::logicals(0, 3)))
 <typename T, typename M>(T const& a0, M const& t)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
-  TTS_EQUAL(eve::is_unit(a0), map([](auto e) -> eve::logical<v_t> { return eve::sqr(e) == v_t(1); }, a0));
+  TTS_EQUAL(eve::is_unit(a0), tts::map([](auto e) -> eve::logical<v_t> { return eve::sqr(e) == v_t(1); }, a0));
   TTS_EQUAL(eve::is_unit[t](a0), eve::if_else(t, eve::is_unit(a0), eve::false_(eve::as(a0))));
 };

--- a/test/unit/module/core/is_unordered.cpp
+++ b/test/unit/module/core/is_unordered.cpp
@@ -31,15 +31,14 @@ TTS_CASE_WITH("Check behavior of eve::is_unordered(simd)",
               tts::generate(tts::ramp(0), tts::reverse_ramp(4, 2), tts::logicals(0, 3)))
 <typename T, typename M>(T a0, T const& a1, M const& t)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
   a0.set(0, eve::nan(eve::as<v_t>()));
   TTS_EQUAL(eve::is_unordered(a0, a1),
-            map([](auto e, auto f) -> eve::logical<v_t> { return (e != e) || (f != f); }, a0, a1));
+            tts::map([](auto e, auto f) -> eve::logical<v_t> { return (e != e) || (f != f); }, a0, a1));
   TTS_EQUAL(eve::is_unordered(a0, v_t(1)),
-            map([](auto e) -> eve::logical<v_t> { return (e != e); }, a0));
+            tts::map([](auto e) -> eve::logical<v_t> { return (e != e); }, a0));
   TTS_EQUAL(eve::is_unordered(v_t(14), a1),
-            map([](auto e) -> eve::logical<v_t> { return (e != e); }, a1));
+            tts::map([](auto e) -> eve::logical<v_t> { return (e != e); }, a1));
   TTS_EQUAL(eve::is_unordered[t](a0, a1),
             eve::if_else(t, eve::is_unordered(a0, a1), eve::false_(eve::as(a0))));
 };
@@ -52,7 +51,6 @@ TTS_CASE_TPL("Check behavior of eve::is_unordered(simd)", eve::test::simd::ieee_
 {
   using v_t = eve::element_type_t<T>;
   using eve::as;
-  using eve::detail::map;
 
   auto cases = tts::limits(tgt);
 

--- a/test/unit/module/core/lerp.cpp
+++ b/test/unit/module/core/lerp.cpp
@@ -40,13 +40,12 @@ TTS_CASE_WITH("Check behavior of lerp on ieee floating",
 <typename T>(T const& a0, T const& a1, T const& a2)
 {
   using eve::lerp;
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
   TTS_ULP_EQUAL(lerp(a0, a1, a2),
-                map([&](auto e, auto f, auto g) -> v_t { return std::lerp(e, f, g); }, a0, a1, a2),
+                tts::map([&](auto e, auto f, auto g) -> v_t { return std::lerp(e, f, g); }, a0, a1, a2),
                 8);
   TTS_ULP_EQUAL(lerp[eve::pedantic](a0, a1, a2),
-                map([&](auto e, auto f, auto g) -> v_t { return std::lerp(e, f, g); }, a0, a1, a2),
+                tts::map([&](auto e, auto f, auto g) -> v_t { return std::lerp(e, f, g); }, a0, a1, a2),
                 8);
 };
 

--- a/test/unit/module/core/lo.cpp
+++ b/test/unit/module/core/lo.cpp
@@ -38,11 +38,11 @@ TTS_CASE_WITH("Check behavior of lo(wide) on unsigned integral ",
   if constexpr( s == 4 )
   {
     TTS_EQUAL(eve::lo(a0),
-              map([&](auto e) -> v_t { return d_t(eve::shr(eve::shl(e, s), s)); }, a0));
+              tts::map([&](auto e) -> v_t { return d_t(eve::shr(eve::shl(e, s), s)); }, a0));
   }
   else
   {
     TTS_EQUAL(eve::lo(a0),
-              map([&](auto e) -> d_t { return d_t(eve::shr(eve::shl(e, s), s)); }, a0));
+              tts::map([&](auto e) -> d_t { return d_t(eve::shr(eve::shl(e, s), s)); }, a0));
   }
 };

--- a/test/unit/module/core/logical_and.cpp
+++ b/test/unit/module/core/logical_and.cpp
@@ -36,24 +36,23 @@ TTS_CASE_WITH("Check behavior of eve::logical_and(simd)",
               tts::generate(tts::logicals(0, 3), tts::logicals(1, 2), tts::randoms(0, 2)))
 <typename M, typename T>(M const& l0, M const& l1, T const& a0)
 {
-  using eve::detail::map;
   using l_t = eve::element_type_t<M>;
 
-  TTS_EQUAL(eve::logical_and(l0, true), map([](auto e) -> l_t { return e; }, l0));
-  TTS_EQUAL(eve::logical_and(true, l1), map([](auto e) -> l_t { return e; }, l1));
-  TTS_EQUAL(eve::logical_and(l0, true), map([](auto e) -> l_t { return e; }, l0));
+  TTS_EQUAL(eve::logical_and(l0, true), tts::map([](auto e) -> l_t { return e; }, l0));
+  TTS_EQUAL(eve::logical_and(true, l1), tts::map([](auto e) -> l_t { return e; }, l1));
+  TTS_EQUAL(eve::logical_and(l0, true), tts::map([](auto e) -> l_t { return e; }, l0));
   TTS_EQUAL(eve::logical_and(l0, false), eve::false_(eve::as<M>()));
-  TTS_EQUAL(eve::logical_and(l0, l1), map([](auto e, auto f) -> l_t { return e && f; }, l0, l1));
+  TTS_EQUAL(eve::logical_and(l0, l1), tts::map([](auto e, auto f) -> l_t { return e && f; }, l0, l1));
   TTS_EQUAL(eve::logical_and(l0, l1.get(0)),
-            map([&](auto e) -> l_t { return e && l1.get(0); }, l0));
+            tts::map([&](auto e) -> l_t { return e && l1.get(0); }, l0));
   TTS_EQUAL(eve::logical_and(l0.get(0), l1),
-            map([&](auto f) -> l_t { return l0.get(0) && f; }, l1));
+            tts::map([&](auto f) -> l_t { return l0.get(0) && f; }, l1));
   using v_t  = eve::element_type_t<T>;
   using d_t  = eve::downgrade_t<v_t>;
   auto da0   = eve::convert(a0, eve::as<d_t>());
   using dl_t = eve::as_logical_t<d_t>;
   TTS_EQUAL(eve::logical_and(l1, da0 > 1),
-            map([](auto e, auto f) -> l_t { return (f > 1) && e; }, l1, da0));
+            tts::map([](auto e, auto f) -> l_t { return (f > 1) && e; }, l1, da0));
   TTS_EQUAL(eve::logical_and(da0 > 1, l1),
-            map([](auto e, auto f) -> dl_t { return bool((e > 1) && f); }, da0, l1));
+            tts::map([](auto e, auto f) -> dl_t { return bool((e > 1) && f); }, da0, l1));
 };

--- a/test/unit/module/core/logical_andnot.cpp
+++ b/test/unit/module/core/logical_andnot.cpp
@@ -36,25 +36,24 @@ TTS_CASE_WITH("Check behavior of eve::logical_andnot(simd)",
               tts::generate(tts::logicals(0, 3), tts::logicals(1, 2), tts::randoms(0, 2)))
 <typename M, typename T>(M const& l0, M const& l1, T const& a0)
 {
-  using eve::detail::map;
   using l_t = eve::element_type_t<M>;
 
   TTS_EQUAL(eve::logical_andnot(l0, true), eve::false_(eve::as<M>()));
-  TTS_EQUAL(eve::logical_andnot(true, l1), map([](auto e) -> l_t { return !e; }, l1));
+  TTS_EQUAL(eve::logical_andnot(true, l1), tts::map([](auto e) -> l_t { return !e; }, l1));
   TTS_EQUAL(eve::logical_andnot(false, l1), eve::false_(eve::as<M>()));
-  TTS_EQUAL(eve::logical_andnot(l0, false), map([](auto e) -> l_t { return e; }, l0));
+  TTS_EQUAL(eve::logical_andnot(l0, false), tts::map([](auto e) -> l_t { return e; }, l0));
   TTS_EQUAL(eve::logical_andnot(l0, l1),
-            map([](auto e, auto f) -> l_t { return e && !f; }, l0, l1));
+            tts::map([](auto e, auto f) -> l_t { return e && !f; }, l0, l1));
   TTS_EQUAL(eve::logical_andnot(l0, l1.get(0)),
-            map([&](auto e) -> l_t { return e && !l1.get(0); }, l0));
+            tts::map([&](auto e) -> l_t { return e && !l1.get(0); }, l0));
   TTS_EQUAL(eve::logical_andnot(l0.get(0), l1),
-            map([&](auto f) -> l_t { return l0.get(0) && !f; }, l1));
+            tts::map([&](auto f) -> l_t { return l0.get(0) && !f; }, l1));
   using v_t  = eve::element_type_t<T>;
   using d_t  = eve::downgrade_t<v_t>;
   auto da0   = eve::convert(a0, eve::as<d_t>());
   using dl_t = eve::as_logical_t<d_t>;
   TTS_EQUAL(eve::logical_andnot(l1, da0 > 1),
-            map([](auto e, auto f) -> l_t { return !(f > 1) && e; }, l1, da0));
+            tts::map([](auto e, auto f) -> l_t { return !(f > 1) && e; }, l1, da0));
   TTS_EQUAL(eve::logical_andnot(da0 > 1, l1),
-            map([](auto e, auto f) -> dl_t { return dl_t((e > 1) && !f); }, da0, l1));
+            tts::map([](auto e, auto f) -> dl_t { return dl_t((e > 1) && !f); }, da0, l1));
 };

--- a/test/unit/module/core/logical_not.cpp
+++ b/test/unit/module/core/logical_not.cpp
@@ -30,10 +30,9 @@ TTS_CASE_WITH("Check behavior of eve::logical_not(simd)",
               tts::generate(tts::logicals(0, 3)))
 <typename T>(T const& a0)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
-  TTS_EQUAL(eve::logical_not(a0), map([](auto e) -> v_t { return !e; }, a0));
+  TTS_EQUAL(eve::logical_not(a0), tts::map([](auto e) -> v_t { return !e; }, a0));
   TTS_EQUAL(eve::logical_not(true), false);
   TTS_EQUAL(eve::logical_not(false), true);
 };

--- a/test/unit/module/core/logical_notand.cpp
+++ b/test/unit/module/core/logical_notand.cpp
@@ -36,7 +36,6 @@ TTS_CASE_WITH("Check behavior of eve::logical_notand(simd)",
               tts::generate(tts::logicals(0, 3), tts::logicals(1, 2), tts::randoms(0, 2)))
 <typename M, typename T>(M const& l0, M const& l1, T const& a0)
 {
-  using eve::detail::map;
   using l_t = eve::element_type_t<M>;
 
   TTS_EQUAL(eve::logical_notand(l0, true), !l0);
@@ -44,17 +43,17 @@ TTS_CASE_WITH("Check behavior of eve::logical_notand(simd)",
   TTS_EQUAL(eve::logical_notand(false, l1), l1);
   TTS_EQUAL(eve::logical_notand(l0, false), eve::false_(eve::as<M>()));
   TTS_EQUAL(eve::logical_notand(l0, l1),
-            map([](auto e, auto f) -> l_t { return !e && f; }, l0, l1));
+            tts::map([](auto e, auto f) -> l_t { return !e && f; }, l0, l1));
   TTS_EQUAL(eve::logical_notand(l0, l1.get(0)),
-            map([&](auto e) -> l_t { return !e && l1.get(0); }, l0));
+            tts::map([&](auto e) -> l_t { return !e && l1.get(0); }, l0));
   TTS_EQUAL(eve::logical_notand(l0.get(0), l1),
-            map([&](auto f) -> l_t { return !l0.get(0) && f; }, l1));
+            tts::map([&](auto f) -> l_t { return !l0.get(0) && f; }, l1));
   using v_t  = eve::element_type_t<T>;
   using d_t  = eve::downgrade_t<v_t>;
   auto da0   = eve::convert(a0, eve::as<d_t>());
   using dl_t = eve::as_logical_t<d_t>;
   TTS_EQUAL(eve::logical_notand(l1, da0 > 1),
-            map([](auto e, auto f) -> l_t { return (f > 1) && !e; }, l1, da0));
+            tts::map([](auto e, auto f) -> l_t { return (f > 1) && !e; }, l1, da0));
   TTS_EQUAL(eve::logical_notand(da0 > 1, l1),
-            map([](auto e, auto f) -> dl_t { return dl_t(!(e > 1) && f); }, da0, l1));
+            tts::map([](auto e, auto f) -> dl_t { return dl_t(!(e > 1) && f); }, da0, l1));
 };

--- a/test/unit/module/core/logical_notor.cpp
+++ b/test/unit/module/core/logical_notor.cpp
@@ -36,24 +36,23 @@ TTS_CASE_WITH("Check behavior of eve::logical_notor(simd)",
               tts::generate(tts::logicals(0, 3), tts::logicals(1, 2), tts::randoms(0, 2)))
 <typename M, typename T>(M const& l0, M const& l1, T const& a0)
 {
-  using eve::detail::map;
   using l_t = eve::element_type_t<M>;
 
   TTS_EQUAL(eve::logical_notor(l0, true), eve::true_(eve::as<M>()));
   TTS_EQUAL(eve::logical_notor(true, l1), l1);
   TTS_EQUAL(eve::logical_notor(false, l1), eve::true_(eve::as<M>()));
-  TTS_EQUAL(eve::logical_notor(l0, false), map([](auto e) -> l_t { return !e; }, l0));
-  TTS_EQUAL(eve::logical_notor(l0, l1), map([](auto e, auto f) -> l_t { return !e || f; }, l0, l1));
+  TTS_EQUAL(eve::logical_notor(l0, false), tts::map([](auto e) -> l_t { return !e; }, l0));
+  TTS_EQUAL(eve::logical_notor(l0, l1), tts::map([](auto e, auto f) -> l_t { return !e || f; }, l0, l1));
   TTS_EQUAL(eve::logical_notor(l0, l1.get(0)),
-            map([&](auto e) -> l_t { return !e || l1.get(0); }, l0));
+            tts::map([&](auto e) -> l_t { return !e || l1.get(0); }, l0));
   TTS_EQUAL(eve::logical_notor(l0.get(0), l1),
-            map([&](auto f) -> l_t { return !l0.get(0) || f; }, l1));
+            tts::map([&](auto f) -> l_t { return !l0.get(0) || f; }, l1));
   using v_t  = eve::element_type_t<T>;
   using d_t  = eve::downgrade_t<v_t>;
   auto da0   = eve::convert(a0, eve::as<d_t>());
   using dl_t = eve::as_logical_t<d_t>;
   TTS_EQUAL(eve::logical_notor(l1, da0 > 1),
-            map([](auto e, auto f) -> l_t { return (f > 1) || !e; }, l1, da0));
+            tts::map([](auto e, auto f) -> l_t { return (f > 1) || !e; }, l1, da0));
   TTS_EQUAL(eve::logical_notor(da0 > 1, l1),
-            map([](auto e, auto f) -> dl_t { return dl_t(!(e > 1) || f); }, da0, l1));
+            tts::map([](auto e, auto f) -> dl_t { return dl_t(!(e > 1) || f); }, da0, l1));
 };

--- a/test/unit/module/core/logical_or.cpp
+++ b/test/unit/module/core/logical_or.cpp
@@ -36,22 +36,21 @@ TTS_CASE_WITH("Check behavior of eve::logical_or(simd)",
               tts::generate(tts::logicals(0, 3), tts::logicals(1, 2), tts::randoms(0, 2)))
 <typename M, typename T>(M const& l0, M const& l1, T const& a0)
 {
-  using eve::detail::map;
   using l_t = eve::element_type_t<M>;
 
   TTS_EQUAL(eve::logical_or(l0, true), eve::true_(eve::as<M>()));
   TTS_EQUAL(eve::logical_or(true, l1), eve::true_(eve::as<M>()));
-  TTS_EQUAL(eve::logical_or(false, l1), map([](auto e) -> l_t { return e; }, l1));
-  TTS_EQUAL(eve::logical_or(l0, false), map([](auto e) -> l_t { return e; }, l0));
-  TTS_EQUAL(eve::logical_or(l0, l1), map([](auto e, auto f) -> l_t { return e || f; }, l0, l1));
-  TTS_EQUAL(eve::logical_or(l0, l1.get(0)), map([&](auto e) -> l_t { return e || l1.get(0); }, l0));
-  TTS_EQUAL(eve::logical_or(l0.get(0), l1), map([&](auto f) -> l_t { return l0.get(0) || f; }, l1));
+  TTS_EQUAL(eve::logical_or(false, l1), tts::map([](auto e) -> l_t { return e; }, l1));
+  TTS_EQUAL(eve::logical_or(l0, false), tts::map([](auto e) -> l_t { return e; }, l0));
+  TTS_EQUAL(eve::logical_or(l0, l1), tts::map([](auto e, auto f) -> l_t { return e || f; }, l0, l1));
+  TTS_EQUAL(eve::logical_or(l0, l1.get(0)), tts::map([&](auto e) -> l_t { return e || l1.get(0); }, l0));
+  TTS_EQUAL(eve::logical_or(l0.get(0), l1), tts::map([&](auto f) -> l_t { return l0.get(0) || f; }, l1));
   using v_t  = eve::element_type_t<T>;
   using d_t  = eve::downgrade_t<v_t>;
   auto da0   = eve::convert(a0, eve::as<d_t>());
   using dl_t = eve::as_logical_t<d_t>;
   TTS_EQUAL(eve::logical_or(l1, da0 > 1),
-            map([](auto e, auto f) -> l_t { return (f > 1) || e; }, l1, da0));
+            tts::map([](auto e, auto f) -> l_t { return (f > 1) || e; }, l1, da0));
   TTS_EQUAL(eve::logical_or(da0 > 1, l1),
-            map([](auto e, auto f) -> dl_t { return bool((e > 1) || f); }, da0, l1));
+            tts::map([](auto e, auto f) -> dl_t { return bool((e > 1) || f); }, da0, l1));
 };

--- a/test/unit/module/core/logical_ornot.cpp
+++ b/test/unit/module/core/logical_ornot.cpp
@@ -36,25 +36,23 @@ TTS_CASE_WITH("Check behavior of eve::logical_ornot(simd)",
               tts::generate(tts::logicals(0, 3), tts::logicals(1, 2), tts::randoms(0, 2)))
 <typename M, typename T>(M const& l0, M const& l1, T const& a0)
 {
-  using eve::detail::map;
   using l_t = eve::element_type_t<M>;
 
   TTS_EQUAL(eve::logical_ornot(l0, true), l0);
   TTS_EQUAL(eve::logical_ornot(true, l1), eve::true_(eve::as<M>()));
-  TTS_EQUAL(eve::logical_ornot(false, l1), map([](auto e) -> l_t { return !e; }, l1));
+  TTS_EQUAL(eve::logical_ornot(false, l1), tts::map([](auto e) -> l_t { return !e; }, l1));
   TTS_EQUAL(eve::logical_ornot(l0, false), eve::true_(eve::as<M>()));
-  ;
-  TTS_EQUAL(eve::logical_ornot(l0, l1), map([](auto e, auto f) -> l_t { return e || !f; }, l0, l1));
+  TTS_EQUAL(eve::logical_ornot(l0, l1), tts::map([](auto e, auto f) -> l_t { return e || !f; }, l0, l1));
   TTS_EQUAL(eve::logical_ornot(l0, l1.get(0)),
-            map([&](auto e) -> l_t { return e || !l1.get(0); }, l0));
+            tts::map([&](auto e) -> l_t { return e || !l1.get(0); }, l0));
   TTS_EQUAL(eve::logical_ornot(l0.get(0), l1),
-            map([&](auto f) -> l_t { return l0.get(0) || !f; }, l1));
+            tts::map([&](auto f) -> l_t { return l0.get(0) || !f; }, l1));
   using v_t  = eve::element_type_t<T>;
   using d_t  = eve::downgrade_t<v_t>;
   auto da0   = eve::convert(a0, eve::as<d_t>());
   using dl_t = eve::as_logical_t<d_t>;
   TTS_EQUAL(eve::logical_ornot(l1, da0 > 1),
-            map([](auto e, auto f) -> l_t { return !(f > 1) || e; }, l1, da0));
+            tts::map([](auto e, auto f) -> l_t { return !(f > 1) || e; }, l1, da0));
   TTS_EQUAL(eve::logical_ornot(da0 > 1, l1),
-            map([](auto e, auto f) -> dl_t { return dl_t((e > 1) || !f); }, da0, l1));
+            tts::map([](auto e, auto f) -> dl_t { return dl_t((e > 1) || !f); }, da0, l1));
 };

--- a/test/unit/module/core/logical_xor.cpp
+++ b/test/unit/module/core/logical_xor.cpp
@@ -36,25 +36,23 @@ TTS_CASE_WITH("Check behavior of eve::logical_xor(simd)",
               tts::generate(tts::logicals(0, 3), tts::logicals(1, 2), tts::randoms(0, 2)))
 <typename M, typename T>(M const& l0, M const& l1, T const& a0)
 {
-  using eve::detail::map;
   using l_t = eve::element_type_t<M>;
 
   TTS_EQUAL(eve::logical_xor(l0, true), !l0);
   TTS_EQUAL(eve::logical_xor(true, l1), !l1);
   TTS_EQUAL(eve::logical_xor(false, l1), l1);
   TTS_EQUAL(eve::logical_xor(l0, false), l0);
-  ;
-  TTS_EQUAL(eve::logical_xor(l0, l1), map([](auto e, auto f) -> l_t { return e != f; }, l0, l1));
+  TTS_EQUAL(eve::logical_xor(l0, l1), tts::map([](auto e, auto f) -> l_t { return e != f; }, l0, l1));
   TTS_EQUAL(eve::logical_xor(l0, l1.get(0)),
-            map([&](auto e) -> l_t { return e != l1.get(0); }, l0));
+            tts::map([&](auto e) -> l_t { return e != l1.get(0); }, l0));
   TTS_EQUAL(eve::logical_xor(l0.get(0), l1),
-            map([&](auto f) -> l_t { return l0.get(0) != f; }, l1));
+            tts::map([&](auto f) -> l_t { return l0.get(0) != f; }, l1));
   using v_t  = eve::element_type_t<T>;
   using d_t  = eve::downgrade_t<v_t>;
   auto da0   = eve::convert(a0, eve::as<d_t>());
   using dl_t = eve::as_logical_t<d_t>;
   TTS_EQUAL(eve::logical_xor(l1, da0 > 1),
-            map([](auto e, auto f) -> l_t { return (f > 1) != e; }, l1, da0));
+            tts::map([](auto e, auto f) -> l_t { return (f > 1) != e; }, l1, da0));
   TTS_EQUAL(eve::logical_xor(da0 > 1, l1),
-            map([](auto e, auto f) -> dl_t { return dl_t((e > 1) != f); }, da0, l1));
+            tts::map([](auto e, auto f) -> dl_t { return dl_t((e > 1) != f); }, da0, l1));
 };

--- a/test/unit/module/core/manhattan.cpp
+++ b/test/unit/module/core/manhattan.cpp
@@ -40,13 +40,12 @@ TTS_CASE_WITH("Check behavior of manhattan on all types full range",
 {
   using eve::abs;
   using eve::manhattan;
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
   auto m    = [](auto a, auto b, auto c) -> v_t { return abs(a) + abs(b) + abs(c); };
-  TTS_ULP_EQUAL(manhattan((a0), (a1), (a2)), map(m, a0, a1, a2), 2);
-  TTS_ULP_EQUAL(manhattan[eve::pedantic]((a0), (a1), (a2)), map(m, a0, a1, a2), 2);
-  TTS_ULP_EQUAL(manhattan(kumi::tuple{(a0), (a1), (a2)}), map(m, a0, a1, a2), 2);
-  TTS_ULP_EQUAL(manhattan[eve::pedantic](kumi::tuple{(a0), (a1), (a2)}), map(m, a0, a1, a2), 2);
+  TTS_ULP_EQUAL(manhattan((a0), (a1), (a2)), tts::map(m, a0, a1, a2), 2);
+  TTS_ULP_EQUAL(manhattan[eve::pedantic]((a0), (a1), (a2)), tts::map(m, a0, a1, a2), 2);
+  TTS_ULP_EQUAL(manhattan(kumi::tuple{(a0), (a1), (a2)}), tts::map(m, a0, a1, a2), 2);
+  TTS_ULP_EQUAL(manhattan[eve::pedantic](kumi::tuple{(a0), (a1), (a2)}), tts::map(m, a0, a1, a2), 2);
 };
 
 

--- a/test/unit/module/core/mantissa.cpp
+++ b/test/unit/module/core/mantissa.cpp
@@ -31,14 +31,13 @@ TTS_CASE_WITH("Check behavior of mantissa on wide",
               tts::generate(tts::randoms(eve::valmin, eve::valmax), tts::logicals(0, 3)))
 <typename T, typename M>(T const& a0, M const& t)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
   auto m    = [](auto x) -> v_t
   {
     int n;
     return std::frexp(x, &n) * 2;
   };
-  TTS_EQUAL(eve::mantissa(a0), map(m, a0));
+  TTS_EQUAL(eve::mantissa(a0), tts::map(m, a0));
   TTS_EQUAL(eve::mantissa[t](a0), eve::if_else(t, eve::mantissa(a0), a0));
 };
 

--- a/test/unit/module/core/max.cpp
+++ b/test/unit/module/core/max.cpp
@@ -49,16 +49,15 @@ TTS_CASE_WITH("Check behavior of max on all types full range",
 {
   using eve::abs;
   using eve::max;
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
   auto m    = [](auto a, auto b, auto c) -> v_t { return std::max(std::max(a, b), c); };
-  TTS_ULP_EQUAL(max(a0, a1, a2), map(m, a0, a1, a2), 2);
-  TTS_ULP_EQUAL(max[eve::pedantic](a0, a1, a2), map(m, a0, a1, a2), 2);
-  TTS_ULP_EQUAL(max[eve::numeric](a0, a1, a2), map(m, a0, a1, a2), 2);
+  TTS_ULP_EQUAL(max(a0, a1, a2), tts::map(m, a0, a1, a2), 2);
+  TTS_ULP_EQUAL(max[eve::pedantic](a0, a1, a2), tts::map(m, a0, a1, a2), 2);
+  TTS_ULP_EQUAL(max[eve::numeric](a0, a1, a2), tts::map(m, a0, a1, a2), 2);
 
   TTS_ULP_EQUAL(max(kumi::tuple{a0, a1, a2}), max(a0, a1, a2), 2);
-  TTS_ULP_EQUAL(max[eve::numeric](kumi::tuple{a0, a1, a2}), map(m, a0, a1, a2), 2);
-  TTS_ULP_EQUAL(max[eve::pedantic](kumi::tuple{a0, a1, a2}), map(m, a0, a1, a2), 2);
+  TTS_ULP_EQUAL(max[eve::numeric](kumi::tuple{a0, a1, a2}), tts::map(m, a0, a1, a2), 2);
+  TTS_ULP_EQUAL(max[eve::pedantic](kumi::tuple{a0, a1, a2}), tts::map(m, a0, a1, a2), 2);
 };
 
 TTS_CASE_TPL("Check values of max", eve::test::simd::ieee_reals)

--- a/test/unit/module/core/maxabs.cpp
+++ b/test/unit/module/core/maxabs.cpp
@@ -57,18 +57,17 @@ TTS_CASE_WITH("Check behavior of maxabs on all types full range",
 {
   using eve::abs;
   using eve::maxabs;
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
   auto m    = [](auto a, auto b, auto c) -> v_t
   { return eve::max(eve::abs(a), eve::abs(b), eve::abs(c)); };
-  TTS_ULP_EQUAL(maxabs((a0), (a1), (a2)), map(m, a0, a1, a2), 2);
-  TTS_ULP_EQUAL(eve::maxabs[eve::pedantic]((a0), (a1), (a2)), map(m, a0, a1, a2), 2);
-  TTS_ULP_EQUAL(eve::maxabs[eve::numeric]((a0), (a1), (a2)), map(m, a0, a1, a2), 2);
-  TTS_ULP_EQUAL(eve::maxabs[eve::saturated]((a0), (a1), (a2)), map(m, a0, a1, a2), 2);
-  TTS_ULP_EQUAL(maxabs(kumi::tuple{(a0), (a1), (a2)}), map(m, a0, a1, a2), 2);
-  TTS_ULP_EQUAL(eve::maxabs[eve::pedantic](kumi::tuple{(a0), (a1), (a2)}), map(m, a0, a1, a2), 2);
-  TTS_ULP_EQUAL(eve::maxabs[eve::numeric](kumi::tuple{(a0), (a1), (a2)}), map(m, a0, a1, a2), 2);
-  TTS_ULP_EQUAL(eve::maxabs[eve::saturated](kumi::tuple{(a0), (a1), (a2)}), map(m, a0, a1, a2), 2);
+  TTS_ULP_EQUAL(maxabs((a0), (a1), (a2)), tts::map(m, a0, a1, a2), 2);
+  TTS_ULP_EQUAL(eve::maxabs[eve::pedantic]((a0), (a1), (a2)), tts::map(m, a0, a1, a2), 2);
+  TTS_ULP_EQUAL(eve::maxabs[eve::numeric]((a0), (a1), (a2)), tts::map(m, a0, a1, a2), 2);
+  TTS_ULP_EQUAL(eve::maxabs[eve::saturated]((a0), (a1), (a2)), tts::map(m, a0, a1, a2), 2);
+  TTS_ULP_EQUAL(maxabs(kumi::tuple{(a0), (a1), (a2)}), tts::map(m, a0, a1, a2), 2);
+  TTS_ULP_EQUAL(eve::maxabs[eve::pedantic](kumi::tuple{(a0), (a1), (a2)}), tts::map(m, a0, a1, a2), 2);
+  TTS_ULP_EQUAL(eve::maxabs[eve::numeric](kumi::tuple{(a0), (a1), (a2)}), tts::map(m, a0, a1, a2), 2);
+  TTS_ULP_EQUAL(eve::maxabs[eve::saturated](kumi::tuple{(a0), (a1), (a2)}), tts::map(m, a0, a1, a2), 2);
 
   TTS_IEEE_EQUAL(maxabs[t](a0, a1), eve::if_else(t, maxabs(a0, a1), a0));
 };

--- a/test/unit/module/core/maxmag.cpp
+++ b/test/unit/module/core/maxmag.cpp
@@ -57,17 +57,16 @@ TTS_CASE_WITH("Check behavior of maxmag on all types full range",
 {
   using eve::abs;
   using eve::maxmag;
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
   auto m    = [](auto a, auto b, auto c) -> v_t { return maxmag(maxmag(b, c), a); };
-  TTS_ULP_EQUAL(maxmag((a0), (a1), (a2)), map(m, a0, a1, a2), 2);
-  TTS_ULP_EQUAL(eve::maxmag[eve::pedantic]((a0), (a1), (a2)), map(m, a0, a1, a2), 2);
-  TTS_ULP_EQUAL(eve::maxmag[eve::numeric]((a0), (a1), (a2)), map(m, a0, a1, a2), 2);
-  TTS_ULP_EQUAL(eve::maxmag[eve::saturated]((a0), (a1), (a2)), map(m, a0, a1, a2), 2);
- TTS_ULP_EQUAL(maxmag(kumi::tuple{(a0), (a1), (a2)}), map(m, a0, a1, a2), 2);
-  TTS_ULP_EQUAL(eve::maxmag[eve::pedantic](kumi::tuple{(a0), (a1), (a2)}), map(m, a0, a1, a2), 2);
-  TTS_ULP_EQUAL(eve::maxmag[eve::numeric](kumi::tuple{(a0), (a1), (a2)}), map(m, a0, a1, a2), 2);
-  TTS_ULP_EQUAL(eve::maxmag[eve::saturated](kumi::tuple{(a0), (a1), (a2)}), map(m, a0, a1, a2), 2);
+  TTS_ULP_EQUAL(maxmag((a0), (a1), (a2)), tts::map(m, a0, a1, a2), 2);
+  TTS_ULP_EQUAL(eve::maxmag[eve::pedantic]((a0), (a1), (a2)), tts::map(m, a0, a1, a2), 2);
+  TTS_ULP_EQUAL(eve::maxmag[eve::numeric]((a0), (a1), (a2)), tts::map(m, a0, a1, a2), 2);
+  TTS_ULP_EQUAL(eve::maxmag[eve::saturated]((a0), (a1), (a2)), tts::map(m, a0, a1, a2), 2);
+ TTS_ULP_EQUAL(maxmag(kumi::tuple{(a0), (a1), (a2)}), tts::map(m, a0, a1, a2), 2);
+  TTS_ULP_EQUAL(eve::maxmag[eve::pedantic](kumi::tuple{(a0), (a1), (a2)}), tts::map(m, a0, a1, a2), 2);
+  TTS_ULP_EQUAL(eve::maxmag[eve::numeric](kumi::tuple{(a0), (a1), (a2)}), tts::map(m, a0, a1, a2), 2);
+  TTS_ULP_EQUAL(eve::maxmag[eve::saturated](kumi::tuple{(a0), (a1), (a2)}), tts::map(m, a0, a1, a2), 2);
 
   TTS_IEEE_EQUAL(maxmag[t](a0, a1), eve::if_else(t, maxmag(a0, a1), a0));
 };

--- a/test/unit/module/core/min.cpp
+++ b/test/unit/module/core/min.cpp
@@ -49,12 +49,11 @@ TTS_CASE_WITH ( "Check behavior of min on all types full range"
 {
   using eve::abs;
   using eve::min;
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
   auto m    = [](auto a, auto b, auto c) -> v_t { return std::min(std::min(a, b), c); };
-  TTS_ULP_EQUAL(min(a0, a1, a2), map(m, a0, a1, a2), 2);
-  TTS_ULP_EQUAL(min[eve::pedantic](a0, a1, a2), map(m, a0, a1, a2), 2);
-  TTS_ULP_EQUAL(min[eve::numeric](a0, a1, a2), map(m, a0, a1, a2), 2);
+  TTS_ULP_EQUAL(min(a0, a1, a2), tts::map(m, a0, a1, a2), 2);
+  TTS_ULP_EQUAL(min[eve::pedantic](a0, a1, a2), tts::map(m, a0, a1, a2), 2);
+  TTS_ULP_EQUAL(min[eve::numeric](a0, a1, a2), tts::map(m, a0, a1, a2), 2);
 };
 
 TTS_CASE_TPL("Check values of min", eve::test::simd::ieee_reals)

--- a/test/unit/module/core/minabs.cpp
+++ b/test/unit/module/core/minabs.cpp
@@ -57,18 +57,17 @@ TTS_CASE_WITH("Check behavior of minabs on all types full range",
 {
   using eve::abs;
   using eve::minabs;
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
   auto m    = [](auto a, auto b, auto c) -> v_t
   { return eve::min(eve::abs(a), eve::abs(b), eve::abs(c)); };
-  TTS_ULP_EQUAL(minabs((a0), (a1), (a2)), map(m, a0, a1, a2), 2);
-  TTS_ULP_EQUAL(eve::minabs[eve::pedantic]((a0), (a1), (a2)), map(m, a0, a1, a2), 2);
-  TTS_ULP_EQUAL(eve::minabs[eve::numeric]((a0), (a1), (a2)), map(m, a0, a1, a2), 2);
-  TTS_ULP_EQUAL(eve::minabs[eve::saturated]((a0), (a1), (a2)), map(m, a0, a1, a2), 2);
-  TTS_ULP_EQUAL(minabs(kumi::tuple{(a0), (a1), (a2)}), map(m, a0, a1, a2), 2);
-  TTS_ULP_EQUAL(eve::minabs[eve::pedantic](kumi::tuple{(a0), (a1), (a2)}), map(m, a0, a1, a2), 2);
-  TTS_ULP_EQUAL(eve::minabs[eve::numeric](kumi::tuple{(a0), (a1), (a2)}), map(m, a0, a1, a2), 2);
-  TTS_ULP_EQUAL(eve::minabs[eve::saturated](kumi::tuple{(a0), (a1), (a2)}), map(m, a0, a1, a2), 2);
+  TTS_ULP_EQUAL(minabs((a0), (a1), (a2)), tts::map(m, a0, a1, a2), 2);
+  TTS_ULP_EQUAL(eve::minabs[eve::pedantic]((a0), (a1), (a2)), tts::map(m, a0, a1, a2), 2);
+  TTS_ULP_EQUAL(eve::minabs[eve::numeric]((a0), (a1), (a2)), tts::map(m, a0, a1, a2), 2);
+  TTS_ULP_EQUAL(eve::minabs[eve::saturated]((a0), (a1), (a2)), tts::map(m, a0, a1, a2), 2);
+  TTS_ULP_EQUAL(minabs(kumi::tuple{(a0), (a1), (a2)}), tts::map(m, a0, a1, a2), 2);
+  TTS_ULP_EQUAL(eve::minabs[eve::pedantic](kumi::tuple{(a0), (a1), (a2)}), tts::map(m, a0, a1, a2), 2);
+  TTS_ULP_EQUAL(eve::minabs[eve::numeric](kumi::tuple{(a0), (a1), (a2)}), tts::map(m, a0, a1, a2), 2);
+  TTS_ULP_EQUAL(eve::minabs[eve::saturated](kumi::tuple{(a0), (a1), (a2)}), tts::map(m, a0, a1, a2), 2);
 
   TTS_IEEE_EQUAL(minabs[t](a0, a1), eve::if_else(t, minabs(a0, a1), a0));
 };

--- a/test/unit/module/core/minmag.cpp
+++ b/test/unit/module/core/minmag.cpp
@@ -57,17 +57,16 @@ TTS_CASE_WITH("Check behavior of minmag on all types full range",
 {
   using eve::abs;
   using eve::minmag;
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
   auto m    = [](auto a, auto b, auto c) -> v_t { return minmag(minmag(a, b), c); };
-  TTS_ULP_EQUAL(minmag((a0), (a1), (a2)), map(m, a0, a1, a2), 2);
-  TTS_ULP_EQUAL(eve::minmag[eve::pedantic]((a0), (a1), (a2)), map(m, a0, a1, a2), 2);
-  TTS_ULP_EQUAL(eve::minmag[eve::numeric]((a0), (a1), (a2)), map(m, a0, a1, a2), 2);
-  TTS_ULP_EQUAL(eve::minmag[eve::saturated]((a0), (a1), (a2)), map(m, a0, a1, a2), 2);
-  TTS_ULP_EQUAL(minmag(kumi::tuple{(a0), (a1), (a2)}), map(m, a0, a1, a2), 2);
-  TTS_ULP_EQUAL(eve::minmag[eve::pedantic](kumi::tuple{(a0), (a1), (a2)}), map(m, a0, a1, a2), 2);
-  TTS_ULP_EQUAL(eve::minmag[eve::numeric](kumi::tuple{(a0), (a1), (a2)}), map(m, a0, a1, a2), 2);
-  TTS_ULP_EQUAL(eve::minmag[eve::saturated](kumi::tuple{(a0), (a1), (a2)}), map(m, a0, a1, a2), 2);
+  TTS_ULP_EQUAL(minmag((a0), (a1), (a2)), tts::map(m, a0, a1, a2), 2);
+  TTS_ULP_EQUAL(eve::minmag[eve::pedantic]((a0), (a1), (a2)), tts::map(m, a0, a1, a2), 2);
+  TTS_ULP_EQUAL(eve::minmag[eve::numeric]((a0), (a1), (a2)), tts::map(m, a0, a1, a2), 2);
+  TTS_ULP_EQUAL(eve::minmag[eve::saturated]((a0), (a1), (a2)), tts::map(m, a0, a1, a2), 2);
+  TTS_ULP_EQUAL(minmag(kumi::tuple{(a0), (a1), (a2)}), tts::map(m, a0, a1, a2), 2);
+  TTS_ULP_EQUAL(eve::minmag[eve::pedantic](kumi::tuple{(a0), (a1), (a2)}), tts::map(m, a0, a1, a2), 2);
+  TTS_ULP_EQUAL(eve::minmag[eve::numeric](kumi::tuple{(a0), (a1), (a2)}), tts::map(m, a0, a1, a2), 2);
+  TTS_ULP_EQUAL(eve::minmag[eve::saturated](kumi::tuple{(a0), (a1), (a2)}), tts::map(m, a0, a1, a2), 2);
 
   TTS_IEEE_EQUAL(minmag[t](a0, a1), eve::if_else(t, minmag(a0, a1), a0));
 };

--- a/test/unit/module/core/minus.cpp
+++ b/test/unit/module/core/minus.cpp
@@ -47,10 +47,9 @@ TTS_CASE_WITH("Check behavior of eve::minus(eve::wide)",
               tts::generate(tts::randoms(-10, +10), tts::logicals(0, 3)))
 <typename T, typename M>(T const& a0, M const& mask)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
-  TTS_EQUAL(eve::minus(a0), map([](auto e) -> v_t { return -e; }, a0));
+  TTS_EQUAL(eve::minus(a0), tts::map([](auto e) -> v_t { return -e; }, a0));
   TTS_EQUAL(eve::minus[mask](a0), eve::if_else(mask, eve::minus(a0), a0));
   TTS_EQUAL(eve::minus[eve::if_(mask).else_(99)](a0), eve::if_else(mask, eve::minus(a0), T{99}));
   TTS_EQUAL(eve::minus[eve::ignore_all](a0), a0);
@@ -65,10 +64,9 @@ TTS_CASE_WITH("Check behavior of eve::minus[eve::saturated](eve::wide)",
               tts::generate(tts::randoms(eve::valmin, eve::valmax), tts::logicals(0, 3)))
 <typename T, typename M>(T const& a0, M const& mask)
 {
-  using eve::detail::map;
 
   TTS_EQUAL(eve::minus[eve::saturated](a0),
-            map([](auto e)
+            tts::map([](auto e)
                 { return e == eve::valmin(eve::as(e)) ? eve::valmax(eve::as(e)) : eve::minus(e); },
                 a0));
   TTS_EQUAL(eve::minus[mask][eve::saturated](a0),

--- a/test/unit/module/core/mul.cpp
+++ b/test/unit/module/core/mul.cpp
@@ -78,19 +78,18 @@ TTS_CASE_WITH("Check behavior of mul on wide",
   using eve::lower;
   using eve::upper;
   using eve::strict;
-  using eve::detail::map;
-  TTS_ULP_EQUAL(mul(a0, a2), map([](auto e, auto f) { return mul(e, f); }, a0, a2), 0.5);
-  TTS_ULP_EQUAL(mul[saturated](a0, a2), map([&](auto e, auto f) { return mul[saturated](e, f); }, a0, a2), 0.5);
-  TTS_ULP_EQUAL(mul(a0, a1, a2), map([&](auto e, auto f, auto g) { return mul(mul(e, f), g); }, a0, a1, a2), 0.5);
-  TTS_ULP_EQUAL(mul[saturated](a0, a1, a2), map([&](auto e, auto f, auto g) { return mul[saturated](mul[saturated](e, f), g); }, a0, a1, a2), 0.5);
-  TTS_ULP_EQUAL(mul(kumi::tuple{a0, a2}), map([](auto e, auto f) { return mul(e, f); }, a0, a2), 0.5);
-  TTS_ULP_EQUAL(mul[saturated](kumi::tuple{a0, a2}), map([&](auto e, auto f) { return mul[saturated](e, f); }, a0, a2), 0.5);
-  TTS_ULP_EQUAL(mul(kumi::tuple{a0, a1, a2}), map([&](auto e, auto f, auto g) { return mul(mul(e, f), g); }, a0, a1, a2), 0.5);
-  TTS_ULP_EQUAL(mul[saturated](kumi::tuple{a0, a1, a2}), map([&](auto e, auto f, auto g) { return mul[saturated](mul[saturated](e, f), g); }, a0, a1, a2), 0.5);
+  TTS_ULP_EQUAL(mul(a0, a2), tts::map([](auto e, auto f) { return mul(e, f); }, a0, a2), 0.5);
+  TTS_ULP_EQUAL(mul[saturated](a0, a2), tts::map([&](auto e, auto f) { return mul[saturated](e, f); }, a0, a2), 0.5);
+  TTS_ULP_EQUAL(mul(a0, a1, a2), tts::map([&](auto e, auto f, auto g) { return mul(mul(e, f), g); }, a0, a1, a2), 0.5);
+  TTS_ULP_EQUAL(mul[saturated](a0, a1, a2), tts::map([&](auto e, auto f, auto g) { return mul[saturated](mul[saturated](e, f), g); }, a0, a1, a2), 0.5);
+  TTS_ULP_EQUAL(mul(kumi::tuple{a0, a2}), tts::map([](auto e, auto f) { return mul(e, f); }, a0, a2), 0.5);
+  TTS_ULP_EQUAL(mul[saturated](kumi::tuple{a0, a2}), tts::map([&](auto e, auto f) { return mul[saturated](e, f); }, a0, a2), 0.5);
+  TTS_ULP_EQUAL(mul(kumi::tuple{a0, a1, a2}), tts::map([&](auto e, auto f, auto g) { return mul(mul(e, f), g); }, a0, a1, a2), 0.5);
+  TTS_ULP_EQUAL(mul[saturated](kumi::tuple{a0, a1, a2}), tts::map([&](auto e, auto f, auto g) { return mul[saturated](mul[saturated](e, f), g); }, a0, a1, a2), 0.5);
   if constexpr (eve::floating_value<T>)
   {
-    TTS_ULP_EQUAL( mul[lower](kumi::tuple{a0, a1, a2}), map([&](auto e, auto f, auto g) { return mul[lower](mul[lower](e, f), g); }, a0, a1, a2), 1.0);
-    TTS_ULP_EQUAL( mul[upper](kumi::tuple{a0, a1, a2}), map([&](auto e, auto f, auto g) { return mul[upper](mul[upper](e, f), g); }, a0, a1, a2), 1.0);
+    TTS_ULP_EQUAL( mul[lower](kumi::tuple{a0, a1, a2}), tts::map([&](auto e, auto f, auto g) { return mul[lower](mul[lower](e, f), g); }, a0, a1, a2), 1.0);
+    TTS_ULP_EQUAL( mul[upper](kumi::tuple{a0, a1, a2}), tts::map([&](auto e, auto f, auto g) { return mul[upper](mul[upper](e, f), g); }, a0, a1, a2), 1.0);
     TTS_EXPECT(eve::all(mul[upper](a0, a1, a2) >=  mul[lower](a0, a1, a2)));
     T  w0{0.1};
     T  w1{0.12f};
@@ -118,12 +117,11 @@ TTS_CASE_WITH("Check behavior of mul on signed types",
 {
   using eve::mul;
   using eve::saturated;
-  using eve::detail::map;
   TTS_EQUAL(mul[a2 > T(64)](a0, a1),
-            map([](auto e, auto f, auto g) { return g > 64 ? mul(e, f) : e; }, a0, a1, a2));
+            tts::map([](auto e, auto f, auto g) { return g > 64 ? mul(e, f) : e; }, a0, a1, a2));
   TTS_EQUAL(
       mul[saturated][a2 > T(64)](a0, a1),
-      map([](auto e, auto f, auto g) { return g > 64 ? mul[saturated](e, f) : e; }, a0, a1, a2));
+      tts::map([](auto e, auto f, auto g) { return g > 64 ? mul[saturated](e, f) : e; }, a0, a1, a2));
 };
 
 

--- a/test/unit/module/core/negabsmax.cpp
+++ b/test/unit/module/core/negabsmax.cpp
@@ -53,18 +53,17 @@ TTS_CASE_WITH("Check behavior of negabsmax on all types full range",
 {
   using eve::abs;
   using eve::negabsmax;
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
   auto m = [](auto a, auto b, auto c) -> v_t { return -eve::abs(eve::max(a, b, c)); };
-  TTS_ULP_EQUAL(negabsmax((a0), (a1), (a2)), map(m, a0, a1, a2), 2);
-  TTS_ULP_EQUAL(eve::negabsmax[eve::pedantic]((a0), (a1), (a2)), map(m, a0, a1, a2), 2);
-  TTS_ULP_EQUAL(eve::negabsmax[eve::numeric]((a0), (a1), (a2)), map(m, a0, a1, a2), 2);
-  TTS_ULP_EQUAL(eve::negabsmax[eve::saturated]((a0), (a1), (a2)), map(m, a0, a1, a2), 2);
-  TTS_ULP_EQUAL(negabsmax(kumi::tuple{(a0), (a1), (a2)}), map(m, a0, a1, a2), 2);
-  TTS_ULP_EQUAL(eve::negabsmax[eve::pedantic](kumi::tuple{(a0), (a1), (a2)}), map(m, a0, a1, a2), 2);
-  TTS_ULP_EQUAL(eve::negabsmax[eve::numeric](kumi::tuple{(a0), (a1), (a2)}), map(m, a0, a1, a2), 2);
-  TTS_ULP_EQUAL(eve::negabsmax[eve::saturated](kumi::tuple{(a0), (a1), (a2)}), map(m, a0, a1, a2), 2);
+  TTS_ULP_EQUAL(negabsmax((a0), (a1), (a2)), tts::map(m, a0, a1, a2), 2);
+  TTS_ULP_EQUAL(eve::negabsmax[eve::pedantic]((a0), (a1), (a2)), tts::map(m, a0, a1, a2), 2);
+  TTS_ULP_EQUAL(eve::negabsmax[eve::numeric]((a0), (a1), (a2)), tts::map(m, a0, a1, a2), 2);
+  TTS_ULP_EQUAL(eve::negabsmax[eve::saturated]((a0), (a1), (a2)), tts::map(m, a0, a1, a2), 2);
+  TTS_ULP_EQUAL(negabsmax(kumi::tuple{(a0), (a1), (a2)}), tts::map(m, a0, a1, a2), 2);
+  TTS_ULP_EQUAL(eve::negabsmax[eve::pedantic](kumi::tuple{(a0), (a1), (a2)}), tts::map(m, a0, a1, a2), 2);
+  TTS_ULP_EQUAL(eve::negabsmax[eve::numeric](kumi::tuple{(a0), (a1), (a2)}), tts::map(m, a0, a1, a2), 2);
+  TTS_ULP_EQUAL(eve::negabsmax[eve::saturated](kumi::tuple{(a0), (a1), (a2)}), tts::map(m, a0, a1, a2), 2);
 
   TTS_IEEE_EQUAL(negabsmax[t](a0, a1), eve::if_else(t, negabsmax(a0, a1), a0));
 };

--- a/test/unit/module/core/negabsmin.cpp
+++ b/test/unit/module/core/negabsmin.cpp
@@ -49,18 +49,17 @@ TTS_CASE_WITH("Check behavior of negabsmin on all types full range",
 {
   using eve::abs;
   using eve::negabsmin;
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
   auto m = [](auto a, auto b, auto c) -> v_t { return eve::minus[eve::saturated](eve::abs[eve::saturated](eve::min(a, b, c))); };
-  TTS_ULP_EQUAL(negabsmin((a0), (a1), (a2)), map(m, a0, a1, a2), 2);
-  TTS_ULP_EQUAL(eve::negabsmin[eve::pedantic]((a0), (a1), (a2)), map(m, a0, a1, a2), 2);
-  TTS_ULP_EQUAL(eve::negabsmin[eve::numeric]((a0), (a1), (a2)), map(m, a0, a1, a2), 2);
-  TTS_ULP_EQUAL(eve::negabsmin[eve::saturated]((a0), (a1), (a2)), map(m, a0, a1, a2), 2);
-//   TTS_ULP_EQUAL(negabsmin(kumi::tuple{(a0), (a1), (a2)}), map(m, a0, a1, a2), 2);
-//   TTS_ULP_EQUAL(eve::negabsmin[eve::pedantic](kumi::tuple{(a0), (a1), (a2)}), map(m, a0, a1, a2), 2);
-//   TTS_ULP_EQUAL(eve::negabsmin[eve::numeric](kumi::tuple{(a0), (a1), (a2)}), map(m, a0, a1, a2), 2);
-//   TTS_ULP_EQUAL(eve::negabsmin[eve::saturated](kumi::tuple{(a0), (a1), (a2)}), map(m, a0, a1, a2), 2);
+  TTS_ULP_EQUAL(negabsmin((a0), (a1), (a2)), tts::map(m, a0, a1, a2), 2);
+  TTS_ULP_EQUAL(eve::negabsmin[eve::pedantic]((a0), (a1), (a2)), tts::map(m, a0, a1, a2), 2);
+  TTS_ULP_EQUAL(eve::negabsmin[eve::numeric]((a0), (a1), (a2)), tts::map(m, a0, a1, a2), 2);
+  TTS_ULP_EQUAL(eve::negabsmin[eve::saturated]((a0), (a1), (a2)), tts::map(m, a0, a1, a2), 2);
+//   TTS_ULP_EQUAL(negabsmin(kumi::tuple{(a0), (a1), (a2)}), tts::map(m, a0, a1, a2), 2);
+//   TTS_ULP_EQUAL(eve::negabsmin[eve::pedantic](kumi::tuple{(a0), (a1), (a2)}), tts::map(m, a0, a1, a2), 2);
+//   TTS_ULP_EQUAL(eve::negabsmin[eve::numeric](kumi::tuple{(a0), (a1), (a2)}), tts::map(m, a0, a1, a2), 2);
+//   TTS_ULP_EQUAL(eve::negabsmin[eve::saturated](kumi::tuple{(a0), (a1), (a2)}), tts::map(m, a0, a1, a2), 2);
 
   TTS_IEEE_EQUAL(negabsmin[t](a0, a1), eve::if_else(t, negabsmin(a0, a1), a0));
 };

--- a/test/unit/module/core/negate.cpp
+++ b/test/unit/module/core/negate.cpp
@@ -70,10 +70,9 @@ TTS_CASE_WITH("Check behavior of negate(wide)",
 <typename T>(T const& a0, T const& a1)
 {
   using eve::negate;
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
   TTS_ULP_EQUAL(
-      negate(a0, a1), map([](auto e, auto f) -> v_t { return e * eve::sign(f); }, a0, a1), 2);
+      negate(a0, a1), tts::map([](auto e, auto f) -> v_t { return e * eve::sign(f); }, a0, a1), 2);
 };
 
 //==================================================================================================

--- a/test/unit/module/core/negatenz.cpp
+++ b/test/unit/module/core/negatenz.cpp
@@ -76,9 +76,8 @@ TTS_CASE_WITH("Check behavior of negatenz(wide)",
 <typename T>(T const& a0, T const& a1)
 {
   using eve::negatenz;
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
-  TTS_ULP_EQUAL( negatenz(a0, a1), map([](auto e, auto f) -> v_t { return e*eve::signnz(f); }, a0, a1), 2);
+  TTS_ULP_EQUAL( negatenz(a0, a1), tts::map([](auto e, auto f) -> v_t { return e*eve::signnz(f); }, a0, a1), 2);
 };
 
 

--- a/test/unit/module/core/negmaxabs.cpp
+++ b/test/unit/module/core/negmaxabs.cpp
@@ -49,7 +49,6 @@ TTS_CASE_WITH("Check behavior of negmaxabs on all types full range",
 {
   using eve::abs;
   using eve::negmaxabs;
-  using eve::detail::map;
 
   TTS_ULP_EQUAL(negmaxabs(a0, a1, a2), -eve::maxabs(a0, a1, a2), 2);
   TTS_ULP_EQUAL(eve::negmaxabs[eve::pedantic](a0, a1, a2),  -eve::maxabs[eve::pedantic](a0, a1, a2), 2);

--- a/test/unit/module/core/negminabs.cpp
+++ b/test/unit/module/core/negminabs.cpp
@@ -49,7 +49,6 @@ TTS_CASE_WITH("Check behavior of negminabs on all types full range",
 {
   using eve::abs;
   using eve::negminabs;
-  using eve::detail::map;
 
   TTS_ULP_EQUAL(negminabs(a0, a1, a2), -eve::minabs(a0, a1, a2), 2);
   TTS_ULP_EQUAL(eve::negminabs[eve::pedantic](a0, a1, a2),  -eve::minabs[eve::pedantic](a0, a1, a2), 2);

--- a/test/unit/module/core/next.cpp
+++ b/test/unit/module/core/next.cpp
@@ -38,14 +38,14 @@
                tts::generate(tts::randoms(-10, +10), tts::logicals(0, 3)))
  <typename T, typename M>(T const& a0, M const& t)
  {
-   using eve::detail::map;
+   ;
    using v_t = eve::element_type_t<T>;
    if constexpr( eve::floating_value<v_t> )
    {
      auto n = [](auto e) -> v_t { return std::nextafter(e, eve::valmax(eve::as(e))); };
-     TTS_EQUAL(eve::next(a0), map(n, a0));
+     TTS_EQUAL(eve::next(a0), tts::map(n, a0));
      auto nn = [n](auto e) -> v_t { return n(n(e)); };
-     TTS_EQUAL(eve::next(a0, 2), map(nn, a0));
+     TTS_EQUAL(eve::next(a0, 2), tts::map(nn, a0));
    }
    else
    {

--- a/test/unit/module/core/nextafter.cpp
+++ b/test/unit/module/core/nextafter.cpp
@@ -34,12 +34,11 @@ TTS_CASE_WITH("Check behavior of eve::nextafter",
                             tts::randoms(eve::valmin, eve::valmax)))
 <typename T>(T const& a0, T const& a1)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
   if constexpr( eve::floating_value<v_t> )
   {
     auto n = [](auto e, auto f) -> v_t { return std::nextafter(e, f); };
-    TTS_EQUAL(eve::nextafter(a0, a1), map(n, a0, a1));
+    TTS_EQUAL(eve::nextafter(a0, a1), tts::map(n, a0, a1));
     TTS_IEEE_EQUAL(eve::nextafter[eve::pedantic](eve::nan(eve::as<T>()), T(1)),
                    eve::nan(eve::as<T>()));
     TTS_IEEE_EQUAL(eve::nextafter[eve::pedantic](T(1), eve::nan(eve::as<T>())),

--- a/test/unit/module/core/oneminus.cpp
+++ b/test/unit/module/core/oneminus.cpp
@@ -51,10 +51,9 @@ TTS_CASE_WITH("Check behavior of eve::oneminus(eve::wide)",
   using eve::as;
   using eve::oneminus;
   using eve::saturated;
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
-  TTS_EQUAL(oneminus(a0), map([](auto e) -> v_t { return 1 - e; }, a0));
+  TTS_EQUAL(oneminus(a0), tts::map([](auto e) -> v_t { return 1 - e; }, a0));
   TTS_EQUAL(oneminus[mask](a0), eve::if_else(mask, oneminus(a0), a0));
   if constexpr( eve::unsigned_value<T> )
     TTS_EQUAL(oneminus[saturated](a0),

--- a/test/unit/module/core/popcount.cpp
+++ b/test/unit/module/core/popcount.cpp
@@ -29,10 +29,9 @@ TTS_CASE_WITH("Check behavior of eve::popcount(simd)",
               tts::generate(tts::randoms(eve::valmin, eve::valmax), tts::logicals(0, 3)))
 <typename T, typename M>(T const& a0, M const&)
 {
-  using eve::detail::map;
   using i_t  = eve::as_integer_t<T, unsigned>;
   using vi_t = eve::element_type_t<i_t>;
 
-  TTS_EQUAL(eve::popcount(a0), map([](vi_t e) -> vi_t { return std::popcount(e); }, a0));
+  TTS_EQUAL(eve::popcount(a0), tts::map([](vi_t e) -> vi_t { return std::popcount(e); }, a0));
   //  TTS_EQUAL(eve::popcount[t](a0), eve::if_else(t, eve::popcount(a0), a0));
 };

--- a/test/unit/module/core/prev.cpp
+++ b/test/unit/module/core/prev.cpp
@@ -38,14 +38,13 @@ TTS_CASE_WITH("Check behavior of eve::prev(eve::wide)",
               tts::generate(tts::randoms(-10, +10), tts::logicals(0, 3)))
 <typename T, typename M>(T const& a0, M const& t)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
   if constexpr( eve::floating_value<v_t> )
   {
     auto n = [](auto e) -> v_t { return std::nextafter(e, eve::valmin(eve::as(e))); };
-    TTS_EQUAL(eve::prev(a0), map(n, a0));
+    TTS_EQUAL(eve::prev(a0), tts::map(n, a0));
     auto nn = [n](auto e) -> v_t { return n(n(e)); };
-    TTS_EQUAL(eve::prev(a0, 2), map(nn, a0));
+    TTS_EQUAL(eve::prev(a0, 2), tts::map(nn, a0));
   }
   else
   {

--- a/test/unit/module/core/rat.cpp
+++ b/test/unit/module/core/rat.cpp
@@ -33,6 +33,6 @@ TTS_CASE_WITH("Check behavior of eve::rat(simd)",
 {
   using v_t   = eve::element_type_t<T>;
   auto [n, d] = eve::rat(a0 / 37);
-  TTS_EQUAL(n, eve::detail::map([](auto e) -> v_t { return e; }, a0));
+  TTS_EQUAL(n, tts::map([](auto e) -> v_t { return e; }, a0));
   TTS_EQUAL(d, T(37));
 };

--- a/test/unit/module/core/rec.cpp
+++ b/test/unit/module/core/rec.cpp
@@ -45,13 +45,12 @@ TTS_CASE_WITH("Check behavior of eve::rec(eve::wide)",
               tts::generate(tts::randoms(mini, maxi), tts::logicals(0, 3)))
 <typename T, typename M>(T const& a0, M const& mask)
 {
-  using eve::detail::map;
   using eve::lower;
   using eve::upper;
   using v_t = eve::element_type_t<T>;
 
   TTS_ULP_EQUAL(eve::rec(a0),
-                map([](auto e) -> v_t { return e ? v_t(1 / e) : eve::valmax(eve::as<v_t>()); }, a0),
+                tts::map([](auto e) -> v_t { return e ? v_t(1 / e) : eve::valmax(eve::as<v_t>()); }, a0),
                 2.5);
 
   TTS_EQUAL(eve::rec[mask](a0), eve::if_else(mask, eve::rec(a0), a0));

--- a/test/unit/module/core/rem.cpp
+++ b/test/unit/module/core/rem.cpp
@@ -50,13 +50,12 @@ TTS_CASE_WITH("Check behavior of rem on wide",
 <typename T>(T a0, T a1)
 {
   using eve::rem;
-  using eve::detail::map;
 
   auto thrs = std::same_as<eve::element_type_t<T>, float> ? 5e-4 : 5e-12;
-  TTS_RELATIVE_EQUAL(rem(a0, a1), map([](auto e, auto f) { return eve::rem(e, f); }, a0, a1), thrs);
+  TTS_RELATIVE_EQUAL(rem(a0, a1), tts::map([](auto e, auto f) { return eve::rem(e, f); }, a0, a1), thrs);
 
   a1 = eve::if_else(eve::is_eqz(a1), eve::one, a1);
-  TTS_RELATIVE_EQUAL(rem(a0, a1), map([](auto e, auto f) { return eve::rem(e, f); }, a0, a1), thrs);
+  TTS_RELATIVE_EQUAL(rem(a0, a1), tts::map([](auto e, auto f) { return eve::rem(e, f); }, a0, a1), thrs);
 };
 
 //==================================================================================================
@@ -106,37 +105,36 @@ TTS_CASE_WITH("Check behavior of rem on signed types",
   using eve::is_nez;
   using eve::pedantic;
   using eve::rem;
-  using eve::detail::map;
   auto a2b = eve::if_else(a2 >= 0, eve::one, a2);
   a2 = eve::if_else(a2 >= 0, eve::zero, a2);
 
   TTS_RELATIVE_EQUAL(rem[is_nez(a2)](a0, a2),
-                map([](auto e, auto f, auto g) { return is_nez(f) ? rem(e, g) : e; }, a0, a2, a2b),
+                tts::map([](auto e, auto f, auto g) { return is_nez(f) ? rem(e, g) : e; }, a0, a2, a2b),
                 0.001);
 
   TTS_ULP_EQUAL(
     rem[a2 > T(64)](a0, a1),
-    map([](auto e, auto f, auto g) { return g > 64 ? rem(e, f) : e; }, a0, a1, a2),
+    tts::map([](auto e, auto f, auto g) { return g > 64 ? rem(e, f) : e; }, a0, a1, a2),
     2);
   a1 = eve::if_else(eve::is_eqz(a1), eve::one, a1);
   TTS_ULP_EQUAL(
     rem[a2 > T(64)](a0, a1),
-    map([](auto e, auto f, auto g) { return g > 64 ? rem(e, f) : e; }, a0, a1, a2),
+    tts::map([](auto e, auto f, auto g) { return g > 64 ? rem(e, f) : e; }, a0, a1, a2),
     2);
 
   a2b = eve::if_else(a2 == 0, eve::one, a2);
 
   TTS_RELATIVE_EQUAL(
-    rem[is_nez(a2)](a0, a2), map([](auto e, auto f, auto g) { return f ? rem(e, g) :e; }, a0, a2, a2b), 0.001);
+    rem[is_nez(a2)](a0, a2), tts::map([](auto e, auto f, auto g) { return f ? rem(e, g) :e; }, a0, a2, a2b), 0.001);
 
   TTS_RELATIVE_EQUAL(
     rem[a2 > T(64)](a0, a1),
-    map([](auto e, auto f, auto g) { return g > 64 ? rem(e, f) : e; }, a0, a1, a2),
+    tts::map([](auto e, auto f, auto g) { return g > 64 ? rem(e, f) : e; }, a0, a1, a2),
     0.001);
   a1 = eve::if_else(eve::is_eqz(a1), eve::one, a1);
   TTS_RELATIVE_EQUAL(
     rem[a2 > T(64)](a0, a1),
-    map([](auto e, auto f, auto g) { return g > 64 ? rem(e, f) : e; }, a0, a1, a2),
+    tts::map([](auto e, auto f, auto g) { return g > 64 ? rem(e, f) : e; }, a0, a1, a2),
     0.001);
 };
 

--- a/test/unit/module/core/remainder.cpp
+++ b/test/unit/module/core/remainder.cpp
@@ -48,11 +48,10 @@ TTS_CASE_WITH("Check behavior of remainder on wide",
 <typename T>(T a0, T a1)
 {
   using eve::remainder;
-  using eve::detail::map;
 
   auto thrs = std::same_as<eve::element_type_t<T>, float> ? 5e-4 : 5e-12;
   a1 = eve::if_else(eve::is_eqz(a1), eve::one, a1);
-  TTS_RELATIVE_EQUAL(remainder(a0, a1), map([](auto e, auto f) { return std::remainder(e, f); }, a0, a1), thrs);
+  TTS_RELATIVE_EQUAL(remainder(a0, a1), tts::map([](auto e, auto f) { return std::remainder(e, f); }, a0, a1), thrs);
 };
 
 

--- a/test/unit/module/core/rotl.cpp
+++ b/test/unit/module/core/rotl.cpp
@@ -48,15 +48,15 @@ TTS_CASE_WITH("Check behavior of rotl on wide",
   using eve::rotl;
   TTS_EQUAL(rotl(a0, 0u), a0);
   TTS_EQUAL(rotl(a0, eve::index<0>), a0);
-  TTS_EQUAL(rotl(a0, 1u), map([](auto e) { return std::rotl(e, 1u); }, a0));
-  TTS_EQUAL(rotl(a0, eve::index<4>), map([](auto e) { return std::rotl(e, 4u); }, a0));
+  TTS_EQUAL(rotl(a0, 1u), tts::map([](auto e) { return std::rotl(e, 1u); }, a0));
+  TTS_EQUAL(rotl(a0, eve::index<4>), tts::map([](auto e) { return std::rotl(e, 4u); }, a0));
   using v_t = eve::element_type_t<T>;
   a0        = eve::one(eve::as(a0));
   a1        = eve::iota(eve::as(a0));
   a1        = a1 % (sizeof(v_t) * 8);
   auto ua1  =  eve::convert(a1, eve::int_from<T>());
-  TTS_EQUAL(rotl(a0, a1), map([](auto e, auto f) -> v_t { return std::rotl(e, f); }, a0, a1));
-  TTS_EQUAL(rotl(a0, ua1), map([](auto e, auto f) -> v_t { return std::rotl(e, f); }, a0, ua1));
+  TTS_EQUAL(rotl(a0, a1), tts::map([](auto e, auto f) -> v_t { return std::rotl(e, f); }, a0, a1));
+  TTS_EQUAL(rotl(a0, ua1), tts::map([](auto e, auto f) -> v_t { return std::rotl(e, f); }, a0, ua1));
 };
 
 //======================================================================================================================

--- a/test/unit/module/core/rotr.cpp
+++ b/test/unit/module/core/rotr.cpp
@@ -48,15 +48,15 @@ TTS_CASE_WITH("Check behavior of rotr on wide",
   using eve::rotr;
   TTS_EQUAL(rotr(a0, 0u), a0);
   TTS_EQUAL(rotr(a0, eve::index<0>), a0);
-  TTS_EQUAL(rotr(a0, 1u), map([](auto e) { return std::rotr(e, 1u); }, a0));
-  TTS_EQUAL(rotr(a0, eve::index<4>), map([](auto e) { return std::rotr(e, 4u); }, a0));
+  TTS_EQUAL(rotr(a0, 1u), tts::map([](auto e) { return std::rotr(e, 1u); }, a0));
+  TTS_EQUAL(rotr(a0, eve::index<4>), tts::map([](auto e) { return std::rotr(e, 4u); }, a0));
   using v_t = eve::element_type_t<T>;
   a0        = eve::one(eve::as(a0));
   a1        = eve::iota(eve::as(a0));
   a1        = a1 % (sizeof(v_t) * 8);
   auto ua1  =  eve::convert(a1,  eve::int_from<T>());
-  TTS_EQUAL(rotr(a0, a1), map([](auto e, auto f) -> v_t { return std::rotr(e, f); }, a0, a1));
-  TTS_EQUAL(rotr(a0, ua1), map([](auto e, auto f) -> v_t { return std::rotr(e, f); }, a0, ua1));
+  TTS_EQUAL(rotr(a0, a1), tts::map([](auto e, auto f) -> v_t { return std::rotr(e, f); }, a0, a1));
+  TTS_EQUAL(rotr(a0, ua1), tts::map([](auto e, auto f) -> v_t { return std::rotr(e, f); }, a0, ua1));
 };
 
 //======================================================================================================================

--- a/test/unit/module/core/roundscale.cpp
+++ b/test/unit/module/core/roundscale.cpp
@@ -33,14 +33,13 @@ TTS_CASE_WITH("Check behavior of roundscale(wide) and diff on  floating types",
               tts::generate(tts::randoms(-100.0, 100.0)))
 <typename T>(T const& a0)
 {
-  using eve::detail::map;
   using eve::rec;
   using eve::sqr;
   TTS_ULP_EQUAL(eve::roundscale(a0, 4),
-                map([&](auto e) { return eve::ldexp(eve::nearest(eve::ldexp(e, 4)), -4); }, a0),
+                tts::map([&](auto e) { return eve::ldexp(eve::nearest(eve::ldexp(e, 4)), -4); }, a0),
                 2);
   TTS_ULP_EQUAL(eve::roundscale(a0, 10),
-                map([&](auto e) { return eve::ldexp(eve::nearest(eve::ldexp(e, 10)), -10); }, a0),
+                tts::map([&](auto e) { return eve::ldexp(eve::nearest(eve::ldexp(e, 10)), -10); }, a0),
                 2);
 };
 

--- a/test/unit/module/core/rshl.cpp
+++ b/test/unit/module/core/rshl.cpp
@@ -50,12 +50,12 @@ TTS_CASE_WITH("Check behavior of rshl on integral types",
 <typename T, typename U>(T const& a0, U const& a1)
 {
   using eve::rshl;
-  TTS_EQUAL(rshl(a0, a1), map([&](auto e, auto f) { return rshl(e, f); }, a0, a1));
+  TTS_EQUAL(rshl(a0, a1), tts::map([&](auto e, auto f) { return rshl(e, f); }, a0, a1));
   auto val = a1.get(0);
-  TTS_EQUAL(rshl(a0, val), map([&](auto e) { return rshl(e, val); }, a0));
+  TTS_EQUAL(rshl(a0, val), tts::map([&](auto e) { return rshl(e, val); }, a0));
 
-  TTS_EQUAL(rshl(a0, eve::index<1>), map([&](auto e) { return rshl(e, 1); }, a0));
-  TTS_EQUAL(rshl(a0, eve::index<-1>), map([&](auto e) { return rshl(e, -1); }, a0));
+  TTS_EQUAL(rshl(a0, eve::index<1>), tts::map([&](auto e) { return rshl(e, 1); }, a0));
+  TTS_EQUAL(rshl(a0, eve::index<-1>), tts::map([&](auto e) { return rshl(e, -1); }, a0));
 };
 
 

--- a/test/unit/module/core/rshr.cpp
+++ b/test/unit/module/core/rshr.cpp
@@ -52,13 +52,13 @@ TTS_CASE_WITH("Check behavior of rshr on integral types",
 <typename T, typename U>(T const& a0, U const& a1)
 {
   using eve::rshr;
-  TTS_EQUAL(rshr(a0, a1), map([&](auto e, auto f) { return rshr(e, f); }, a0, a1));
+  TTS_EQUAL(rshr(a0, a1), tts::map([&](auto e, auto f) { return rshr(e, f); }, a0, a1));
 
   auto val = a1.get(0);
-  TTS_EQUAL(rshr(a0, val), map([&](auto e) { return rshr(e, val); }, a0));
+  TTS_EQUAL(rshr(a0, val), tts::map([&](auto e) { return rshr(e, val); }, a0));
 
-  TTS_EQUAL(rshr(a0, eve::index<1>), map([&](auto e) { return rshr(e, 1); }, a0));
-  TTS_EQUAL(rshr(a0, eve::index<-1>), map([&](auto e) { return rshr(e, -1); }, a0));
+  TTS_EQUAL(rshr(a0, eve::index<1>), tts::map([&](auto e) { return rshr(e, 1); }, a0));
+  TTS_EQUAL(rshr(a0, eve::index<-1>), tts::map([&](auto e) { return rshr(e, -1); }, a0));
 };
 
 

--- a/test/unit/module/core/rsqrt.cpp
+++ b/test/unit/module/core/rsqrt.cpp
@@ -43,7 +43,7 @@ TTS_CASE_WITH("Check behavior of rsqrt on wide",
 {
   using v_t = eve::element_type_t<T>;
   auto st   = [](auto e) -> v_t { return eve::rec(std::sqrt(e)); };
-  TTS_ULP_EQUAL(eve::rsqrt(a0), map(st, a0), 2);
+  TTS_ULP_EQUAL(eve::rsqrt(a0), tts::map(st, a0), 2);
 };
 
 TTS_CASE_TPL("Check behavior of pedantic(rsqrt)", eve::test::simd::ieee_reals)

--- a/test/unit/module/core/shl.cpp
+++ b/test/unit/module/core/shl.cpp
@@ -56,9 +56,8 @@ TTS_CASE_WITH("Check behavior of bit_shl(wide, integral constant)",
 <typename T, typename L>(T a0, L test)
 {
   using eve::shl;
-  using eve::detail::map;
   using v_t = typename T::value_type;
-  TTS_EQUAL(shl(a0, eve::index<1>), map([&](auto e) -> v_t { return e << 1; }, a0));
+  TTS_EQUAL(shl(a0, eve::index<1>), tts::map([&](auto e) -> v_t { return e << 1; }, a0));
   TTS_EQUAL(shl[test](a0, eve::index<1>), eve::if_else(test, eve::shl(a0, eve::index<1>), a0));
 };
 

--- a/test/unit/module/core/shr.cpp
+++ b/test/unit/module/core/shr.cpp
@@ -57,9 +57,8 @@ TTS_CASE_WITH("Check behavior of bit_shl(wide, integral constant)",
 <typename T, typename L>(T a0, L test)
 {
   using eve::shr;
-  using eve::detail::map;
   using v_t = typename T::value_type;
-  TTS_EQUAL(shr(a0, eve::index<1>), map([&](auto e) -> v_t { return e >> 1; }, a0));
+  TTS_EQUAL(shr(a0, eve::index<1>), tts::map([&](auto e) -> v_t { return e >> 1; }, a0));
   TTS_EQUAL(shr[test](a0, eve::index<1>), eve::if_else(test, eve::shr(a0, eve::index<1>), a0));
 };
 

--- a/test/unit/module/core/sign.cpp
+++ b/test/unit/module/core/sign.cpp
@@ -39,7 +39,6 @@ TTS_CASE_WITH("Check behavior of eve::sign(eve::wide)",
               tts::generate(tts::randoms(-10, +10), tts::logicals(0, 3)))
 <typename T, typename M>(T const& a0, M const& mask)
 {
-  using eve::detail::map;
   using eve::all;
   using eve::is_positive;
   using eve::is_negative;
@@ -51,6 +50,6 @@ TTS_CASE_WITH("Check behavior of eve::sign(eve::wide)",
     TTS_EXPECT( all(is_negative(eve::sign(eve::mzero(eve::as(a0))))) );
   }
 
-  TTS_EQUAL(eve::sign(a0), map([](auto e) -> v_t { return e > 0 ? 1 : (e ? -1 : 0); }, a0));
+  TTS_EQUAL(eve::sign(a0), tts::map([](auto e) -> v_t { return e > 0 ? 1 : (e ? -1 : 0); }, a0));
   TTS_EQUAL(eve::sign[mask](a0), eve::if_else(mask, eve::sign(a0), a0));
 };

--- a/test/unit/module/core/sign_alternate.cpp
+++ b/test/unit/module/core/sign_alternate.cpp
@@ -34,10 +34,9 @@ TTS_CASE_WITH("Check behavior of eve::sign_alternate(eve::wide)",
   using eve::as;
   using eve::saturated;
   using eve::sign_alternate;
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
   auto a0   = eve::trunc(a00);
   TTS_EQUAL(sign_alternate(a0),
-            map([](auto e) -> v_t { return eve::is_odd(e) ? v_t(-1) : v_t(1); }, a0));
+            tts::map([](auto e) -> v_t { return eve::is_odd(e) ? v_t(-1) : v_t(1); }, a0));
   TTS_EQUAL(sign_alternate[mask](a0), eve::if_else(mask, sign_alternate(a0), a0));
 };

--- a/test/unit/module/core/signnz.cpp
+++ b/test/unit/module/core/signnz.cpp
@@ -37,10 +37,9 @@ TTS_CASE_WITH("Check behavior of eve::signnz(eve::wide)",
               tts::generate(tts::randoms(-10, +10), tts::logicals(0, 3)))
 <typename T, typename M>(T const& a0, M const& mask)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
-  TTS_EQUAL(eve::signnz(a0), map([](auto e) -> v_t { return e >= 0 ? 1 : -1; }, a0));
+  TTS_EQUAL(eve::signnz(a0), tts::map([](auto e) -> v_t { return e >= 0 ? 1 : -1; }, a0));
   TTS_EQUAL(eve::signnz[mask](a0), eve::if_else(mask, eve::signnz(a0), a0));
   if constexpr( eve::floating_value<T> )
   {

--- a/test/unit/module/core/sqr.cpp
+++ b/test/unit/module/core/sqr.cpp
@@ -53,10 +53,9 @@ TTS_CASE_WITH("Check behavior of eve::sqr(eve::wide)",
   using eve::sqr;
   using eve::lower;
   using eve::upper;
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
-  TTS_EQUAL(sqr(a0), map([](auto e) -> v_t { return e * e; }, a0));
+  TTS_EQUAL(sqr(a0), tts::map([](auto e) -> v_t { return e * e; }, a0));
   TTS_EQUAL(sqr(a0), a0*a0);
   TTS_EQUAL(sqr[lower](a0), eve::mul[lower](a0, a0));
   TTS_EQUAL(sqr[upper](a0), eve::mul[upper](a0, a0));
@@ -64,7 +63,7 @@ TTS_CASE_WITH("Check behavior of eve::sqr(eve::wide)",
   if constexpr( eve::integral_value<T> )
   {
     TTS_EQUAL(sqr[saturated](a0),
-              map(
+              tts::map(
                   [](auto e) -> v_t {
                     return eve::abs[eve::saturated](e) > eve::sqrtvalmax(as(e)) ? eve::valmax(as(e))
                                                                            : e * e;

--- a/test/unit/module/core/sqrt.cpp
+++ b/test/unit/module/core/sqrt.cpp
@@ -38,10 +38,9 @@ TTS_CASE_WITH("Check behavior of sqrt(wide) and diff on  floating types",
               tts::generate(tts::randoms(0, eve::valmax)))
 <typename T>(T const& a0)
 {
-  using eve::detail::map;
   using eve::rec;
   using eve::sqr;
-  TTS_ULP_EQUAL(eve::sqrt(a0), map([&](auto e) { return std::sqrt(e); }, a0), 2);
+  TTS_ULP_EQUAL(eve::sqrt(a0), tts::map([&](auto e) { return std::sqrt(e); }, a0), 2);
 
   TTS_EXPECT(eve::all(eve::sqrt[eve::lower](a0) <= eve::sqrt(a0)));
   TTS_EXPECT(eve::all(eve::sqrt[eve::upper](a0) >= eve::sqrt(a0)));
@@ -59,8 +58,7 @@ TTS_CASE_WITH("Check behavior of sqrt[cond](wide) on  floating types",
 {
   using v_t = eve::element_type_t<T>;
   auto val  = eve::unsigned_value<v_t> ? (eve::valmax(eve::as<v_t>()) / 2) : 0;
-  using eve::detail::map;
-  TTS_ULP_EQUAL(eve::sqrt[a0 < val](a0), map([&](auto e) { return (e < val) ? std::sqrt(e) : e; }, a0), 2);
+  TTS_ULP_EQUAL(eve::sqrt[a0 < val](a0), tts::map([&](auto e) { return (e < val) ? std::sqrt(e) : e; }, a0), 2);
 };
 
 

--- a/test/unit/module/core/sub.cpp
+++ b/test/unit/module/core/sub.cpp
@@ -76,30 +76,29 @@ TTS_CASE_WITH("Check behavior of sub on wide",
   using eve::upper;
   using eve::strict;
   using eve::sub;
-  using eve::detail::map;
-
-  TTS_EQUAL(sub(a0, a2), map([](auto e, auto f) { return sub(e, f); }, a0, a2));
+  
+  TTS_EQUAL(sub(a0, a2), tts::map([](auto e, auto f) { return sub(e, f); }, a0, a2));
   TTS_EQUAL(sub[saturated](a0, a2),
-            map([&](auto e, auto f) { return sub[saturated](e, f); }, a0, a2));
+            tts::map([&](auto e, auto f) { return sub[saturated](e, f); }, a0, a2));
   TTS_EQUAL(sub(a0, a1, a2),
-            map([&](auto e, auto f, auto g) { return sub(sub(e, f), g); }, a0, a1, a2));
+            tts::map([&](auto e, auto f, auto g) { return sub(sub(e, f), g); }, a0, a1, a2));
   TTS_EQUAL(sub[saturated](a0, a1, a2),
-            map([&](auto e, auto f, auto g) { return sub[saturated](sub[saturated](e, f), g); },
+            tts::map([&](auto e, auto f, auto g) { return sub[saturated](sub[saturated](e, f), g); },
                 a0,a1,a2)
             );
-  TTS_EQUAL(sub(kumi::tuple{a0, a2}), map([](auto e, auto f) { return sub(e, f); }, a0, a2));
+  TTS_EQUAL(sub(kumi::tuple{a0, a2}), tts::map([](auto e, auto f) { return sub(e, f); }, a0, a2));
   TTS_EQUAL(sub[saturated](kumi::tuple{a0, a2}),
-            map([&](auto e, auto f) { return sub[saturated](e, f); }, a0, a2));
+            tts::map([&](auto e, auto f) { return sub[saturated](e, f); }, a0, a2));
   TTS_EQUAL(sub(kumi::tuple{a0, a1, a2}),
-            map([&](auto e, auto f, auto g) { return sub(sub(e, f), g); }, a0, a1, a2));
+            tts::map([&](auto e, auto f, auto g) { return sub(sub(e, f), g); }, a0, a1, a2));
   TTS_EQUAL(sub[saturated](kumi::tuple{a0, a1, a2}),
-            map([&](auto e, auto f, auto g) { return sub[saturated](sub[saturated](e, f), g); },
+            tts::map([&](auto e, auto f, auto g) { return sub[saturated](sub[saturated](e, f), g); },
                 a0,a1,a2)
             );
   if constexpr (eve::floating_value<T>)
   {
-    TTS_ULP_EQUAL( sub[lower](kumi::tuple{a0, a1, a2}), map([&](auto e, auto f, auto g) { return sub[lower](sub[lower](e, f), g); }, a0, a1, a2), 1.0);
-    TTS_ULP_EQUAL( sub[upper](kumi::tuple{a0, a1, a2}), map([&](auto e, auto f, auto g) { return sub[upper](sub[upper](e, f), g); }, a0, a1, a2), 1.0);
+    TTS_ULP_EQUAL( sub[lower](kumi::tuple{a0, a1, a2}), tts::map([&](auto e, auto f, auto g) { return sub[lower](sub[lower](e, f), g); }, a0, a1, a2), 1.0);
+    TTS_ULP_EQUAL( sub[upper](kumi::tuple{a0, a1, a2}), tts::map([&](auto e, auto f, auto g) { return sub[upper](sub[upper](e, f), g); }, a0, a1, a2), 1.0);
     TTS_EXPECT(eve::all(sub[upper](a0, a1, a2) >=  sub[lower](a0, a1, a2)));
     T w0(1);
     T w1(eve::smallestposval(eve::as<T>()));
@@ -127,16 +126,15 @@ TTS_CASE_WITH("Check behavior of sub on signed types",
 {
   using eve::saturated;
   using eve::sub;
-  using eve::detail::map;
 
   auto e0 = a2.get(0);
 
   TTS_EQUAL(sub[e0 > T(64)](a0, a1),
-            map([e0](auto e, auto f) { return e0 > 64 ? sub(e, f) : e; }, a0, a1));
+            tts::map([e0](auto e, auto f) { return e0 > 64 ? sub(e, f) : e; }, a0, a1));
   TTS_EQUAL(sub[a2 > T(64)](a0, a1),
-            map([](auto e, auto f, auto g) { return g > 64 ? sub(e, f) : e; }, a0, a1, a2));
+            tts::map([](auto e, auto f, auto g) { return g > 64 ? sub(e, f) : e; }, a0, a1, a2));
   TTS_EQUAL(sub[saturated][a2 > T(64)](a0, a1)
-           , map([](auto e, auto f, auto g) { return g > 64 ? sub[saturated](e, f) : e; }, a0, a1, a2));
+           , tts::map([](auto e, auto f, auto g) { return g > 64 ? sub[saturated](e, f) : e; }, a0, a1, a2));
 };
 
 /// TODO waiting for interface simplifications to sub scalar tests

--- a/test/unit/module/core/sum_of_prod.cpp
+++ b/test/unit/module/core/sum_of_prod.cpp
@@ -83,7 +83,6 @@ TTS_CASE_WITH("Check behavior of sum_of_prod upper lower on all types",
 {
   using eve::as;
   using eve::sum_of_prod;
-  using eve::detail::map;
   using eve::lower;
   using eve::upper;
   using eve::strict;

--- a/test/unit/module/core/swap_pairs.cpp
+++ b/test/unit/module/core/swap_pairs.cpp
@@ -20,11 +20,10 @@ TTS_CASE_WITH("Check behavior of swap_pairs(simd) on all types",
 {
   using v_t = eve::element_type_t<T>;
   using eve::swap_pairs;
-  using eve::detail::map;
   constexpr size_t S =  eve::cardinal_v<v_t>-1;
   constexpr auto _0 = eve::index_t<0>();
   constexpr auto _S = eve::index_t<S>();
   constexpr auto _H = eve::index_t<S/2>();
-  TTS_EQUAL(swap_pairs(a0, _0, _S), map([_0, _S](auto e) -> v_t { return swap_pairs(e, _0, _S); }, a0));
-  TTS_EQUAL(swap_pairs(a0, _0, _H), map([_0, _H](auto e) -> v_t { return swap_pairs(e, _0, _H); }, a0));
+  TTS_EQUAL(swap_pairs(a0, _0, _S), tts::map([_0, _S](auto e) -> v_t { return swap_pairs(e, _0, _S); }, a0));
+  TTS_EQUAL(swap_pairs(a0, _0, _H), tts::map([_0, _H](auto e) -> v_t { return swap_pairs(e, _0, _H); }, a0));
 };

--- a/test/unit/module/core/tchebeval.inactive
+++ b/test/unit/module/core/tchebeval.inactive
@@ -67,15 +67,15 @@ TTS_CASE_WITH("Check behavior of tchebeval on wide",
 
   TTS_EQUAL(tchebeval(a0), T(0));
   TTS_EQUAL(tchebeval(a0, 1.0), T(0.5));
-  TTS_EQUAL(tchebeval(a0, 1.0), map(bcl1, a0));
-  TTS_EQUAL(tchebeval(a0, 1.0, 2.0), map(bcl2, a0));
-  TTS_EQUAL(tchebeval(a0, 1.0, 2.0, 3.0), map(bcl3, a0));
+  TTS_EQUAL(tchebeval(a0, 1.0), tts::map(bcl1, a0));
+  TTS_EQUAL(tchebeval(a0, 1.0, 2.0), tts::map(bcl2, a0));
+  TTS_EQUAL(tchebeval(a0, 1.0, 2.0, 3.0), tts::map(bcl3, a0));
   TTS_ULP_EQUAL(tchebeval(0.0, 1.0, 2.0, 3.0), bcl3(0.0), 0.5);
 
   TTS_EQUAL((tchebeval)(a0), T(0));
   TTS_EQUAL((tchebeval)(a0, c1), T(0.5));
-  TTS_EQUAL((tchebeval)(a0, c2), map(bcl2, a0));
-  TTS_EQUAL((tchebeval)(a0, c3), map(bcl3, a0));
+  TTS_EQUAL((tchebeval)(a0, c2), tts::map(bcl2, a0));
+  TTS_EQUAL((tchebeval)(a0, c3), tts::map(bcl3, a0));
   TTS_ULP_EQUAL((tchebeval)(v_t(0.24), c3), bcl3(v_t(0.24)), 2.0);
   TTS_ULP_EQUAL((tchebeval)(v_t(0.24), v_t(-1), v_t(1), c3), bcl3(v_t(0.24)), 0.5);
   TTS_ULP_EQUAL((tchebeval)(v_t(-0.24), v_t(-1), v_t(1), c3), bcl3(v_t(-0.24)), 0.5);

--- a/test/unit/module/elliptic/ellint_1.cpp
+++ b/test/unit/module/elliptic/ellint_1.cpp
@@ -41,13 +41,12 @@ TTS_CASE_WITH("Check behavior of ellint_1 on wide",
               tts::generate(tts::randoms(0, 1.0), tts::randoms(0, eve::pio_2)))
 <typename T>(T const& k, T const& phi)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
   TTS_ULP_EQUAL(
-      eve::ellint_1(k), map([](auto e) -> v_t { return boost::math::ellint_1(e); }, k), 16);
+      eve::ellint_1(k), tts::map([](auto e) -> v_t { return boost::math::ellint_1(e); }, k), 16);
   TTS_ULP_EQUAL(eve::ellint_1(phi, k),
-                map([](auto e, auto f) -> v_t { return boost::math::ellint_1(e, f); }, k, phi),
+                tts::map([](auto e, auto f) -> v_t { return boost::math::ellint_1(e, f); }, k, phi),
                 16);
 };
 

--- a/test/unit/module/elliptic/ellint_2.cpp
+++ b/test/unit/module/elliptic/ellint_2.cpp
@@ -41,13 +41,12 @@ TTS_CASE_WITH("Check behavior of ellint_2 on wide",
               tts::generate(tts::randoms(0, 1.0), tts::randoms(0, eve::pio_2)))
 <typename T>(T const& k, T const& phi)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
   TTS_ULP_EQUAL(
-      eve::ellint_2(k), map([](auto e) -> v_t { return boost::math::ellint_2(e); }, k), 10);
+      eve::ellint_2(k), tts::map([](auto e) -> v_t { return boost::math::ellint_2(e); }, k), 10);
   TTS_ULP_EQUAL(eve::ellint_2(phi, k),
-                map([](auto e, auto f) -> v_t { return boost::math::ellint_2(e, f); }, k, phi),
+                tts::map([](auto e, auto f) -> v_t { return boost::math::ellint_2(e, f); }, k, phi),
                 10);
 };
 

--- a/test/unit/module/elliptic/ellint_d.cpp
+++ b/test/unit/module/elliptic/ellint_d.cpp
@@ -41,13 +41,12 @@ TTS_CASE_WITH("Check behavior of ellint_d on wide",
               tts::generate(tts::randoms(0, 1.0), tts::randoms(0, eve::pio_2)))
 <typename T>(T const& k, T const& phi)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
   TTS_ULP_EQUAL(
-      eve::ellint_d(k), map([](auto e) -> v_t { return boost::math::ellint_d(e); }, k), 24);
+      eve::ellint_d(k), tts::map([](auto e) -> v_t { return boost::math::ellint_d(e); }, k), 24);
   TTS_ULP_EQUAL(eve::ellint_d(phi, k),
-                map([](auto e, auto f) -> v_t { return boost::math::ellint_d(e, f); }, k, phi),
+                tts::map([](auto e, auto f) -> v_t { return boost::math::ellint_d(e, f); }, k, phi),
                 24);
 };
 

--- a/test/unit/module/elliptic/ellint_rc.cpp
+++ b/test/unit/module/elliptic/ellint_rc.cpp
@@ -39,11 +39,10 @@ TTS_CASE_WITH("Check behavior of ellint_rc on wide",
               tts::generate(tts::randoms(0, 100.0), tts::randoms(0, 100.0)))
 <typename T>(T const& x, T const& y)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
   TTS_ULP_EQUAL(eve::ellint_rc(x, y),
-                map([](auto e, auto f) -> v_t { return boost::math::ellint_rc(e, f); }, x, y),
+                tts::map([](auto e, auto f) -> v_t { return boost::math::ellint_rc(e, f); }, x, y),
                 11);
 };
 

--- a/test/unit/module/elliptic/ellint_rd.cpp
+++ b/test/unit/module/elliptic/ellint_rd.cpp
@@ -43,12 +43,11 @@ TTS_CASE_WITH("Check behavior of ellint_rd on wide",
               tts::generate(tts::randoms(0, 100.0), tts::randoms(0, 100.0), tts::randoms(0, 100.0)))
 <typename T>(T const& x, T const& y, T const& z)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
   TTS_ULP_EQUAL(
       eve::ellint_rd(x, y, z),
-      map([](auto e, auto f, auto g) -> v_t { return boost::math::ellint_rd(e, f, g); }, x, y, z),
+      tts::map([](auto e, auto f, auto g) -> v_t { return boost::math::ellint_rd(e, f, g); }, x, y, z),
       11);
 };
 

--- a/test/unit/module/elliptic/ellint_rf.cpp
+++ b/test/unit/module/elliptic/ellint_rf.cpp
@@ -43,12 +43,11 @@ TTS_CASE_WITH("Check behavior of ellint_rf on wide",
               tts::generate(tts::randoms(0, 100.0), tts::randoms(0, 100.0), tts::randoms(0, 100.0)))
 <typename T>(T const& x, T const& y, T const& z)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
   TTS_ULP_EQUAL(
       eve::ellint_rf(x, y, z),
-      map([](auto e, auto f, auto g) -> v_t { return boost::math::ellint_rf(e, f, g); }, x, y, z),
+      tts::map([](auto e, auto f, auto g) -> v_t { return boost::math::ellint_rf(e, f, g); }, x, y, z),
       11);
 };
 

--- a/test/unit/module/elliptic/ellint_rg.cpp
+++ b/test/unit/module/elliptic/ellint_rg.cpp
@@ -43,12 +43,11 @@ TTS_CASE_WITH("Check behavior of ellint_rg on wide",
               tts::generate(tts::randoms(0, 100.0), tts::randoms(0, 100.0), tts::randoms(0, 100.0)))
 <typename T>(T const& x, T const& y, T const& z)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
   TTS_ULP_EQUAL(
       eve::ellint_rg(x, y, z),
-      map([](auto e, auto f, auto g) -> v_t { return boost::math::ellint_rg(e, f, g); }, x, y, z),
+      tts::map([](auto e, auto f, auto g) -> v_t { return boost::math::ellint_rg(e, f, g); }, x, y, z),
       11);
 };
 

--- a/test/unit/module/elliptic/ellint_rj.cpp
+++ b/test/unit/module/elliptic/ellint_rj.cpp
@@ -54,11 +54,10 @@ TTS_CASE_WITH("Check behavior of ellint_rj on wide",
                             tts::randoms(0, 100.0)))
 <typename T>(T const& x, T const& y, T const& z, T const& p)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
   TTS_ULP_EQUAL(eve::ellint_rj(x, y, z, p),
-                map([](auto e, auto f, auto g, auto h) -> v_t
+                tts::map([](auto e, auto f, auto g, auto h) -> v_t
                     { return boost::math::ellint_rj(e, f, g, h); },
                     x,
                     y,

--- a/test/unit/module/math/acos.cpp
+++ b/test/unit/module/math/acos.cpp
@@ -35,20 +35,18 @@ TTS_CASE_TPL("Check return types of acos", eve::test::simd::ieee_reals)
 TTS_CASE_WITH("Check behavior of acos", eve::test::simd::ieee_reals, tts::generate(tts::randoms(-1.0, 1.0)))
 <typename T>(T const& a0)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
-  TTS_ULP_EQUAL(eve::acos(a0), map([](auto e) -> v_t { return std::acos(e); }, a0), 2);
+  TTS_ULP_EQUAL(eve::acos(a0), tts::map([](auto e) -> v_t { return std::acos(e); }, a0), 2);
 };
 
 TTS_CASE_WITH("Check behavior of acos[raw]", eve::test::simd::ieee_reals, tts::generate(tts::randoms(1.-1e-6, 1.0)))
 <typename T>(T const& a0)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
-  TTS_ABSOLUTE_EQUAL( eve::acos[eve::raw](a0), map([](auto e) -> v_t { return std::acos(e); }, a0)
+  TTS_ABSOLUTE_EQUAL( eve::acos[eve::raw](a0), tts::map([](auto e) -> v_t { return std::acos(e); }, a0)
                     , 100 * eve::eps(eve::as<v_t>())
                     );
-  TTS_ABSOLUTE_EQUAL( eve::acos[eve::raw](-a0), map([](auto e) -> v_t { return std::acos(e); }, -a0)
+  TTS_ABSOLUTE_EQUAL( eve::acos[eve::raw](-a0), tts::map([](auto e) -> v_t { return std::acos(e); }, -a0)
                     , 100 * eve::eps(eve::as<v_t>())
                     );
 };

--- a/test/unit/module/math/acosd.cpp
+++ b/test/unit/module/math/acosd.cpp
@@ -35,20 +35,18 @@ TTS_CASE_TPL("Check return types of acosd", eve::test::simd::ieee_reals)
 TTS_CASE_WITH("Check behavior of acosd", eve::test::simd::ieee_reals, tts::generate(tts::randoms(-1.0, 1.0)))
 <typename T>(T const& a0)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
-  TTS_ULP_EQUAL(eve::acosd(a0), map([](auto e) -> v_t { return eve::radindeg(std::acos(e)); }, a0), 2);
+  TTS_ULP_EQUAL(eve::acosd(a0), tts::map([](auto e) -> v_t { return eve::radindeg(std::acos(e)); }, a0), 2);
 };
 
 TTS_CASE_WITH("Check behavior of acosd[raw]", eve::test::simd::ieee_reals, tts::generate(tts::randoms(1.-1e-6, 1.0)))
 <typename T>(T const& a0)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
-  TTS_ABSOLUTE_EQUAL( eve::acosd[eve::raw](a0), map([](auto e) -> v_t { return eve::radindeg(std::acos(e)); }, a0)
+  TTS_ABSOLUTE_EQUAL( eve::acosd[eve::raw](a0), tts::map([](auto e) -> v_t { return eve::radindeg(std::acos(e)); }, a0)
                     , 200 * eve::eps(eve::as<v_t>())
                     );
-  TTS_ABSOLUTE_EQUAL( eve::acosd[eve::raw](-a0), map([](auto e) -> v_t { return eve::radindeg(std::acos(e)); }, -a0)
+  TTS_ABSOLUTE_EQUAL( eve::acosd[eve::raw](-a0), tts::map([](auto e) -> v_t { return eve::radindeg(std::acos(e)); }, -a0)
                     , 200 * eve::eps(eve::as<v_t>())
                     );
 };

--- a/test/unit/module/math/acosh.cpp
+++ b/test/unit/module/math/acosh.cpp
@@ -32,11 +32,10 @@ TTS_CASE_WITH("Check behavior of acosh on wide",
               tts::generate(tts::randoms(1.0, eve::valmax), tts::randoms(1.0, 100.0)))
 <typename T>(T const& a0, T const& a1)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
-  TTS_ULP_EQUAL(eve::acosh(a0), map([](auto e) -> v_t { return std::acosh(e); }, a0), 2);
-  TTS_ULP_EQUAL(eve::acosh(a1), map([](auto e) -> v_t { return std::acosh(e); }, a1), 2);
+  TTS_ULP_EQUAL(eve::acosh(a0), tts::map([](auto e) -> v_t { return std::acosh(e); }, a0), 2);
+  TTS_ULP_EQUAL(eve::acosh(a1), tts::map([](auto e) -> v_t { return std::acosh(e); }, a1), 2);
 };
 
 

--- a/test/unit/module/math/acospi.cpp
+++ b/test/unit/module/math/acospi.cpp
@@ -35,20 +35,18 @@ TTS_CASE_TPL("Check return types of acospi", eve::test::simd::ieee_reals)
 TTS_CASE_WITH("Check behavior of acospi", eve::test::simd::ieee_reals, tts::generate(tts::randoms(-1.0, 1.0)))
 <typename T>(T const& a0)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
-  TTS_ULP_EQUAL(eve::acospi(a0), map([](auto e) -> v_t { return eve::radinpi(std::acos(e)); }, a0), 2);
+  TTS_ULP_EQUAL(eve::acospi(a0), tts::map([](auto e) -> v_t { return eve::radinpi(std::acos(e)); }, a0), 2);
 };
 
 TTS_CASE_WITH("Check behavior of acospi[raw]", eve::test::simd::ieee_reals, tts::generate(tts::randoms(1.-1e-6, 1.0)))
 <typename T>(T const& a0)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
-  TTS_ABSOLUTE_EQUAL( eve::acospi[eve::raw](a0), map([](auto e) -> v_t { return eve::radinpi(std::acos(e)); }, a0)
+  TTS_ABSOLUTE_EQUAL( eve::acospi[eve::raw](a0), tts::map([](auto e) -> v_t { return eve::radinpi(std::acos(e)); }, a0)
                     , 200 * eve::eps(eve::as<v_t>())
                     );
-  TTS_ABSOLUTE_EQUAL( eve::acospi[eve::raw](-a0), map([](auto e) -> v_t { return eve::radinpi(std::acos(e)); }, -a0)
+  TTS_ABSOLUTE_EQUAL( eve::acospi[eve::raw](-a0), tts::map([](auto e) -> v_t { return eve::radinpi(std::acos(e)); }, -a0)
                     , 200 * eve::eps(eve::as<v_t>())
                     );
 };

--- a/test/unit/module/math/acot.cpp
+++ b/test/unit/module/math/acot.cpp
@@ -32,10 +32,9 @@ TTS_CASE_WITH("Check behavior of acot on wide",
               tts::generate(tts::randoms(-1000., +1000.)))
 <typename T>(T const& a0)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
-  TTS_ULP_EQUAL(eve::acot(a0), map([](auto e) -> v_t { return std::atan(1 / e); }, a0), 2);
+  TTS_ULP_EQUAL(eve::acot(a0), tts::map([](auto e) -> v_t { return std::atan(1 / e); }, a0), 2);
 };
 
 

--- a/test/unit/module/math/acotd.cpp
+++ b/test/unit/module/math/acotd.cpp
@@ -32,11 +32,10 @@ TTS_CASE_WITH("Check behavior of acotd on wide",
               tts::generate(tts::randoms(-1e20, 1e20)))
 <typename T>(T const& a0)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
   TTS_ULP_EQUAL(
-      eve::acotd(a0), map([](auto e) -> v_t { return eve::radindeg(std::atan(1 / e)); }, a0), 2);
+      eve::acotd(a0), tts::map([](auto e) -> v_t { return eve::radindeg(std::atan(1 / e)); }, a0), 2);
 };
 
 

--- a/test/unit/module/math/acoth.cpp
+++ b/test/unit/module/math/acoth.cpp
@@ -32,10 +32,9 @@ TTS_CASE_WITH("Check behavior of acoth on wide",
               tts::generate(tts::randoms(1.0, 1e20)))
 <typename T>(T const& a0)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
-  TTS_ULP_EQUAL(eve::acoth(a0), map([](auto e) -> v_t { return std::atanh(1 / e); }, a0), 2);
+  TTS_ULP_EQUAL(eve::acoth(a0), tts::map([](auto e) -> v_t { return std::atanh(1 / e); }, a0), 2);
 };
 
 

--- a/test/unit/module/math/acotpi.cpp
+++ b/test/unit/module/math/acotpi.cpp
@@ -32,11 +32,10 @@ TTS_CASE_WITH("Check behavior of acotpi on wide",
               tts::generate(tts::randoms(-1e20, 1e20)))
 <typename T>(T const& a0)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
   TTS_ULP_EQUAL(
-      eve::acotpi(a0), map([](auto e) -> v_t { return eve::radinpi(std::atan(1 / e)); }, a0), 2);
+      eve::acotpi(a0), tts::map([](auto e) -> v_t { return eve::radinpi(std::atan(1 / e)); }, a0), 2);
 };
 
 

--- a/test/unit/module/math/acsc.cpp
+++ b/test/unit/module/math/acsc.cpp
@@ -35,17 +35,16 @@ TTS_CASE_WITH("Check behavior of acsc on wide",
                             tts::randoms(-100.0, -1.0)))
 <typename T>(T const& a0, T const& a1, T const& a2, T const& a3)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
   auto sacsc = [](auto e) -> v_t { return std::asin(1 / e); };
-  TTS_ULP_EQUAL(eve::acsc(a0), map(sacsc, a0), 2);
+  TTS_ULP_EQUAL(eve::acsc(a0), tts::map(sacsc, a0), 2);
 
-  TTS_ULP_EQUAL(eve::acsc(a1), map(sacsc, a1), 2);
+  TTS_ULP_EQUAL(eve::acsc(a1), tts::map(sacsc, a1), 2);
 
-  TTS_ULP_EQUAL(eve::acsc(a2), map(sacsc, a2), 2);
+  TTS_ULP_EQUAL(eve::acsc(a2), tts::map(sacsc, a2), 2);
 
-  TTS_ULP_EQUAL(eve::acsc(a3), map(sacsc, a3), 2);
+  TTS_ULP_EQUAL(eve::acsc(a3), tts::map(sacsc, a3), 2);
 };
 
 

--- a/test/unit/module/math/acscd.cpp
+++ b/test/unit/module/math/acscd.cpp
@@ -35,17 +35,16 @@ TTS_CASE_WITH("Check behavior of acscd on wide",
                             tts::randoms(-100.0, -1.0)))
 <typename T>(T const& a0, T const& a1, T const& a2, T const& a3)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
   auto sacscd = [](auto e) -> v_t { return eve::radindeg(std::asin(1 / e)); };
-  TTS_ULP_EQUAL(eve::acscd(a0), map(sacscd, a0), 2);
+  TTS_ULP_EQUAL(eve::acscd(a0), tts::map(sacscd, a0), 2);
 
-  TTS_ULP_EQUAL(eve::acscd(a1), map(sacscd, a1), 2);
+  TTS_ULP_EQUAL(eve::acscd(a1), tts::map(sacscd, a1), 2);
 
-  TTS_ULP_EQUAL(eve::acscd(a2), map(sacscd, a2), 2);
+  TTS_ULP_EQUAL(eve::acscd(a2), tts::map(sacscd, a2), 2);
 
-  TTS_ULP_EQUAL(eve::acscd(a3), map(sacscd, a3), 2);
+  TTS_ULP_EQUAL(eve::acscd(a3), tts::map(sacscd, a3), 2);
 };
 
 

--- a/test/unit/module/math/acsch.cpp
+++ b/test/unit/module/math/acsch.cpp
@@ -32,11 +32,10 @@ TTS_CASE_WITH("Check behavior of acsch on wide",
               tts::generate(tts::randoms(-1e20, 1e20), tts::randoms(-100.0, 100.0)))
 <typename T>(T const& a0, T const& a1)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
-  TTS_ULP_EQUAL(eve::acsch(a0), map([](auto e) -> v_t { return std::asinh(1 / e); }, a0), 2);
-  TTS_ULP_EQUAL(eve::acsch(a1), map([](auto e) -> v_t { return std::asinh(1 / e); }, a1), 2);
+  TTS_ULP_EQUAL(eve::acsch(a0), tts::map([](auto e) -> v_t { return std::asinh(1 / e); }, a0), 2);
+  TTS_ULP_EQUAL(eve::acsch(a1), tts::map([](auto e) -> v_t { return std::asinh(1 / e); }, a1), 2);
 };
 
 

--- a/test/unit/module/math/acscpi.cpp
+++ b/test/unit/module/math/acscpi.cpp
@@ -35,17 +35,16 @@ TTS_CASE_WITH("Check behavior of acscpi on wide",
                             tts::randoms(-100.0, -1.0)))
 <typename T>(T const& a0, T const& a1, T const& a2, T const& a3)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
   auto sacscpi = [](auto e) -> v_t { return eve::radinpi(std::asin(1 / e)); };
-  TTS_ULP_EQUAL(eve::acscpi(a0), map(sacscpi, a0), 2);
+  TTS_ULP_EQUAL(eve::acscpi(a0), tts::map(sacscpi, a0), 2);
 
-  TTS_ULP_EQUAL(eve::acscpi(a1), map(sacscpi, a1), 2);
+  TTS_ULP_EQUAL(eve::acscpi(a1), tts::map(sacscpi, a1), 2);
 
-  TTS_ULP_EQUAL(eve::acscpi(a2), map(sacscpi, a2), 2);
+  TTS_ULP_EQUAL(eve::acscpi(a2), tts::map(sacscpi, a2), 2);
 
-  TTS_ULP_EQUAL(eve::acscpi(a3), map(sacscpi, a3), 2);
+  TTS_ULP_EQUAL(eve::acscpi(a3), tts::map(sacscpi, a3), 2);
 };
 
 

--- a/test/unit/module/math/agd.cpp
+++ b/test/unit/module/math/agd.cpp
@@ -35,11 +35,10 @@ TTS_CASE_WITH("Check behavior of agd on wide",
               tts::generate(tts::randoms(mini, maxi), tts::randoms(-1.0, 1.0)))
 <typename T>(T const& a0, T const& a1)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
   using eve::agd;
-  TTS_ULP_EQUAL(agd(a0), map([](auto e) -> v_t { return 2*std::atanh(std::tan(e*eve::half(eve::as(e)))); }, a0), 8.0);
-  TTS_ULP_EQUAL(agd(a1), map([](auto e) -> v_t { return 2*std::atanh(std::tan(e*eve::half(eve::as(e)))); }, a1), 8.0);
+  TTS_ULP_EQUAL(agd(a0), tts::map([](auto e) -> v_t { return 2*std::atanh(std::tan(e*eve::half(eve::as(e)))); }, a0), 8.0);
+  TTS_ULP_EQUAL(agd(a1), tts::map([](auto e) -> v_t { return 2*std::atanh(std::tan(e*eve::half(eve::as(e)))); }, a1), 8.0);
 };
 
 

--- a/test/unit/module/math/arg.cpp
+++ b/test/unit/module/math/arg.cpp
@@ -34,11 +34,10 @@ TTS_CASE_WITH("Check behavior of eve::arg(simd)",
               tts::generate(tts::between(-1.0, 1.0)))
 <typename T>(T const& a0)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
   std::cout << "a0 " << a0 << std::endl;
   TTS_EQUAL(eve::arg(a0),
-            map([](auto e) -> v_t { return e >= 0 ? 0 : eve::pi(eve::as(v_t())); }, a0));
+            tts::map([](auto e) -> v_t { return e >= 0 ? 0 : eve::pi(eve::as(v_t())); }, a0));
 };
 
 //==================================================================================================
@@ -49,13 +48,12 @@ TTS_CASE_WITH("Check behavior of eve::arg[eve::pedantic](simd)",
               tts::generate(tts::between(-1.0, 1.0)))
 <typename T>(T a0)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
   auto cases = tts::limits(tts::type<T> {});
 
   TTS_EQUAL(eve::arg[eve::pedantic](a0),
-            map([](auto e) -> v_t { return e >= 0 ? 0 : eve::pi(eve::as(v_t())); }, a0));
+            tts::map([](auto e) -> v_t { return e >= 0 ? 0 : eve::pi(eve::as(v_t())); }, a0));
   TTS_IEEE_EQUAL(eve::arg[eve::pedantic](cases.nan), cases.nan);
 };
 

--- a/test/unit/module/math/asec.cpp
+++ b/test/unit/module/math/asec.cpp
@@ -35,17 +35,16 @@ TTS_CASE_WITH("Check behavior of asec on wide",
                             tts::randoms(-100.0, -1.0)))
 <typename T>(T const& a0, T const& a1, T const& a2, T const& a3)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
   auto sasec = [](auto e) -> v_t { return std::acos(1 / e); };
-  TTS_ULP_EQUAL(eve::asec(a0), map(sasec, a0), 3.5);
+  TTS_ULP_EQUAL(eve::asec(a0), tts::map(sasec, a0), 3.5);
 
-  TTS_ULP_EQUAL(eve::asec(a1), map(sasec, a1), 2);
+  TTS_ULP_EQUAL(eve::asec(a1), tts::map(sasec, a1), 2);
 
-  TTS_ULP_EQUAL(eve::asec(a2), map(sasec, a2), 2);
+  TTS_ULP_EQUAL(eve::asec(a2), tts::map(sasec, a2), 2);
 
-  TTS_ULP_EQUAL(eve::asec(a3), map(sasec, a3), 2);
+  TTS_ULP_EQUAL(eve::asec(a3), tts::map(sasec, a3), 2);
 };
 
 

--- a/test/unit/module/math/asecd.cpp
+++ b/test/unit/module/math/asecd.cpp
@@ -35,17 +35,16 @@ TTS_CASE_WITH("Check behavior of asecd on wide",
                             tts::randoms(-100.0, -1.0)))
 <typename T>(T const& a0, T const& a1, T const& a2, T const& a3)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
   auto sasecd = [](auto e) -> v_t { return eve::radindeg(std::acos(1 / e)); };
-  TTS_ULP_EQUAL(eve::asecd(a0), map(sasecd, a0), 2);
+  TTS_ULP_EQUAL(eve::asecd(a0), tts::map(sasecd, a0), 2);
 
-  TTS_ULP_EQUAL(eve::asecd(a1), map(sasecd, a1), 2);
+  TTS_ULP_EQUAL(eve::asecd(a1), tts::map(sasecd, a1), 2);
 
-  TTS_ULP_EQUAL(eve::asecd(a2), map(sasecd, a2), 2);
+  TTS_ULP_EQUAL(eve::asecd(a2), tts::map(sasecd, a2), 2);
 
-  TTS_ULP_EQUAL(eve::asecd(a3), map(sasecd, a3), 2);
+  TTS_ULP_EQUAL(eve::asecd(a3), tts::map(sasecd, a3), 2);
 };
 
 

--- a/test/unit/module/math/asech.cpp
+++ b/test/unit/module/math/asech.cpp
@@ -32,9 +32,8 @@ TTS_CASE_WITH("Check behavior of asech on wide",
               tts::generate(tts::randoms(0, 1.0)))
 <typename T>(T const& a0)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
-  TTS_ULP_EQUAL(eve::asech(a0), map([](auto e) -> v_t { return std::acosh(1 / e); }, a0), 2);
+  TTS_ULP_EQUAL(eve::asech(a0), tts::map([](auto e) -> v_t { return std::acosh(1 / e); }, a0), 2);
 };
 
 

--- a/test/unit/module/math/asecpi.cpp
+++ b/test/unit/module/math/asecpi.cpp
@@ -35,17 +35,16 @@ TTS_CASE_WITH("Check behavior of asecpi on wide",
                             tts::randoms(-100.0, -1.0)))
 <typename T>(T const& a0, T const& a1, T const& a2, T const& a3)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
   auto sasecpi = [](auto e) -> v_t { return eve::radinpi(std::acos(1 / e)); };
-  TTS_ULP_EQUAL(eve::asecpi(a0), map(sasecpi, a0), 2);
+  TTS_ULP_EQUAL(eve::asecpi(a0), tts::map(sasecpi, a0), 2);
 
-  TTS_ULP_EQUAL(eve::asecpi(a1), map(sasecpi, a1), 2);
+  TTS_ULP_EQUAL(eve::asecpi(a1), tts::map(sasecpi, a1), 2);
 
-  TTS_ULP_EQUAL(eve::asecpi(a2), map(sasecpi, a2), 2);
+  TTS_ULP_EQUAL(eve::asecpi(a2), tts::map(sasecpi, a2), 2);
 
-  TTS_ULP_EQUAL(eve::asecpi(a3), map(sasecpi, a3), 2);
+  TTS_ULP_EQUAL(eve::asecpi(a3), tts::map(sasecpi, a3), 2);
 };
 
 

--- a/test/unit/module/math/asin.cpp
+++ b/test/unit/module/math/asin.cpp
@@ -32,10 +32,9 @@ TTS_CASE_WITH("Check behavior of asin on wide",
               tts::generate(tts::randoms(-1, 1)))
 <typename T>(T const& a0)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
-  TTS_ULP_EQUAL(eve::asin(a0), map([](auto e) -> v_t { return std::asin(e); }, a0), 2);
+  TTS_ULP_EQUAL(eve::asin(a0), tts::map([](auto e) -> v_t { return std::asin(e); }, a0), 2);
 };
 
 

--- a/test/unit/module/math/asind.cpp
+++ b/test/unit/module/math/asind.cpp
@@ -32,11 +32,10 @@ TTS_CASE_WITH("Check behavior of asind on wide",
               tts::generate(tts::randoms(-1, 1)))
 <typename T>(T const& a0)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
   TTS_ULP_EQUAL(
-      eve::asind(a0), map([](auto e) -> v_t { return eve::radindeg(std::asin(e)); }, a0), 2);
+      eve::asind(a0), tts::map([](auto e) -> v_t { return eve::radindeg(std::asin(e)); }, a0), 2);
 };
 
 

--- a/test/unit/module/math/asinh.cpp
+++ b/test/unit/module/math/asinh.cpp
@@ -32,10 +32,9 @@ TTS_CASE_WITH("Check behavior of asinh on wide",
               tts::generate(tts::randoms(eve::valmin, eve::valmax)))
 <typename T>(T const& a0)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
-  TTS_ULP_EQUAL(eve::asinh(a0), map([](auto e) -> v_t { return std::asinh(e); }, a0), 2);
+  TTS_ULP_EQUAL(eve::asinh(a0), tts::map([](auto e) -> v_t { return std::asinh(e); }, a0), 2);
 };
 
 

--- a/test/unit/module/math/asinpi.cpp
+++ b/test/unit/module/math/asinpi.cpp
@@ -32,11 +32,10 @@ TTS_CASE_WITH("Check behavior of asinpi on wide",
               tts::generate(tts::randoms(-1, 1)))
 <typename T>(T const& a0)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
   TTS_ULP_EQUAL(
-      eve::asinpi(a0), map([](auto e) -> v_t { return eve::radinpi(std::asin(e)); }, a0), 2);
+      eve::asinpi(a0), tts::map([](auto e) -> v_t { return eve::radinpi(std::asin(e)); }, a0), 2);
 };
 
 

--- a/test/unit/module/math/atan.cpp
+++ b/test/unit/module/math/atan.cpp
@@ -32,11 +32,10 @@ TTS_CASE_WITH("Check behavior of atan on wide",
               tts::generate(tts::randoms(eve::valmin, eve::valmax), tts::randoms(-1.0, 1.0)))
 <typename T>(T const& a0, T const& a1)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
-  TTS_ULP_EQUAL(eve::atan(a0), map([](auto e) -> v_t { return std::atan(e); }, a0), 2);
-  TTS_ULP_EQUAL(eve::atan(a1), map([](auto e) -> v_t { return std::atan(e); }, a1), 2);
+  TTS_ULP_EQUAL(eve::atan(a0), tts::map([](auto e) -> v_t { return std::atan(e); }, a0), 2);
+  TTS_ULP_EQUAL(eve::atan(a1), tts::map([](auto e) -> v_t { return std::atan(e); }, a1), 2);
 };
 
 

--- a/test/unit/module/math/atan2.cpp
+++ b/test/unit/module/math/atan2.cpp
@@ -40,13 +40,12 @@ TTS_CASE_WITH("Check behavior of atan2 on wide",
                             tts::randoms(-1.0, 1.0)))
 <typename T>(T const& a0, T const& a1, T const& a2, T const& a3)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
   TTS_ULP_EQUAL(
-      eve::atan2(a0, a1), map([](auto e, auto f) -> v_t { return std::atan2(e, f); }, a0, a1), 2);
+      eve::atan2(a0, a1), tts::map([](auto e, auto f) -> v_t { return std::atan2(e, f); }, a0, a1), 2);
   TTS_ULP_EQUAL(
-      eve::atan2(a2, a3), map([](auto e, auto f) -> v_t { return std::atan2(e, f); }, a2, a3), 2);
+      eve::atan2(a2, a3), tts::map([](auto e, auto f) -> v_t { return std::atan2(e, f); }, a2, a3), 2);
 };
 
 TTS_CASE_TPL("Check behavior of pedantic(atan2)", eve::test::simd::ieee_reals)

--- a/test/unit/module/math/atan2d.cpp
+++ b/test/unit/module/math/atan2d.cpp
@@ -40,14 +40,13 @@ TTS_CASE_WITH("Check behavior of atan2d on wide",
                             tts::randoms(-1.0, 1.0)))
 <typename T>(T const& a0, T const& a1, T const& a2, T const& a3)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
   TTS_ULP_EQUAL(eve::atan2d(a0, a1),
-                map([](auto e, auto f) -> v_t { return eve::radindeg(std::atan2(e, f)); }, a0, a1),
+                tts::map([](auto e, auto f) -> v_t { return eve::radindeg(std::atan2(e, f)); }, a0, a1),
                 2);
   TTS_ULP_EQUAL(eve::atan2d(a2, a3),
-                map([](auto e, auto f) -> v_t { return eve::radindeg(std::atan2(e, f)); }, a2, a3),
+                tts::map([](auto e, auto f) -> v_t { return eve::radindeg(std::atan2(e, f)); }, a2, a3),
                 2);
 };
 

--- a/test/unit/module/math/atan2pi.cpp
+++ b/test/unit/module/math/atan2pi.cpp
@@ -40,14 +40,13 @@ TTS_CASE_WITH("Check behavior of atan2pi on wide",
                             tts::randoms(-1.0, 1.0)))
 <typename T>(T const& a0, T const& a1, T const& a2, T const& a3)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
   TTS_ULP_EQUAL(eve::atan2pi(a0, a1),
-                map([](auto e, auto f) -> v_t { return eve::radinpi(std::atan2(e, f)); }, a0, a1),
+                tts::map([](auto e, auto f) -> v_t { return eve::radinpi(std::atan2(e, f)); }, a0, a1),
                 2);
   TTS_ULP_EQUAL(eve::atan2pi(a2, a3),
-                map([](auto e, auto f) -> v_t { return eve::radinpi(std::atan2(e, f)); }, a2, a3),
+                tts::map([](auto e, auto f) -> v_t { return eve::radinpi(std::atan2(e, f)); }, a2, a3),
                 2);
 };
 

--- a/test/unit/module/math/atand.cpp
+++ b/test/unit/module/math/atand.cpp
@@ -32,13 +32,12 @@ TTS_CASE_WITH("Check behavior of atand on wide",
               tts::generate(tts::randoms(eve::valmin, eve::valmax), tts::randoms(-1.0, 1.0)))
 <typename T>(T const& a0, T const& a1)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
   TTS_ULP_EQUAL(
-      eve::atand(a0), map([](auto e) -> v_t { return eve::radindeg(std::atan(e)); }, a0), 2);
+      eve::atand(a0), tts::map([](auto e) -> v_t { return eve::radindeg(std::atan(e)); }, a0), 2);
   TTS_ULP_EQUAL(
-      eve::atand(a1), map([](auto e) -> v_t { return eve::radindeg(std::atan(e)); }, a1), 2);
+      eve::atand(a1), tts::map([](auto e) -> v_t { return eve::radindeg(std::atan(e)); }, a1), 2);
 };
 
 

--- a/test/unit/module/math/atanh.cpp
+++ b/test/unit/module/math/atanh.cpp
@@ -32,10 +32,9 @@ TTS_CASE_WITH("Check behavior of atanh on wide",
               tts::generate(tts::randoms(-1.0, 1.0)))
 <typename T>(T const& a0)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
-  TTS_ULP_EQUAL(eve::atanh(a0), map([](auto e) -> v_t { return std::atanh(e); }, a0), 2);
+  TTS_ULP_EQUAL(eve::atanh(a0), tts::map([](auto e) -> v_t { return std::atanh(e); }, a0), 2);
 };
 
 

--- a/test/unit/module/math/atanpi.cpp
+++ b/test/unit/module/math/atanpi.cpp
@@ -32,13 +32,12 @@ TTS_CASE_WITH("Check behavior of atanpi on wide",
               tts::generate(tts::randoms(eve::valmin, eve::valmax), tts::randoms(-1.0, 1.0)))
 <typename T>(T const& a0, T const& a1)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
   TTS_ULP_EQUAL(
-      eve::atanpi(a0), map([](auto e) -> v_t { return eve::radinpi(std::atan(e)); }, a0), 2);
+      eve::atanpi(a0), tts::map([](auto e) -> v_t { return eve::radinpi(std::atan(e)); }, a0), 2);
   TTS_ULP_EQUAL(
-      eve::atanpi(a1), map([](auto e) -> v_t { return eve::radinpi(std::atan(e)); }, a1), 2);
+      eve::atanpi(a1), tts::map([](auto e) -> v_t { return eve::radinpi(std::atan(e)); }, a1), 2);
 };
 
 

--- a/test/unit/module/math/cbrt.cpp
+++ b/test/unit/module/math/cbrt.cpp
@@ -32,10 +32,9 @@ TTS_CASE_WITH("Check behavior of cbrt on wide",
               tts::generate(tts::randoms(eve::valmin, eve::valmax)))
 <typename T>(T const& a0)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
-  TTS_ULP_EQUAL(eve::cbrt(a0), map([](auto e) -> v_t { return std::cbrt(e); }, a0), 2);
+  TTS_ULP_EQUAL(eve::cbrt(a0), tts::map([](auto e) -> v_t { return std::cbrt(e); }, a0), 2);
 };
 
 

--- a/test/unit/module/math/cos.cpp
+++ b/test/unit/module/math/cos.cpp
@@ -45,21 +45,20 @@ TTS_CASE_WITH("Check behavior of cos on wide",
 <typename T>(T const& a0, T const& a1, T const& a2, T const& a3, T const& a4)
 {
   using eve::cos;
-  using eve::detail::map;
 
   using v_t = eve::element_type_t<T>;
   auto ref  = [](auto e) -> v_t { return std::cos(e); };
-  TTS_ULP_EQUAL(cos[eve::quarter_circle](a0), map(ref, a0), 2);
-  TTS_ULP_EQUAL(cos[eve::half_circle](a0), map(ref, a0), 2);
-  TTS_ULP_EQUAL(cos[eve::half_circle](a1), map(ref, a1), 2);
-  TTS_ULP_EQUAL(cos[eve::full_circle](a0), map(ref, a0), 2);
-  TTS_ULP_EQUAL(cos[eve::full_circle](a1), map(ref, a1), 2);
-  TTS_ULP_EQUAL(cos[eve::full_circle](a2), map(ref, a2), 2);
-  TTS_ULP_EQUAL(cos(a0), map(ref, a0), 2);
-  TTS_ULP_EQUAL(cos(a1), map(ref, a1), 2);
-  TTS_ULP_EQUAL(cos(a2), map(ref, a2), 2);
-  TTS_ULP_EQUAL(cos(a3), map(ref, a3), 2);
-  TTS_ULP_EQUAL(cos(a4), map(ref, a4), 2);
+  TTS_ULP_EQUAL(cos[eve::quarter_circle](a0), tts::map(ref, a0), 2);
+  TTS_ULP_EQUAL(cos[eve::half_circle](a0), tts::map(ref, a0), 2);
+  TTS_ULP_EQUAL(cos[eve::half_circle](a1), tts::map(ref, a1), 2);
+  TTS_ULP_EQUAL(cos[eve::full_circle](a0), tts::map(ref, a0), 2);
+  TTS_ULP_EQUAL(cos[eve::full_circle](a1), tts::map(ref, a1), 2);
+  TTS_ULP_EQUAL(cos[eve::full_circle](a2), tts::map(ref, a2), 2);
+  TTS_ULP_EQUAL(cos(a0), tts::map(ref, a0), 2);
+  TTS_ULP_EQUAL(cos(a1), tts::map(ref, a1), 2);
+  TTS_ULP_EQUAL(cos(a2), tts::map(ref, a2), 2);
+  TTS_ULP_EQUAL(cos(a3), tts::map(ref, a3), 2);
+  TTS_ULP_EQUAL(cos(a4), tts::map(ref, a4), 2);
 };
 
 

--- a/test/unit/module/math/cosd.cpp
+++ b/test/unit/module/math/cosd.cpp
@@ -37,16 +37,15 @@ TTS_CASE_WITH("Check behavior of cosd on wide",
 <typename T>(T const& a0, T const& a1, T const& a2)
 {
   using eve::cosd;
-  using eve::detail::map;
 
   using eve::deginrad;
   using v_t = eve::element_type_t<T>;
   auto ref  = [](auto e) -> v_t { return eve::cospi(double(e / 180.0l)); };
 
-  TTS_ULP_EQUAL(cosd[eve::quarter_circle](a0), map(ref, a0), 2);
-  TTS_ULP_EQUAL(cosd(a0), map(ref, a0), 2);
-  TTS_ULP_EQUAL(cosd(a1), map(ref, a1), 30);
-  TTS_ULP_EQUAL(cosd(a2), map(ref, a2), 420);
+  TTS_ULP_EQUAL(cosd[eve::quarter_circle](a0), tts::map(ref, a0), 2);
+  TTS_ULP_EQUAL(cosd(a0), tts::map(ref, a0), 2);
+  TTS_ULP_EQUAL(cosd(a1), tts::map(ref, a1), 30);
+  TTS_ULP_EQUAL(cosd(a2), tts::map(ref, a2), 420);
 };
 
 TTS_CASE_TPL("Check return types of cosd", eve::test::simd::ieee_reals)

--- a/test/unit/module/math/cosh.cpp
+++ b/test/unit/module/math/cosh.cpp
@@ -40,13 +40,12 @@ TTS_CASE_WITH("Check behavior of cosh on wide",
                             tts::randoms(-1.0, 1.0)))
 <typename T>(T const& a0, T const& a1)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
   using eve::cosh;
   using eve::sinh;
 
-  TTS_ULP_EQUAL(cosh(a0), map([](auto e) -> v_t { return std::cosh(e); }, a0), 2);
-  TTS_ULP_EQUAL(cosh(a1), map([](auto e) -> v_t { return std::cosh(e); }, a1), 2);
+  TTS_ULP_EQUAL(cosh(a0), tts::map([](auto e) -> v_t { return std::cosh(e); }, a0), 2);
+  TTS_ULP_EQUAL(cosh(a1), tts::map([](auto e) -> v_t { return std::cosh(e); }, a1), 2);
 };
 
 

--- a/test/unit/module/math/cospi.cpp
+++ b/test/unit/module/math/cospi.cpp
@@ -42,13 +42,12 @@ TTS_CASE_WITH("Check behavior of cospi on wide",
   <typename T>(T const& a0, T const& a1, T const& a2)
 {
   using eve::cospi;
-  using eve::detail::map;
 
   long double  pi = 3.1415926535897932384626433832795028841971693993751l;
   using v_t = eve::element_type_t<T>;
   auto ref  = [pi](auto e) -> v_t { return std::cos((pi*(long double)e)); };
-  TTS_ULP_EQUAL(cospi[eve::quarter_circle](a0), map(ref, a0), 2);
-  TTS_ULP_EQUAL(cospi(a0), map(ref, a0), 2);
+  TTS_ULP_EQUAL(cospi[eve::quarter_circle](a0), tts::map(ref, a0), 2);
+  TTS_ULP_EQUAL(cospi(a0), tts::map(ref, a0), 2);
   TTS_ULP_EQUAL(cospi(a1), cospi(eve::frac(a1)+eve::one[eve::is_odd(eve::trunc(a1))](eve::as(a1))), 2);
   TTS_ULP_EQUAL(cospi(a2), cospi(eve::frac(a2)+eve::one[eve::is_odd(eve::trunc(a2))](eve::as(a2))), 2);
 };

--- a/test/unit/module/math/cot.cpp
+++ b/test/unit/module/math/cot.cpp
@@ -46,22 +46,21 @@ TTS_CASE_WITH("Check behavior of cot on wide",
 <typename T>(T const& a0, T const& a1, T const& a2, T const& a3, T const& a4)
 {
   using eve::cot;
-  using eve::detail::map;
 
   using v_t = eve::element_type_t<T>;
   auto ref  = [](auto e) -> v_t { return 1 / std::tan(double(e)); };
-  TTS_ULP_EQUAL(cot[eve::quarter_circle](a0), map(ref, a0), 2);
-  TTS_ULP_EQUAL(cot[eve::half_circle](a0), map(ref, a0), 2);
-  TTS_ULP_EQUAL(cot[eve::half_circle](a1), map(ref, a1), 2);
-  TTS_ULP_EQUAL(cot[eve::full_circle](a0), map(ref, a0), 2);
-  TTS_ULP_EQUAL(cot[eve::full_circle](a1), map(ref, a1), 2);
-  TTS_ULP_EQUAL(cot[eve::full_circle](a2), map(ref, a2), 2);
+  TTS_ULP_EQUAL(cot[eve::quarter_circle](a0), tts::map(ref, a0), 2);
+  TTS_ULP_EQUAL(cot[eve::half_circle](a0), tts::map(ref, a0), 2);
+  TTS_ULP_EQUAL(cot[eve::half_circle](a1), tts::map(ref, a1), 2);
+  TTS_ULP_EQUAL(cot[eve::full_circle](a0), tts::map(ref, a0), 2);
+  TTS_ULP_EQUAL(cot[eve::full_circle](a1), tts::map(ref, a1), 2);
+  TTS_ULP_EQUAL(cot[eve::full_circle](a2), tts::map(ref, a2), 2);
 
-  TTS_ULP_EQUAL(cot(a0), map(ref, a0), 2);
-  TTS_ULP_EQUAL(cot(a1), map(ref, a1), 2);
-  TTS_ULP_EQUAL(cot(a2), map(ref, a2), 2);
-  TTS_ULP_EQUAL(cot(a3), map(ref, a3), 2);
-  TTS_ULP_EQUAL(cot(a4), map(ref, a4), 2);
+  TTS_ULP_EQUAL(cot(a0), tts::map(ref, a0), 2);
+  TTS_ULP_EQUAL(cot(a1), tts::map(ref, a1), 2);
+  TTS_ULP_EQUAL(cot(a2), tts::map(ref, a2), 2);
+  TTS_ULP_EQUAL(cot(a3), tts::map(ref, a3), 2);
+  TTS_ULP_EQUAL(cot(a4), tts::map(ref, a4), 2);
 
   TTS_IEEE_EQUAL(cot(T(0)), eve::inf(eve::as<T>()));
   TTS_IEEE_EQUAL(cot(T(-0.)), eve::minf(eve::as<T>()));

--- a/test/unit/module/math/cotd.cpp
+++ b/test/unit/module/math/cotd.cpp
@@ -35,7 +35,6 @@ TTS_CASE_WITH("Check behavior of cotd on wide",
 <typename T>(T const& a0, T const& a1, T const& a2)
 {
   using eve::cotd;
-  using eve::detail::map;
 
   using eve::deginrad;
   using v_t = eve::element_type_t<T>;
@@ -44,10 +43,10 @@ TTS_CASE_WITH("Check behavior of cotd on wide",
     auto d = eve::sind(e);
     return d ? eve::cosd(e) / eve::sind(e) : eve::nan(eve::as(e));
   };
-  TTS_ULP_EQUAL(cotd[eve::quarter_circle](a0), map(ref, a0), 2);
-  TTS_ULP_EQUAL(eve::cotd(a0), map(ref, a0), 2);
-  TTS_ULP_EQUAL(eve::cotd(a1), map(ref, a1), 2);
-  TTS_ULP_EQUAL(eve::cotd(a2), map(ref, a2), 2);
+  TTS_ULP_EQUAL(cotd[eve::quarter_circle](a0), tts::map(ref, a0), 2);
+  TTS_ULP_EQUAL(eve::cotd(a0), tts::map(ref, a0), 2);
+  TTS_ULP_EQUAL(eve::cotd(a1), tts::map(ref, a1), 2);
+  TTS_ULP_EQUAL(eve::cotd(a2), tts::map(ref, a2), 2);
 };
 
 TTS_CASE_TPL("Check corner cases of cotd", eve::test::simd::ieee_reals)

--- a/test/unit/module/math/coth.cpp
+++ b/test/unit/module/math/coth.cpp
@@ -41,13 +41,12 @@ TTS_CASE_WITH("Check behavior of coth on wide",
                             tts::randoms(-1.0, 1.0)))
 <typename T>(T const& a0, T const& a1)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
   using eve::coth;
   using eve::sinh;
 
-  TTS_ULP_EQUAL(coth(a0), map([](auto e) -> v_t { return 1.0 / std::tanh(double(e)); }, a0), 2);
-  TTS_ULP_EQUAL(coth(a1), map([](auto e) -> v_t { return 1.0 / std::tanh(double(e)); }, a1), 2);
+  TTS_ULP_EQUAL(coth(a0), tts::map([](auto e) -> v_t { return 1.0 / std::tanh(double(e)); }, a0), 2);
+  TTS_ULP_EQUAL(coth(a1), tts::map([](auto e) -> v_t { return 1.0 / std::tanh(double(e)); }, a1), 2);
 
   TTS_IEEE_EQUAL(eve::coth(T(0)), eve::inf(eve::as<T>()));
   TTS_IEEE_EQUAL(eve::coth(T(-0.)), eve::minf(eve::as<T>()));

--- a/test/unit/module/math/cotpi.cpp
+++ b/test/unit/module/math/cotpi.cpp
@@ -42,7 +42,6 @@ TTS_CASE_WITH("Check behavior of cotpi on wide",
 <typename T>(T const& a0, T const& a1, T const& a2, T const& a3)
 {
   using eve::cotpi;
-  using eve::detail::map;
 
   using eve::deginrad;
   using eve::pi;
@@ -55,11 +54,11 @@ TTS_CASE_WITH("Check behavior of cotpi on wide",
 //     auto d = std::sin(pi*e);
 //    return d ? std::cos(pi*e) / d : eve::nan(eve::as(e));
   };
-  TTS_ULP_EQUAL(cotpi[eve::quarter_circle](a0), map(ref, a0), 2);
-  TTS_ULP_EQUAL(cotpi(a0), map(ref, a0), 2);
-  TTS_ULP_EQUAL(cotpi(a1), map(ref, a1), 2);
-  TTS_ULP_EQUAL(cotpi(a2), map(ref, a2), 2);
-  TTS_ULP_EQUAL(cotpi(a3), map(ref, a3), 2);
+  TTS_ULP_EQUAL(cotpi[eve::quarter_circle](a0), tts::map(ref, a0), 2);
+  TTS_ULP_EQUAL(cotpi(a0), tts::map(ref, a0), 2);
+  TTS_ULP_EQUAL(cotpi(a1), tts::map(ref, a1), 2);
+  TTS_ULP_EQUAL(cotpi(a2), tts::map(ref, a2), 2);
+  TTS_ULP_EQUAL(cotpi(a3), tts::map(ref, a3), 2);
 };
 
 

--- a/test/unit/module/math/csc.cpp
+++ b/test/unit/module/math/csc.cpp
@@ -44,17 +44,16 @@ TTS_CASE_WITH("Check behavior of csc on wide",
 <typename T>(T const& a0, T const& a1, T const& a2, T const& a3)
 {
   using eve::csc;
-  using eve::detail::map;
 
   using v_t = eve::element_type_t<T>;
   auto ref  = [](auto e) -> v_t { return 1.0 / std::sin(double(e)); };
-  TTS_ULP_EQUAL(csc[eve::quarter_circle](a0), map(ref, a0), 2);
-  TTS_ULP_EQUAL(csc[eve::half_circle   ](a0), map(ref, a0), 2);
-  TTS_ULP_EQUAL(csc[eve::half_circle   ](a1), map(ref, a1), 2);
-  TTS_ULP_EQUAL(csc(a0), map(ref, a0), 2);
-  TTS_ULP_EQUAL(csc(a1), map(ref, a1), 2);
-  TTS_ULP_EQUAL(csc(a2), map(ref, a2), 2);
-  TTS_ULP_EQUAL(csc(a3), map(ref, a3), 2);
+  TTS_ULP_EQUAL(csc[eve::quarter_circle](a0), tts::map(ref, a0), 2);
+  TTS_ULP_EQUAL(csc[eve::half_circle   ](a0), tts::map(ref, a0), 2);
+  TTS_ULP_EQUAL(csc[eve::half_circle   ](a1), tts::map(ref, a1), 2);
+  TTS_ULP_EQUAL(csc(a0), tts::map(ref, a0), 2);
+  TTS_ULP_EQUAL(csc(a1), tts::map(ref, a1), 2);
+  TTS_ULP_EQUAL(csc(a2), tts::map(ref, a2), 2);
+  TTS_ULP_EQUAL(csc(a3), tts::map(ref, a3), 2);
 };
 
 

--- a/test/unit/module/math/cscd.cpp
+++ b/test/unit/module/math/cscd.cpp
@@ -35,7 +35,6 @@ TTS_CASE_WITH("Check behavior of cscd on wide",
 <typename T>(T const& a0, T const& a1, T const& a2)
 {
   using eve::cscd;
-  using eve::detail::map;
 
   using eve::deginrad;
   using v_t = eve::element_type_t<T>;
@@ -44,10 +43,10 @@ TTS_CASE_WITH("Check behavior of cscd on wide",
     auto d = eve::sind(e);
     return d ? 1.0 / d : eve::nan(eve::as(e));
   };
-  TTS_ULP_EQUAL(cscd[eve::quarter_circle](a0), map(ref, a0), 4);
-  TTS_ULP_EQUAL(eve::cscd(a0), map(ref, a0), 2);
-  TTS_ULP_EQUAL(eve::cscd(a1), map(ref, a1), 2);
-  TTS_ULP_EQUAL(eve::cscd(a2), map(ref, a2), 2);
+  TTS_ULP_EQUAL(cscd[eve::quarter_circle](a0), tts::map(ref, a0), 4);
+  TTS_ULP_EQUAL(eve::cscd(a0), tts::map(ref, a0), 2);
+  TTS_ULP_EQUAL(eve::cscd(a1), tts::map(ref, a1), 2);
+  TTS_ULP_EQUAL(eve::cscd(a2), tts::map(ref, a2), 2);
 };
 
 

--- a/test/unit/module/math/csch.cpp
+++ b/test/unit/module/math/csch.cpp
@@ -43,13 +43,12 @@ TTS_CASE_WITH("Check behavior of csch on wide",
                             tts::randoms(-1.0, 1.0)))
 <typename T>(T const& a0, T const& a1)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
   using eve::coth;
   using eve::csch;
 
-  TTS_ULP_EQUAL(csch(a0), map([](auto e) -> v_t { return 1.0 / std::sinh(e); }, a0), 2);
-  TTS_ULP_EQUAL(csch(a1), map([](auto e) -> v_t { return 1.0 / std::sinh(e); }, a1), 2);
+  TTS_ULP_EQUAL(csch(a0), tts::map([](auto e) -> v_t { return 1.0 / std::sinh(e); }, a0), 2);
+  TTS_ULP_EQUAL(csch(a1), tts::map([](auto e) -> v_t { return 1.0 / std::sinh(e); }, a1), 2);
 };
 
 

--- a/test/unit/module/math/cscpi.cpp
+++ b/test/unit/module/math/cscpi.cpp
@@ -41,7 +41,6 @@ TTS_CASE_WITH("Check behavior of cscpi on wide",
 <typename T>(T const& a0, T const& a1, T const& a2, T const& a3)
 {
   using eve::cscpi;
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
   auto ref  = [](auto e) -> v_t
   {
@@ -52,11 +51,11 @@ TTS_CASE_WITH("Check behavior of cscpi on wide",
   using eve::deginrad;
   using eve::pi;
   using v_t = eve::element_type_t<T>;
-  TTS_ULP_EQUAL(cscpi[eve::quarter_circle](a0), map(ref, a0), 2);
-  TTS_ULP_EQUAL(cscpi(a0), map(ref, a0), 2);
-  TTS_ULP_EQUAL(cscpi(a1), map(ref, a1), 2);
-  TTS_ULP_EQUAL(cscpi(a2), map(ref, a2), 2);
-  TTS_ULP_EQUAL(cscpi(a3), map(ref, a3), 2);
+  TTS_ULP_EQUAL(cscpi[eve::quarter_circle](a0), tts::map(ref, a0), 2);
+  TTS_ULP_EQUAL(cscpi(a0), tts::map(ref, a0), 2);
+  TTS_ULP_EQUAL(cscpi(a1), tts::map(ref, a1), 2);
+  TTS_ULP_EQUAL(cscpi(a2), tts::map(ref, a2), 2);
+  TTS_ULP_EQUAL(cscpi(a3), tts::map(ref, a3), 2);
 };
 
 

--- a/test/unit/module/math/exp.cpp
+++ b/test/unit/module/math/exp.cpp
@@ -32,14 +32,13 @@ TTS_CASE_WITH("Check behavior of exp on wide",
               tts::generate(tts::randoms(eve::minlog, eve::maxlog), tts::randoms(-1.0, 1.0)))
 <typename T>(T const& a0, T const& a1)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
-  TTS_ULP_EQUAL(eve::exp(a0), map([](auto e) -> v_t { return std::exp(e); }, a0), 2);
-  TTS_ULP_EQUAL(eve::exp(a1), map([](auto e) -> v_t { return std::exp(e); }, a1), 2);
+  TTS_ULP_EQUAL(eve::exp(a0), tts::map([](auto e) -> v_t { return std::exp(e); }, a0), 2);
+  TTS_ULP_EQUAL(eve::exp(a1), tts::map([](auto e) -> v_t { return std::exp(e); }, a1), 2);
 
-  TTS_ULP_EQUAL(eve::exp[eve::pedantic](a0), map([](auto e) -> v_t { return std::exp(e); }, a0), 2);
-  TTS_ULP_EQUAL(eve::exp[eve::pedantic](a1), map([](auto e) -> v_t { return std::exp(e); }, a1), 2);
+  TTS_ULP_EQUAL(eve::exp[eve::pedantic](a0), tts::map([](auto e) -> v_t { return std::exp(e); }, a0), 2);
+  TTS_ULP_EQUAL(eve::exp[eve::pedantic](a1), tts::map([](auto e) -> v_t { return std::exp(e); }, a1), 2);
 };
 
 TTS_CASE_TPL("Check return types of exp", eve::test::simd::ieee_reals)

--- a/test/unit/module/math/exp10.cpp
+++ b/test/unit/module/math/exp10.cpp
@@ -30,16 +30,15 @@ TTS_CASE_WITH ( "Check behavior of exp10 on wide"
               )
 <typename T>(T const& a0, T const& a1)
 {
-  using eve::detail::map;
   using v_t       = eve::element_type_t<T>;
   long double l10 = std::log(10.0l);
-  TTS_ULP_EQUAL(eve::exp10(a0), map([l10](auto e) -> v_t { return std::exp(l10 * e); }, a0), 380) << "a0 " << a0 << '\n';
+  TTS_ULP_EQUAL(eve::exp10(a0), tts::map([l10](auto e) -> v_t { return std::exp(l10 * e); }, a0), 380) << "a0 " << a0 << '\n';
 
   TTS_ULP_EQUAL(eve::exp10[eve::pedantic](a0),
-                map([l10](auto e) -> v_t { return std::exp(l10 * e); }, a0),
+                tts::map([l10](auto e) -> v_t { return std::exp(l10 * e); }, a0),
                 380);
   TTS_ULP_EQUAL(eve::exp10[eve::pedantic](a1),
-                map([l10](auto e) -> v_t { return std::exp(l10 * e); }, a1),
+                tts::map([l10](auto e) -> v_t { return std::exp(l10 * e); }, a1),
                 2);
 };
 

--- a/test/unit/module/math/exp2.cpp
+++ b/test/unit/module/math/exp2.cpp
@@ -32,13 +32,12 @@ TTS_CASE_WITH("Check behavior of exp2 on wide",
               tts::generate(tts::randoms(eve::minlog2, eve::maxlog2), tts::randoms(-1.0, 1.0)))
 <typename T>(T const& a0, T const& a1)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
-  TTS_ULP_EQUAL(eve::exp2(a0), map([](auto e) -> v_t { return std::exp2(e); }, a0), 30);
-  TTS_ULP_EQUAL(eve::exp2(a1), map([](auto e) -> v_t { return std::exp2(e); }, a1), 2);
+  TTS_ULP_EQUAL(eve::exp2(a0), tts::map([](auto e) -> v_t { return std::exp2(e); }, a0), 30);
+  TTS_ULP_EQUAL(eve::exp2(a1), tts::map([](auto e) -> v_t { return std::exp2(e); }, a1), 2);
 
-  TTS_ULP_EQUAL(eve::exp2[eve::pedantic](a0), map([](auto e) -> v_t { return std::exp2(e); }, a0), 30);
-  TTS_ULP_EQUAL(eve::exp2[eve::pedantic](a1), map([](auto e) -> v_t { return std::exp2(e); }, a1), 2);
+  TTS_ULP_EQUAL(eve::exp2[eve::pedantic](a0), tts::map([](auto e) -> v_t { return std::exp2(e); }, a0), 30);
+  TTS_ULP_EQUAL(eve::exp2[eve::pedantic](a1), tts::map([](auto e) -> v_t { return std::exp2(e); }, a1), 2);
 };
 
 TTS_CASE_TPL("Check return types of exp2", eve::test::simd::ieee_reals)

--- a/test/unit/module/math/expm1.cpp
+++ b/test/unit/module/math/expm1.cpp
@@ -30,13 +30,12 @@ TTS_CASE_WITH ( "Check behavior of expm1 on wide"
               )
 <typename T>(T const& a0, T const& a1)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
-  TTS_ULP_EQUAL(eve::expm1(a0), map([](auto e) -> v_t { return std::expm1(e); }, a0), 30);
-  TTS_ULP_EQUAL(eve::expm1(a1), map([](auto e) -> v_t { return std::expm1(e); }, a1), 2);
-  TTS_ULP_EQUAL(eve::expm1[eve::pedantic](a0), map([](auto e) -> v_t { return std::expm1(e); }, a0), 30);
-  TTS_ULP_EQUAL(eve::expm1[eve::pedantic](a1), map([](auto e) -> v_t { return std::expm1(e); }, a1), 2);
+  TTS_ULP_EQUAL(eve::expm1(a0), tts::map([](auto e) -> v_t { return std::expm1(e); }, a0), 30);
+  TTS_ULP_EQUAL(eve::expm1(a1), tts::map([](auto e) -> v_t { return std::expm1(e); }, a1), 2);
+  TTS_ULP_EQUAL(eve::expm1[eve::pedantic](a0), tts::map([](auto e) -> v_t { return std::expm1(e); }, a0), 30);
+  TTS_ULP_EQUAL(eve::expm1[eve::pedantic](a1), tts::map([](auto e) -> v_t { return std::expm1(e); }, a1), 2);
 };
 
 TTS_CASE_TPL("Check return types of expm1", eve::test::simd::ieee_reals)

--- a/test/unit/module/math/expmx2.cpp
+++ b/test/unit/module/math/expmx2.cpp
@@ -39,11 +39,10 @@ TTS_CASE_WITH("Check behavior of exp on wide",
              )
 <typename T>(T const& a0)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
   TTS_ULP_EQUAL(eve::expmx2(a0),
-                map(
+                tts::map(
                     [](auto e) -> v_t
                     {
                       long double le = e;

--- a/test/unit/module/math/expx2.cpp
+++ b/test/unit/module/math/expx2.cpp
@@ -37,11 +37,10 @@ TTS_CASE_WITH("Check behavior of exp on wide",
               tts::generate(tts::randoms(mini, maxi), tts::randoms(-1.0, 1.0)))
 <typename T>(T const& a0, T const& a1)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
   TTS_ULP_EQUAL(eve::expx2(a0),
-                map(
+                tts::map(
                     [](auto e) -> v_t
                     {
                       long double le = e;
@@ -50,7 +49,7 @@ TTS_CASE_WITH("Check behavior of exp on wide",
                     a0),
                 200);
   TTS_ULP_EQUAL(eve::expx2(a1),
-                map(
+                tts::map(
                     [](auto e) -> v_t
                     {
                       long double le = e;

--- a/test/unit/module/math/gd.cpp
+++ b/test/unit/module/math/gd.cpp
@@ -42,13 +42,12 @@ TTS_CASE_WITH("Check behavior of gd on wide",
                             tts::randoms(-1.0, 1.0)))
 <typename T>(T const& a0, T const& a1)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
   using eve::gd;
   using eve::sinh;
 
-  TTS_ULP_EQUAL(gd(a0), map([](auto e) -> v_t { return std::atan(std::sinh(e)); }, a0), 2);
-  TTS_ULP_EQUAL(gd(a1), map([](auto e) -> v_t { return std::atan(std::sinh(e)); }, a1), 2);
+  TTS_ULP_EQUAL(gd(a0), tts::map([](auto e) -> v_t { return std::atan(std::sinh(e)); }, a0), 2);
+  TTS_ULP_EQUAL(gd(a1), tts::map([](auto e) -> v_t { return std::atan(std::sinh(e)); }, a1), 2);
 };
 
 

--- a/test/unit/module/math/geommean.cpp
+++ b/test/unit/module/math/geommean.cpp
@@ -47,10 +47,9 @@ TTS_CASE_WITH("Check behavior of geommean(wide)",
 <typename T>(T const& a0, T const& a1, T const& a2)
 {
   using eve::geommean;
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
   TTS_ULP_EQUAL(geommean(a0, a1),
-                map(
+                tts::map(
                     [](auto e, auto f) -> v_t {
                       return (eve::sign(e) * eve::sign(f) >= 0) ? std::sqrt(e * f)
                                                                 : eve::nan(eve::as<v_t>());
@@ -59,13 +58,13 @@ TTS_CASE_WITH("Check behavior of geommean(wide)",
                     a1),
                 2);
   TTS_ULP_EQUAL(geommean(a0, a1, a2),
-                map([](auto e, auto f, auto g) { return std::cbrt(g * f * e); }, a0, a1, a2),
+                tts::map([](auto e, auto f, auto g) { return std::cbrt(g * f * e); }, a0, a1, a2),
                 30);
   TTS_ULP_EQUAL(geommean[eve::pedantic](a0, a1, a2),
-                map([](auto e, auto f, auto g) { return std::cbrt(g * f * e); }, a0, a1, a2),
+                tts::map([](auto e, auto f, auto g) { return std::cbrt(g * f * e); }, a0, a1, a2),
                 30);
  TTS_ULP_EQUAL(geommean(kumi::tuple{a0, a1, a2}),
-                map([](auto e, auto f, auto g) { return std::cbrt(g * f * e); }, a0, a1, a2),
+                tts::map([](auto e, auto f, auto g) { return std::cbrt(g * f * e); }, a0, a1, a2),
                 30);
 };
 

--- a/test/unit/module/math/hypot.cpp
+++ b/test/unit/module/math/hypot.cpp
@@ -85,23 +85,22 @@ TTS_CASE_WITH("Check behavior of hypot(wide)",
 {
   using eve::hypot;
   using eve::pedantic;
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
   TTS_ULP_EQUAL(
-      hypot(a0, a1), map([](auto e, auto f) -> v_t { return std::hypot(e, f); }, a0, a1), 2);
+      hypot(a0, a1), tts::map([](auto e, auto f) -> v_t { return std::hypot(e, f); }, a0, a1), 2);
   if constexpr( eve::floating_value<T> )
   {
     TTS_ULP_EQUAL(hypot(a0, a1, a2),
-                  map([](auto e, auto f, auto g) { return std::hypot(e, f, g); }, a0, a1, a2),
+                  tts::map([](auto e, auto f, auto g) { return std::hypot(e, f, g); }, a0, a1, a2),
                   2);
     TTS_ULP_EQUAL(hypot[pedantic](a0, a1, a2),
-                  map([](auto e, auto f, auto g) { return std::hypot(e, f, g); }, a0, a1, a2),
+                  tts::map([](auto e, auto f, auto g) { return std::hypot(e, f, g); }, a0, a1, a2),
                   2);
     TTS_ULP_EQUAL(hypot(kumi::tuple{a0, a1, a2}),
-                  map([](auto e, auto f, auto g) { return std::hypot(e, f, g); }, a0, a1, a2),
+                  tts::map([](auto e, auto f, auto g) { return std::hypot(e, f, g); }, a0, a1, a2),
                   2);
     TTS_ULP_EQUAL(hypot[pedantic](kumi::tuple{a0, a1, a2}),
-                  map([](auto e, auto f, auto g) { return std::hypot(e, f, g); }, a0, a1, a2),
+                  tts::map([](auto e, auto f, auto g) { return std::hypot(e, f, g); }, a0, a1, a2),
                   2);
    }
 };

--- a/test/unit/module/math/log.cpp
+++ b/test/unit/module/math/log.cpp
@@ -32,11 +32,10 @@ TTS_CASE_WITH("Check behavior of log on wide",
               tts::generate(tts::randoms(eve::eps, eve::valmax), tts::randoms(0.5, 2.0)))
 <typename T>(T const& a0, T const& a1)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
-  TTS_ULP_EQUAL(eve::log(a0), map([](auto e) -> v_t { return std::log(e); }, a0), 2);
-  TTS_ULP_EQUAL(eve::log(a1), map([](auto e) -> v_t { return std::log(e); }, a1), 2);
+  TTS_ULP_EQUAL(eve::log(a0), tts::map([](auto e) -> v_t { return std::log(e); }, a0), 2);
+  TTS_ULP_EQUAL(eve::log(a1), tts::map([](auto e) -> v_t { return std::log(e); }, a1), 2);
 };
 
 TTS_CASE_TPL("Check return types of log", eve::test::simd::ieee_reals)

--- a/test/unit/module/math/log10.cpp
+++ b/test/unit/module/math/log10.cpp
@@ -32,11 +32,10 @@ TTS_CASE_WITH("Check behavior of log10 on wide",
               tts::generate(tts::randoms(eve::eps, eve::valmax), tts::randoms(0.5, 2.0)))
 <typename T>(T const& a0, T const& a1)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
-  TTS_ULP_EQUAL(eve::log10(a0), map([](auto e) -> v_t { return std::log10(e); }, a0), 2);
-  TTS_ULP_EQUAL(eve::log10(a1), map([](auto e) -> v_t { return std::log10(e); }, a1), 2);
+  TTS_ULP_EQUAL(eve::log10(a0), tts::map([](auto e) -> v_t { return std::log10(e); }, a0), 2);
+  TTS_ULP_EQUAL(eve::log10(a1), tts::map([](auto e) -> v_t { return std::log10(e); }, a1), 2);
 };
 
 TTS_CASE_TPL("Check return types of log10", eve::test::simd::ieee_reals)

--- a/test/unit/module/math/log1p.cpp
+++ b/test/unit/module/math/log1p.cpp
@@ -32,11 +32,10 @@ TTS_CASE_WITH("Check behavior of log1p on wide",
               tts::generate(tts::randoms(0.0, eve::valmax), tts::randoms(0.5, 2.0)))
 <typename T>(T const& a0, T const& a1)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
-  TTS_ULP_EQUAL(eve::log1p(a0), map([](auto e) -> v_t { return std::log1p(e); }, a0), 2);
-  TTS_ULP_EQUAL(eve::log1p(a1), map([](auto e) -> v_t { return std::log1p(e); }, a1), 2);
+  TTS_ULP_EQUAL(eve::log1p(a0), tts::map([](auto e) -> v_t { return std::log1p(e); }, a0), 2);
+  TTS_ULP_EQUAL(eve::log1p(a1), tts::map([](auto e) -> v_t { return std::log1p(e); }, a1), 2);
 };
 
 TTS_CASE_TPL("Check return types of log1p", eve::test::simd::ieee_reals)

--- a/test/unit/module/math/log2.cpp
+++ b/test/unit/module/math/log2.cpp
@@ -32,11 +32,10 @@ TTS_CASE_WITH("Check behavior of log2 on wide",
               tts::generate(tts::randoms(eve::eps, eve::valmax), tts::randoms(0.5, 2.0)))
 <typename T>(T const& a0, T const& a1)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
-  TTS_ULP_EQUAL(eve::log2(a0), map([](auto e) -> v_t { return std::log2(e); }, a0), 2);
-  TTS_ULP_EQUAL(eve::log2(a1), map([](auto e) -> v_t { return std::log2(e); }, a1), 2);
+  TTS_ULP_EQUAL(eve::log2(a0), tts::map([](auto e) -> v_t { return std::log2(e); }, a0), 2);
+  TTS_ULP_EQUAL(eve::log2(a1), tts::map([](auto e) -> v_t { return std::log2(e); }, a1), 2);
 };
 
 TTS_CASE_TPL("Check return types of log2", eve::test::simd::ieee_reals)

--- a/test/unit/module/math/log_abs.cpp
+++ b/test/unit/module/math/log_abs.cpp
@@ -32,10 +32,9 @@ TTS_CASE_WITH("Check behavior of log_abs on wide",
               tts::generate(tts::randoms(-1, 1)))
 <typename T>(T const& a0)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
-  TTS_ULP_EQUAL(eve::log_abs(a0), map([](auto e) -> v_t { return std::log(std::abs(e)); }, a0), 2);
+  TTS_ULP_EQUAL(eve::log_abs(a0), tts::map([](auto e) -> v_t { return std::log(std::abs(e)); }, a0), 2);
 };
 
 

--- a/test/unit/module/math/logspace_add.cpp
+++ b/test/unit/module/math/logspace_add.cpp
@@ -49,7 +49,6 @@ TTS_CASE_WITH("Check behavior of logspace_add on wide",
                             tts::randoms(0.5, 2.0)))
 <typename T>(T const& a0, T const& a1, T const& a2, T const& a3, T const& a4, T const& a5)
 {
-  using eve::detail::map;
 
   auto la0 = eve::log(a0);
   auto la1 = eve::log(a1);

--- a/test/unit/module/math/logspace_sub.cpp
+++ b/test/unit/module/math/logspace_sub.cpp
@@ -48,7 +48,6 @@ TTS_CASE_WITH("Check behavior of logspace_sub on wide",
                             tts::randoms(0.5, 2.0)))
 <typename T>(T const& a0, T const& a1, T const& a2, T const& a3, T const& a4, T const& a5)
 {
-  using eve::detail::map;
 
   auto la0 = eve::log(a0);
   auto la1 = eve::log(a1);

--- a/test/unit/module/math/lpnorm_2.cpp
+++ b/test/unit/module/math/lpnorm_2.cpp
@@ -25,7 +25,6 @@ TTS_CASE_WITH("Check behavior of lpnorm on wide",
                             tts::randoms(0.5, 2.0)))
 <typename T>(T const& a0, T const& a1, T const& a2, T const& a3, T const& a4, T const& a5)
 {
-  using eve::detail::map;
 
   TTS_ULP_EQUAL(eve::lpnorm(2, a0, a1), eve::hypot(a0, a1), 2);
   TTS_ULP_EQUAL(eve::lpnorm(2, a2, a3), eve::hypot(a2, a3), 2);

--- a/test/unit/module/math/nthroot.cpp
+++ b/test/unit/module/math/nthroot.cpp
@@ -39,17 +39,16 @@ TTS_CASE_WITH("Check behavior of nthroot on wide",
                             tts::as_integer(tts::randoms(1, 10))))
 <typename T, typename U>(T const& a0, T const& a1, U const& a2, U const& a3)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
   TTS_ULP_EQUAL(eve::nthroot(a0, U(2) * a2 + U(1)),
-                map([](auto e, auto f) -> v_t
+                tts::map([](auto e, auto f) -> v_t
                     { return std::pow(std::abs(e), eve::rec(2.0 * f + 1.0)) * eve::sign(e); },
                     a0,
                     a2),
                 100);
   TTS_ULP_EQUAL(eve::nthroot(a1, a3),
-                map([](auto e, auto f) -> v_t { return std::pow(e, eve::rec(double(f))); }, a1, a3),
+                tts::map([](auto e, auto f) -> v_t { return std::pow(e, eve::rec(double(f))); }, a1, a3),
                 100);
 };
 

--- a/test/unit/module/math/pow.cpp
+++ b/test/unit/module/math/pow.cpp
@@ -38,7 +38,7 @@ TTS_CASE_WITH("Check behavior of pow on wide",
   using v_t = eve::element_type_t<T>;
 
   TTS_RELATIVE_EQUAL(eve::pow(a0, a1),
-                     eve::detail::map([](auto e, auto f) -> v_t { return std::pow(std::abs(e), f); }, a0, a1),
+                     tts::map([](auto e, auto f) -> v_t { return std::pow(std::abs(e), f); }, a0, a1),
                      0.001);
 };
 

--- a/test/unit/module/math/pow1p.cpp
+++ b/test/unit/module/math/pow1p.cpp
@@ -39,16 +39,15 @@ TTS_CASE_WITH("Check behavior of pow1p on wide",
                             tts::randoms(-1.0, 1.0)))
 <typename T>(T const& a0, T const& a1, T const& a2, T const& a3)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
   TTS_ULP_EQUAL(
       eve::pow1p(a0, a1),
-      map([](auto e, auto f) -> v_t { return std::pow(double(e + 1), double(f)); }, a0, a1),
+      tts::map([](auto e, auto f) -> v_t { return std::pow(double(e + 1), double(f)); }, a0, a1),
       64);
   TTS_ULP_EQUAL(
       eve::pow1p(a2, a3),
-      map([](auto e, auto f) -> v_t { return std::pow(double(e + 1), double(f)); }, a2, a3),
+      tts::map([](auto e, auto f) -> v_t { return std::pow(double(e + 1), double(f)); }, a2, a3),
       64);
 };
 

--- a/test/unit/module/math/pow_abs.cpp
+++ b/test/unit/module/math/pow_abs.cpp
@@ -37,14 +37,13 @@ TTS_CASE_WITH("Check behavior of pow_abs on wide",
                             tts::randoms(-1.0, 1.0)))
 <typename T>(T const& a0, T const& a1, T const& a2, T const& a3)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
   TTS_ULP_EQUAL(eve::pow_abs(a0, a1),
-                map([](auto e, auto f) -> v_t { return std::pow(std::abs(e), f); }, a0, a1),
+                tts::map([](auto e, auto f) -> v_t { return std::pow(std::abs(e), f); }, a0, a1),
                 32);
   TTS_ULP_EQUAL(eve::pow_abs(a2, a3),
-                map([](auto e, auto f) -> v_t { return std::pow(std::abs(e), f); }, a2, a3),
+                tts::map([](auto e, auto f) -> v_t { return std::pow(std::abs(e), f); }, a2, a3),
                 2);
 };
 

--- a/test/unit/module/math/powm1.cpp
+++ b/test/unit/module/math/powm1.cpp
@@ -34,12 +34,11 @@ TTS_CASE_WITH("Check behavior of powm1 on wide",
               tts::generate(tts::randoms(1.0, 10.0), tts::randoms(-1.0, 1.0)))
 <typename T>(T const& a0, T const& a1)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
   TTS_RELATIVE_EQUAL(
       eve::powm1(a0, a1),
-      map([](auto e, auto f) -> v_t { return eve::pow(double(e), double(f)) - 1; }, a0, a1),
+      tts::map([](auto e, auto f) -> v_t { return eve::pow(double(e), double(f)) - 1; }, a0, a1),
       0.001);
 };
 

--- a/test/unit/module/math/sec.cpp
+++ b/test/unit/module/math/sec.cpp
@@ -43,17 +43,16 @@ TTS_CASE_WITH("Check behavior of sec on wide",
 <typename T>(T const& a0, T const& a1, T const& a2, T const& a3)
 {
   using eve::sec;
-  using eve::detail::map;
 
   using v_t = eve::element_type_t<T>;
   auto ref  = [](auto e) -> v_t { return 1 / std::cos(e); };
-  TTS_ULP_EQUAL(sec[eve::quarter_circle](a0), map(ref, a0), 2);
-  TTS_ULP_EQUAL(sec[eve::half_circle   ](a0), map(ref, a0), 2);
-  TTS_ULP_EQUAL(sec[eve::half_circle   ](a1), map(ref, a1), 2);
-  TTS_ULP_EQUAL(sec(a0), map(ref, a0), 2);
-  TTS_ULP_EQUAL(sec(a1), map(ref, a1), 2);
-  TTS_ULP_EQUAL(sec(a2), map(ref, a2), 2);
-  TTS_ULP_EQUAL(sec(a3), map(ref, a3), 2);
+  TTS_ULP_EQUAL(sec[eve::quarter_circle](a0), tts::map(ref, a0), 2);
+  TTS_ULP_EQUAL(sec[eve::half_circle   ](a0), tts::map(ref, a0), 2);
+  TTS_ULP_EQUAL(sec[eve::half_circle   ](a1), tts::map(ref, a1), 2);
+  TTS_ULP_EQUAL(sec(a0), tts::map(ref, a0), 2);
+  TTS_ULP_EQUAL(sec(a1), tts::map(ref, a1), 2);
+  TTS_ULP_EQUAL(sec(a2), tts::map(ref, a2), 2);
+  TTS_ULP_EQUAL(sec(a3), tts::map(ref, a3), 2);
 };
 
 

--- a/test/unit/module/math/secd.cpp
+++ b/test/unit/module/math/secd.cpp
@@ -35,17 +35,16 @@ TTS_CASE_WITH("Check behavior of secd on wide",
 <typename T>(T const& a0, T const& a1, T const& a2)
 {
   using eve::secd;
-  using eve::detail::map;
 
   using eve::deginrad;
   using v_t = eve::element_type_t<T>;
 //  auto ref  = [](auto e) -> v_t { return 1.0l / eve::cospi(double(e / 180.0l)); };
   auto ref  = [](auto e) -> v_t { return 1.0 / eve::cosd(e); };
 
-  TTS_ULP_EQUAL(secd[eve::quarter_circle](a0), map(ref, a0), 4);
-  TTS_ULP_EQUAL(secd(a0), map(ref, a0), 4);
-  TTS_ULP_EQUAL(secd(a1), map(ref, a1), 4);
-  TTS_ULP_EQUAL(secd(a2), map(ref, a2), 512);
+  TTS_ULP_EQUAL(secd[eve::quarter_circle](a0), tts::map(ref, a0), 4);
+  TTS_ULP_EQUAL(secd(a0), tts::map(ref, a0), 4);
+  TTS_ULP_EQUAL(secd(a1), tts::map(ref, a1), 4);
+  TTS_ULP_EQUAL(secd(a2), tts::map(ref, a2), 512);
 };
 
 TTS_CASE_TPL("Check return types of secd", eve::test::simd::ieee_reals)

--- a/test/unit/module/math/sech.cpp
+++ b/test/unit/module/math/sech.cpp
@@ -41,15 +41,14 @@ TTS_CASE_WITH("Check behavior of sech on wide",
                             tts::randoms(-1.0, 1.0)))
 <typename T>(T const& a0, T const& a1)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
   using eve::cosh;
   using eve::sech;
 
   auto rel = std::is_same_v<v_t, float> ? 2e-5 : 1e-13;
 
-  TTS_RELATIVE_EQUAL(sech(a0), map([](auto e) -> v_t { return 1 / std::cosh(e); }, a0), rel);
-  TTS_RELATIVE_EQUAL(sech(a1), map([](auto e) -> v_t { return 1 / std::cosh(e); }, a1), rel);
+  TTS_RELATIVE_EQUAL(sech(a0), tts::map([](auto e) -> v_t { return 1 / std::cosh(e); }, a0), rel);
+  TTS_RELATIVE_EQUAL(sech(a1), tts::map([](auto e) -> v_t { return 1 / std::cosh(e); }, a1), rel);
 };
 
 

--- a/test/unit/module/math/secpi.cpp
+++ b/test/unit/module/math/secpi.cpp
@@ -41,7 +41,6 @@ TTS_CASE_WITH("Check behavior of secpi on wide",
 <typename T>(T const& a0, T const& a1, T const& a2, T const& a3)
 {
   using eve::secpi;
-  using eve::detail::map;
 
   using eve::deginrad;
   using eve::pi;
@@ -51,11 +50,11 @@ TTS_CASE_WITH("Check behavior of secpi on wide",
     auto c =eve::cospi(e);
     return c ? eve::rec(c) : eve::nan(eve::as(e));
   };
-  TTS_ULP_EQUAL(secpi[eve::quarter_circle](a0), map(ref, a0), 2);
-  TTS_ULP_EQUAL(secpi(a0), map(ref, a0), 2);
-  TTS_ULP_EQUAL(secpi(a1), map(ref, a1), 2);
-  TTS_ULP_EQUAL(secpi(a2), map(ref, a2), 2);
-  TTS_ULP_EQUAL(secpi(a3), map(ref, a3), 2);
+  TTS_ULP_EQUAL(secpi[eve::quarter_circle](a0), tts::map(ref, a0), 2);
+  TTS_ULP_EQUAL(secpi(a0), tts::map(ref, a0), 2);
+  TTS_ULP_EQUAL(secpi(a1), tts::map(ref, a1), 2);
+  TTS_ULP_EQUAL(secpi(a2), tts::map(ref, a2), 2);
+  TTS_ULP_EQUAL(secpi(a3), tts::map(ref, a3), 2);
 };
 
 

--- a/test/unit/module/math/sigmoid.cpp
+++ b/test/unit/module/math/sigmoid.cpp
@@ -32,11 +32,10 @@ TTS_CASE_WITH("Check behavior of exp on wide",
               tts::generate(tts::randoms(eve::minlog, eve::maxlog), tts::randoms(-1.0, 1.0)))
 <typename T>(T const& a0, T const& a1)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
 
-  TTS_ULP_EQUAL(eve::sigmoid(a0), map([](auto e) -> v_t { return eve::rec(eve::inc(std::exp(-e))); }, a0), 2);
-  TTS_ULP_EQUAL(eve::sigmoid(a1), map([](auto e) -> v_t { return eve::rec(eve::inc(std::exp(-e))); }, a1), 2);
+  TTS_ULP_EQUAL(eve::sigmoid(a0), tts::map([](auto e) -> v_t { return eve::rec(eve::inc(std::exp(-e))); }, a0), 2);
+  TTS_ULP_EQUAL(eve::sigmoid(a1), tts::map([](auto e) -> v_t { return eve::rec(eve::inc(std::exp(-e))); }, a1), 2);
 };
 
 

--- a/test/unit/module/math/sin.cpp
+++ b/test/unit/module/math/sin.cpp
@@ -46,21 +46,20 @@ TTS_CASE_WITH("Check behavior of sin on wide",
 <typename T>(T const& a0, T const& a1, T const& a2, T const& a3, T const& a4)
 {
   using eve::sin;
-  using eve::detail::map;
 
   using v_t = eve::element_type_t<T>;
   auto ref  = [](auto e) -> v_t { return std::sin(e); };
-  TTS_ULP_EQUAL(sin[eve::quarter_circle](a0), map(ref, a0), 2);
-  TTS_ULP_EQUAL(sin[eve::half_circle](a0), map(ref, a0), 2);
-  TTS_ULP_EQUAL(sin[eve::half_circle](a1), map(ref, a1), 2);
-  TTS_ULP_EQUAL(sin[eve::full_circle](a0), map(ref, a0), 2);
-  TTS_ULP_EQUAL(sin[eve::full_circle](a1), map(ref, a1), 2);
-  TTS_ULP_EQUAL(sin[eve::full_circle](a2), map(ref, a2), 2);
-  TTS_ULP_EQUAL(sin(a0), map(ref, a0), 2);
-  TTS_ULP_EQUAL(sin(a1), map(ref, a1), 2);
-  TTS_ULP_EQUAL(sin(a2), map(ref, a2), 2);
-  TTS_ULP_EQUAL(sin(a3), map(ref, a3), 2);
-  TTS_ULP_EQUAL(sin(a4), map(ref, a4), 2);
+  TTS_ULP_EQUAL(sin[eve::quarter_circle](a0), tts::map(ref, a0), 2);
+  TTS_ULP_EQUAL(sin[eve::half_circle](a0), tts::map(ref, a0), 2);
+  TTS_ULP_EQUAL(sin[eve::half_circle](a1), tts::map(ref, a1), 2);
+  TTS_ULP_EQUAL(sin[eve::full_circle](a0), tts::map(ref, a0), 2);
+  TTS_ULP_EQUAL(sin[eve::full_circle](a1), tts::map(ref, a1), 2);
+  TTS_ULP_EQUAL(sin[eve::full_circle](a2), tts::map(ref, a2), 2);
+  TTS_ULP_EQUAL(sin(a0), tts::map(ref, a0), 2);
+  TTS_ULP_EQUAL(sin(a1), tts::map(ref, a1), 2);
+  TTS_ULP_EQUAL(sin(a2), tts::map(ref, a2), 2);
+  TTS_ULP_EQUAL(sin(a3), tts::map(ref, a3), 2);
+  TTS_ULP_EQUAL(sin(a4), tts::map(ref, a4), 2);
 };
 
 

--- a/test/unit/module/math/sinc.cpp
+++ b/test/unit/module/math/sinc.cpp
@@ -36,13 +36,12 @@ TTS_CASE_WITH("Check behavior of sinc on wide",
 <typename T>(T const& a0, T const& a1)
 {
   using eve::sinc;
-  using eve::detail::map;
 
   using v_t = eve::element_type_t<T>;
 
   auto ref = [](auto e) -> v_t { return e ? std::sin(e) / e : v_t(1); };
-  TTS_ULP_EQUAL(sinc(a0), map(ref, a0), 2);
-  TTS_ULP_EQUAL(sinc(a1), map(ref, a1), 2);
+  TTS_ULP_EQUAL(sinc(a0), tts::map(ref, a0), 2);
+  TTS_ULP_EQUAL(sinc(a1), tts::map(ref, a1), 2);
 };
 
 

--- a/test/unit/module/math/sincos.cpp
+++ b/test/unit/module/math/sincos.cpp
@@ -46,50 +46,49 @@ TTS_CASE_WITH("Check behavior of cos on wide",
 <typename T>(T const& a0, T const& a1, T const& a2, T const& a3, T const& a4)
 {
   using eve::sincos;
-  using eve::detail::map;
 
   using v_t = eve::element_type_t<T>;
   auto refc = [](auto e) -> v_t { return std::cos(e); };
   auto refs = [](auto e) -> v_t { return std::sin(e); };
   {
     auto [s, c] = sincos[eve::quarter_circle](a0);
-    TTS_ULP_EQUAL(s, map(refs, a0), 2);
-    TTS_ULP_EQUAL(c, map(refc, a0), 2);
+    TTS_ULP_EQUAL(s, tts::map(refs, a0), 2);
+    TTS_ULP_EQUAL(c, tts::map(refc, a0), 2);
   }
   {
     auto [s, c] = sincos[eve::half_circle](a0);
-    TTS_ULP_EQUAL(s, map(refs, a0), 2);
-    TTS_ULP_EQUAL(c, map(refc, a0), 2);
+    TTS_ULP_EQUAL(s, tts::map(refs, a0), 2);
+    TTS_ULP_EQUAL(c, tts::map(refc, a0), 2);
     auto [s1, c1] = sincos[eve::half_circle](a1);
-    TTS_ULP_EQUAL(s1, map(refs, a1), 2);
-    TTS_ULP_EQUAL(c1, map(refc, a1), 2);
+    TTS_ULP_EQUAL(s1, tts::map(refs, a1), 2);
+    TTS_ULP_EQUAL(c1, tts::map(refc, a1), 2);
   }
   {
     auto [s, c] = sincos[eve::full_circle](a0);
-    TTS_ULP_EQUAL(s, map(refs, a0), 2);
-    TTS_ULP_EQUAL(c, map(refc, a0), 2);
+    TTS_ULP_EQUAL(s, tts::map(refs, a0), 2);
+    TTS_ULP_EQUAL(c, tts::map(refc, a0), 2);
     auto [s1, c1] = sincos[eve::full_circle](a1);
-    TTS_ULP_EQUAL(s1, map(refs, a1), 2);
-    TTS_ULP_EQUAL(c1, map(refc, a1), 2);
+    TTS_ULP_EQUAL(s1, tts::map(refs, a1), 2);
+    TTS_ULP_EQUAL(c1, tts::map(refc, a1), 2);
     auto [s2, c2] = sincos[eve::full_circle](a2);
-    TTS_ULP_EQUAL(s2, map(refs, a2), 2);
-    TTS_ULP_EQUAL(c2, map(refc, a2), 2);
+    TTS_ULP_EQUAL(s2, tts::map(refs, a2), 2);
+    TTS_ULP_EQUAL(c2, tts::map(refc, a2), 2);
   }
   {
     auto [s, c] = sincos(a0);
-    TTS_ULP_EQUAL(s, map(refs, a0), 2);
-    TTS_ULP_EQUAL(c, map(refc, a0), 2);
+    TTS_ULP_EQUAL(s, tts::map(refs, a0), 2);
+    TTS_ULP_EQUAL(c, tts::map(refc, a0), 2);
     auto [s1, c1] = sincos(a1);
-    TTS_ULP_EQUAL(s1, map(refs, a1), 2);
-    TTS_ULP_EQUAL(c1, map(refc, a1), 2);
+    TTS_ULP_EQUAL(s1, tts::map(refs, a1), 2);
+    TTS_ULP_EQUAL(c1, tts::map(refc, a1), 2);
     auto [s2, c2] = sincos(a2);
-    TTS_ULP_EQUAL(s2, map(refs, a2), 2);
-    TTS_ULP_EQUAL(c2, map(refc, a2), 2);
+    TTS_ULP_EQUAL(s2, tts::map(refs, a2), 2);
+    TTS_ULP_EQUAL(c2, tts::map(refc, a2), 2);
     auto [s3, c3] = sincos(a3);
-    TTS_ULP_EQUAL(s3, map(refs, a3), 2);
-    TTS_ULP_EQUAL(c3, map(refc, a3), 2);
+    TTS_ULP_EQUAL(s3, tts::map(refs, a3), 2);
+    TTS_ULP_EQUAL(c3, tts::map(refc, a3), 2);
     auto [s4, c4] = sincos(a4);
-    TTS_ULP_EQUAL(s4, map(refs, a4), 2);
-    TTS_ULP_EQUAL(c4, map(refc, a4), 2);
+    TTS_ULP_EQUAL(s4, tts::map(refs, a4), 2);
+    TTS_ULP_EQUAL(c4, tts::map(refc, a4), 2);
   }
 };

--- a/test/unit/module/math/sind.cpp
+++ b/test/unit/module/math/sind.cpp
@@ -35,16 +35,15 @@ TTS_CASE_WITH("Check behavior of sind on wide",
 <typename T>(T const& a0, T const& a1, T const& a2)
 {
   using eve::sind;
-  using eve::detail::map;
 
   using eve::deginrad;
   using v_t = eve::element_type_t<T>;
   auto ref  = [](auto e) -> v_t { return eve::sinpi(double(e / 180.0l)); };
 
-  TTS_ULP_EQUAL(sind[eve::quarter_circle](a0), map(ref, a0), 2);
-  TTS_ULP_EQUAL(sind(a0), map(ref, a0), 2);
-  TTS_ULP_EQUAL(sind(a1), map(ref, a1), 30);
-  TTS_ULP_EQUAL(sind(a2), map(ref, a2), 1024);
+  TTS_ULP_EQUAL(sind[eve::quarter_circle](a0), tts::map(ref, a0), 2);
+  TTS_ULP_EQUAL(sind(a0), tts::map(ref, a0), 2);
+  TTS_ULP_EQUAL(sind(a1), tts::map(ref, a1), 30);
+  TTS_ULP_EQUAL(sind(a2), tts::map(ref, a2), 1024);
 };
 
 TTS_CASE_TPL("Check return types of sind", eve::test::simd::ieee_reals)

--- a/test/unit/module/math/sindcosd.cpp
+++ b/test/unit/module/math/sindcosd.cpp
@@ -33,25 +33,24 @@ TTS_CASE_WITH("Check behavior of sindcosd on wide",
 <typename T>(T const& a0, T const& a1, T const& a2)
 {
   using eve::sindcosd;
-  using eve::detail::map;
 
   using v_t = eve::element_type_t<T>;
   auto refc = [](auto e) -> v_t { return eve::cosd(e); };
   auto refs = [](auto e) -> v_t { return eve::sind(e); };
   {
     auto [s, c] = sindcosd[eve::quarter_circle](a0);
-    TTS_ULP_EQUAL(s, map(refs, a0), 2);
-    TTS_ULP_EQUAL(c, map(refc, a0), 2);
+    TTS_ULP_EQUAL(s, tts::map(refs, a0), 2);
+    TTS_ULP_EQUAL(c, tts::map(refc, a0), 2);
   }
   {
     auto [s, c] = sindcosd(a0);
-    TTS_ULP_EQUAL(s, map(refs, a0), 2);
-    TTS_ULP_EQUAL(c, map(refc, a0), 2);
+    TTS_ULP_EQUAL(s, tts::map(refs, a0), 2);
+    TTS_ULP_EQUAL(c, tts::map(refc, a0), 2);
     auto [s1, c1] = sindcosd(a1);
-    TTS_ULP_EQUAL(s1, map(refs, a1), 2);
-    TTS_ULP_EQUAL(c1, map(refc, a1), 30);
+    TTS_ULP_EQUAL(s1, tts::map(refs, a1), 2);
+    TTS_ULP_EQUAL(c1, tts::map(refc, a1), 30);
     auto [s2, c2] = sindcosd(a2);
-    TTS_ULP_EQUAL(s2, map(refs, a2), 51);
-    TTS_ULP_EQUAL(c2, map(refc, a2), 51);
+    TTS_ULP_EQUAL(s2, tts::map(refs, a2), 51);
+    TTS_ULP_EQUAL(c2, tts::map(refc, a2), 51);
   }
 };

--- a/test/unit/module/math/sinh.cpp
+++ b/test/unit/module/math/sinh.cpp
@@ -43,13 +43,12 @@ TTS_CASE_WITH("Check behavior of sinh on wide",
                             tts::randoms(-1.0, 1.0)))
 <typename T>(T const& a0, T const& a1)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
   using eve::cosh;
   using eve::sinh;
 
-  TTS_ULP_EQUAL(sinh(a0), map([](auto e) -> v_t { return std::sinh(e); }, a0), 2);
-  TTS_ULP_EQUAL(sinh(a1), map([](auto e) -> v_t { return std::sinh(e); }, a1), 2);
+  TTS_ULP_EQUAL(sinh(a0), tts::map([](auto e) -> v_t { return std::sinh(e); }, a0), 2);
+  TTS_ULP_EQUAL(sinh(a1), tts::map([](auto e) -> v_t { return std::sinh(e); }, a1), 2);
 
   TTS_ULP_EQUAL(eve::sinh(eve::inf(eve::as<v_t>())), eve::inf(eve::as<v_t>()), 0.5);
   TTS_ULP_EQUAL(eve::sinh(eve::minf(eve::as<v_t>())), eve::minf(eve::as<v_t>()), 0.5);

--- a/test/unit/module/math/sinhc.cpp
+++ b/test/unit/module/math/sinhc.cpp
@@ -35,12 +35,11 @@ TTS_CASE_WITH("Check behavior of sinhc on wide",
 <typename T>(T const& a0, T const& a1)
 {
   using eve::sinhc;
-  using eve::detail::map;
 
   using v_t = eve::element_type_t<T>;
   auto ref  = [](auto e) -> v_t { return e ? std::sinh(e) / e : v_t(1); };
-  TTS_ULP_EQUAL(sinhc(a0), map(ref, a0), 2);
-  TTS_ULP_EQUAL(sinhc(a1), map(ref, a1), 2);
+  TTS_ULP_EQUAL(sinhc(a0), tts::map(ref, a0), 2);
+  TTS_ULP_EQUAL(sinhc(a1), tts::map(ref, a1), 2);
 };
 
 

--- a/test/unit/module/math/sinhcosh.cpp
+++ b/test/unit/module/math/sinhcosh.cpp
@@ -43,12 +43,11 @@ TTS_CASE_WITH("Check behavior of cos on wide",
 <typename T>(T const& a0)
 {
   using eve::sinhcosh;
-  using eve::detail::map;
 
   using v_t   = eve::element_type_t<T>;
   auto refc   = [](auto e) -> v_t { return std::cosh(e); };
   auto refs   = [](auto e) -> v_t { return std::sinh(e); };
   auto [s, c] = sinhcosh(a0);
-  TTS_ULP_EQUAL(s, map(refs, a0), 2);
-  TTS_ULP_EQUAL(c, map(refc, a0), 2);
+  TTS_ULP_EQUAL(s, tts::map(refs, a0), 2);
+  TTS_ULP_EQUAL(c, tts::map(refc, a0), 2);
 };

--- a/test/unit/module/math/sinpi.cpp
+++ b/test/unit/module/math/sinpi.cpp
@@ -42,12 +42,11 @@ TTS_CASE_WITH("Check behavior of sinpi on wide",
   <typename T>(T const& a0, T const& a1, T const& a2)
 {
   using eve::sinpi;
-  using eve::detail::map;
 
   using v_t = eve::element_type_t<T>;
   long double  pi = 3.1415926535897932384626433832795028841971693993751l;
   auto ref  = [pi](auto e) -> v_t { return std::sin((pi*(long double)e)); };
-  TTS_ULP_EQUAL(sinpi[eve::quarter_circle](a0), map(ref, a0), 2);
+  TTS_ULP_EQUAL(sinpi[eve::quarter_circle](a0), tts::map(ref, a0), 2);
   TTS_ULP_EQUAL(sinpi(a1), sinpi(eve::frac(a1)+eve::one[eve::is_odd(eve::trunc(a1))](eve::as(a1))), 2);
   TTS_ULP_EQUAL(sinpi(a2), sinpi(eve::frac(a2)+eve::one[eve::is_odd(eve::trunc(a2))](eve::as(a2))), 2);
 };

--- a/test/unit/module/math/sinpic.cpp
+++ b/test/unit/module/math/sinpic.cpp
@@ -36,13 +36,12 @@ TTS_CASE_WITH("Check behavior of sinpic on wide",
 <typename T>(T const& a0, T const& a1)
 {
   using eve::sinpic;
-  using eve::detail::map;
 
   using v_t = eve::element_type_t<T>;
   v_t  dpi  = 3.1415926535897932384626433832795028841971693993751;
   auto ref  = [dpi](auto e) -> v_t { return e ? eve::sinpi(e) / (dpi * e) : v_t(1); };
-  TTS_ULP_EQUAL(sinpic(a0), map(ref, a0), 3);
-  TTS_ULP_EQUAL(sinpic(a1), map(ref, a1), 3);
+  TTS_ULP_EQUAL(sinpic(a0), tts::map(ref, a0), 3);
+  TTS_ULP_EQUAL(sinpic(a1), tts::map(ref, a1), 3);
 };
 
 

--- a/test/unit/module/math/sinpicospi.cpp
+++ b/test/unit/module/math/sinpicospi.cpp
@@ -41,28 +41,27 @@ TTS_CASE_WITH("Check behavior of cos on wide",
 <typename T>(T const& a0, T const& a1, T const& a2, T const& a3)
 {
   using eve::sinpicospi;
-  using eve::detail::map;
 
   using v_t = eve::element_type_t<T>;
   auto refc = [](auto e) -> v_t { return eve::cospi(e); };
   auto refs = [](auto e) -> v_t { return eve::sinpi(e); };
   {
     auto [s, c] =  sinpicospi[eve::quarter_circle](a0);
-    TTS_ULP_EQUAL(s, map(refs, a0), 2);
-    TTS_ULP_EQUAL(c, map(refc, a0), 2);
+    TTS_ULP_EQUAL(s, tts::map(refs, a0), 2);
+    TTS_ULP_EQUAL(c, tts::map(refc, a0), 2);
   }
   {
     auto [s, c] = sinpicospi(a0);
-    TTS_ULP_EQUAL(s, map(refs, a0), 2);
-    TTS_ULP_EQUAL(c, map(refc, a0), 2);
+    TTS_ULP_EQUAL(s, tts::map(refs, a0), 2);
+    TTS_ULP_EQUAL(c, tts::map(refc, a0), 2);
     auto [s1, c1] = sinpicospi(a1);
-    TTS_ULP_EQUAL(s1, map(refs, a1), 2);
-    TTS_ULP_EQUAL(c1, map(refc, a1), 2);
+    TTS_ULP_EQUAL(s1, tts::map(refs, a1), 2);
+    TTS_ULP_EQUAL(c1, tts::map(refc, a1), 2);
     auto [s2, c2] = sinpicospi(a2);
-    TTS_ULP_EQUAL(s2, map(refs, a2), 2);
-    TTS_ULP_EQUAL(c2, map(refc, a2), 2);
+    TTS_ULP_EQUAL(s2, tts::map(refs, a2), 2);
+    TTS_ULP_EQUAL(c2, tts::map(refc, a2), 2);
     auto [s3, c3] = sinpicospi(a3);
-    TTS_ULP_EQUAL(s3, map(refs, a3), 2);
-    TTS_ULP_EQUAL(c3, map(refc, a3), 2);
+    TTS_ULP_EQUAL(s3, tts::map(refs, a3), 2);
+    TTS_ULP_EQUAL(c3, tts::map(refc, a3), 2);
   }
 };

--- a/test/unit/module/math/tan.cpp
+++ b/test/unit/module/math/tan.cpp
@@ -48,21 +48,20 @@ TTS_CASE_WITH("Check behavior of tan on wide",
 <typename T>(T const& a0, T const& a1, T const& a2, T const& a3, T const& a4)
 {
   using eve::tan;
-  using eve::detail::map;
 
   using v_t = eve::element_type_t<T>;
   auto ref  = [](auto e) -> v_t { return std::tan(double(e)); };
-  TTS_ULP_EQUAL(tan[eve::quarter_circle](a0), map(ref, a0), 2);
-  TTS_ULP_EQUAL(tan[eve::half_circle   ](a0), map(ref, a0), 2);
-  TTS_ULP_EQUAL(tan[eve::half_circle   ](a1), map(ref, a1), 2);
-  TTS_ULP_EQUAL(tan[eve::full_circle   ](a0), map(ref, a0), 4);
-  TTS_ULP_EQUAL(tan[eve::full_circle   ](a1), map(ref, a1), 4);
-  TTS_ULP_EQUAL(tan[eve::full_circle   ](a2), map(ref, a2), 4);
-  TTS_ULP_EQUAL(tan(a0), map(ref, a0), 4);
-  TTS_ULP_EQUAL(tan(a1), map(ref, a1), 4);
-  TTS_ULP_EQUAL(tan(a2), map(ref, a2), 4);
-  TTS_ULP_EQUAL(tan(a3), map(ref, a3), 4);
-  TTS_ULP_EQUAL(tan(a4), map(ref, a4), 4);
+  TTS_ULP_EQUAL(tan[eve::quarter_circle](a0), tts::map(ref, a0), 2);
+  TTS_ULP_EQUAL(tan[eve::half_circle   ](a0), tts::map(ref, a0), 2);
+  TTS_ULP_EQUAL(tan[eve::half_circle   ](a1), tts::map(ref, a1), 2);
+  TTS_ULP_EQUAL(tan[eve::full_circle   ](a0), tts::map(ref, a0), 4);
+  TTS_ULP_EQUAL(tan[eve::full_circle   ](a1), tts::map(ref, a1), 4);
+  TTS_ULP_EQUAL(tan[eve::full_circle   ](a2), tts::map(ref, a2), 4);
+  TTS_ULP_EQUAL(tan(a0), tts::map(ref, a0), 4);
+  TTS_ULP_EQUAL(tan(a1), tts::map(ref, a1), 4);
+  TTS_ULP_EQUAL(tan(a2), tts::map(ref, a2), 4);
+  TTS_ULP_EQUAL(tan(a3), tts::map(ref, a3), 4);
+  TTS_ULP_EQUAL(tan(a4), tts::map(ref, a4), 4);
 };
 
 

--- a/test/unit/module/math/tand.cpp
+++ b/test/unit/module/math/tand.cpp
@@ -35,7 +35,6 @@ TTS_CASE_WITH("Check behavior of tand on wide",
 <typename T>(T const& a0, T const& a1, T const& a2)
 {
   using eve::tand;
-  using eve::detail::map;
 
   using eve::deginrad;
   using v_t = eve::element_type_t<T>;
@@ -44,10 +43,10 @@ TTS_CASE_WITH("Check behavior of tand on wide",
     auto d = eve::cosd(e);
     return d ? eve::sind(e) / d : eve::nan(eve::as(e));
   };
-  TTS_ULP_EQUAL(tand[eve::quarter_circle](a0), map(ref, a0), 2);
-  TTS_ULP_EQUAL(tand(a0), map(ref, a0), 2);
-  TTS_ULP_EQUAL(tand(a1), map(ref, a1), 2);
-  TTS_ULP_EQUAL(tand(a2), map(ref, a2), 2);
+  TTS_ULP_EQUAL(tand[eve::quarter_circle](a0), tts::map(ref, a0), 2);
+  TTS_ULP_EQUAL(tand(a0), tts::map(ref, a0), 2);
+  TTS_ULP_EQUAL(tand(a1), tts::map(ref, a1), 2);
+  TTS_ULP_EQUAL(tand(a2), tts::map(ref, a2), 2);
 };
 
 

--- a/test/unit/module/math/tanh.cpp
+++ b/test/unit/module/math/tanh.cpp
@@ -43,11 +43,10 @@ TTS_CASE_WITH("Check behavior of tanh on wide",
                             tts::randoms(-1.0, 1.0)))
 <typename T>(T const& a0, T const& a1)
 {
-  using eve::detail::map;
   using v_t = eve::element_type_t<T>;
   using eve::tanh;
-  TTS_ULP_EQUAL(tanh(a0), map([](auto e) -> v_t { return std::tanh(double(e)); }, a0), 4);
-  TTS_ULP_EQUAL(tanh(a1), map([](auto e) -> v_t { return std::tanh(double(e)); }, a1), 4);
+  TTS_ULP_EQUAL(tanh(a0), tts::map([](auto e) -> v_t { return std::tanh(double(e)); }, a0), 4);
+  TTS_ULP_EQUAL(tanh(a1), tts::map([](auto e) -> v_t { return std::tanh(double(e)); }, a1), 4);
 };
 
 

--- a/test/unit/module/math/tanpi.cpp
+++ b/test/unit/module/math/tanpi.cpp
@@ -41,7 +41,6 @@ TTS_CASE_WITH("Check behavior of tanpi on wide",
 <typename T>(T const& a0, T const& a1, T const& a2, T const& a3)
 {
   using eve::tanpi;
-  using eve::detail::map;
 
   using eve::deginrad;
   using eve::pi;
@@ -51,11 +50,11 @@ TTS_CASE_WITH("Check behavior of tanpi on wide",
     auto d = eve::cospi(e);
     return d ? eve::sinpi(e) / d : eve::nan(eve::as(e));
   };
-  TTS_ULP_EQUAL(tanpi[eve::quarter_circle](a0), map(ref, a0), 2);
-  TTS_ULP_EQUAL(tanpi(a0), map(ref, a0), 2);
-  TTS_ULP_EQUAL(tanpi(a1), map(ref, a1), 2);
-  TTS_ULP_EQUAL(tanpi(a2), map(ref, a2), 2);
-  TTS_ULP_EQUAL(tanpi(a3), map(ref, a3), 2);
+  TTS_ULP_EQUAL(tanpi[eve::quarter_circle](a0), tts::map(ref, a0), 2);
+  TTS_ULP_EQUAL(tanpi(a0), tts::map(ref, a0), 2);
+  TTS_ULP_EQUAL(tanpi(a1), tts::map(ref, a1), 2);
+  TTS_ULP_EQUAL(tanpi(a2), tts::map(ref, a2), 2);
+  TTS_ULP_EQUAL(tanpi(a3), tts::map(ref, a3), 2);
 };
 
 

--- a/test/unit/module/polynomial/abel.cpp
+++ b/test/unit/module/polynomial/abel.cpp
@@ -37,9 +37,8 @@ TTS_CASE_WITH("Check behavior of abel on wide",
 <typename T, typename I>(T const& a0, T const& a1, I const&)
 {
   using v_t =  eve::element_type_t<T>;
-  auto std_abel = [](uint32_t n, auto x, auto a) ->v_t{ return x*std::pow(x-n*a, n-1); };
   for( unsigned int n = 1; n < 6; ++n )
   {
-    TTS_ULP_EQUAL(eve::abel(n, a0, a1), map(std_abel, n, a0, a1), 3.0);
+    TTS_ULP_EQUAL(eve::abel(n, a0, a1), tts::map([](auto x, auto a, uint32_t n) -> v_t { return x * std::pow(x - n * a, n - 1); }, a0, a1, n), 3.0);
   }
 };

--- a/test/unit/module/polynomial/jacobi.cpp
+++ b/test/unit/module/polynomial/jacobi.cpp
@@ -42,7 +42,7 @@ TTS_CASE_WITH( "Check behavior of diff jacobi on wide"
 {
   auto dt = eve::jacobi(i0, a0, a1, a2);
   auto bdt1 = [&](auto i, auto e, auto f,  auto g){return boost::math::jacobi(i, e, f, g); };
-  TTS_ULP_EQUAL(dt, eve::detail::map(bdt1, i0, a0, a1, a2), 1000);
+  TTS_ULP_EQUAL(dt, tts::map(bdt1, i0, a0, a1, a2), 1000);
 };
 #else
 TTS_CASE("Check return types of jacobi")

--- a/test/unit/module/polynomial/jacobi.cpp
+++ b/test/unit/module/polynomial/jacobi.cpp
@@ -41,8 +41,8 @@ TTS_CASE_WITH( "Check behavior of diff jacobi on wide"
   <typename T, typename I>(T const& a0, T const& a1, T const& a2, I const & i0)
 {
   auto dt = eve::jacobi(i0, a0, a1, a2);
-  auto bdt1 = [&](auto i, auto e, auto f,  auto g){return boost::math::jacobi(i, e, f, g); };
-  TTS_ULP_EQUAL(dt, tts::map(bdt1, i0, a0, a1, a2), 1000);
+  auto bdt1 = [&](auto e, auto f, auto g, auto i){return boost::math::jacobi(i, e, f, g); };
+  TTS_ULP_EQUAL(dt, tts::map(bdt1, a0, a1, a2, i0), 1000);
 };
 #else
 TTS_CASE("Check return types of jacobi")

--- a/test/unit/module/polynomial/legendre.inactive
+++ b/test/unit/module/polynomial/legendre.inactive
@@ -131,10 +131,10 @@ TTS_CASE_WITH("Check behavior of associated legendre p on wide",
   }
 
 #if defined(__cpp_lib_math_special_functions)
-  TTS_ULP_EQUAL(eve__legendrev(j0, i0, a0), map(std_assoc, j0, i0, a0), 100);
+  TTS_ULP_EQUAL(eve__legendrev(j0, i0, a0), tts::map(std_assoc, j0, i0, a0), 100);
 #endif
 
-  TTS_ULP_EQUAL(cse__legendrev(i0, j0, a0), map(boost_legendrev, i0, j0, a0), 100);
+  TTS_ULP_EQUAL(cse__legendrev(i0, j0, a0), tts::map(boost_legendrev, i0, j0, a0), 100);
 };
 
 /////////////spherical legendre
@@ -173,8 +173,8 @@ TTS_CASE_WITH("Check behavior of spherical legendre on wide",
 
   j0 = eve::min(i0, j0);
 #if defined(__cpp_lib_math_special_functions)
-  TTS_ULP_EQUAL(eve__slegendre(i0, j0, a0), map(std_slegendre, i0, j0, a0), 100);
+  TTS_ULP_EQUAL(eve__slegendre(i0, j0, a0), tts::map(std_slegendre, i0, j0, a0), 100);
 #else
-  TTS_RELATIVE_EQUAL(eve__slegendre(i0, j0, a0), map(boost_slegendre, i0, j0, a0), 0.01);
+  TTS_RELATIVE_EQUAL(eve__slegendre(i0, j0, a0), tts::map(boost_slegendre, i0, j0, a0), 0.01);
 #endif
 };

--- a/test/unit/module/polynomial/tchebytchev.cpp
+++ b/test/unit/module/polynomial/tchebytchev.cpp
@@ -54,10 +54,10 @@ TTS_CASE_WITH("Check behavior of tchebytchev on wide",
   auto eve__tchebytchev = [](uint32_t n, auto x) { return eve::tchebytchev(n, x); };
   for( unsigned int n = 0; n < 6; ++n )
   {
-    auto boost_tchebytchev = [&](auto i, auto e)
+    auto boost_tchebytchev = [&](auto e, auto i)
     { return boost::math::chebyshev_t((unsigned int)i, e); };
-    TTS_ULP_EQUAL(eve__tchebytchev(n, a0), tts::map(boost_tchebytchev, n, a0), 320);
-    TTS_ULP_EQUAL(eve__tchebytchev(n, a1), tts::map(boost_tchebytchev, n, a1), 320);
+    TTS_ULP_EQUAL(eve__tchebytchev(n, a0), tts::map(boost_tchebytchev, a0, n), 320);
+    TTS_ULP_EQUAL(eve__tchebytchev(n, a1), tts::map(boost_tchebytchev, a1, n), 320);
   }
 };
 

--- a/test/unit/module/polynomial/tchebytchev.cpp
+++ b/test/unit/module/polynomial/tchebytchev.cpp
@@ -56,8 +56,8 @@ TTS_CASE_WITH("Check behavior of tchebytchev on wide",
   {
     auto boost_tchebytchev = [&](auto i, auto e)
     { return boost::math::chebyshev_t((unsigned int)i, e); };
-    TTS_ULP_EQUAL(eve__tchebytchev(n, a0), map(boost_tchebytchev, n, a0), 320);
-    TTS_ULP_EQUAL(eve__tchebytchev(n, a1), map(boost_tchebytchev, n, a1), 320);
+    TTS_ULP_EQUAL(eve__tchebytchev(n, a0), tts::map(boost_tchebytchev, n, a0), 320);
+    TTS_ULP_EQUAL(eve__tchebytchev(n, a1), tts::map(boost_tchebytchev, n, a1), 320);
   }
 };
 

--- a/test/unit/module/special/beta.cpp
+++ b/test/unit/module/special/beta.cpp
@@ -40,7 +40,7 @@ TTS_CASE_WITH("Check behavior of beta on wide",
   using elt_t = eve::element_type_t<T>;
 
   TTS_ULP_EQUAL(
-      eve::beta(a0, a1), map([&](auto e, auto f) -> elt_t { return std::beta(e, f); }, a0, a1), 64);
+      eve::beta(a0, a1), tts::map([&](auto e, auto f) -> elt_t { return std::beta(e, f); }, a0, a1), 64);
   TTS_ULP_EQUAL(beta(T(-0.0), T(-0.0)), T(std::beta(elt_t(-0.0), elt_t(-0.0))), 0);
   TTS_ULP_EQUAL(beta(T(0.0), T(0.0)), T(std::beta(elt_t(0.0), elt_t(0.0))), 0);
   TTS_ULP_EQUAL(beta(T(1.0), T(1.0)), T(std::beta(elt_t(1.0), elt_t(1.0))), 0);

--- a/test/unit/module/special/erf.cpp
+++ b/test/unit/module/special/erf.cpp
@@ -35,7 +35,7 @@ TTS_CASE_WITH("Check behavior of erf on wide",
   using v_t = eve::element_type_t<T>;
   using eve::as;
   using eve::erf;
-  TTS_ULP_EQUAL(erf(a0), map([&](auto e) -> v_t { return std::erf(e); }, a0), 2);
+  TTS_ULP_EQUAL(erf(a0), tts::map([&](auto e) -> v_t { return std::erf(e); }, a0), 2);
   TTS_ULP_EQUAL(erf(T(0.5)), T(std::erf(v_t(0.5))), 1.);
   TTS_ULP_EQUAL(erf(T(-35)), T(std::erf(v_t(-35))), 0.5);
   TTS_ULP_EQUAL(

--- a/test/unit/module/special/erf_inv.cpp
+++ b/test/unit/module/special/erf_inv.cpp
@@ -39,7 +39,7 @@ TTS_CASE_WITH("Check behavior of erf_inv on wide",
   using v_t = eve::element_type_t<T>;
   using eve::as;
   using eve::erf_inv;
-  TTS_ULP_EQUAL(erf_inv(a0), map([](auto e) { return boost::math::erf_inv(e); }, a0), 8);
+  TTS_ULP_EQUAL(erf_inv(a0), tts::map([](auto e) { return boost::math::erf_inv(e); }, a0), 8);
   TTS_ULP_EQUAL(erf_inv(T(0.5)), T(boost::math::erf_inv(v_t(0.5))), 1.);
 
   if constexpr( eve::platform::supports_denormals )

--- a/test/unit/module/special/erfc.cpp
+++ b/test/unit/module/special/erfc.cpp
@@ -39,7 +39,7 @@ TTS_CASE_WITH("Check behavior of erfc on wide",
   using v_t = eve::element_type_t<T>;
   using eve::as;
   using eve::erfc;
-  TTS_ULP_EQUAL(erfc(a0), map([&](auto e) -> v_t { return std::erfc(e); }, a0), 30);
+  TTS_ULP_EQUAL(erfc(a0), tts::map([&](auto e) -> v_t { return std::erfc(e); }, a0), 30);
   TTS_ULP_EQUAL(erfc(T(0.5)), T(std::erfc(v_t(0.5))), 2.0);
   TTS_ULP_EQUAL(erfc(T(-35)), T(std::erfc(v_t(-35))), 0.5);
   TTS_ULP_EQUAL(

--- a/test/unit/module/special/erfc_inv.cpp
+++ b/test/unit/module/special/erfc_inv.cpp
@@ -46,7 +46,7 @@ TTS_CASE_WITH("Check behavior of erfc_inv on wide",
   using v_t = eve::element_type_t<T>;
   using eve::as;
   using eve::erfc_inv;
-  TTS_ULP_EQUAL(erfc_inv(a0), map([](auto e) { return boost::math::erfc_inv(e); }, a0), 2);
+  TTS_ULP_EQUAL(erfc_inv(a0), tts::map([](auto e) { return boost::math::erfc_inv(e); }, a0), 2);
   TTS_ULP_EQUAL(erfc_inv(T(0.5)), T(boost::math::erfc_inv(v_t(0.5))), 1.);
 
   if constexpr( eve::platform::supports_invalids )

--- a/test/unit/module/special/erfcx.cpp
+++ b/test/unit/module/special/erfcx.cpp
@@ -36,7 +36,7 @@ TTS_CASE_WITH("Check behavior of erfcx on wide",
   using eve::as;
   using eve::erfcx;
   TTS_ULP_EQUAL(
-      erfcx(a0), map([&](auto e) -> v_t { return std::exp(e * e) * std::erfc(e); }, a0), 8);
+      erfcx(a0), tts::map([&](auto e) -> v_t { return std::exp(e * e) * std::erfc(e); }, a0), 8);
   TTS_ULP_EQUAL(erfcx(T(-0.0)), T(1), 0);
   TTS_ULP_EQUAL(erfcx(T(0)), T(1), 0);
   TTS_ULP_EQUAL(erfcx(T(eve::epso_2(as<T>()))), T(0.999999999999999874724746818321), 0.5);

--- a/test/unit/module/special/exp_int.cpp
+++ b/test/unit/module/special/exp_int.cpp
@@ -47,7 +47,7 @@ TTS_CASE_WITH("Check behavior of exp_int on wide",
   using eve::exp_int;
   for( int i = 1; i < 4; ++i )
   {
-    TTS_ULP_EQUAL(exp_int(i, a0), map([i](auto e) { return boost::math::expint(i, e); }, a0), 24);
+    TTS_ULP_EQUAL(exp_int(i, a0), tts::map([i](auto e) { return boost::math::expint(i, e); }, a0), 24);
   }
 
   if constexpr( eve::platform::supports_invalids )

--- a/test/unit/module/special/gamma_p.cpp
+++ b/test/unit/module/special/gamma_p.cpp
@@ -43,7 +43,7 @@ TTS_CASE_WITH("Check behavior of gamma_p on wide",
   using v_t = eve::element_type_t<T>;
   using eve::gamma_p;
   TTS_RELATIVE_EQUAL(eve::gamma_p(a0, a1),
-                     map([&](auto e, auto f) -> v_t { return boost::math::gamma_p(f, e); }, a0, a1),
+                     tts::map([&](auto e, auto f) -> v_t { return boost::math::gamma_p(f, e); }, a0, a1),
                      1e-3);
 
   if constexpr( eve::platform::supports_invalids )

--- a/test/unit/module/special/gamma_p_inv.cpp
+++ b/test/unit/module/special/gamma_p_inv.cpp
@@ -43,7 +43,7 @@ TTS_CASE_WITH("Check behavior of gamma_p_inv on wide",
   using eve::gamma_p_inv;
   TTS_RELATIVE_EQUAL(
       eve::gamma_p_inv(a0, a1),
-      map([&](auto e, auto f) -> v_t { return boost::math::gamma_p_inv(f, e); }, a0, a1),
+      tts::map([&](auto e, auto f) -> v_t { return boost::math::gamma_p_inv(f, e); }, a0, a1),
       4);
 
   auto bggpi = [](auto e, auto f) { return boost::math::gamma_p_inv(f, e); };

--- a/test/unit/module/special/lambert.cpp
+++ b/test/unit/module/special/lambert.cpp
@@ -76,25 +76,25 @@ TTS_CASE_WITH("Check behavior of lambert on wide",
     { return eve::is_positive(v) ? boost::math::lambert_w0(v) : boost::math::lambert_wm1(v); };
     {
       auto [w0, wm1] = eve::lambert(a0);
-      TTS_ULP_EQUAL(w0, map(std_w0, a0), 10.0);
-      TTS_RELATIVE_EQUAL(wm1, map(std_wm1, a0), 0.001);
+      TTS_ULP_EQUAL(w0, tts::map(std_w0, a0), 10.0);
+      TTS_RELATIVE_EQUAL(wm1, tts::map(std_wm1, a0), 0.001);
     }
     {
       auto [w0, wm1] = eve::lambert(a1);
-      TTS_ULP_EQUAL(w0, map(std_w0, a1), 512.0);
-      TTS_RELATIVE_EQUAL(wm1, map(std_wm1, a1), 0.001);
+      TTS_ULP_EQUAL(w0, tts::map(std_w0, a1), 512.0);
+      TTS_RELATIVE_EQUAL(wm1, tts::map(std_wm1, a1), 0.001);
     }
     {
       elt_t tol      = 10000 * eve::eps(eve::as<elt_t>());
       auto [w0, wm1] = eve::lambert(a2);
-      TTS_ABSOLUTE_EQUAL(w0, map(std_w0, a2), tol);
-      TTS_ABSOLUTE_EQUAL(wm1, map(std_wm1, a2), tol);
+      TTS_ABSOLUTE_EQUAL(w0, tts::map(std_w0, a2), tol);
+      TTS_ABSOLUTE_EQUAL(wm1, tts::map(std_wm1, a2), tol);
     }
     {
       elt_t tol      = 10000 * eve::eps(eve::as<elt_t>());
       auto [w0, wm1] = eve::lambert(a3);
-      TTS_ABSOLUTE_EQUAL(w0, map(std_w0, a3), tol);
-      TTS_RELATIVE_EQUAL(wm1, map(std_wm1, a3), 0.001);
+      TTS_ABSOLUTE_EQUAL(w0, tts::map(std_w0, a3), tol);
+      TTS_RELATIVE_EQUAL(wm1, tts::map(std_wm1, a3), 0.001);
     }
   }
 };
@@ -143,25 +143,25 @@ TTS_CASE_WITH("Check behavior of lambert on wide",
     { return eve::is_positive(v) ? boost::math::lambert_w0(v) : boost::math::lambert_wm1(v); };
     {
       auto [w0, wm1] = eve::lambert(a0);
-      TTS_ULP_EQUAL(w0, map(std_w0, a0), 10.0);
-      TTS_RELATIVE_EQUAL(wm1, map(std_wm1, a0), 0.001);
+      TTS_ULP_EQUAL(w0, tts::map(std_w0, a0), 10.0);
+      TTS_RELATIVE_EQUAL(wm1, tts::map(std_wm1, a0), 0.001);
     }
     {
       auto [w0, wm1] = eve::lambert(a1);
-      TTS_ULP_EQUAL(w0, map(std_w0, a1), 512.0);
-      TTS_RELATIVE_EQUAL(wm1, map(std_wm1, a1), 0.001);
+      TTS_ULP_EQUAL(w0, tts::map(std_w0, a1), 512.0);
+      TTS_RELATIVE_EQUAL(wm1, tts::map(std_wm1, a1), 0.001);
     }
     {
       elt_t tol      = 10000 * eve::eps(eve::as<elt_t>());
       auto [w0, wm1] = eve::lambert(a2);
-      TTS_ABSOLUTE_EQUAL(w0, map(std_w0, a2), tol);
-      TTS_ABSOLUTE_EQUAL(wm1, map(std_wm1, a2), tol);
+      TTS_ABSOLUTE_EQUAL(w0, tts::map(std_w0, a2), tol);
+      TTS_ABSOLUTE_EQUAL(wm1, tts::map(std_wm1, a2), tol);
     }
     {
       elt_t tol      = 10000 * eve::eps(eve::as<elt_t>());
       auto [w0, wm1] = eve::lambert(a3);
-      TTS_ABSOLUTE_EQUAL(w0, map(std_w0, a3), tol);
-      TTS_RELATIVE_EQUAL(wm1, map(std_wm1, a3), 0.001);
+      TTS_ABSOLUTE_EQUAL(w0, tts::map(std_w0, a3), tol);
+      TTS_RELATIVE_EQUAL(wm1, tts::map(std_wm1, a3), 0.001);
     }
   }
 };

--- a/test/unit/module/special/lbeta.cpp
+++ b/test/unit/module/special/lbeta.cpp
@@ -40,7 +40,7 @@ TTS_CASE_WITH("Check behavior of lbeta on wide",
   using elt_t = eve::element_type_t<T>;
 
   TTS_ULP_EQUAL(
-    eve::lbeta(a0, a1), map([&](auto e, auto f) -> elt_t { return std::log(std::beta(e, f)); }, a0, a1), 64);
+    eve::lbeta(a0, a1), tts::map([&](auto e, auto f) -> elt_t { return std::log(std::beta(e, f)); }, a0, a1), 64);
   TTS_ULP_EQUAL(lbeta(T(-0.0), T(-0.0)), T(std::log(std::beta(elt_t(-0.0), elt_t(-0.0)))), 0);
   TTS_ULP_EQUAL(lbeta(T(0.0), T(0.0)), T(std::log(std::beta(elt_t(0.0), elt_t(0.0)))), 0);
   TTS_ULP_EQUAL(lbeta(T(1.0), T(1.0)), T(std::log(std::beta(elt_t(1.0), elt_t(1.0)))), 0);

--- a/test/unit/module/special/log_abs_gamma.cpp
+++ b/test/unit/module/special/log_abs_gamma.cpp
@@ -34,7 +34,7 @@ TTS_CASE_WITH("Check behavior of log_abs_gamma on wide",
 {
   using v_t = eve::element_type_t<T>;
   using eve::log_abs_gamma;
-  TTS_RELATIVE_EQUAL(log_abs_gamma(a0), map([&](auto e) -> v_t { return std::lgamma(e); }, a0), 0.1);
+  TTS_RELATIVE_EQUAL(log_abs_gamma(a0), tts::map([&](auto e) -> v_t { return std::lgamma(e); }, a0), 0.1);
 
   TTS_ULP_EQUAL(log_abs_gamma(T(0.5)), T(std::lgamma(v_t(0.5))), 1.);
   TTS_ULP_EQUAL(log_abs_gamma(T(-35)), T(std::lgamma(v_t(-35))), 0.5);

--- a/test/unit/module/special/log_gamma.cpp
+++ b/test/unit/module/special/log_gamma.cpp
@@ -34,7 +34,7 @@ TTS_CASE_WITH("Check behavior of log_gamma on wide",
 {
   using v_t = eve::element_type_t<T>;
   using eve::log_gamma;
-  TTS_RELATIVE_EQUAL(log_gamma(a0), map([&](auto e) -> v_t { auto x = std::lgamma(e);
+  TTS_RELATIVE_EQUAL(log_gamma(a0), tts::map([&](auto e) -> v_t { auto x = std::lgamma(e);
                                           return eve::is_lez(eve::signgam(e)) ?
                                             eve::nan(eve::as(e)) : x; }, a0), 5e-2);
 

--- a/test/unit/module/special/tgamma.cpp
+++ b/test/unit/module/special/tgamma.cpp
@@ -37,7 +37,7 @@ TTS_CASE_WITH("Check behavior of tgamma on wide",
 #if defined(__cpp_lib_math_special_functions)
   using v_t = eve::element_type_t<T>;
 
-  TTS_ULP_EQUAL(tgamma(a0), map([&](auto e) -> v_t { return std::tgamma(e); }, a0), 4);
+  TTS_ULP_EQUAL(tgamma(a0), tts::map([&](auto e) -> v_t { return std::tgamma(e); }, a0), 4);
 #endif // __cpp_lib_math_special_functions
 
   if constexpr( eve::platform::supports_invalids )

--- a/test/unit/module/special/zeta.cpp
+++ b/test/unit/module/special/zeta.cpp
@@ -38,7 +38,7 @@ TTS_CASE_WITH("Check behavior of zeta on wide",
 #if defined(__cpp_lib_math_special_functions)
   using v_t = eve::element_type_t<T>;
   TTS_RELATIVE_EQUAL(
-      zeta(a0), map([](auto e) -> v_t { return std::riemann_zeta(v_t(e)); }, a0), 0.4);
+      zeta(a0), tts::map([](auto e) -> v_t { return std::riemann_zeta(v_t(e)); }, a0), 0.4);
   TTS_ULP_EQUAL(eve::zeta(T(0)), T(std::riemann_zeta(v_t(0))), 0.5);
   TTS_ULP_EQUAL(eve::zeta(T(-0.0)), T(std::riemann_zeta(v_t(-0.0))), 0.5);
   TTS_ULP_EQUAL(eve::zeta(T(1.5)), T(std::riemann_zeta(v_t(1.5))), 1.5);


### PR DESCRIPTION
Removed reference to `eve::detail::map` from the unit tests.
This is in preparation for a larger PR that will sunset the current `eve::detail::map` function in favour of a new non-api-compatible implementation that reduces the number of template instantiations.

The new `tts::map` replacement should be easier for the compiler to type-check and is drop-in for the most part.
This new function return type is based on its first parameter which greatly simplify the return type computation, at the cost of having to pass wide parameters first. This only breaks one test, `unit.polynomial.abel.exe`, that was fixed by reordering some parameters inside a call to `map`.