### PR TITLE
unroll search

### DIFF
--- a/include/eve/module/algo.hpp
+++ b/include/eve/module/algo.hpp
@@ -30,12 +30,13 @@
 #include <eve/module/algo/algo/copy_if.hpp>
 #include <eve/module/algo/algo/equal.hpp>
 #include <eve/module/algo/algo/fill.hpp>
-#include <eve/module/algo/algo/find.hpp>
 #include <eve/module/algo/algo/find_last.hpp>
-#include <eve/module/algo/algo/for_each.hpp>
-#include <eve/module/algo/algo/for_each_iteration.hpp>
+#include <eve/module/algo/algo/find.hpp>
 #include <eve/module/algo/algo/for_each_iteration_fixed_overflow.hpp>
+#include <eve/module/algo/algo/for_each_iteration_with_expensive_optional_part.hpp>
+#include <eve/module/algo/algo/for_each_iteration.hpp>
 #include <eve/module/algo/algo/for_each_selected.hpp>
+#include <eve/module/algo/algo/for_each.hpp>
 #include <eve/module/algo/algo/inclusive_scan.hpp>
 #include <eve/module/algo/algo/iota.hpp>
 #include <eve/module/algo/algo/iterator_helpers.hpp>

--- a/include/eve/module/algo/algo/for_each_iteration_with_expensive_optional_part.hpp
+++ b/include/eve/module/algo/algo/for_each_iteration_with_expensive_optional_part.hpp
@@ -1,0 +1,250 @@
+//==================================================================================================
+/*
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+*/
+//==================================================================================================
+#pragma once
+
+#include <eve/module/algo/algo/concepts.hpp>
+#include <eve/module/algo/algo/traits.hpp>
+#include <eve/module/core.hpp>
+
+namespace eve::algo
+{
+
+enum class continue_break_expensive {
+  continue_,
+  break_,
+  expensive,
+};
+
+namespace detail
+{
+  struct for_each_iteration_with_expensive_optional_part_common
+  {
+      template <typename I, typename S, typename Delegate>
+      struct small_steps_lambda
+      {
+          I& f;
+          S& l;
+          continue_break_expensive& delegate_reply;
+          Delegate& delegate;
+
+          template <int i>
+          EVE_FORCEINLINE bool operator()(std::integral_constant<int, i>)
+          {
+            if (f == l) return true;
+
+            delegate_reply = delegate.step(f, eve::ignore_none);
+            f += iterator_cardinal_v<I>;
+
+            return delegate_reply != continue_break_expensive::continue_;
+          }
+      };
+
+      template<typename Traits, typename I, typename S, typename Delegate>
+      EVE_FORCEINLINE continue_break_expensive main_loop(Traits,
+                                      I &f,
+                                      S l,
+                                      Delegate &delegate) const {
+        auto delegate_reply = continue_break_expensive::continue_;
+        while (true) {
+          if (eve::detail::for_until_<0, 1, get_unrolling<Traits>()>(
+            small_steps_lambda<I, S, Delegate>{f, l, delegate_reply, delegate}
+          )) {
+            return delegate_reply;
+          }
+        }
+      }
+  };
+
+  template<typename Traits, iterator I, sentinel_for<I> S>
+  struct for_each_iteration_with_expensive_optional_part_precise_f_l
+      : for_each_iteration_with_expensive_optional_part_common
+  {
+    Traits traits;
+    I      base;
+    I      f;
+    S      l;
+
+    for_each_iteration_with_expensive_optional_part_precise_f_l(Traits t, I i, S s)
+        : traits(t)
+        , base(i)
+        , f(i)
+        , l(s)
+    {
+      EVE_ASSERT(((l - f) % iterator_cardinal_v<I> == 0),
+                 " len of the range is no divisible by cardinal "
+                     << "when `divisible by cardinal is passed`: " << "l - f: " << (l - f)
+                     << " iterator_cardinal_v<I>: " << iterator_cardinal_v<I>);
+    }
+
+    template<typename Delegate> EVE_FORCEINLINE void operator()(Delegate& delegate)
+    {
+      continue_break_expensive action;
+      while( true )
+      {
+        action = this->main_loop(traits, f, l, delegate);
+        if( action == continue_break_expensive::expensive) {
+          if( !delegate.expensive_part() ) {
+            continue;
+          }
+        }
+        return;
+      }
+    }
+  };
+
+  template<typename Traits, iterator I, sentinel_for<I> S>
+  struct for_each_iteration_with_expensive_optional_part_precise_f
+      : for_each_iteration_with_expensive_optional_part_common
+  {
+    Traits traits;
+    I      base;
+    I      f;
+    S      l;
+
+    for_each_iteration_with_expensive_optional_part_precise_f(Traits t, I i, S s)
+        : traits(t)
+        , base(i)
+        , f(i)
+        , l(s)
+    {}
+
+    template<typename Delegate> EVE_FORCEINLINE void operator()(Delegate& delegate)
+    {
+      I precise_l = f + (((l - f) / iterator_cardinal_v<I>)*iterator_cardinal_v<I>);
+
+      continue_break_expensive action = continue_break_expensive::continue_;
+
+    main_loop:
+      action = this->main_loop(traits, f, precise_l, delegate);
+      if( action == continue_break_expensive::break_ ) return;
+      if( action == continue_break_expensive::expensive ) goto expensive_part;
+
+      if( precise_l == l ) return;
+      {
+        eve::keep_first ignore {l - precise_l};
+        action = delegate.step(f, ignore);
+      }
+
+      if( action == continue_break_expensive::expensive ) {
+        // hack to exit after the `expensive_part` without any extra checks.
+        l = precise_l;
+        goto expensive_part;
+      }
+      return;
+
+    expensive_part:
+      if( delegate.expensive_part() ) return;
+      goto main_loop;
+    }
+  };
+
+  template<typename Traits, iterator I, sentinel_for<I> S>
+  struct for_each_iteration_with_expensive_optional_part_aligning
+    : for_each_iteration_with_expensive_optional_part_common
+  {
+    Traits traits;
+    I base;
+    I f;
+    S l;
+
+    for_each_iteration_with_expensive_optional_part_aligning(Traits traits, I f, S l)
+        : traits(traits)
+        , base(f.previous_partially_aligned())
+        , f(f)
+        , l(l)
+    {}
+
+    template<typename Delegate> EVE_FORCEINLINE void operator()(Delegate& delegate)
+    {
+      auto aligned_f = base;
+      auto aligned_l = (f + (l - f)).previous_partially_aligned();
+
+      continue_break_expensive action = continue_break_expensive::continue_;
+
+      eve::ignore_first ignore_first {f - aligned_f};
+
+      if( aligned_f != aligned_l )
+      {
+        action       = delegate.step(aligned_f, ignore_first);
+        ignore_first = eve::ignore_first {0};
+
+        if( action == continue_break_expensive::break_ ) return;
+        if( action == continue_break_expensive::expensive ) goto expensive_part;
+        aligned_f += iterator_cardinal_v<I>;
+
+     main_loop:
+        // handles aligned_f == aligned_l
+        action = this->main_loop(traits, aligned_f, aligned_l, delegate);
+        if( action == continue_break_expensive::break_ ) return;
+        if( action == continue_break_expensive::expensive ) goto expensive_part;
+      }
+
+      if( aligned_f == l ) { return; }
+
+      {
+        eve::ignore_last ignore_last {aligned_l + iterator_cardinal_v<I> - l};
+        action = delegate.step(aligned_l, ignore_first && ignore_last);
+      }
+      if( action == continue_break_expensive::expensive ) {
+        l = aligned_l;  // hack that pevents comming here after the expensive part
+        goto expensive_part;
+      }
+      return;
+
+    expensive_part:
+      if( delegate.expensive_part() ) return;
+      goto main_loop;
+    }
+  };
+}
+
+//================================================================================================
+//! @addtogroup algos
+//! @{
+//!    @var for_each_iteration_with_expensive_optional_part
+//!
+//!    @brief low level util for writing algorithms. A variation on for_each_iteration that has a
+//!    place for work we don't want duplicated in assembly.
+//!
+//!   **Defined in Header**
+//!
+//!   @code
+//!   #include <eve/module/algo.hpp>
+//!   @endcode
+//!
+//!   `for_each_iteration`, even if not unrolled, generates a few copies of the
+//!   callback code. For some algorithms we want to move out a piece of callback code
+//!   but we still don't want a function call. Think search: we want to move the more
+//!   expensive part of validating match outside.
+//!
+//!   You can find example usage in the search implementation.
+//! @}
+//================================================================================================
+struct
+{
+  template<typename Traits, iterator I, sentinel_for<I> S>
+  auto operator()(Traits traits, I f, S l) const
+  {
+    EVE_ASSERT(f != l,
+               "for_each_iteration_with_expensive_optional_part requires a non-empty range");
+    if constexpr( !Traits::contains(no_aligning) && !partially_aligned_iterator<I> )
+    {
+      return detail::for_each_iteration_with_expensive_optional_part_aligning {traits, f, l};
+    }
+    else if constexpr( Traits::contains(divisible_by_cardinal) )
+    {
+      return detail::for_each_iteration_with_expensive_optional_part_precise_f_l {traits, f, l};
+    }
+    else
+    {
+      return detail::for_each_iteration_with_expensive_optional_part_precise_f {traits, f, l};
+    }
+  }
+} inline constexpr for_each_iteration_with_expensive_optional_part;
+
+}

--- a/include/eve/module/algo/algo/for_each_iteration_with_expensive_optional_part.hpp
+++ b/include/eve/module/algo/algo/for_each_iteration_with_expensive_optional_part.hpp
@@ -156,11 +156,11 @@ namespace detail
     I      f;
     S      l;
 
-    for_each_iteration_with_expensive_optional_part_aligning(Traits traits, I f, S l)
-        : traits(traits)
-        , base(f.previous_partially_aligned())
-        , f(f)
-        , l(l)
+    for_each_iteration_with_expensive_optional_part_aligning(Traits t, I i, S s)
+        : traits(t)
+        , base(i.previous_partially_aligned())
+        , f(i)
+        , l(s)
     {}
 
     template<typename Delegate> EVE_FORCEINLINE void operator()(Delegate& delegate)

--- a/include/eve/module/algo/algo/for_each_iteration_with_expensive_optional_part.hpp
+++ b/include/eve/module/algo/algo/for_each_iteration_with_expensive_optional_part.hpp
@@ -28,7 +28,7 @@ namespace detail
     {
       while( f < l )
       {
-        if (delegate.step(f, eve::ignore_none)) return true;
+        if( delegate.step(f, eve::ignore_none) ) return true;
         f += iterator_cardinal_v<I>;
       }
       return false;
@@ -105,7 +105,7 @@ namespace detail
       {
         // expensive part before main loop should help when expensive part
         // it forms a separate while loop.
-        if( delegate.expensive_part() ) return;
+        if( delegate.expensive_part(f) ) return;
         f += iterator_cardinal_v<I>;
       main_loop:
         if( !this->main_loop(traits, f, unroll_l, l, delegate) ) return;
@@ -138,7 +138,7 @@ namespace detail
     // expensive part before main loop should help when expensive part
     // it forms a separate while loop.
     expensive_part:
-      if( delegate.expensive_part() ) return;
+      if( delegate.expensive_part(f) ) return;
       f += iterator_cardinal_v<I>;
     main_loop:
       if( this->main_loop(traits, f, unroll_l, precise_l, delegate) ) { goto expensive_part; }
@@ -184,7 +184,8 @@ namespace detail
         {
           bool first_step_res = delegate.step(aligned_f, ignore_first);
           ignore_first        = eve::ignore_first {0};
-          if( !first_step_res ) {
+          if( !first_step_res )
+          {
             aligned_f += iterator_cardinal_v<I>;
             goto main_loop;
           }
@@ -193,7 +194,7 @@ namespace detail
       // expensive part before main loop should help when expensive part
       // it forms a separate while loop.
       expensive_part:
-        if( delegate.expensive_part() ) return;
+        if( delegate.expensive_part(f) ) return;
         aligned_f += iterator_cardinal_v<I>;
       main_loop:
         // handles aligned_f == aligned_l

--- a/include/eve/module/algo/algo/for_each_iteration_with_expensive_optional_part.hpp
+++ b/include/eve/module/algo/algo/for_each_iteration_with_expensive_optional_part.hpp
@@ -35,10 +35,9 @@ namespace detail
     }
 
     template<typename Traits, typename I, typename S, typename Delegate>
-    EVE_FORCEINLINE bool main_loop(Traits tr, I& f, auto unroll_l, S l, Delegate& delegate) const
+    EVE_FORCEINLINE bool main_loop(Traits tr, I& f, auto /*unroll_l*/, S l, Delegate& delegate) const
     requires(get_unrolling<Traits>() == 1)
     {
-      (void)unroll_l;
       return no_unrolling_loop(tr, f, l, delegate);
     }
 
@@ -194,7 +193,7 @@ namespace detail
       // expensive part before main loop should help when expensive part
       // it forms a separate while loop.
       expensive_part:
-        if( delegate.expensive_part(f) ) return;
+        if( delegate.expensive_part(aligned_f) ) return;
         aligned_f += iterator_cardinal_v<I>;
       main_loop:
         // handles aligned_f == aligned_l

--- a/include/eve/module/algo/algo/for_each_iteration_with_expensive_optional_part.hpp
+++ b/include/eve/module/algo/algo/for_each_iteration_with_expensive_optional_part.hpp
@@ -35,12 +35,11 @@ namespace detail
           template <int i>
           EVE_FORCEINLINE bool operator()(std::integral_constant<int, i>)
           {
-            if (f == l) return true;
-
             delegate_reply = delegate.step(f, eve::ignore_none);
             f += iterator_cardinal_v<I>;
 
-            return delegate_reply != continue_break_expensive::continue_;
+            if (delegate_reply != continue_break_expensive::continue_) return true;
+            return f == l;
           }
       };
 
@@ -50,6 +49,8 @@ namespace detail
                                       S l,
                                       Delegate &delegate) const {
         auto delegate_reply = continue_break_expensive::continue_;
+        if (f == l) return delegate_reply;
+
         while (true) {
           if (eve::detail::for_until_<0, 1, get_unrolling<Traits>()>(
             small_steps_lambda<I, S, Delegate>{f, l, delegate_reply, delegate}

--- a/include/eve/module/algo/algo/search.hpp
+++ b/include/eve/module/algo/algo/search.hpp
@@ -57,7 +57,7 @@ namespace detail
         return res_t {verify, unalign(haystack_it)};
       }
 
-      EVE_FORCEINLINE auto tail(auto zip_it, eve::relative_conditional_expr auto ignore)
+      EVE_FORCEINLINE bool tail(auto zip_it, eve::relative_conditional_expr auto ignore)
       {
         pos = get<0>(zip_it);
 
@@ -66,30 +66,25 @@ namespace detail
         precheck     = equal_fn(haystack_front, needle_front);
 
         if (!eve::any[ignore](precheck)) {
-          return continue_break_expensive::continue_;
+          return false;
         }
 
         precheck = precheck && ignore.mask(as(precheck));
 
-        return continue_break_expensive::expensive;
+        return true;
       }
 
-      EVE_FORCEINLINE auto main_part(auto zip_it)
+      EVE_FORCEINLINE bool main_part(auto zip_it)
       {
         auto [haystack_front, haystack_back] = eve::load(zip_it);
 
         pos = get<0>(zip_it);
         precheck = equal_fn(haystack_front, needle_front) && equal_fn(haystack_back, needle_back);
-
-        if (!eve::any(precheck)) {
-          return continue_break_expensive::continue_;
-        }
-
-        return continue_break_expensive::expensive;
+        return eve::any(precheck);
       }
 
       template<eve::relative_conditional_expr C>
-      EVE_FORCEINLINE auto step(auto zip_it, C ignore)
+      EVE_FORCEINLINE bool step(auto zip_it, C ignore)
       {
         if constexpr( C::is_complete && C::is_inverted ) { return main_part(zip_it); }
         else { return tail(zip_it, ignore); }

--- a/include/eve/module/algo/algo/search.hpp
+++ b/include/eve/module/algo/algo/search.hpp
@@ -432,6 +432,6 @@ template<typename TraitsSupport> struct search_ : TraitsSupport
 //!
 //!   @godbolt{doc/algo/search.cpp}
 //================================================================================================
-inline constexpr auto search = function_with_traits<search_>[eve::algo::unroll<2>];
+inline constexpr auto search = function_with_traits<search_>[eve::algo::unroll<4>];
 
 }

--- a/test/unit/module/algo/algorithm/search_special_cases.cpp
+++ b/test/unit/module/algo/algorithm/search_special_cases.cpp
@@ -34,6 +34,15 @@ TTS_CASE("eve.algo.search, smoke test")
   TTS_EQUAL(found - haystack.begin(), 35);
 };
 
+TTS_CASE("eve.algo.search, doesn't stop bug")
+{
+  std::vector<std::int8_t> haystack(1000U, 1);
+  std::vector<std::int8_t> needle{1, 2, 1};
+
+  auto found = eve::algo::search(haystack, needle);
+  TTS_EQUAL(found - haystack.begin(), (std::ptrdiff_t)haystack.size());
+};
+
 TTS_CASE("eve.algo.search, last char of 32") {
   std::vector<std::int8_t> haystack;
   haystack.resize(32);

--- a/test/unit/module/algo/for_each_iteration_with_expensive_optional_part.cpp
+++ b/test/unit/module/algo/for_each_iteration_with_expensive_optional_part.cpp
@@ -1,0 +1,289 @@
+//==================================================================================================
+/**
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+**/
+//==================================================================================================
+
+#include "unit/module/algo/algo_test.hpp"
+
+#include <eve/module/algo.hpp>
+
+#include <cstdint>
+#include <vector>
+
+namespace {
+
+struct fixture
+{
+  fixture()
+  {
+    data.fill(0);
+    data[0] = data[1] = data[2] = data[3] = '_';
+  }
+
+  auto aligned_begin()
+  {
+    using ap = eve::aligned_ptr<char, eve::fixed<4>>;
+    return eve::algo::ptr_iterator<ap, eve::fixed<4>> {ap(data.begin())};
+  }
+
+  auto aligned_end() { return aligned_begin() + data.size(); }
+
+  auto unaligned_begin() { return eve::unalign(aligned_begin()); }
+  auto unaligned_end() { return eve::unalign(aligned_end()); }
+
+  std::string_view res() { return data.data(); }
+
+  alignas(64) std::array<char, 100> data;
+};
+
+struct test_delegate {
+  char* data;
+  std::vector<std::ptrdiff_t> where_to_expensive;
+  std::ptrdiff_t expensive_returns_true_at;
+  std::ptrdiff_t stop_at = -1;
+
+  std::ptrdiff_t where_to_expensive_pos = 0;
+  char* remembered_expesnive = nullptr;
+
+  test_delegate(
+    char* data,
+    std::vector<std::ptrdiff_t> where_to_expensive,
+    std::ptrdiff_t expensive_returns_true_at = -1,
+    std::ptrdiff_t stop_at = -1
+  ) : data(data),
+      where_to_expensive(where_to_expensive),
+      expensive_returns_true_at(expensive_returns_true_at),
+      stop_at(stop_at) {}
+
+  eve::algo::continue_break_expensive step(auto it, auto ignore) {
+
+    auto  tgt = eve::as<eve::wide<std::int8_t, eve::fixed<4>>> {};
+    char *ptr = it.ptr;
+
+    std::ptrdiff_t it_idx = it.ptr - data;
+    std::cerr << "step: it idx: " << it_idx << " ignore: " << ignore << std::endl;
+
+    for( std::ptrdiff_t i = ignore.offset(tgt); i; --i ) { *ptr++ = 'i'; }
+    for( std::ptrdiff_t i = ignore.count(tgt); i; --i ) {
+      *ptr++ = 'a';
+    }
+    for( std::ptrdiff_t i = ignore.roffset(tgt); i; --i ) { *ptr++ = 'i'; }
+
+    if (where_to_expensive_pos < std::ssize(where_to_expensive)) {
+      auto next_expensive = where_to_expensive[where_to_expensive_pos];
+
+      if ( it_idx <= next_expensive && next_expensive < it_idx + 4 ) {
+        remembered_expesnive = data + next_expensive;
+        return eve::algo::continue_break_expensive::expensive;
+      }
+    }
+
+    if ( stop_at != -1 && stop_at < it_idx + 4) {
+      return eve::algo::continue_break_expensive::break_;
+    }
+    return eve::algo::continue_break_expensive::continue_;
+  }
+
+  bool expensive_part() {
+    *remembered_expesnive = 'e';
+    if (remembered_expesnive - data == expensive_returns_true_at) {
+      return true;
+    }
+    return false;
+  }
+};
+
+template <bool align, int unroll>
+struct run_test_impl {
+  int offset;
+  int size;
+  std::vector<std::ptrdiff_t> where_to_expensive;
+  int expensive_returns_true_at;
+  int stop_at;
+
+
+  template <bool divisible>
+  std::string run_impl(
+    auto& fix,
+    auto f,
+    auto l
+  ) {
+    test_delegate d {
+      fix.data.data(),
+      where_to_expensive,
+      expensive_returns_true_at,
+      stop_at
+    };
+
+    auto iter = eve::algo::for_each_iteration_with_expensive_optional_part(
+      []{
+        if constexpr (align && !divisible) {
+          return eve::algo::traits{eve::algo::unroll<unroll>};
+        } else if constexpr (align && divisible) {
+          return eve::algo::traits{eve::algo::divisible_by_cardinal, eve::algo::unroll<unroll>};
+        } else if constexpr (!align && !divisible) {
+          return eve::algo::traits{eve::algo::no_aligning, eve::algo::unroll<unroll>};
+        } else if constexpr (!align && divisible) {
+          return eve::algo::traits{
+            eve::algo::no_aligning, eve::algo::divisible_by_cardinal, eve::algo::unroll<unroll>
+          };
+        }
+      }(),
+      f,
+      l
+    );
+    iter(d);
+    return std::string(fix.res());
+  }
+
+  std::string operator()() {
+    std::string res;
+    {
+      fixture fix;
+      auto f = fix.unaligned_begin() + offset;
+      auto l = f + size;
+      res = run_impl<false>(fix, f, l);
+    }
+
+    // just aligned
+    if (offset % 4 == 0) {
+      std::string res1;
+      fixture fix;
+      auto f = fix.aligned_begin() + offset;
+      auto l = eve::unalign(f) + size;
+      res1 = run_impl<false>(fix, f, l);
+      TTS_EQUAL(res, res1);
+    }
+
+    // just divisible
+    if (size % 4 == 0) {
+      std::string res1;
+      fixture fix;
+      auto f = fix.unaligned_begin() + offset;
+      auto l = eve::unalign(f) + size;
+      res1 = run_impl<true>(fix, f, l);
+      TTS_EQUAL(res, res1);
+    }
+
+    // 1. align/unaling divisible
+    if (offset % 4 == 0 && size % 4 == 0) {
+      std::string res1;
+      fixture fix;
+      auto f = fix.aligned_begin() + offset;
+      auto l = eve::unalign(f) + size;
+      res1 = run_impl<true>(fix, f, l);
+      TTS_EQUAL(res, res1);
+    }
+
+    // 2. aligned both ends
+    if (offset % 4 == 0 && size % 4 == 0) {
+      std::string res1;
+      fixture fix;
+      auto f = fix.aligned_begin() + offset;
+      auto l = f + size;
+      res1 = run_impl<true>(fix, f, l);
+      TTS_EQUAL(res, res1);
+    }
+
+    return res;
+  }
+};
+
+template <bool align>
+std::string
+run_test(
+  int offset,
+  int size,
+  std::vector<std::ptrdiff_t> where_to_expensive = {},
+  int expensive_returns_true_at = -1,
+  int stop_at = -1
+) {
+  std::string unroll1 = run_test_impl<align, 1>{
+    offset,
+    size,
+    where_to_expensive,
+    expensive_returns_true_at,
+    stop_at
+  }();
+
+  std::string unroll2 = run_test_impl<align, 2>{
+    offset,
+    size,
+    where_to_expensive,
+    expensive_returns_true_at,
+    stop_at
+  }();
+
+  std::string unroll4 = run_test_impl<align, 4>{
+    offset,
+    size,
+    where_to_expensive,
+    expensive_returns_true_at,
+    stop_at
+  }();
+
+  TTS_EQUAL(unroll1, unroll2);
+  TTS_EQUAL(unroll1, unroll4);
+  return unroll1;
+}
+
+}  // namespace
+
+TTS_CASE("eve.algo.for_each_iteration_with_expensive_optional_part, aligning, no matches") {
+  TTS_EQUAL(run_test<true>(0, 1), "aiii");
+  TTS_EQUAL(run_test<true>(0, 2), "aaii");
+  TTS_EQUAL(run_test<true>(1, 1), "iaii");
+  TTS_EQUAL(run_test<true>(1, 2), "iaai");
+  TTS_EQUAL(run_test<true>(1, 3), "iaaa");
+
+  TTS_EQUAL(run_test<true>(0, 8),
+    "aaaa"
+    "aaaa");
+
+  TTS_EQUAL(run_test<true>(1, 14),
+    "iaaa"
+    "aaaa"
+    "aaaa"
+    "aaai");
+};
+
+TTS_CASE("eve.algo.for_each_iteration_with_expensive_optional_part, no aligning, no matches") {
+  TTS_EQUAL(run_test<false>(0, 1), "aiii");
+  TTS_EQUAL(run_test<false>(0, 2), "aaii");
+  TTS_EQUAL(run_test<false>(1, 1), "_aiii");
+  TTS_EQUAL(run_test<false>(1, 2), "_aaii");
+  TTS_EQUAL(run_test<false>(1, 3), "_aaai");
+
+  TTS_EQUAL(run_test<false>(0, 8),
+    "aaaa"
+    "aaaa");
+
+  TTS_EQUAL(run_test<false>(1, 8),
+    "_"
+    "aaaa"
+    "aaaa");
+
+  TTS_EQUAL(run_test<false>(1, 14),
+    "_"
+    "aaaa"
+    "aaaa"
+    "aaaa"
+    "aaii");
+};
+
+TTS_CASE("eve.algo.for_each_iteration_with_expensive_optional_part, aligning, some expensive") {
+  TTS_EQUAL(run_test<true>(
+    0, 1,
+    /*where to expensive*/ {0}
+  ),
+  "eiii");
+  TTS_EQUAL(run_test<true>(
+    0, 4,
+    /*where to expensive*/ {0, 1, 2, 3}
+  ),
+  "eaaa");
+
+};

--- a/test/unit/module/algo/for_each_iteration_with_expensive_optional_part.cpp
+++ b/test/unit/module/algo/for_each_iteration_with_expensive_optional_part.cpp
@@ -15,6 +15,8 @@
 
 namespace {
 
+constexpr std::size_t kMaxTestDataSize = 100;
+
 struct fixture
 {
   fixture()
@@ -36,7 +38,7 @@ struct fixture
 
   std::string_view res() { return data.data(); }
 
-  alignas(64) std::array<char, 100> data;
+  alignas(64) std::array<char, kMaxTestDataSize> data;
 };
 
 struct test_delegate {
@@ -62,6 +64,7 @@ struct test_delegate {
 
     std::ptrdiff_t it_idx = it.ptr - data;
     std::cerr << "step: it idx: " << it_idx << " ignore: " << ignore << std::endl;
+    TTS_LESS_EQUAL(it_idx, (std::ptrdiff_t)kMaxTestDataSize, REQUIRED) << "sanity check";
 
     for( std::ptrdiff_t i = ignore.offset(tgt); i; --i ) { *ptr++ = 'i'; }
     for( std::ptrdiff_t i = ignore.count(tgt); i; --i ) {
@@ -96,7 +99,6 @@ struct run_test_impl {
   int size;
   std::vector<std::ptrdiff_t> where_to_expensive;
   int expensive_returns_true_at;
-
 
   template <bool divisible>
   std::string run_impl(

--- a/test/unit/module/algo/for_each_iteration_with_expensive_optional_part.cpp
+++ b/test/unit/module/algo/for_each_iteration_with_expensive_optional_part.cpp
@@ -47,7 +47,7 @@ struct test_delegate {
   std::ptrdiff_t expensive_returns_true_at;
 
   std::ptrdiff_t where_to_expensive_pos = 0;
-  char* remembered_expesnive = nullptr;
+  std::ptrdiff_t expensive_offset = 0;
 
   test_delegate(
     char* data,
@@ -76,7 +76,7 @@ struct test_delegate {
       auto next_expensive = where_to_expensive[where_to_expensive_pos];
 
       if ( it_idx <= next_expensive && next_expensive < it_idx + 4 ) {
-        remembered_expesnive = data + next_expensive;
+        expensive_offset = next_expensive - it_idx;
         return true;
       }
     }
@@ -84,9 +84,10 @@ struct test_delegate {
     return false;
   }
 
-  bool expensive_part() {
-    *remembered_expesnive = 'e';
-    if (remembered_expesnive - data == expensive_returns_true_at) {
+  bool expensive_part(auto base_expensive) {
+    char* where_to_write = data + (base_expensive.ptr - data) + expensive_offset;
+    *where_to_write = 'e';
+    if (where_to_write - data == expensive_returns_true_at) {
       return true;
     }
     return false;

--- a/test/unit/module/algo/for_each_iteration_with_expensive_optional_part.cpp
+++ b/test/unit/module/algo/for_each_iteration_with_expensive_optional_part.cpp
@@ -69,7 +69,10 @@ struct test_delegate
     TTS_LESS_EQUAL(it_idx, (std::ptrdiff_t)kMaxTestDataSize, REQUIRED) << "sanity check";
 
     for( std::ptrdiff_t i = ignore.offset(tgt); i; --i ) { *ptr++ = 'i'; }
-    for( std::ptrdiff_t i = ignore.count(tgt); i; --i ) { *ptr++ = 'a'; }
+    for( std::ptrdiff_t i = ignore.count(tgt); i; --i ) {
+      TTS_EXPECT(*ptr == 0 || *ptr == '_') << "repeated processing: " << *ptr << " ptr - data: "  << (ptr - data);
+      *ptr++ = 'a';
+    }
     for( std::ptrdiff_t i = ignore.roffset(tgt); i; --i ) { *ptr++ = 'i'; }
 
     if( where_to_expensive_pos < std::ssize(where_to_expensive) )
@@ -89,6 +92,7 @@ struct test_delegate
   bool expensive_part(auto base_expensive)
   {
     char *where_to_write = data + (base_expensive.ptr - data) + expensive_offset;
+    TTS_EQUAL(*where_to_write, 'a') << "repeated processing";
     *where_to_write      = 'e';
     if( where_to_write - data == expensive_returns_true_at ) { return true; }
     return false;

--- a/test/unit/module/algo/iteration_test.hpp
+++ b/test/unit/module/algo/iteration_test.hpp
@@ -1,3 +1,10 @@
+//==================================================================================================
+/**
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+**/
+//==================================================================================================
 
 #include "unit/module/algo/algo_test.hpp"
 


### PR DESCRIPTION
unrolling search while also putting the "check for match" in an isolated place to make the codegen smaller.

I need to add more tests for iteration but other than that should be revieable.

The benchmarks for this also need improvements, the simplest (and not a very good one) is find for one char.

Here is the numbers for that (you should look at the best one always).

This is timing for find (baseline)

```
/name:find 0/size:10000/type:char/algorithm:eve::algo::find_if/percentage:100/padding:0      55.5 ns         55.5 ns     12491744
/name:find 0/size:10000/type:char/algorithm:eve::algo::find_if/percentage:100/padding:8      55.8 ns         55.8 ns     12606370
/name:find 0/size:10000/type:char/algorithm:eve::algo::find_if/percentage:100/padding:16     89.2 ns         89.2 ns      7866881
/name:find 0/size:10000/type:char/algorithm:eve::algo::find_if/percentage:100/padding:24     87.9 ns         87.9 ns      7962216
/name:find 0/size:10000/type:char/algorithm:eve::algo::find_if/percentage:100/padding:32     62.9 ns         62.9 ns     11197921
/name:find 0/size:10000/type:char/algorithm:eve::algo::find_if/percentage:100/padding:40     60.6 ns         60.6 ns     11972006
/name:find 0/size:10000/type:char/algorithm:eve::algo::find_if/percentage:100/padding:48     75.7 ns         75.7 ns      9416124
/name:find 0/size:10000/type:char/algorithm:eve::algo::find_if/percentage:100/padding:56     73.2 ns         73.2 ns      9590033
```

This is the performance for search for a single char now:

```
/name:find 0/size:10000/type:char/algorithm:eve::algo::search/percentage:100/padding:0         166 ns          166 ns      4209565
/name:find 0/size:10000/type:char/algorithm:eve::algo::search/percentage:100/padding:8         129 ns          129 ns      5348094
/name:find 0/size:10000/type:char/algorithm:eve::algo::search/percentage:100/padding:16        126 ns          126 ns      5584025
/name:find 0/size:10000/type:char/algorithm:eve::algo::search/percentage:100/padding:24        152 ns          152 ns      4592188
/name:find 0/size:10000/type:char/algorithm:eve::algo::search/percentage:100/padding:32        150 ns          150 ns      4663308
/name:find 0/size:10000/type:char/algorithm:eve::algo::search/percentage:100/padding:40        129 ns          129 ns      5412031
/name:find 0/size:10000/type:char/algorithm:eve::algo::search/percentage:100/padding:48        125 ns          125 ns      5611149
/name:find 0/size:10000/type:char/algorithm:eve::algo::search/percentage:100/padding:56        166 ns          166 ns      4205887
```

This is the performance for search for a single char before:

```
----------------------------------------------------------------------------------------------------------------------------------
Benchmark                                                                                        Time             CPU   Iterations
----------------------------------------------------------------------------------------------------------------------------------
/name:find 0/size:10000/type:char/algorithm:eve::algo::search/percentage:100/padding:0         140 ns          140 ns      4937022
/name:find 0/size:10000/type:char/algorithm:eve::algo::search/percentage:100/padding:8         200 ns          200 ns      3499883
/name:find 0/size:10000/type:char/algorithm:eve::algo::search/percentage:100/padding:16        200 ns          200 ns      3511696
/name:find 0/size:10000/type:char/algorithm:eve::algo::search/percentage:100/padding:24        138 ns          138 ns      5085738
/name:find 0/size:10000/type:char/algorithm:eve::algo::search/percentage:100/padding:32        137 ns          137 ns      5099563
/name:find 0/size:10000/type:char/algorithm:eve::algo::search/percentage:100/padding:40        167 ns          167 ns      4232450
/name:find 0/size:10000/type:char/algorithm:eve::algo::search/percentage:100/padding:48        167 ns          167 ns      4253506
/name:find 0/size:10000/type:char/algorithm:eve::algo::search/percentage:100/padding:56        138 ns          138 ns      5061660
```
