### PR TITLE
Support compress for RISC-V

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -147,9 +147,11 @@ jobs:
           mkdir build && cd build
           cmake .. -G Ninja -DEVE_OPTIONS="${{ matrix.cfg.opts }}" -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchain/${{ matrix.cfg.comp }}.${{ matrix.cfg.arch }}.cmake
       - name: Compiling Unit Tests
-        run:  cd build && ninja unit.meta.exe unit.arch.exe  unit.core.bit_cast.exe unit.api.regular.wide.exe unit.core.simd_cast.exe -j 5
+        run:  cd build && ninja unit.meta.exe unit.arch.exe  unit.core.bit_cast.exe unit.api.regular.wide.exe unit.core.simd_cast.exe unit.core.count_true.exe unit.memory.store.exe unit.memory.store_equivalent.exe -j 5
+      - name: Compiling Big Unit Tests
+        run:  cd build && ninja unit.api.compress.exe -j 2
       - name: Running Unit Tests
-        run:  cd build && ctest --output-on-failure -j 4  -R "^unit.meta.*.exe|^unit.arch.*.exe|unit.core.bit_cast.exe|unit.api.regular.wide.exe|unit.core.simd_cast.exe"
+        run:  cd build && ctest --output-on-failure -j 4  -R "^unit.meta.*.exe|^unit.arch.*.exe|unit.core.bit_cast.exe|unit.api.regular.wide.exe|unit.core.simd_cast.exe|^unit.api.compress.*|unit.core.count_true.exe|unit.memory.store.*"
 
   ##################################################################################################
   ## Mac OS X Targets

--- a/include/eve/detail/function/simd/riscv/load.hpp
+++ b/include/eve/detail/function/simd/riscv/load.hpp
@@ -71,7 +71,7 @@ requires(rvv_abi<abi_t<T, N>>)
     return eve::replace_ignored(res, cond, cond.alternative);
   }
   else if constexpr( C::is_complete && !C::is_inverted ) return wide<T, N>(0);
-  else if constexpr( C::is_complete && C::is_inverted && N() == expected_cardinal_v<T> )
+  else if constexpr( C::is_complete && C::is_inverted )
   {
     return perform_alternative_load(rvv_true<T, N>(), tgt, ptr);
   }

--- a/include/eve/module/core/compress/compress.hpp
+++ b/include/eve/module/core/compress/compress.hpp
@@ -101,3 +101,7 @@ namespace eve
 #if defined(EVE_INCLUDE_ARM_SVE_HEADER)
 #  include <eve/module/core/compress/simd/arm/sve/compress.hpp>
 #endif
+
+#if defined(EVE_INCLUDE_RISCV_HEADER)
+#  include <eve/module/core/compress/simd/riscv/compress.hpp>
+#endif

--- a/include/eve/module/core/compress/simd/common/compress_copy.hpp
+++ b/include/eve/module/core/compress/simd/common/compress_copy.hpp
@@ -20,7 +20,8 @@ struct compress_copy_core
   {
     using COut = typename Settings::cond_out_t;
     if constexpr( eve::has_emulated_abi_v<L> ) return compress_copy_scalar;
-    else if constexpr( eve::current_api >= sve || eve::current_api >= avx512 )
+    else if constexpr( eve::current_api >= sve || eve::current_api >= avx512
+                       || eve::current_api >= rvv )
       return compress_copy_simd;
     else if constexpr( Settings::is_sparse || !COut::is_complete ) return compress_copy_scalar;
     else return compress_copy_simd;

--- a/include/eve/module/core/compress/simd/riscv/compress.hpp
+++ b/include/eve/module/core/compress/simd/riscv/compress.hpp
@@ -1,0 +1,27 @@
+//==================================================================================================
+/*
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+*/
+//==================================================================================================
+#pragma once
+#include <eve/conditional.hpp>
+namespace eve::detail
+{
+
+template<relative_conditional_expr C, typename T, typename N, typename U>
+EVE_FORCEINLINE auto
+compress_(EVE_SUPPORTS(rvv_), C c, wide<T, N> v, logical<wide<U, N>> mask) noexcept
+requires rvv_abi<abi_t<T, N>>
+{
+  auto                c_mask        = expand_mask(c, as<wide<T, N>> {});
+  auto                formated_mask = simd_cast(mask, as<logical<wide<T, N>>> {});
+  logical<wide<T, N>> real_mask     = __riscv_vmand(c_mask, formated_mask, N::value);
+  wide<T, N>          init {0};
+  wide<T, N>          compressed      = __riscv_vcompress_tu(init, v, real_mask, N::value);
+  auto                new_element_num = count_true(real_mask);
+  kumi::tuple         cur {compressed, new_element_num};
+  return kumi::tuple<decltype(cur)> {cur};
+}
+}

--- a/include/eve/module/core/regular/convert.hpp
+++ b/include/eve/module/core/regular/convert.hpp
@@ -103,3 +103,7 @@ namespace eve
 #if defined(EVE_INCLUDE_ARM_SVE_HEADER)
 #  include <eve/module/core/regular/impl/simd/arm/sve/convert.hpp>
 #endif
+
+#if defined(EVE_INCLUDE_RISCV_HEADER)
+#  include <eve/module/core/regular/impl/simd/riscv/convert.hpp>
+#endif

--- a/include/eve/module/core/regular/count_true.hpp
+++ b/include/eve/module/core/regular/count_true.hpp
@@ -81,3 +81,7 @@ EVE_MAKE_CALLABLE(count_true_, count_true);
 #if defined(EVE_INCLUDE_ARM_SVE_HEADER)
 #  include <eve/module/core/regular/impl/simd/arm/sve/count_true.hpp>
 #endif
+
+#if defined(EVE_INCLUDE_RISCV_HEADER)
+#  include <eve/module/core/regular/impl/simd/riscv/count_true.hpp>
+#endif

--- a/include/eve/module/core/regular/impl/simd/riscv/convert.hpp
+++ b/include/eve/module/core/regular/impl/simd/riscv/convert.hpp
@@ -1,0 +1,29 @@
+//==================================================================================================
+/*
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+*/
+//==================================================================================================
+#pragma once
+
+#include <eve/arch/riscv/rvv_utils.hpp>
+#include <eve/as.hpp>
+#include <eve/concept/value.hpp>
+#include <eve/detail/category.hpp>
+#include <eve/detail/function/bit_cast.hpp>
+#include <eve/detail/implementation.hpp>
+
+namespace eve::detail
+{
+
+template<value In, scalar_value Out>
+EVE_FORCEINLINE auto
+convert_impl(EVE_REQUIRES(rvv_), logical<In> v, as<logical<Out>> tgt) noexcept
+requires rvv_abi<typename In::abi_type>
+{
+  using out_t = as_wide_t<logical<Out>, cardinal_t<In>>;
+  return simd_cast(v, as<out_t> {});
+}
+
+}

--- a/include/eve/module/core/regular/impl/simd/riscv/count_true.hpp
+++ b/include/eve/module/core/regular/impl/simd/riscv/count_true.hpp
@@ -1,0 +1,48 @@
+//==================================================================================================
+/*
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+*/
+//==================================================================================================
+#pragma once
+
+#include <eve/concept/conditional.hpp>
+#include <eve/concept/value.hpp>
+#include <eve/detail/implementation.hpp>
+
+namespace eve::detail
+{
+template<scalar_value T, typename N, relative_conditional_expr C>
+EVE_FORCEINLINE std::ptrdiff_t
+                count_true_(EVE_SUPPORTS(cpu_), C cond, logical<wide<T, N>> v) noexcept
+requires rvv_abi<abi_t<T, N>>
+{
+  if constexpr( C::is_complete )
+  {
+    if constexpr( !C::is_inverted ) return 0;
+    else return __riscv_vcpop(v, N::value);
+  }
+  else
+  {
+    auto const m = cond.mask(as<wide<T, N>> {});
+    return __riscv_vcpop(m, v, N::value);
+  }
+}
+
+template<scalar_value T, typename N>
+EVE_FORCEINLINE std::ptrdiff_t
+                count_true_(EVE_SUPPORTS(rvv_), logical<wide<T, N>> v) noexcept
+requires rvv_abi<abi_t<T, N>>
+{
+  return count_true[ignore_none](v);
+}
+
+template<scalar_value T, typename N>
+EVE_FORCEINLINE std::ptrdiff_t
+                count_true_(EVE_SUPPORTS(rvv_), top_bits<logical<wide<T, N>>> v) noexcept
+requires rvv_abi<abi_t<T, N>>
+{
+  return count_true[ignore_none](v.storage);
+}
+}

--- a/include/eve/module/core/regular/impl/simd/riscv/store.hpp
+++ b/include/eve/module/core/regular/impl/simd/riscv/store.hpp
@@ -1,0 +1,77 @@
+//==================================================================================================
+/*
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+*/
+//==================================================================================================
+#pragma once
+#include <eve/arch/riscv/rvv_common_masks.hpp>
+#include <eve/concept/value.hpp>
+#include <eve/detail/category.hpp>
+#include <eve/detail/implementation.hpp>
+#include <eve/module/core/regular/unalign.hpp>
+
+namespace eve::detail
+{
+
+template<arithmetic_scalar_value T, typename N, simd_compatible_ptr<wide<T, N>> Ptr>
+EVE_FORCEINLINE void
+riscv_store(logical<wide<T, N>> mask, wide<T, N> v, Ptr p)
+requires rvv_abi<abi_t<T, N>>
+{
+  constexpr auto c = categorize<wide<T, N>>();
+  if constexpr( match(c, category::size8_) ) return __riscv_vse8(mask, p, v, N::value);
+  if constexpr( match(c, category::size16_) ) return __riscv_vse16(mask, p, v, N::value);
+  if constexpr( match(c, category::size32_) ) return __riscv_vse32(mask, p, v, N::value);
+  if constexpr( match(c, category::size64_) ) return __riscv_vse64(mask, p, v, N::value);
+}
+
+template<arithmetic_scalar_value T, typename N, simd_compatible_ptr<wide<T, N>> Ptr>
+EVE_FORCEINLINE void
+riscv_store(wide<T, N> v, Ptr p)
+requires rvv_abi<abi_t<T, N>>
+{
+  constexpr auto c = categorize<wide<T, N>>();
+  if constexpr( match(c, category::size8_) ) return __riscv_vse8(p, v, N::value);
+  if constexpr( match(c, category::size16_) ) return __riscv_vse16(p, v, N::value);
+  if constexpr( match(c, category::size32_) ) return __riscv_vse32(p, v, N::value);
+  if constexpr( match(c, category::size64_) ) return __riscv_vse64(p, v, N::value);
+}
+
+// Regular store
+template<arithmetic_scalar_value T, typename N, simd_compatible_ptr<wide<T, N>> Ptr>
+EVE_FORCEINLINE void
+store_(EVE_SUPPORTS(rvv_), wide<T, N> v, Ptr p)
+requires(rvv_abi<abi_t<T, N>> && !has_store_equivalent<wide<T, N>, Ptr>)
+{
+  auto const tgt = as<wide<T>> {};
+  auto       ptr = unalign(p);
+
+  return riscv_store(v, p);
+}
+
+// Conditional store
+template<scalar_value T,
+         typename N,
+         relative_conditional_expr       C,
+         simd_compatible_ptr<wide<T, N>> Ptr>
+EVE_FORCEINLINE void
+store_(EVE_SUPPORTS(rvv_), C const& cond, wide<T, N> const& v, Ptr ptr) noexcept
+requires rvv_abi<abi_t<T, N>> && (!has_store_equivalent<wide<T, N>, Ptr>)
+{
+  auto p = unalign(ptr);
+  if constexpr( C::is_complete )
+  {
+    if constexpr( !C::is_inverted ) return;
+    else return riscv_store(v, p);
+  }
+  else if constexpr( C::has_alternative )
+  {
+    auto full_data = eve::replace_ignored(v, cond, cond.alternative);
+    return riscv_store(full_data, p);
+  }
+  else riscv_store(cond.mask(as<wide<T, N>> {}), v, p);
+}
+
+}

--- a/include/eve/module/core/regular/store.hpp
+++ b/include/eve/module/core/regular/store.hpp
@@ -90,3 +90,7 @@ EVE_MAKE_CALLABLE(store_, store);
 #if defined(EVE_INCLUDE_ARM_SVE_HEADER)
 #  include <eve/module/core/regular/impl/simd/arm/sve/store.hpp>
 #endif
+
+#if defined(EVE_INCLUDE_RISCV_HEADER)
+#  include <eve/module/core/regular/impl/simd/riscv/store.hpp>
+#endif

--- a/test/tts/tts.hpp
+++ b/test/tts/tts.hpp
@@ -445,6 +445,7 @@ namespace tts
     }
     using type = decltype(filter_impl(Type {}));
   };
+
   template<typename T> struct type {};
   using real_types        = types < double,float>;
   using int_types         = types < std::int64_t , std::int32_t , std::int16_t , std::int8_t>;

--- a/test/unit/api/compress/compress_copy_logical.large.cpp
+++ b/test/unit/api/compress/compress_copy_logical.large.cpp
@@ -11,7 +11,7 @@
 
 using test_types = eve::test::wides<tts::types<double, std::int64_t, std::uint64_t, float, std::int32_t, std::uint32_t>>::type;
 
-TTS_CASE_TPL("Check compress copy logical", test_types)
+TTS_CASE_TPL("Check compress copy logical", simd_types_for_compress<test_types>)
 <typename T>(tts::type<T>) {
   compress_copy_tst(eve::as<eve::logical<T>>{}, eve::compress_copy);
 };

--- a/test/unit/api/compress/compress_copy_logical.small.cpp
+++ b/test/unit/api/compress/compress_copy_logical.small.cpp
@@ -11,7 +11,7 @@
 
 using test_types = eve::test::wides<tts::types<std::int16_t, std::uint16_t, std::int8_t, std::uint8_t>>::type;
 
-TTS_CASE_TPL("Check compress copy logical", test_types)
+TTS_CASE_TPL("Check compress copy logical", simd_types_for_compress<test_types>)
 <typename T>(tts::type<T>) {
   compress_copy_tst(eve::as<eve::logical<T>>{}, eve::compress_copy);
 };

--- a/test/unit/api/compress/compress_copy_scalar_logical.large.cpp
+++ b/test/unit/api/compress/compress_copy_scalar_logical.large.cpp
@@ -11,7 +11,7 @@
 
 using test_types = eve::test::wides<tts::types<double, std::int64_t, std::uint64_t, float, std::int32_t, std::uint32_t>>::type;
 
-TTS_CASE_TPL("Check compress copy logical", test_types)
+TTS_CASE_TPL("Check compress copy logical", simd_types_for_compress<test_types>)
 <typename T>(tts::type<T>) {
   compress_copy_tst(eve::as<eve::logical<T>>{}, eve::compress_copy_scalar);
 };

--- a/test/unit/api/compress/compress_copy_scalar_logical.small.cpp
+++ b/test/unit/api/compress/compress_copy_scalar_logical.small.cpp
@@ -11,7 +11,7 @@
 
 using test_types = eve::test::wides<tts::types<std::int16_t, std::uint16_t, std::int8_t, std::uint8_t>>::type;
 
-TTS_CASE_TPL("Check compress copy logical", test_types)
+TTS_CASE_TPL("Check compress copy logical", simd_types_for_compress<test_types>)
 <typename T>(tts::type<T>) {
   compress_copy_tst(eve::as<eve::logical<T>>{}, eve::compress_copy_scalar);
 };

--- a/test/unit/api/compress/compress_copy_scalar_tuple.large.cpp
+++ b/test/unit/api/compress/compress_copy_scalar_tuple.large.cpp
@@ -11,8 +11,9 @@
 
 using test_types = eve::test::wides<tts::types<double, std::int64_t, std::uint64_t, float, std::int32_t, std::uint32_t>>::type;
 
-TTS_CASE_TPL("Check compress copy behavior", test_types)
+TTS_CASE_TPL("Check compress copy behavior", simd_types_for_compress<test_types>)
 <typename T>(tts::type<T>) {
   using e_t = kumi::tuple<std::int8_t, eve::element_type_t<T>, double>;
-  compress_copy_tst(eve::as<eve::wide<e_t, typename T::cardinal_type>>{}, eve::compress_copy_scalar);
+  compress_copy_tst(eve::as<eve::wide<e_t, typename T::cardinal_type>> {},
+                    eve::compress_copy_scalar);
 };

--- a/test/unit/api/compress/compress_copy_scalar_tuple.small.cpp
+++ b/test/unit/api/compress/compress_copy_scalar_tuple.small.cpp
@@ -11,8 +11,9 @@
 
 using test_types = eve::test::wides<tts::types<std::int16_t, std::uint16_t, std::int8_t, std::uint8_t>>::type;
 
-TTS_CASE_TPL("Check compress copy behavior", test_types)
+TTS_CASE_TPL("Check compress copy behavior", simd_types_for_compress<test_types>)
 <typename T>(tts::type<T>) {
   using e_t = kumi::tuple<std::int8_t, eve::element_type_t<T>, double>;
-  compress_copy_tst(eve::as<eve::wide<e_t, typename T::cardinal_type>>{}, eve::compress_copy_scalar);
+  compress_copy_tst(eve::as<eve::wide<e_t, typename T::cardinal_type>> {},
+                    eve::compress_copy_scalar);
 };

--- a/test/unit/api/compress/compress_copy_scalar_wide.large.cpp
+++ b/test/unit/api/compress/compress_copy_scalar_wide.large.cpp
@@ -11,7 +11,7 @@
 
 using test_types = eve::test::wides<tts::types<double, std::int64_t, std::uint64_t, float, std::int32_t, std::uint32_t>>::type;
 
-TTS_CASE_TPL("Check compress copy behavior", test_types)
+TTS_CASE_TPL("Check compress copy behavior", simd_types_for_compress<test_types>)
 <typename T>(tts::type<T>) {
   compress_copy_tst(eve::as<T>{}, eve::compress_copy_scalar);
 };

--- a/test/unit/api/compress/compress_copy_scalar_wide.small.cpp
+++ b/test/unit/api/compress/compress_copy_scalar_wide.small.cpp
@@ -11,7 +11,7 @@
 
 using test_types = eve::test::wides<tts::types<std::int16_t, std::uint16_t, std::int8_t, std::uint8_t>>::type;
 
-TTS_CASE_TPL("Check compress copy behavior", test_types)
+TTS_CASE_TPL("Check compress copy behavior", simd_types_for_compress<test_types>)
 <typename T>(tts::type<T>) {
   compress_copy_tst(eve::as<T>{}, eve::compress_copy_scalar);
 };

--- a/test/unit/api/compress/compress_copy_simd_logical.large.cpp
+++ b/test/unit/api/compress/compress_copy_simd_logical.large.cpp
@@ -11,7 +11,7 @@
 
 using test_types = eve::test::wides<tts::types<double, std::int64_t, std::uint64_t, float, std::int32_t, std::uint32_t>>::type;
 
-TTS_CASE_TPL("Check compress copy logical", test_types)
+TTS_CASE_TPL("Check compress copy logical", simd_types_for_compress<test_types>)
 <typename T>(tts::type<T>) {
   compress_copy_tst(eve::as<eve::logical<T>>{}, eve::compress_copy_simd);
 };

--- a/test/unit/api/compress/compress_copy_simd_logical.small.cpp
+++ b/test/unit/api/compress/compress_copy_simd_logical.small.cpp
@@ -11,7 +11,7 @@
 
 using test_types = eve::test::wides<tts::types<std::int16_t, std::uint16_t, std::int8_t, std::uint8_t>>::type;
 
-TTS_CASE_TPL("Check compress copy logical", test_types)
+TTS_CASE_TPL("Check compress copy logical", simd_types_for_compress<test_types>)
 <typename T>(tts::type<T>) {
   compress_copy_tst(eve::as<eve::logical<T>>{}, eve::compress_copy_simd);
 };

--- a/test/unit/api/compress/compress_copy_simd_tuple.large.cpp
+++ b/test/unit/api/compress/compress_copy_simd_tuple.large.cpp
@@ -11,8 +11,8 @@
 
 using test_types = eve::test::wides<tts::types<double, std::int64_t, std::uint64_t, float, std::int32_t, std::uint32_t>>::type;
 
-TTS_CASE_TPL("Check compress copy behavior", eve::test::simd::all_types)
+TTS_CASE_TPL("Check compress copy behavior", simd_types_for_compress<test_types>)
 <typename T>(tts::type<T>) {
   using e_t = kumi::tuple<std::int8_t, eve::element_type_t<T>, double>;
-  compress_copy_tst(eve::as<eve::wide<e_t, typename T::cardinal_type>>{}, eve::compress_copy_simd);
+  compress_copy_tst(eve::as<eve::wide<e_t, typename T::cardinal_type>> {}, eve::compress_copy_simd);
 };

--- a/test/unit/api/compress/compress_copy_simd_tuple.small.cpp
+++ b/test/unit/api/compress/compress_copy_simd_tuple.small.cpp
@@ -9,8 +9,8 @@
 
 #include <eve/module/core.hpp>
 
-TTS_CASE_TPL("Check compress copy behavior", eve::test::simd::all_types)
+TTS_CASE_TPL("Check compress copy behavior", simd_types_for_compress<eve::test::simd::all_types>)
 <typename T>(tts::type<T>) {
   using e_t = kumi::tuple<std::int8_t, eve::element_type_t<T>, double>;
-  compress_copy_tst(eve::as<eve::wide<e_t, typename T::cardinal_type>>{}, eve::compress_copy_simd);
+  compress_copy_tst(eve::as<eve::wide<e_t, typename T::cardinal_type>> {}, eve::compress_copy_simd);
 };

--- a/test/unit/api/compress/compress_copy_simd_wide.large.cpp
+++ b/test/unit/api/compress/compress_copy_simd_wide.large.cpp
@@ -11,7 +11,7 @@
 
 using test_types = eve::test::wides<tts::types<double, std::int64_t, std::uint64_t, float, std::int32_t, std::uint32_t>>::type;
 
-TTS_CASE_TPL("Check compress copy behavior", test_types)
+TTS_CASE_TPL("Check compress copy behavior", simd_types_for_compress<test_types>)
 <typename T>(tts::type<T>) {
   compress_copy_tst(eve::as<T>{}, eve::compress_copy_simd);
 };

--- a/test/unit/api/compress/compress_copy_simd_wide.small.cpp
+++ b/test/unit/api/compress/compress_copy_simd_wide.small.cpp
@@ -11,7 +11,7 @@
 
 using test_types = eve::test::wides<tts::types<std::int16_t, std::uint16_t, std::int8_t, std::uint8_t>>::type;
 
-TTS_CASE_TPL("Check compress copy behavior", test_types)
+TTS_CASE_TPL("Check compress copy behavior", simd_types_for_compress<test_types>)
 <typename T>(tts::type<T>) {
   compress_copy_tst(eve::as<T>{}, eve::compress_copy_simd);
 };

--- a/test/unit/api/compress/compress_copy_test.hpp
+++ b/test/unit/api/compress/compress_copy_test.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 #include "test.hpp"
+#include "unit/api/compress/compress_test_filter.hpp"
 
 template<typename T>
 T
@@ -151,7 +152,8 @@ compress_copy_tst_mask(eve::as<T> tgt, L m, auto algo)
       for( int j = 0; j != T::size() - i; ++j ) { for_ignore_tests(eve::ignore_extrema(i, j)); }
     }
   }
-  else if constexpr( eve::has_bundle_abi_v<T> && eve::current_api >= eve::sve )
+  else if constexpr( eve::has_bundle_abi_v<T>
+                     && (eve::current_api >= eve::sve || eve::current_api >= eve::rvv) )
   {
     for_ignore_tests(eve::ignore_extrema(0, 0));
     for_ignore_tests(eve::ignore_extrema(5, 1));
@@ -222,7 +224,7 @@ compress_copy_tst(eve::as<T> tgt, auto algo)
     compress_copy_tst_l_type(eve::as<T> {}, eve::as<T> {}, eve::compress_copy);
 
     // is just impossibly slow
-    if constexpr( eve::current_api != eve::sve512 )
+    if constexpr( eve::current_api != eve::sve512 && eve::current_api != eve::rvv )
     {
       compress_copy_tst_l_type(
           eve::as<T> {}, eve::as<eve::logical<eve::wide<std::uint8_t, N>>> {}, eve::compress_copy);
@@ -240,7 +242,7 @@ compress_copy_tst(eve::as<T> tgt, auto algo)
     }
 
     // is just impossibly slow
-    if constexpr( eve::current_api != eve::sve512 )
+    if constexpr( eve::current_api != eve::sve512 && eve::current_api != eve::rvv )
     {
       if constexpr( !std::same_as<e_t, std::uint16_t> )
       {

--- a/test/unit/api/compress/compress_copy_tuple.large.cpp
+++ b/test/unit/api/compress/compress_copy_tuple.large.cpp
@@ -11,8 +11,8 @@
 
 using test_types = eve::test::wides<tts::types<double, std::int64_t, std::uint64_t, float, std::int32_t, std::uint32_t>>::type;
 
-TTS_CASE_TPL("Check compress copy behavior", eve::test::simd::all_types)
+TTS_CASE_TPL("Check compress copy behavior", simd_types_for_compress<test_types>)
 <typename T>(tts::type<T>) {
   using e_t = kumi::tuple<std::int8_t, eve::element_type_t<T>, double>;
-  compress_copy_tst(eve::as<eve::wide<e_t, typename T::cardinal_type>>{}, eve::compress_copy);
+  compress_copy_tst(eve::as<eve::wide<e_t, typename T::cardinal_type>> {}, eve::compress_copy);
 };

--- a/test/unit/api/compress/compress_copy_tuple.small.cpp
+++ b/test/unit/api/compress/compress_copy_tuple.small.cpp
@@ -11,8 +11,8 @@
 
 using test_types = eve::test::wides<tts::types<std::int16_t, std::uint16_t, std::int8_t, std::uint8_t>>::type;
 
-TTS_CASE_TPL("Check compress copy behavior", eve::test::simd::all_types)
+TTS_CASE_TPL("Check compress copy behavior", simd_types_for_compress<test_types>)
 <typename T>(tts::type<T>) {
   using e_t = kumi::tuple<std::int8_t, eve::element_type_t<T>, double>;
-  compress_copy_tst(eve::as<eve::wide<e_t, typename T::cardinal_type>>{}, eve::compress_copy);
+  compress_copy_tst(eve::as<eve::wide<e_t, typename T::cardinal_type>> {}, eve::compress_copy);
 };

--- a/test/unit/api/compress/compress_copy_wide.large.cpp
+++ b/test/unit/api/compress/compress_copy_wide.large.cpp
@@ -11,7 +11,7 @@
 
 using test_types = eve::test::wides<tts::types<double, std::int64_t, std::uint64_t, float, std::int32_t, std::uint32_t>>::type;
 
-TTS_CASE_TPL("Check compress copy behavior", test_types)
+TTS_CASE_TPL("Check compress copy behavior", simd_types_for_compress<test_types>)
 <typename T>(tts::type<T>) {
   compress_copy_tst(eve::as<T>{}, eve::compress_copy);
 };

--- a/test/unit/api/compress/compress_copy_wide.small.cpp
+++ b/test/unit/api/compress/compress_copy_wide.small.cpp
@@ -11,7 +11,7 @@
 
 using test_types = eve::test::wides<tts::types<std::int16_t, std::uint16_t, std::int8_t, std::uint8_t>>::type;
 
-TTS_CASE_TPL("Check compress copy behavior", test_types)
+TTS_CASE_TPL("Check compress copy behavior", simd_types_for_compress<test_types>)
 <typename T>(tts::type<T>) {
   compress_copy_tst(eve::as<T>{}, eve::compress_copy);
 };

--- a/test/unit/api/compress/compress_logical.cpp
+++ b/test/unit/api/compress/compress_logical.cpp
@@ -1,9 +1,8 @@
 #include "unit/api/compress/compress_test.hpp"
 
-TTS_CASE_WITH( "Check compress behavior for logicals"
-        , eve::test::simd::all_types
-        , tts::generate(tts::logicals(1,2))
-        )
+TTS_CASE_WITH("Check compress behavior for logicals",
+              simd_types_for_compress<eve::test::simd::all_types>,
+              tts::generate(tts::logicals(1, 2)))
 <typename L> (L logical_data)
 {
   using N = eve::fixed<L::size()>;

--- a/test/unit/api/compress/compress_test.hpp
+++ b/test/unit/api/compress/compress_test.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 #include "test.hpp"
+#include "unit/api/compress/compress_test_filter.hpp"
 
 #include <algorithm>
 #include <array>

--- a/test/unit/api/compress/compress_test_filter.hpp
+++ b/test/unit/api/compress/compress_test_filter.hpp
@@ -1,0 +1,22 @@
+
+//==================================================================================================
+/**
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+**/
+//==================================================================================================
+#pragma once
+#include "test.hpp"
+template<typename Type> struct rvv_compress_filter
+{
+  static constexpr bool value = eve::detail::is_one_of<eve::element_type_t<Type>>(
+      eve::detail::types<std::int8_t, std::uint16_t, float, double> {});
+};
+
+#ifdef SPY_SIMD_IS_RISCV_FIXED_RVV
+template<typename types_to_filter>
+using simd_types_for_compress = tts::filter<rvv_compress_filter, types_to_filter>::type;
+#else
+template<typename types_to_filter> using simd_types_for_compress = types_to_filter;
+#endif

--- a/test/unit/api/compress/compress_wide.cpp
+++ b/test/unit/api/compress/compress_wide.cpp
@@ -1,9 +1,8 @@
 #include "unit/api/compress/compress_test.hpp"
 
-TTS_CASE_WITH( "Check compress behavior"
-        , eve::test::simd::all_types
-        , tts::generate(tts::ramp(1))
-        )
+TTS_CASE_WITH("Check compress behavior",
+              simd_types_for_compress<eve::test::simd::all_types>,
+              tts::generate(tts::ramp(1)))
 <typename T> (T data)
 {
   compress_test<eve::logical<T>>(data);

--- a/test/unit/api/compress/compress_wide_diff_logicals.cpp
+++ b/test/unit/api/compress/compress_wide_diff_logicals.cpp
@@ -8,11 +8,9 @@
 #include "compress_test.hpp"
 #include <eve/module/core.hpp>
 
-
-TTS_CASE_WITH( "Check compress wide diff logicals"
-        , eve::test::simd::all_types
-        , tts::generate(tts::ramp(1))
-        )
+TTS_CASE_WITH("Check compress wide diff logicals",
+              simd_types_for_compress<eve::test::simd::all_types>,
+              tts::generate(tts::ramp(1)))
 <typename T> (T data)
 {
   using N = eve::fixed<T::size()>;


### PR DESCRIPTION
Hi

This patch adds support for `compress` for RISC-V.

Also I've added some needed support for `store`, `count_true` and minor support for `convert` implemented. For now unit tests for `convert` can not be added, as we have some problems with saturated arithmetics here.