### PR TITLE
Cleanup emulated ABI handling

### DIFF
--- a/include/eve/module/core/regular/impl/rotl.hpp
+++ b/include/eve/module/core/regular/impl/rotl.hpp
@@ -26,9 +26,8 @@ namespace eve::detail
       if( n >= 0 ) return (v << n) | (v >> (-n & width));
       else         return (v << n) | (v >> n);
     }
-    else if constexpr( scalar_value<T> )                            return rotl[o](as_wide_as_t<T,S>(v), s);
-    else if constexpr( has_native_abi_v<T> && has_native_abi_v<S>)  return map(rotl[o], v, s);
-    else                                                            return apply_over(rotl[o], v, s);
+    else if constexpr (scalar_value<T>) return rotl[o](as_wide_as_t<T,S>(v), s);
+    else                                return map(rotl[o], v, s);
   }
 
   template<typename T, auto S, callable_options O>

--- a/include/eve/module/core/regular/saturate.hpp
+++ b/include/eve/module/core/regular/saturate.hpp
@@ -160,10 +160,6 @@ namespace eve
 
         if constexpr( std::same_as<elt_u, Target> )
           return a0;
-        else if constexpr( has_aggregated_abi_v<U> )
-          return aggregate(eve::saturate, a0, at);
-        else if constexpr( has_emulated_abi_v<U> )
-          return map(eve::saturate, a0, at);
         else
         {
           if constexpr( std::is_floating_point_v<Target> ) // saturating to floating point

--- a/include/eve/module/core/regular/saturate.hpp
+++ b/include/eve/module/core/regular/saturate.hpp
@@ -25,7 +25,7 @@ namespace eve
   struct saturate_t : strict_elementwise_callable<saturate_t, Options>
   {
     template<value U, scalar_value T>
-    EVE_FORCEINLINE constexpr U operator()(U t0, as<T> const & target) const noexcept
+    EVE_FORCEINLINE constexpr U operator()(U t0, as<T> target) const noexcept
     {
       return EVE_DISPATCH_CALL(t0, target);
     }
@@ -84,7 +84,7 @@ namespace eve
     EVE_FORCEINLINE constexpr U saturate_(EVE_REQUIRES(cpu_),
                                                O const &,
                                                U const & a0,
-                                               as<Target> const & at) noexcept
+                                               as<Target>) noexcept
     {
       if constexpr( scalar_value<U>)
       {

--- a/include/eve/module/math/regular/acospi.hpp
+++ b/include/eve/module/math/regular/acospi.hpp
@@ -89,8 +89,7 @@ struct acospi_t : elementwise_callable<acospi_t, Options, raw_option>
     template<typename T, callable_options O>
     constexpr EVE_FORCEINLINE T acospi_(EVE_REQUIRES(cpu_), O const& o, T const& a0)
     {
-      if constexpr( has_native_abi_v<T> ) return radinpi(acos[o](a0));
-      else                                return apply_over(acospi[o], a0);
+      return radinpi(acos[o](a0));
     }
   }
 }

--- a/include/eve/module/math/regular/cbrt.hpp
+++ b/include/eve/module/math/regular/cbrt.hpp
@@ -74,45 +74,40 @@ namespace eve
   namespace detail
   {
     template<eve::floating_value T, callable_options O>
-    EVE_FORCEINLINE constexpr auto
-    cbrt_(EVE_REQUIRES(cpu_), O const & , T x) noexcept
+    EVE_FORCEINLINE constexpr auto cbrt_(EVE_REQUIRES(cpu_), O const& , T x) noexcept
     {
-      if constexpr( has_native_abi_v<T> )
-      {
-        using vt_t = element_type_t<T>;
-        auto test0 = is_eqz(x) || is_not_finite(x);
-        if constexpr( eve::scalar_value<T> )
-          if( test0 ) return x;
-        constexpr vt_t factor[5] = {0.6299605249474365823836,
-                                    0.793700525984099737376,
-                                    1.0,
-                                    1.2599210498948731647672,
-                                    1.587401051968199474751};
-        auto           ax        = eve::abs(x);
-        auto           test      = is_less(eve::abs(x), T(100) * smallestposval(eve::as<T>()));
-        ax                       = ldexp[test](ax, 54);
-        /* Reduce x.  xm now is an range  [0.5, 1.0].  */
-        auto [xm, xe] = ifrexp[raw](ax);
-        T u;
-        if constexpr( std::is_same_v<vt_t, double> )
-          u = eve::reverse_horner(xm, T(0x1.6b69cba168ff2p-2), T(0x1.8218dde9028b4p+0), T(-0x1.0eb8277cd8d5dp+1)
-                                 , T(0x1.39350adad51ecp+1), T(-0x1.d5ae6cfa20f0cp+0)
-                                 , T(0x1.91e2a6fe7e984p-1), T(-0x1.29801e893366dp-3));
-        else if constexpr( std::is_same_v<vt_t, float> )
-          u = eve::reverse_horner(xm, T(0x1.f87bc4p-2f), T(0x1.6527f4p-1f), T(-0x1.88324ap-3f));
-        auto t2 = sqr(u) * u;
-        u *= fma(xm, T(2), t2) / fma(T(2), t2, xm);
+      using vt_t = element_type_t<T>;
+      auto test0 = is_eqz(x) || is_not_finite(x);
+      if constexpr( eve::scalar_value<T> )
+        if( test0 ) return x;
+      constexpr vt_t factor[5] = {0.6299605249474365823836,
+                                  0.793700525984099737376,
+                                  1.0,
+                                  1.2599210498948731647672,
+                                  1.587401051968199474751};
+      auto           ax        = eve::abs(x);
+      auto           test      = is_less(eve::abs(x), T(100) * smallestposval(eve::as<T>()));
+      ax                       = ldexp[test](ax, 54);
+      /* Reduce x.  xm now is an range  [0.5, 1.0].  */
+      auto [xm, xe] = ifrexp[raw](ax);
+      T u;
+      if constexpr( std::is_same_v<vt_t, double> )
+        u = eve::reverse_horner(xm, T(0x1.6b69cba168ff2p-2), T(0x1.8218dde9028b4p+0), T(-0x1.0eb8277cd8d5dp+1)
+                                , T(0x1.39350adad51ecp+1), T(-0x1.d5ae6cfa20f0cp+0)
+                                , T(0x1.91e2a6fe7e984p-1), T(-0x1.29801e893366dp-3));
+      else if constexpr( std::is_same_v<vt_t, float> )
+        u = eve::reverse_horner(xm, T(0x1.f87bc4p-2f), T(0x1.6527f4p-1f), T(-0x1.88324ap-3f));
+      auto t2 = sqr(u) * u;
+      u *= fma(xm, T(2), t2) / fma(T(2), t2, xm);
 
-        if constexpr( eve::scalar_value<T> ) u *= factor[2 + xe % 3];
-        else                            u *= gather(&factor[0], 2 + xe - (xe / 3) * 3);
-        u = minus[is_ltz(x)](u);
-        if constexpr( eve::scalar_value<T> ) xe = add[test](int(xe) / 3, -18);
-        else                            xe = add[test](xe / 3, -18);
-        auto z = ldexp(u, xe);
-        if constexpr( eve::scalar_value<T> ) return z;
-        else                            return if_else(test0, x, z);
-      }
-      else return apply_over(cbrt, x);
+      if constexpr( eve::scalar_value<T> ) u *= factor[2 + xe % 3];
+      else                            u *= gather(&factor[0], 2 + xe - (xe / 3) * 3);
+      u = minus[is_ltz(x)](u);
+      if constexpr( eve::scalar_value<T> ) xe = add[test](int(xe) / 3, -18);
+      else                            xe = add[test](xe / 3, -18);
+      auto z = ldexp(u, xe);
+      if constexpr( eve::scalar_value<T> ) return z;
+      else                            return if_else(test0, x, z);
     }
   }
 }

--- a/include/eve/module/math/regular/expmx2.hpp
+++ b/include/eve/module/math/regular/expmx2.hpp
@@ -71,13 +71,9 @@ namespace eve
   namespace detail
   {
     template<typename T, callable_options O>
-    EVE_FORCEINLINE constexpr T
-    expmx2_(EVE_REQUIRES(cpu_), O const&, T a0) noexcept
+    EVE_FORCEINLINE constexpr T expmx2_(EVE_REQUIRES(cpu_), O const&, T a0) noexcept
     {
-      if constexpr( has_native_abi_v<T> )
-        return rec[pedantic](eve::expx2(a0));
-      else
-        return apply_over(expmx2, a0);
+      return rec[pedantic](eve::expx2(a0));
     }
   }
 }

--- a/include/eve/module/math/regular/expx2.hpp
+++ b/include/eve/module/math/regular/expx2.hpp
@@ -70,45 +70,40 @@ namespace eve
   namespace detail
   {
     template<value T, callable_options O>
-    EVE_FORCEINLINE constexpr T
-    expx2_(EVE_REQUIRES(cpu_), O const&, T a0) noexcept
+    EVE_FORCEINLINE constexpr T expx2_(EVE_REQUIRES(cpu_), O const&, T a0) noexcept
     {
-      if constexpr( has_native_abi_v<T> )
+      if constexpr( eve::platform::supports_invalids && scalar_value<T> )
       {
-        if constexpr( eve::platform::supports_invalids && scalar_value<T> )
-        {
-          if( is_nan(a0) ) return a0;
-        }
-        if constexpr( scalar_value<T> && eve::platform::supports_infinites )
-          if( is_infinite(a0) ) return inf(as<T>());
-        T       x       = eve::abs(a0);
-        using u_t = underlying_type_t<T>;
-        const u_t Expx2c1 = ieee_constant<0x1.0p+5f, 0x1.0000000000000p+7>(eve::as<u_t>{});
-        const u_t Expx2c2 = ieee_constant<0x1.0p-5f, 0x1.0000000000000p-7>(eve::as<u_t>{});
-        /* Represent x as an exact multiple of 1/32 plus a residual.  */
-        T m = Expx2c1 * eve::floor(fma(Expx2c2, x, half(as<T>())));
-        x -= m;
-        /* x**2 = m**2 + 2mf + f**2 */
-        T u  = sqr(m);
-        T u1 = fma(T(2) * m, x, sqr(x));
-        /* u is exact, u1 is small.  */
-        auto gtmxlg = is_not_less_equal(u + u1, maxlog(as<T>()));
-        if constexpr( scalar_value<T> )
-        {
-          if( gtmxlg ) return inf(as<T>());
-          return eve::exp(u) * eve::exp(u1);
-        }
-        else if constexpr( simd_value<T> )
-        {
-          T r = eve::if_else(gtmxlg, eve::inf(as<T>()), eve::exp(u) * eve::exp(u1));
-          if constexpr( eve::platform::supports_infinites ) r = eve::if_else((x == inf(as<T>())), x, r);
-          if constexpr( eve::platform::supports_invalids )
-            r = eve::if_else(is_nan(a0), eve::allbits, r);
-          return r;
-        }
-        return u + u1;
+        if( is_nan(a0) ) return a0;
       }
-      else return apply_over(expx2, a0);
+      if constexpr( scalar_value<T> && eve::platform::supports_infinites )
+        if( is_infinite(a0) ) return inf(as<T>());
+      T       x       = eve::abs(a0);
+      using u_t = underlying_type_t<T>;
+      const u_t Expx2c1 = ieee_constant<0x1.0p+5f, 0x1.0000000000000p+7>(eve::as<u_t>{});
+      const u_t Expx2c2 = ieee_constant<0x1.0p-5f, 0x1.0000000000000p-7>(eve::as<u_t>{});
+      /* Represent x as an exact multiple of 1/32 plus a residual.  */
+      T m = Expx2c1 * eve::floor(fma(Expx2c2, x, half(as<T>())));
+      x -= m;
+      /* x**2 = m**2 + 2mf + f**2 */
+      T u  = sqr(m);
+      T u1 = fma(T(2) * m, x, sqr(x));
+      /* u is exact, u1 is small.  */
+      auto gtmxlg = is_not_less_equal(u + u1, maxlog(as<T>()));
+      if constexpr( scalar_value<T> )
+      {
+        if( gtmxlg ) return inf(as<T>());
+        return eve::exp(u) * eve::exp(u1);
+      }
+      else if constexpr( simd_value<T> )
+      {
+        T r = eve::if_else(gtmxlg, eve::inf(as<T>()), eve::exp(u) * eve::exp(u1));
+        if constexpr( eve::platform::supports_infinites ) r = eve::if_else((x == inf(as<T>())), x, r);
+        if constexpr( eve::platform::supports_invalids )
+          r = eve::if_else(is_nan(a0), eve::allbits, r);
+        return r;
+      }
+      return u + u1;
     }
   }
 }

--- a/include/eve/module/math/regular/hypot.hpp
+++ b/include/eve/module/math/regular/hypot.hpp
@@ -98,61 +98,56 @@ namespace eve
     {
       using r_t = common_value_t<T0, T1, Ts...>;
       using e_t = element_type_t<r_t>;
-      if constexpr( has_native_abi_v<r_t> )
+      if constexpr(sizeof...(Ts) == 0) // 2 parameters
       {
-        if constexpr(sizeof...(Ts) == 0) // 2 parameters
+        if constexpr(O::contains(pedantic))
         {
-          if constexpr(O::contains(pedantic))
-          {
-            ////////////////////////////////////////////////////////////////////////////////////////////////////
-            //  This implementation is inspired by
-            //  AN IMPROVED ALGORITHM FOR HYPOT(A,B) arXiv:1904.09481v6 [math.NA] 14 Jun 2019, CARLOS F. BORGES
-            ////////////////////////////////////////////////////////////////////////////////////////////////////
-            using eve::abs;
-            r_t ax(abs(r0));
-            r_t ay(abs(r1));
-            auto test = ax > ay;
-            eve::swap_if(test, ax, ay); // now 0 <= ax <= ay
-            constexpr auto rsqspvo4 = 1/(sqrtsmallestposval(as<e_t>()));
-            auto scale = if_else(ax > sqrtvalmax(as(ax)), sqrtsmallestposval(as<r_t>())/4
-                                , if_else(ay < sqrtsmallestposval(as(ay)), rsqspvo4
-                                         ,  one)
-                                );
-            ax *= scale;
-            ay *= scale;
-            auto h = sqrt(fma(ax,ax,ay*ay));
-            auto h2 = sqr(h);
-            auto ax2 = sqr(ax);
-            auto x = fma(-ay,ay,h2-ax2) + fma(h,h,-h2) - fma(ax,ax,-ax2);
-            h-= x/(2*h);
-            h /= scale;
-            h = if_else(is_eqz(ay), zero, h);
-            h = if_else(ax <= ay*eve::sqrteps(as<r_t>()), ay, h);
-            h = if_else(is_infinite(ax) || is_infinite(ay), inf(as<r_t>()), h);
-            return h;
-          }
-          else
-          {
-            return eve::sqrt(add(sqr(r_t(r0)), sqr(r_t(r1))));
-          }
+          ////////////////////////////////////////////////////////////////////////////////////////////////////
+          //  This implementation is inspired by
+          //  AN IMPROVED ALGORITHM FOR HYPOT(A,B) arXiv:1904.09481v6 [math.NA] 14 Jun 2019, CARLOS F. BORGES
+          ////////////////////////////////////////////////////////////////////////////////////////////////////
+          using eve::abs;
+          r_t ax(abs(r0));
+          r_t ay(abs(r1));
+          auto test = ax > ay;
+          eve::swap_if(test, ax, ay); // now 0 <= ax <= ay
+          constexpr auto rsqspvo4 = 1/(sqrtsmallestposval(as<e_t>()));
+          auto scale = if_else(ax > sqrtvalmax(as(ax)), sqrtsmallestposval(as<r_t>())/4
+                              , if_else(ay < sqrtsmallestposval(as(ay)), rsqspvo4
+                                        ,  one)
+                              );
+          ax *= scale;
+          ay *= scale;
+          auto h = sqrt(fma(ax,ax,ay*ay));
+          auto h2 = sqr(h);
+          auto ax2 = sqr(ax);
+          auto x = fma(-ay,ay,h2-ax2) + fma(h,h,-h2) - fma(ax,ax,-ax2);
+          h-= x/(2*h);
+          h /= scale;
+          h = if_else(is_eqz(ay), zero, h);
+          h = if_else(ax <= ay*eve::sqrteps(as<r_t>()), ay, h);
+          h = if_else(is_infinite(ax) || is_infinite(ay), inf(as<r_t>()), h);
+          return h;
         }
-        else //N parameters
+        else
         {
-          if constexpr(O::contains(pedantic))
-          {
-            r_t that(hypot[o](r_t(r0), r_t(r1)));
-            ((that = hypot[o](that, r_t(rs))), ...);
-            return that;
-          }
-          else
-          {
-            r_t that = add(sqr(r_t(r0)), sqr(r_t(r1)), sqr(r_t(rs))...);
-            return eve::sqrt(that);
-          }
+          return eve::sqrt(add(sqr(r_t(r0)), sqr(r_t(r1))));
         }
       }
-      else
-        return apply_over(hypot[o], r_t(r0), r_t(r1), r_t(rs)...);
+      else //N parameters
+      {
+        if constexpr(O::contains(pedantic))
+        {
+          r_t that(hypot[o](r_t(r0), r_t(r1)));
+          ((that = hypot[o](that, r_t(rs))), ...);
+          return that;
+        }
+        else
+        {
+          r_t that = add(sqr(r_t(r0)), sqr(r_t(r1)), sqr(r_t(rs))...);
+          return eve::sqrt(that);
+        }
+      }
     }
   }
 }

--- a/include/eve/module/math/regular/log.hpp
+++ b/include/eve/module/math/regular/log.hpp
@@ -91,139 +91,135 @@ namespace eve
         using iT    = as_integer_t<T, signed>;
         constexpr bool is_avx = current_api == avx;
         using TT =  std::conditional_t<is_avx, T, iT >;
-        if constexpr( has_native_abi_v<T> )
+        T Log_2hi   = ieee_constant<0x1.6300000p-1f, 0x1.62e42fee00000p-1>(eve::as<T>{});
+        T Log_2lo   = ieee_constant<-0x1.bd01060p-13f, 0x1.a39ef35793c76p-33>(eve::as<T>{});
+        using uiT   = as_integer_t<T, unsigned>;
+        using elt_t = element_type_t<T>;
+        if constexpr( std::is_same_v<elt_t, float> )
         {
-          T Log_2hi   = ieee_constant<0x1.6300000p-1f, 0x1.62e42fee00000p-1>(eve::as<T>{});
-          T Log_2lo   = ieee_constant<-0x1.bd01060p-13f, 0x1.a39ef35793c76p-33>(eve::as<T>{});
-          using uiT   = as_integer_t<T, unsigned>;
-          using elt_t = element_type_t<T>;
-          if constexpr( std::is_same_v<elt_t, float> )
+          /* origin: FreeBSD /usr/src/lib/msun/src/e_logf.c */
+          /*
+            * ====================================================
+            * Copyright (C) 1993 by Sun Microsystems, Inc. All rights reserved.
+            *
+            * Developed at SunPro, a Sun Microsystems, Inc. business.
+            * Permission to use, copy, modify, and distribute this
+            * software is freely granted, provided that this notice
+            * is preserved.
+            * ====================================================
+            */
+          auto       x = a0;
+          T          f(0);
+          TT         k(0);
+          auto       isnez = is_nez(a0);
+          logical<T> test;
+          if constexpr( eve::platform::supports_denormals )
           {
-            /* origin: FreeBSD /usr/src/lib/msun/src/e_logf.c */
-            /*
-             * ====================================================
-             * Copyright (C) 1993 by Sun Microsystems, Inc. All rights reserved.
-             *
-             * Developed at SunPro, a Sun Microsystems, Inc. business.
-             * Permission to use, copy, modify, and distribute this
-             * software is freely granted, provided that this notice
-             * is preserved.
-             * ====================================================
-             */
-            auto       x = a0;
-            T          f(0);
-            TT         k(0);
-            auto       isnez = is_nez(a0);
-            logical<T> test;
-            if constexpr( eve::platform::supports_denormals )
+            test = is_less(a0, smallestposval(eve::as<T>())) && isnez;
+            if( eve::any(test) )
             {
-              test = is_less(a0, smallestposval(eve::as<T>())) && isnez;
-              if( eve::any(test) )
-              {
-                k = sub[test](k, TT(23));
-                x = if_else(test, x * T(8388608ul), x);
-              }
+              k = sub[test](k, TT(23));
+              x = if_else(test, x * T(8388608ul), x);
             }
-            if constexpr(is_avx)
-            {
-              auto [xx, kk]     = eve::frexp(x);
-              x = xx;
-              auto x_lt_sqrthf = (invsqrt_2(eve::as<T>()) > x);
-              k += dec[x_lt_sqrthf](kk);
-              f = dec(x + if_else(x_lt_sqrthf, x, eve::zero));
-            }
-            else
-            {
-              uiT ix = bit_cast(x, as<uiT>());
-              /* reduce x into [sqrt(2)/2, sqrt(2)] */
-              ix += 0x3f800000 - 0x3f3504f3;
-              k += bit_cast(ix >> 23, as<iT>()) - 0x7f;
-              ix     = (ix & 0x007fffff) + 0x3f3504f3;
-              x      = bit_cast(ix, as<T>());
-              f    = dec(x);
-            }
-            T s    = f / (2.0f + f);
-            T z    = sqr(s);
-            T w    = sqr(z);
-            T t1   = w * eve::reverse_horner(w, T(0x1.999c26p-2f), T(0x1.f13c4cp-3f));
-            T t2   = z * eve::reverse_horner(w, T(0x1.555554p-1f), T(0x1.23d3dcp-2f));
-            T R    = t2 + t1;
-            T hfsq = half(eve::as<T>()) * sqr(f);
-            T dk = convert(k, as<float>());
-            T r  = fma(dk, Log_2hi, ((fma(s, (hfsq + R), dk * Log_2lo) - hfsq) + f));
-            T zz;
-            if constexpr( eve::platform::supports_infinites )
-              zz = if_else(isnez, if_else(a0 == inf(eve::as<T>()), inf(eve::as<T>()), r), minf(eve::as<T>()));
-            else
-              zz = if_else(isnez, r, minf(eve::as<T>()));
-            return if_else(is_ngez(a0), eve::allbits, zz);
           }
-          else // if constexpr(std::is_same_v<elt_t, double>)
+          if constexpr(is_avx)
           {
-            /* origin: FreeBSD /usr/src/lib/msun/src/e_logf.c */
-            /*
-             * ====================================================
-             * Copyright (C) 1993 by Sun Microsystems, Inc. All rights reserved.
-             *
-             * Developed at SunPro, a Sun Microsystems, Inc. business.
-             * Permission to use, copy, modify, and distribute this
-             * software is freely granted, provided that this notice
-             * is preserved.
-             * ====================================================
-             */
-            auto x = a0;
-            T f(0);
-            TT         k(0);
-            auto       isnez = is_nez(a0);
-            logical<T> test;
-            if constexpr( eve::platform::supports_denormals )
-            {
-              test = is_less(a0, smallestposval(eve::as<T>())) && isnez;
-              if( eve::any(test) )
-              {
-                k = sub[test](k, TT(54));
-                x = if_else(test, x * T(18014398509481984ull), x);
-              }
-            }
-            if constexpr(is_avx)
-            {
-              auto [xx, kk]     = eve::frexp(x);
-              x = xx;
-              auto x_lt_sqrthf = (invsqrt_2(eve::as<T>()) > x);
-              k += dec[x_lt_sqrthf](kk);
-              f  = dec(x + if_else(x_lt_sqrthf, x, eve::zero));
-            }
-            else
-            {  /* reduce x into [sqrt(2)/2, sqrt(2)] */
-              uiT hx = bit_cast(x, as<uiT>()) >> 32;
-              hx += 0x3ff00000 - 0x3fe6a09e;
-              k += bit_cast(hx >> 20, as<iT>()) - 0x3ff;
-              hx = (bit_and(hx, 0x000fffffull)) + 0x3fe6a09e;
-              x  = bit_cast(hx << 32 | (bit_and(bit_cast(x, as<uiT>()), 0xffffffffull)), as<T>());
-              f  = dec(x);
-            }
-            T s  = f / (2.0f + f);
-            T z  = sqr(s);
-            T w  = sqr(z);
-            T t1 = w*eve::reverse_horner(w, T(0x1.999999997fa04p-2), T(0x1.c71c51d8e78afp-3), T(0x1.39a09d078c69fp-3));
-            T t2 = z*eve::reverse_horner(w, T(0x1.5555555555593p-1), T(0x1.2492494229359p-2)
-                                        , T(0x1.7466496cb03dep-3), T(0x1.2f112df3e5244p-3));
-            T R    = t2 + t1;
-            T hfsq = half(eve::as<T>()) * sqr(f);
-
-            T dk = convert(k, as<double>());
-            T r  = fma(dk, Log_2hi, ((fma(s, (hfsq + R), dk * Log_2lo) - hfsq) + f));
-            T zz;
-            if constexpr( eve::platform::supports_infinites )
-            {
-              zz = if_else(
-                isnez, if_else(a0 == inf(eve::as<T>()), inf(eve::as<T>()), r), minf(eve::as<T>()));
-            }
-            else { zz = if_else(isnez, r, minf(eve::as<T>())); }
-            return if_else(is_ngez(a0), eve::allbits, zz);
+            auto [xx, kk]     = eve::frexp(x);
+            x = xx;
+            auto x_lt_sqrthf = (invsqrt_2(eve::as<T>()) > x);
+            k += dec[x_lt_sqrthf](kk);
+            f = dec(x + if_else(x_lt_sqrthf, x, eve::zero));
           }
+          else
+          {
+            uiT ix = bit_cast(x, as<uiT>());
+            /* reduce x into [sqrt(2)/2, sqrt(2)] */
+            ix += 0x3f800000 - 0x3f3504f3;
+            k += bit_cast(ix >> 23, as<iT>()) - 0x7f;
+            ix     = (ix & 0x007fffff) + 0x3f3504f3;
+            x      = bit_cast(ix, as<T>());
+            f    = dec(x);
+          }
+          T s    = f / (2.0f + f);
+          T z    = sqr(s);
+          T w    = sqr(z);
+          T t1   = w * eve::reverse_horner(w, T(0x1.999c26p-2f), T(0x1.f13c4cp-3f));
+          T t2   = z * eve::reverse_horner(w, T(0x1.555554p-1f), T(0x1.23d3dcp-2f));
+          T R    = t2 + t1;
+          T hfsq = half(eve::as<T>()) * sqr(f);
+          T dk = convert(k, as<float>());
+          T r  = fma(dk, Log_2hi, ((fma(s, (hfsq + R), dk * Log_2lo) - hfsq) + f));
+          T zz;
+          if constexpr( eve::platform::supports_infinites )
+            zz = if_else(isnez, if_else(a0 == inf(eve::as<T>()), inf(eve::as<T>()), r), minf(eve::as<T>()));
+          else
+            zz = if_else(isnez, r, minf(eve::as<T>()));
+          return if_else(is_ngez(a0), eve::allbits, zz);
         }
-        else return apply_over(log, a0);
+        else // if constexpr(std::is_same_v<elt_t, double>)
+        {
+          /* origin: FreeBSD /usr/src/lib/msun/src/e_logf.c */
+          /*
+            * ====================================================
+            * Copyright (C) 1993 by Sun Microsystems, Inc. All rights reserved.
+            *
+            * Developed at SunPro, a Sun Microsystems, Inc. business.
+            * Permission to use, copy, modify, and distribute this
+            * software is freely granted, provided that this notice
+            * is preserved.
+            * ====================================================
+            */
+          auto x = a0;
+          T f(0);
+          TT         k(0);
+          auto       isnez = is_nez(a0);
+          logical<T> test;
+          if constexpr( eve::platform::supports_denormals )
+          {
+            test = is_less(a0, smallestposval(eve::as<T>())) && isnez;
+            if( eve::any(test) )
+            {
+              k = sub[test](k, TT(54));
+              x = if_else(test, x * T(18014398509481984ull), x);
+            }
+          }
+          if constexpr(is_avx)
+          {
+            auto [xx, kk]     = eve::frexp(x);
+            x = xx;
+            auto x_lt_sqrthf = (invsqrt_2(eve::as<T>()) > x);
+            k += dec[x_lt_sqrthf](kk);
+            f  = dec(x + if_else(x_lt_sqrthf, x, eve::zero));
+          }
+          else
+          {  /* reduce x into [sqrt(2)/2, sqrt(2)] */
+            uiT hx = bit_cast(x, as<uiT>()) >> 32;
+            hx += 0x3ff00000 - 0x3fe6a09e;
+            k += bit_cast(hx >> 20, as<iT>()) - 0x3ff;
+            hx = (bit_and(hx, 0x000fffffull)) + 0x3fe6a09e;
+            x  = bit_cast(hx << 32 | (bit_and(bit_cast(x, as<uiT>()), 0xffffffffull)), as<T>());
+            f  = dec(x);
+          }
+          T s  = f / (2.0f + f);
+          T z  = sqr(s);
+          T w  = sqr(z);
+          T t1 = w*eve::reverse_horner(w, T(0x1.999999997fa04p-2), T(0x1.c71c51d8e78afp-3), T(0x1.39a09d078c69fp-3));
+          T t2 = z*eve::reverse_horner(w, T(0x1.5555555555593p-1), T(0x1.2492494229359p-2)
+                                      , T(0x1.7466496cb03dep-3), T(0x1.2f112df3e5244p-3));
+          T R    = t2 + t1;
+          T hfsq = half(eve::as<T>()) * sqr(f);
+
+          T dk = convert(k, as<double>());
+          T r  = fma(dk, Log_2hi, ((fma(s, (hfsq + R), dk * Log_2lo) - hfsq) + f));
+          T zz;
+          if constexpr( eve::platform::supports_infinites )
+          {
+            zz = if_else(
+              isnez, if_else(a0 == inf(eve::as<T>()), inf(eve::as<T>()), r), minf(eve::as<T>()));
+          }
+          else { zz = if_else(isnez, r, minf(eve::as<T>())); }
+          return if_else(is_ngez(a0), eve::allbits, zz);
+        }
       }
       else // scalar case
       {

--- a/include/eve/module/math/regular/log10.hpp
+++ b/include/eve/module/math/regular/log10.hpp
@@ -88,171 +88,167 @@ namespace eve
     {
       if constexpr(simd_value<T>)
       {
-        if constexpr( has_native_abi_v<T> )
+        using uiT     = as_integer_t<T, unsigned>;
+        using iT      = as_integer_t<T, signed>;
+        using elt_t   = element_type_t<T>;
+        constexpr bool is_avx = current_api == avx;
+        using TT =  std::conditional_t<is_avx, T, iT >;
+        T Invlog_10hi = ieee_constant<0x1.bcc0000p-2f, 0x1.bcb7b15200000p-2>(eve::as<T>{});
+        T Invlog_10lo = ieee_constant<-0x1.09d5b20p-15f, 0x1.b9438ca9aadd5p-36>(eve::as<T>{});
+        T Log10_2hi   = ieee_constant<0x1.3400000p-2f, 0x1.3440000000000p-2>(eve::as<T>{});
+        T Log10_2lo   = ieee_constant<0x1.04d4280p-12f, 0x1.3509f79fef312p-18>(eve::as<T>{});
+        if constexpr( std::is_same_v<elt_t, float> )
         {
-          using uiT     = as_integer_t<T, unsigned>;
-          using iT      = as_integer_t<T, signed>;
-          using elt_t   = element_type_t<T>;
-          constexpr bool is_avx = current_api == avx;
-          using TT =  std::conditional_t<is_avx, T, iT >;
-          T Invlog_10hi = ieee_constant<0x1.bcc0000p-2f, 0x1.bcb7b15200000p-2>(eve::as<T>{});
-          T Invlog_10lo = ieee_constant<-0x1.09d5b20p-15f, 0x1.b9438ca9aadd5p-36>(eve::as<T>{});
-          T Log10_2hi   = ieee_constant<0x1.3400000p-2f, 0x1.3440000000000p-2>(eve::as<T>{});
-          T Log10_2lo   = ieee_constant<0x1.04d4280p-12f, 0x1.3509f79fef312p-18>(eve::as<T>{});
-          if constexpr( std::is_same_v<elt_t, float> )
+          /* origin: FreeBSD /usr/src/lib/msun/src/e_log10f.c */
+          /*
+            * ====================================================
+            * Copyright (C) 1993 by Sun Microsystems, Inc. All rights reserved.
+            *
+            * Developed at SunPro, a Sun Microsystems, Inc. business.
+            * Permission to use, copy, modify, and distribute this
+            * software is freely granted, provided that this notice
+            * is preserved.
+            * ====================================================
+            */
+          T          x = a0;
+          TT         k(0);
+          T f(0);
+          auto       isnez = is_nez(a0);
+          logical<T> test;
+          if constexpr( eve::platform::supports_denormals )
           {
-            /* origin: FreeBSD /usr/src/lib/msun/src/e_log10f.c */
-            /*
-             * ====================================================
-             * Copyright (C) 1993 by Sun Microsystems, Inc. All rights reserved.
-             *
-             * Developed at SunPro, a Sun Microsystems, Inc. business.
-             * Permission to use, copy, modify, and distribute this
-             * software is freely granted, provided that this notice
-             * is preserved.
-             * ====================================================
-             */
-            T          x = a0;
-            TT         k(0);
-            T f(0);
-            auto       isnez = is_nez(a0);
-            logical<T> test;
-            if constexpr( eve::platform::supports_denormals )
+            test = is_less(a0, smallestposval(eve::as<T>())) && isnez;
+            if( eve::any(test) )
             {
-              test = is_less(a0, smallestposval(eve::as<T>())) && isnez;
-              if( eve::any(test) )
-              {
-                k = sub[test](k, TT(25));
-                x = if_else(test, x * T(33554432ul), x);
-              }
+              k = sub[test](k, TT(25));
+              x = if_else(test, x * T(33554432ul), x);
             }
-            if constexpr(is_avx)
-            {
-              auto [xx, kk]     = eve::frexp(x);
-              x = xx;
-              auto x_lt_sqrthf = (invsqrt_2(eve::as<T>()) > x);
-              k += dec[x_lt_sqrthf](kk);
-              f    = dec(x + if_else(x_lt_sqrthf, x, eve::zero));
-            }
-            else
-            {
-              uiT ix = bit_cast(x, as<uiT>());
-              /* reduce x into [sqrt(2)/2, sqrt(2)] */
-              ix += 0x3f800000 - 0x3f3504f3;
-              k += bit_cast(ix >> 23, as<iT>()) - 0x7f;
-              ix       = (ix & 0x007fffff) + 0x3f3504f3;
-              x        = bit_cast(ix, as<T>());
-              f        = dec(x);
-            }
-            T s      = f / (2.0f + f);
-            T z      = sqr(s);
-            T w      = sqr(z);
-            T t1     = w * eve::reverse_horner(w, T(0x1.999c26p-2f), T(0x1.f13c4cp-3f));
-            T t2     = z * eve::reverse_horner(w, T(0x1.555554p-1f), T(0x1.23d3dcp-2f));
-            T R      = t2 + t1;
-            T hfsq   = half(eve::as<T>()) * sqr(f);
-            T dk     = convert(k, as<float>());
-            T hibits = f - hfsq;
-            hibits   = bit_and(hibits, uiT(0xfffff000ul));
-            T lobits = fma(s, hfsq + R, f - hibits - hfsq);
-            //      T r = ((((dk*log10_2lo + (lobits+hibits)*ivln10lo) + lobits*ivln10hi) +
-            //      hibits*ivln10hi) + dk*log10_2hi);
-            T r = fma(dk,
-                      Log10_2hi,
-                      fma(hibits,
-                          Invlog_10hi,
-                          fma(lobits, Invlog_10hi, fma(lobits + hibits, Invlog_10lo, dk * Log10_2lo))));
-            T zz;
-            if constexpr( eve::platform::supports_infinites )
-            {
-              zz = if_else(isnez, if_else(a0 == inf(eve::as<T>()), inf(eve::as<T>()), r), minf(eve::as<T>()));
-            }
-            else { zz = if_else(isnez, r, minf(eve::as<T>())); }
-            return if_else(is_ngez(a0), eve::allbits, zz);
           }
-          else if constexpr( std::is_same_v<elt_t, double> )
+          if constexpr(is_avx)
           {
-            /* origin: FreeBSD /usr/src/lib/msun/src/e_log10f.c */
-            /*
-             * ====================================================
-             * Copyright (C) 1993 by Sun Microsystems, Inc. All rights reserved.
-             *
-             * Developed at SunPro, a Sun Microsystems, Inc. business.
-             * Permission to use, copy, modify, and distribute this
-             * software is freely granted, provided that this notice
-             * is preserved.
-             * ====================================================
-             */
-            T          x = a0;
-            TT         k(0);
-            T          f(0);
-            auto       isnez = is_nez(a0);
-            logical<T> test;
-            if constexpr( eve::platform::supports_denormals )
-            {
-              test = is_less(a0, smallestposval(eve::as<T>())) && isnez;
-              if( eve::any(test) )
-              {
-                k = sub[test](k, TT(54));
-                x = if_else(test, x * T(18014398509481984ull), x);
-              }
-            }
+            auto [xx, kk]     = eve::frexp(x);
+            x = xx;
+            auto x_lt_sqrthf = (invsqrt_2(eve::as<T>()) > x);
+            k += dec[x_lt_sqrthf](kk);
+            f    = dec(x + if_else(x_lt_sqrthf, x, eve::zero));
+          }
+          else
+          {
+            uiT ix = bit_cast(x, as<uiT>());
             /* reduce x into [sqrt(2)/2, sqrt(2)] */
-            if constexpr(is_avx)
-            {
-              auto [xx, kk]     = eve::frexp(x);
-              x =  xx;
-              auto x_lt_sqrthf = (invsqrt_2(eve::as<T>()) > x);
-              k += dec[x_lt_sqrthf](kk);
-              f  = dec(x + if_else(x_lt_sqrthf, x, eve::zero));
-            }
-            else
-            {
-              uiT hx = bit_cast(x, as<uiT>()) >> 32;
-              hx += 0x3ff00000 - 0x3fe6a09e;
-              k += bit_cast(hx >> 20, as<iT>()) - 0x3ff;
-              hx = (bit_and(hx, 0x000fffffull)) + 0x3fe6a09e;
-              x  = bit_cast(hx << 32 | (bit_and(bit_cast(x, as<uiT>()), 0xffffffffull)), as<T>());
-              f  = dec(x);
-            }
-            T s  = f / (2.0f + f);
-            T z  = sqr(s);
-            T w  = sqr(z);
-            T t1 = w * eve::reverse_horner(w, T(0x1.999999997fa04p-2), T(0x1.c71c51d8e78afp-3), T(0x1.39a09d078c69fp-3));
-            T t2 = z * eve::reverse_horner(w, T(0x1.5555555555593p-1), T(0x1.2492494229359p-2)
-                                          , T(0x1.7466496cb03dep-3), T(0x1.2f112df3e5244p-3));
-            T R    = t2 + t1;
-            T hfsq = half(eve::as<T>()) * sqr(f);
-            T dk   = convert(k, as<double>());
-            //      T r = -(hfsq-(s*(hfsq+R))-f)*Invlog_10<T>()+dk*Log_2olog_10<T>(); // fast ?
-            T hi     = f - hfsq;
-            hi       = bit_and(hi, (allbits(eve::as<uiT>()) << 32));
-            T lo     = f - hi - hfsq + s * (hfsq + R);
-            T val_hi = hi * Invlog_10hi;
-            T y      = dk * Log10_2hi;
-            T val_lo = dk * Log10_2lo + (lo + hi) * Invlog_10lo + lo * Invlog_10hi;
-            //
-            //  Extra precision in for adding y is not strictly needed
-            //  since there is no very large cancellation near x = sqrt(2) or
-            //  x = 1/sqrt(2), but we do it anyway since it costs little on CPUs
-            //  with some parallelism and it reduces the error for many args.
-            //
-            T w1 = y + val_hi;
-            val_lo += (y - w1) + val_hi;
-            val_hi = w1;
-
-            T r = val_lo + val_hi;
-            T zz;
-            if constexpr( eve::platform::supports_infinites )
-            {
-              zz = if_else(
-                isnez, if_else(a0 == inf(eve::as<T>()), inf(eve::as<T>()), r), minf(eve::as<T>()));
-            }
-            else { zz = if_else(isnez, r, minf(eve::as<T>())); }
-            return if_else(is_ngez(a0), eve::allbits, zz);
+            ix += 0x3f800000 - 0x3f3504f3;
+            k += bit_cast(ix >> 23, as<iT>()) - 0x7f;
+            ix       = (ix & 0x007fffff) + 0x3f3504f3;
+            x        = bit_cast(ix, as<T>());
+            f        = dec(x);
           }
+          T s      = f / (2.0f + f);
+          T z      = sqr(s);
+          T w      = sqr(z);
+          T t1     = w * eve::reverse_horner(w, T(0x1.999c26p-2f), T(0x1.f13c4cp-3f));
+          T t2     = z * eve::reverse_horner(w, T(0x1.555554p-1f), T(0x1.23d3dcp-2f));
+          T R      = t2 + t1;
+          T hfsq   = half(eve::as<T>()) * sqr(f);
+          T dk     = convert(k, as<float>());
+          T hibits = f - hfsq;
+          hibits   = bit_and(hibits, uiT(0xfffff000ul));
+          T lobits = fma(s, hfsq + R, f - hibits - hfsq);
+          //      T r = ((((dk*log10_2lo + (lobits+hibits)*ivln10lo) + lobits*ivln10hi) +
+          //      hibits*ivln10hi) + dk*log10_2hi);
+          T r = fma(dk,
+                    Log10_2hi,
+                    fma(hibits,
+                        Invlog_10hi,
+                        fma(lobits, Invlog_10hi, fma(lobits + hibits, Invlog_10lo, dk * Log10_2lo))));
+          T zz;
+          if constexpr( eve::platform::supports_infinites )
+          {
+            zz = if_else(isnez, if_else(a0 == inf(eve::as<T>()), inf(eve::as<T>()), r), minf(eve::as<T>()));
+          }
+          else { zz = if_else(isnez, r, minf(eve::as<T>())); }
+          return if_else(is_ngez(a0), eve::allbits, zz);
         }
-        else return apply_over(log10, a0);
+        else if constexpr( std::is_same_v<elt_t, double> )
+        {
+          /* origin: FreeBSD /usr/src/lib/msun/src/e_log10f.c */
+          /*
+            * ====================================================
+            * Copyright (C) 1993 by Sun Microsystems, Inc. All rights reserved.
+            *
+            * Developed at SunPro, a Sun Microsystems, Inc. business.
+            * Permission to use, copy, modify, and distribute this
+            * software is freely granted, provided that this notice
+            * is preserved.
+            * ====================================================
+            */
+          T          x = a0;
+          TT         k(0);
+          T          f(0);
+          auto       isnez = is_nez(a0);
+          logical<T> test;
+          if constexpr( eve::platform::supports_denormals )
+          {
+            test = is_less(a0, smallestposval(eve::as<T>())) && isnez;
+            if( eve::any(test) )
+            {
+              k = sub[test](k, TT(54));
+              x = if_else(test, x * T(18014398509481984ull), x);
+            }
+          }
+          /* reduce x into [sqrt(2)/2, sqrt(2)] */
+          if constexpr(is_avx)
+          {
+            auto [xx, kk]     = eve::frexp(x);
+            x =  xx;
+            auto x_lt_sqrthf = (invsqrt_2(eve::as<T>()) > x);
+            k += dec[x_lt_sqrthf](kk);
+            f  = dec(x + if_else(x_lt_sqrthf, x, eve::zero));
+          }
+          else
+          {
+            uiT hx = bit_cast(x, as<uiT>()) >> 32;
+            hx += 0x3ff00000 - 0x3fe6a09e;
+            k += bit_cast(hx >> 20, as<iT>()) - 0x3ff;
+            hx = (bit_and(hx, 0x000fffffull)) + 0x3fe6a09e;
+            x  = bit_cast(hx << 32 | (bit_and(bit_cast(x, as<uiT>()), 0xffffffffull)), as<T>());
+            f  = dec(x);
+          }
+          T s  = f / (2.0f + f);
+          T z  = sqr(s);
+          T w  = sqr(z);
+          T t1 = w * eve::reverse_horner(w, T(0x1.999999997fa04p-2), T(0x1.c71c51d8e78afp-3), T(0x1.39a09d078c69fp-3));
+          T t2 = z * eve::reverse_horner(w, T(0x1.5555555555593p-1), T(0x1.2492494229359p-2)
+                                        , T(0x1.7466496cb03dep-3), T(0x1.2f112df3e5244p-3));
+          T R    = t2 + t1;
+          T hfsq = half(eve::as<T>()) * sqr(f);
+          T dk   = convert(k, as<double>());
+          //      T r = -(hfsq-(s*(hfsq+R))-f)*Invlog_10<T>()+dk*Log_2olog_10<T>(); // fast ?
+          T hi     = f - hfsq;
+          hi       = bit_and(hi, (allbits(eve::as<uiT>()) << 32));
+          T lo     = f - hi - hfsq + s * (hfsq + R);
+          T val_hi = hi * Invlog_10hi;
+          T y      = dk * Log10_2hi;
+          T val_lo = dk * Log10_2lo + (lo + hi) * Invlog_10lo + lo * Invlog_10hi;
+          //
+          //  Extra precision in for adding y is not strictly needed
+          //  since there is no very large cancellation near x = sqrt(2) or
+          //  x = 1/sqrt(2), but we do it anyway since it costs little on CPUs
+          //  with some parallelism and it reduces the error for many args.
+          //
+          T w1 = y + val_hi;
+          val_lo += (y - w1) + val_hi;
+          val_hi = w1;
+
+          T r = val_lo + val_hi;
+          T zz;
+          if constexpr( eve::platform::supports_infinites )
+          {
+            zz = if_else(
+              isnez, if_else(a0 == inf(eve::as<T>()), inf(eve::as<T>()), r), minf(eve::as<T>()));
+          }
+          else { zz = if_else(isnez, r, minf(eve::as<T>())); }
+          return if_else(is_ngez(a0), eve::allbits, zz);
+        }
       }
       else  // scalar case
       {

--- a/include/eve/module/math/regular/log1p.hpp
+++ b/include/eve/module/math/regular/log1p.hpp
@@ -84,49 +84,81 @@ namespace eve
     {
       if constexpr(simd_value<T>)
       {
-        if constexpr( has_native_abi_v<T> )
+        using elt_t         = element_type_t<T>;
+        using uiT           = as_integer_t<T, unsigned>;
+        using iT            = as_integer_t<T, signed>;
+        const elt_t Log_2hi = ieee_constant<0x1.6300000p-1f, 0x1.62e42fee00000p-1>(eve::as<elt_t>{});
+        const elt_t Log_2lo = ieee_constant<-0x1.bd01060p-13f, 0x1.a39ef35793c76p-33>(eve::as<elt_t>{});
+        constexpr bool is_avx = current_api == avx;
+        if constexpr(is_avx)
         {
-          using elt_t         = element_type_t<T>;
-          using uiT           = as_integer_t<T, unsigned>;
-          using iT            = as_integer_t<T, signed>;
-          const elt_t Log_2hi = ieee_constant<0x1.6300000p-1f, 0x1.62e42fee00000p-1>(eve::as<elt_t>{});
-          const elt_t Log_2lo = ieee_constant<-0x1.bd01060p-13f, 0x1.a39ef35793c76p-33>(eve::as<elt_t>{});
-          constexpr bool is_avx = current_api == avx;
-          if constexpr(is_avx)
+          T    uf          = inc(a0);
+          auto isnez       = is_nez(uf);
+          auto [x, k]      = frexp(uf);
+          auto x_lt_sqrthf = (invsqrt_2(eve::as<T>()) > x);
+          /* reduce x into [sqrt(2)/2, sqrt(2)] */
+          k   = dec[x_lt_sqrthf](k);
+          T f = dec(x + if_else(x_lt_sqrthf, x, eve::zero));
+          /* correction term ~ log(1+x)-log(u), avoid underflow in c/u */
+          T c    = if_else(k >= 2, oneminus(uf - a0), a0 - dec(uf)) / uf;
+          T hfsq = half(eve::as<T>()) * sqr(f);
+          T s    = f / (2.0f + f);
+          T z    = sqr(s);
+          T w    = sqr(z);
+          T t1, t2;
+          if constexpr( std::is_same_v<element_type_t<T>, float> )
           {
-            T    uf          = inc(a0);
-            auto isnez       = is_nez(uf);
-            auto [x, k]      = frexp(uf);
-            auto x_lt_sqrthf = (invsqrt_2(eve::as<T>()) > x);
-            /* reduce x into [sqrt(2)/2, sqrt(2)] */
-            k   = dec[x_lt_sqrthf](k);
-            T f = dec(x + if_else(x_lt_sqrthf, x, eve::zero));
+            t1 = w *
+              eve::reverse_horner(w, T(0x1.999c26p-2f), T(0x1.f13c4cp-3f))
+              ;
+            t2 = z *
+              eve::reverse_horner(w, T(0x1.555554p-1f), T(0x1.23d3dcp-2f))
+              ;
+          }
+          else if constexpr( std::is_same_v<element_type_t<T>, double> )
+          {
+            t1 = w *
+              eve::reverse_horner(w, T(0x1.999999997fa04p-2), T(0x1.c71c51d8e78afp-3), T(0x1.39a09d078c69fp-3))
+              ;
+            t2 = z*eve::reverse_horner(w, T(0x1.5555555555593p-1), T(0x1.2492494229359p-2)
+                                      , T(0x1.7466496cb03dep-3), T(0x1.2f112df3e5244p-3));
+          }
+          T R = t2 + t1;
+          T r = fma(k, Log_2hi, ((fma(s, (hfsq + R), k * Log_2lo + c) - hfsq) + f));
+          T zz;
+          if constexpr( eve::platform::supports_infinites )
+          {
+            zz = if_else(
+              isnez, if_else(a0 == inf(eve::as<T>()), inf(eve::as<T>()), r), minf(eve::as<T>()));
+          }
+          else { zz = if_else(isnez, r, minf(eve::as<T>())); }
+          return if_else(is_ngez(uf), eve::allbits, zz);
+        }
+        else
+        {
+          T           uf      = inc(a0);
+          auto        isnez   = is_nez(uf);
+          if constexpr( std::is_same_v<elt_t, float> )
+          {
+            uiT iu = bit_cast(uf, as<uiT>());
+            iu += 0x3f800000 - 0x3f3504f3;
+            iT k = bit_cast(iu >> 23, as<iT>()) - 0x7f;
             /* correction term ~ log(1+x)-log(u), avoid underflow in c/u */
-            T c    = if_else(k >= 2, oneminus(uf - a0), a0 - dec(uf)) / uf;
-            T hfsq = half(eve::as<T>()) * sqr(f);
+            T c = if_else(k < 25, if_else(k >= 2, oneminus(uf - a0), a0 - dec(uf)), zero);
+            if( eve::any(eve::is_nez(c)) ) c /= uf;
+            /* reduce a0 into [sqrt(2)/2, sqrt(2)] */
+            iu     = (iu & 0x007fffff) + 0x3f3504f3;
+            T f    = dec(bit_cast(iu, as<T>()));
             T s    = f / (2.0f + f);
             T z    = sqr(s);
             T w    = sqr(z);
-            T t1, t2;
-            if constexpr( std::is_same_v<element_type_t<T>, float> )
-            {
-              t1 = w *
-                eve::reverse_horner(w, T(0x1.999c26p-2f), T(0x1.f13c4cp-3f))
-                ;
-              t2 = z *
-                eve::reverse_horner(w, T(0x1.555554p-1f), T(0x1.23d3dcp-2f))
-                ;
-            }
-            else if constexpr( std::is_same_v<element_type_t<T>, double> )
-            {
-              t1 = w *
-                eve::reverse_horner(w, T(0x1.999999997fa04p-2), T(0x1.c71c51d8e78afp-3), T(0x1.39a09d078c69fp-3))
-                ;
-              t2 = z*eve::reverse_horner(w, T(0x1.5555555555593p-1), T(0x1.2492494229359p-2)
-                                        , T(0x1.7466496cb03dep-3), T(0x1.2f112df3e5244p-3));
-            }
-            T R = t2 + t1;
-            T r = fma(k, Log_2hi, ((fma(s, (hfsq + R), k * Log_2lo + c) - hfsq) + f));
+            T R    = fma(w,
+                          eve::reverse_horner(w, T(0x1.999c26p-2f), T(0x1.f13c4cp-3f))
+                        , z * eve::reverse_horner(w, T(0x1.555554p-1f), T(0x1.23d3dcp-2f))
+                        );
+            T hfsq = half(eve::as<T>()) * sqr(f);
+            T dk   = convert(k, as<float>());
+            T r    = fma(dk, Log_2hi, ((fma(s, (hfsq + R), fma(dk, Log_2lo, c)) - hfsq) + f));
             T zz;
             if constexpr( eve::platform::supports_infinites )
             {
@@ -136,92 +168,56 @@ namespace eve
             else { zz = if_else(isnez, r, minf(eve::as<T>())); }
             return if_else(is_ngez(uf), eve::allbits, zz);
           }
-          else
+          else if constexpr( std::is_same_v<elt_t, double> )
           {
-            T           uf      = inc(a0);
-            auto        isnez   = is_nez(uf);
-            if constexpr( std::is_same_v<elt_t, float> )
-            {
-              uiT iu = bit_cast(uf, as<uiT>());
-              iu += 0x3f800000 - 0x3f3504f3;
-              iT k = bit_cast(iu >> 23, as<iT>()) - 0x7f;
-              /* correction term ~ log(1+x)-log(u), avoid underflow in c/u */
-              T c = if_else(k < 25, if_else(k >= 2, oneminus(uf - a0), a0 - dec(uf)), zero);
-              if( eve::any(eve::is_nez(c)) ) c /= uf;
-              /* reduce a0 into [sqrt(2)/2, sqrt(2)] */
-              iu     = (iu & 0x007fffff) + 0x3f3504f3;
-              T f    = dec(bit_cast(iu, as<T>()));
-              T s    = f / (2.0f + f);
-              T z    = sqr(s);
-              T w    = sqr(z);
-              T R    = fma(w,
-                           eve::reverse_horner(w, T(0x1.999c26p-2f), T(0x1.f13c4cp-3f))
-                          , z * eve::reverse_horner(w, T(0x1.555554p-1f), T(0x1.23d3dcp-2f))
-                          );
-              T hfsq = half(eve::as<T>()) * sqr(f);
-              T dk   = convert(k, as<float>());
-              T r    = fma(dk, Log_2hi, ((fma(s, (hfsq + R), fma(dk, Log_2lo, c)) - hfsq) + f));
-              T zz;
-              if constexpr( eve::platform::supports_infinites )
-              {
-                zz = if_else(
-                  isnez, if_else(a0 == inf(eve::as<T>()), inf(eve::as<T>()), r), minf(eve::as<T>()));
-              }
-              else { zz = if_else(isnez, r, minf(eve::as<T>())); }
-              return if_else(is_ngez(uf), eve::allbits, zz);
-            }
-            else if constexpr( std::is_same_v<elt_t, double> )
-            {
-              /* origin: FreeBSD /usr/src/lib/msun/src/e_log1pf.c */
-              /*
-               * ====================================================
-               * Copyright (C) 1993 by Sun Microsystems, Inc. All rights reserved.
-               *
-               * Developed at SunPro, a Sun Microsystems, Inc. business.
-               * Permission to use, copy, modify, and distribute this
-               * software is freely granted, provided that this notice
-               * is preserved.
-               * ====================================================
-               */
-              /* reduce x into [sqrt(2)/2, sqrt(2)] */
-              uiT hu = bit_cast(uf, as<uiT>()) >> 32;
-              hu += 0x3ff00000 - 0x3fe6a09e;
-              iT k = bit_cast(hu >> 20, as<iT>()) - 0x3ff;
-              /* correction term ~ log(1+x)-log(u), avoid underflow in c/u */
-              T c = if_else(k < 54, if_else(k >= 2, oneminus(uf - a0), a0 - dec(uf)), zero);
-              if( eve::any(eve::is_nez(c)) ) c /= uf;
-              hu  = (hu & 0x000fffffull) + 0x3fe6a09e;
-              T f = bit_cast(bit_cast(hu << 32, as<uiT>()) | ((bit_cast(uf, as<uiT>()) & 0xffffffffull)),
-                             as<T>());
-              f   = dec(f);
+            /* origin: FreeBSD /usr/src/lib/msun/src/e_log1pf.c */
+            /*
+              * ====================================================
+              * Copyright (C) 1993 by Sun Microsystems, Inc. All rights reserved.
+              *
+              * Developed at SunPro, a Sun Microsystems, Inc. business.
+              * Permission to use, copy, modify, and distribute this
+              * software is freely granted, provided that this notice
+              * is preserved.
+              * ====================================================
+              */
+            /* reduce x into [sqrt(2)/2, sqrt(2)] */
+            uiT hu = bit_cast(uf, as<uiT>()) >> 32;
+            hu += 0x3ff00000 - 0x3fe6a09e;
+            iT k = bit_cast(hu >> 20, as<iT>()) - 0x3ff;
+            /* correction term ~ log(1+x)-log(u), avoid underflow in c/u */
+            T c = if_else(k < 54, if_else(k >= 2, oneminus(uf - a0), a0 - dec(uf)), zero);
+            if( eve::any(eve::is_nez(c)) ) c /= uf;
+            hu  = (hu & 0x000fffffull) + 0x3fe6a09e;
+            T f = bit_cast(bit_cast(hu << 32, as<uiT>()) | ((bit_cast(uf, as<uiT>()) & 0xffffffffull)),
+                            as<T>());
+            f   = dec(f);
 
-              T hfsq = half(eve::as<T>()) * sqr(f);
-              T s    = f / (2.0 + f);
-              T z    = sqr(s);
-              T w    = sqr(z);
-              T t1   = w *
-                eve::reverse_horner(w, T(0x1.999999997fa04p-2), T(0x1.c71c51d8e78afp-3), T(0x1.39a09d078c69fp-3))
-                ;
-              T t2   = z
-                *
-                eve::reverse_horner(w, T(0x1.5555555555593p-1), T(0x1.2492494229359p-2)
-                                   , T(0x1.7466496cb03dep-3), T(0x1.2f112df3e5244p-3))
-                ;
-              T R  = t2 + t1;
-              T dk = convert(k, as<double>());
-              T r  = fma(dk, Log_2hi, ((fma(s, (hfsq + R), fma(dk, Log_2lo, c)) - hfsq) + f));
-              T zz;
-              if constexpr( eve::platform::supports_infinites )
-              {
-                zz = if_else(
-                  isnez, if_else(a0 == inf(eve::as<T>()), inf(eve::as<T>()), r), minf(eve::as<T>()));
-              }
-              else { zz = if_else(isnez, r, minf(eve::as<T>())); }
-              return if_else(is_ngez(uf), eve::allbits, zz);
+            T hfsq = half(eve::as<T>()) * sqr(f);
+            T s    = f / (2.0 + f);
+            T z    = sqr(s);
+            T w    = sqr(z);
+            T t1   = w *
+              eve::reverse_horner(w, T(0x1.999999997fa04p-2), T(0x1.c71c51d8e78afp-3), T(0x1.39a09d078c69fp-3))
+              ;
+            T t2   = z
+              *
+              eve::reverse_horner(w, T(0x1.5555555555593p-1), T(0x1.2492494229359p-2)
+                                  , T(0x1.7466496cb03dep-3), T(0x1.2f112df3e5244p-3))
+              ;
+            T R  = t2 + t1;
+            T dk = convert(k, as<double>());
+            T r  = fma(dk, Log_2hi, ((fma(s, (hfsq + R), fma(dk, Log_2lo, c)) - hfsq) + f));
+            T zz;
+            if constexpr( eve::platform::supports_infinites )
+            {
+              zz = if_else(
+                isnez, if_else(a0 == inf(eve::as<T>()), inf(eve::as<T>()), r), minf(eve::as<T>()));
             }
+            else { zz = if_else(isnez, r, minf(eve::as<T>())); }
+            return if_else(is_ngez(uf), eve::allbits, zz);
           }
         }
-        else return apply_over(log1p, a0);
       }
       else  // scalar case
       {

--- a/include/eve/module/math/regular/log2.hpp
+++ b/include/eve/module/math/regular/log2.hpp
@@ -96,205 +96,200 @@ namespace eve
   namespace detail
   {
     template<typename T, callable_options O>
-    EVE_FORCEINLINE constexpr T
-    log2_(EVE_REQUIRES(cpu_), O const&, T a0) noexcept
+    EVE_FORCEINLINE constexpr T log2_(EVE_REQUIRES(cpu_), O const&, T a0) noexcept
     {
       if constexpr(simd_value<T>)
       {
-        if constexpr( has_native_abi_v<T> )
+        using uiT   = as_integer_t<T, unsigned>;
+        using iT    = as_integer_t<T, signed>;
+        constexpr bool is_avx = current_api == avx;
+        using TT =  std::conditional_t<is_avx, T, iT >;
+        using elt_t = element_type_t<T>;
+        if constexpr( std::is_same_v<elt_t, float> )
         {
-          using uiT   = as_integer_t<T, unsigned>;
-          using iT    = as_integer_t<T, signed>;
-          constexpr bool is_avx = current_api == avx;
-          using TT =  std::conditional_t<is_avx, T, iT >;
-          using elt_t = element_type_t<T>;
-          if constexpr( std::is_same_v<elt_t, float> )
+          /* origin: FreeBSD /usr/src/lib/msun/src/e_log2f.c */
+          /*
+            * ====================================================
+            * Copyright (C) 1993 by Sun Microsystems, Inc. All rights reserved.
+            *
+            * Developed at SunPro, a Sun Microsystems, Inc. business.
+            * Permission to use, copy, modify, and distribute this
+            * software is freely granted, provided that this notice
+            * is preserved.
+            * ====================================================
+            */
+          T          x = a0;
+          T          f(0);
+          TT         k(0);
+          auto       isnez = is_nez(a0);
+          logical<T> test;
+          if constexpr( eve::platform::supports_denormals )
           {
-            /* origin: FreeBSD /usr/src/lib/msun/src/e_log2f.c */
-            /*
-             * ====================================================
-             * Copyright (C) 1993 by Sun Microsystems, Inc. All rights reserved.
-             *
-             * Developed at SunPro, a Sun Microsystems, Inc. business.
-             * Permission to use, copy, modify, and distribute this
-             * software is freely granted, provided that this notice
-             * is preserved.
-             * ====================================================
-             */
-            T          x = a0;
-            T          f(0);
-            TT         k(0);
-            auto       isnez = is_nez(a0);
-            logical<T> test;
-            if constexpr( eve::platform::supports_denormals )
+            test = is_less(a0, smallestposval(eve::as<T>())) && isnez;
+            if( eve::any(test) )
             {
-              test = is_less(a0, smallestposval(eve::as<T>())) && isnez;
-              if( eve::any(test) )
-              {
-                k = sub[test](k, TT(25));
-                x = if_else(test, x * T(33554432ul), x);
-              }
+              k = sub[test](k, TT(25));
+              x = if_else(test, x * T(33554432ul), x);
             }
-            if constexpr(is_avx)
-            {
-              auto [xx, kk]     = eve::frexp(x);
-              x = xx;
-              auto x_lt_sqrthf = (invsqrt_2(eve::as<T>()) > x);
-              k += dec[x_lt_sqrthf](kk);
-              f = dec(x + if_else(x_lt_sqrthf, x, eve::zero));
-            }
-            else
-            {
-              uiT ix = bit_cast(x, as<uiT>());
-              /* reduce x into [sqrt(2)/2, sqrt(2)] */
-              ix += 0x3f800000 - 0x3f3504f3;
-              k += bit_cast(ix >> 23, as<iT>()) - 0x7f;
-              ix = (ix & 0x007fffff) + 0x3f3504f3;
-              x  = bit_cast(ix, as<T>());
-              f  = dec(x);
-            }
-            T s    = f / (2.0f + f);
-            T z    = sqr(s);
-            T w    = sqr(z);
-            T t1   = w * eve::reverse_horner(w, T(0x1.999c26p-2f), T(0x1.f13c4cp-3f));
-            T t2   = z * eve::reverse_horner(w, T(0x1.555554p-1f), T(0x1.23d3dcp-2f));
-            T R    = t2 + t1;
-            T hfsq = half(eve::as<T>()) * sqr(f);
-
-            T dk = convert(k, as<float>());
-            T r  = fma(fms(s, hfsq + R, hfsq) + f, invlog_2(eve::as<T>()), dk);
-            // The original algorithm does some extra calculation in place of the return line
-            // to get extra precision but this is uneeded for float as the exhaustive test shows
-            // a 0.5 ulp maximal error on the full range.
-            // Moreover all log2(exp2(i)) i =  1..31 are flint
-            // I leave the code here in case an exotic proc will not play the game.
-            //       T  hi = f - hfsq;
-            //       hi =  (hi & uiT(0xfffff000ull));
-            //       T  lo = fma(s, hfsq+R, f - hi - hfsq);
-            //       T r = (lo+hi)*detail::Invlog_2lo<T>() + lo*detail::Invlog_2hi<T>() +
-            //       hi*detail::Invlog_2hi<T>() + k;
-            T zz;
-            if constexpr( eve::platform::supports_infinites )
-            {
-              zz = if_else(
-                isnez, if_else(a0 == inf(eve::as<T>()), inf(eve::as<T>()), r), minf(eve::as<T>()));
-            }
-            else { zz = if_else(isnez, r, minf(eve::as<T>())); }
-            return if_else(is_ngez(a0), eve::allbits, zz);
           }
-          else if constexpr( std::is_same_v<elt_t, double> )
+          if constexpr(is_avx)
           {
-            /* origin: FreeBSD /usr/src/lib/msun/src/e_log2f.c */
-            /*
-             * ====================================================
-             * Copyright (C) 1993 by Sun Microsystems, Inc. All rights reserved.
-             *
-             * Developed at SunPro, a Sun Microsystems, Inc. business.
-             * Permission to use, copy, modify, and distribute this
-             * software is freely granted, provided that this notice
-             * is preserved.
-             * ====================================================
-             */
-            T          x = a0;
-            TT         k(0);
-            T f(0);
-            auto       isnez = is_nez(a0);
-            logical<T> test;
-            if constexpr( eve::platform::supports_denormals )
-            {
-              test = is_less(a0, smallestposval(eve::as<T>())) && isnez;
-              if( eve::any(test) )
-              {
-                k = sub[test](k, TT(54));
-                x = if_else(test, x * T(18014398509481984ull), x);
-              }
-            }
-            if constexpr(is_avx)
-            {
-              auto [xx, kk]     = eve::frexp(x);
-              x = xx;
-              auto x_lt_sqrthf = (invsqrt_2(eve::as<T>()) > x);
-              k += dec[x_lt_sqrthf](kk);
-              f  = dec(x + if_else(x_lt_sqrthf, x, eve::zero));
-            }
-            else
-            {
-              /* reduce x into [sqrt(2)/2, sqrt(2)] */
-              uiT hx = bit_cast(x, as<uiT>()) >> 32;
-              hx += 0x3ff00000 - 0x3fe6a09e;
-              k += bit_cast(hx >> 20, as<iT>()) - 0x3ff;
-              hx = ((hx & 0x000fffffull)) + 0x3fe6a09e;
-              x  = bit_cast(hx << 32 | (bit_and(bit_cast(x, as<uiT>()), 0xffffffffull)), as<T>());
-              f  = dec(x);
-            }
-            T s  = f / (2.0f + f);
-            T z  = sqr(s);
-            T w  = sqr(z);
-            T t1 = w * eve::reverse_horner(w, T(0x1.999999997fa04p-2), T(0x1.c71c51d8e78afp-3), T(0x1.39a09d078c69fp-3));
-            T t2 = z * eve::reverse_horner(w, T(0x1.5555555555593p-1), T(0x1.2492494229359p-2)
-                                          , T(0x1.7466496cb03dep-3), T(0x1.2f112df3e5244p-3));
-            T R    = t2 + t1;
-            T hfsq = half(eve::as<T>()) * sqr(f);
-            //        return -(hfsq-(s*(hfsq+R))-f)*Invlog_2<T>()+dk;  // fast ?
-
-            /*
-             * f-hfsq must (for args near 1) be evaluated in extra precision
-             * to avoid a large cancellation when x is near sqrt(2) or 1/sqrt(2).
-             * This is fairly efficient since f-hfsq only depends on f, so can
-             * be evaluated in parallel with R.  Not combining hfsq with R also
-             * keeps R small (though not as small as a true `lo' term would be),
-             * so that extra precision is not needed for terms involving R.
-             *
-             * Compiler bugs involving extra precision used to break Dekker's
-             * theorem for spitting f-hfsq as hi+lo, unless double was used
-             * or the multi-precision calculations were avoided when double
-             * has extra precision.  These problems are now automatically
-             * avoided as a side effect of the optimization of combining the
-             * Dekker splitting step with the clear-low-bits step.
-             *
-             * y must (for args near sqrt(2) and 1/sqrt(2)) be added in extra
-             * precision to avoid a very large cancellation when x is very near
-             * these values.  Unlike the above cancellations, this problem is
-             * specific to base 2.  It is strange that adding +-1 is so much
-             * harder than adding +-ln2 or +-log10_2.
-             *
-             * This uses Dekker's theorem to normalize y+val_hi, so the
-             * compiler bugs are back in some configurations, sigh.  And I
-             * don't want to used double to avoid them, since that gives a
-             * pessimization and the support for avoiding the pessimization
-             * is not yet available.
-             *
-             * The multi-precision calculations for the multiplications are
-             * routine.
-             */
-
-            /* hi+lo = f - hfsq + s*(hfsq+R) ~ log(1+f) */
-
-            T Invlog_2lo = ieee_constant<-0x1.7135a80p-13f, 0x1.705fc2eefa200p-33>(eve::as<T>{});
-            T Invlog_2hi = ieee_constant<0x1.7160000p+0f, 0x1.7154765200000p+0>(eve::as<T>{});
-            T hi         = f - hfsq;
-            hi           = (hi & (allbits(eve::as<uiT>()) << 32));
-            T lo         = fma(s, hfsq + R, f - hi - hfsq);
-
-            T val_hi = hi * Invlog_2hi;
-            T val_lo = fma(lo + hi, Invlog_2lo, lo * Invlog_2hi);
-
-            T dk = convert(k, as<double>());
-            T w1 = dk + val_hi;
-            val_lo += (dk - w1) + val_hi;
-            val_hi = w1;
-            T r    = val_lo + val_hi;
-            T zz;
-            if constexpr( eve::platform::supports_infinites )
-            {
-              zz = if_else(
-                isnez, if_else(a0 == inf(eve::as<T>()), inf(eve::as<T>()), r), minf(eve::as<T>()));
-            }
-            else { zz = if_else(isnez, r, minf(eve::as<T>())); }
-            return if_else(is_ngez(a0), eve::allbits, zz);
+            auto [xx, kk]     = eve::frexp(x);
+            x = xx;
+            auto x_lt_sqrthf = (invsqrt_2(eve::as<T>()) > x);
+            k += dec[x_lt_sqrthf](kk);
+            f = dec(x + if_else(x_lt_sqrthf, x, eve::zero));
           }
+          else
+          {
+            uiT ix = bit_cast(x, as<uiT>());
+            /* reduce x into [sqrt(2)/2, sqrt(2)] */
+            ix += 0x3f800000 - 0x3f3504f3;
+            k += bit_cast(ix >> 23, as<iT>()) - 0x7f;
+            ix = (ix & 0x007fffff) + 0x3f3504f3;
+            x  = bit_cast(ix, as<T>());
+            f  = dec(x);
+          }
+          T s    = f / (2.0f + f);
+          T z    = sqr(s);
+          T w    = sqr(z);
+          T t1   = w * eve::reverse_horner(w, T(0x1.999c26p-2f), T(0x1.f13c4cp-3f));
+          T t2   = z * eve::reverse_horner(w, T(0x1.555554p-1f), T(0x1.23d3dcp-2f));
+          T R    = t2 + t1;
+          T hfsq = half(eve::as<T>()) * sqr(f);
+
+          T dk = convert(k, as<float>());
+          T r  = fma(fms(s, hfsq + R, hfsq) + f, invlog_2(eve::as<T>()), dk);
+          // The original algorithm does some extra calculation in place of the return line
+          // to get extra precision but this is uneeded for float as the exhaustive test shows
+          // a 0.5 ulp maximal error on the full range.
+          // Moreover all log2(exp2(i)) i =  1..31 are flint
+          // I leave the code here in case an exotic proc will not play the game.
+          //       T  hi = f - hfsq;
+          //       hi =  (hi & uiT(0xfffff000ull));
+          //       T  lo = fma(s, hfsq+R, f - hi - hfsq);
+          //       T r = (lo+hi)*detail::Invlog_2lo<T>() + lo*detail::Invlog_2hi<T>() +
+          //       hi*detail::Invlog_2hi<T>() + k;
+          T zz;
+          if constexpr( eve::platform::supports_infinites )
+          {
+            zz = if_else(
+              isnez, if_else(a0 == inf(eve::as<T>()), inf(eve::as<T>()), r), minf(eve::as<T>()));
+          }
+          else { zz = if_else(isnez, r, minf(eve::as<T>())); }
+          return if_else(is_ngez(a0), eve::allbits, zz);
         }
-        else return apply_over(log2, a0);
+        else if constexpr( std::is_same_v<elt_t, double> )
+        {
+          /* origin: FreeBSD /usr/src/lib/msun/src/e_log2f.c */
+          /*
+            * ====================================================
+            * Copyright (C) 1993 by Sun Microsystems, Inc. All rights reserved.
+            *
+            * Developed at SunPro, a Sun Microsystems, Inc. business.
+            * Permission to use, copy, modify, and distribute this
+            * software is freely granted, provided that this notice
+            * is preserved.
+            * ====================================================
+            */
+          T          x = a0;
+          TT         k(0);
+          T f(0);
+          auto       isnez = is_nez(a0);
+          logical<T> test;
+          if constexpr( eve::platform::supports_denormals )
+          {
+            test = is_less(a0, smallestposval(eve::as<T>())) && isnez;
+            if( eve::any(test) )
+            {
+              k = sub[test](k, TT(54));
+              x = if_else(test, x * T(18014398509481984ull), x);
+            }
+          }
+          if constexpr(is_avx)
+          {
+            auto [xx, kk]     = eve::frexp(x);
+            x = xx;
+            auto x_lt_sqrthf = (invsqrt_2(eve::as<T>()) > x);
+            k += dec[x_lt_sqrthf](kk);
+            f  = dec(x + if_else(x_lt_sqrthf, x, eve::zero));
+          }
+          else
+          {
+            /* reduce x into [sqrt(2)/2, sqrt(2)] */
+            uiT hx = bit_cast(x, as<uiT>()) >> 32;
+            hx += 0x3ff00000 - 0x3fe6a09e;
+            k += bit_cast(hx >> 20, as<iT>()) - 0x3ff;
+            hx = ((hx & 0x000fffffull)) + 0x3fe6a09e;
+            x  = bit_cast(hx << 32 | (bit_and(bit_cast(x, as<uiT>()), 0xffffffffull)), as<T>());
+            f  = dec(x);
+          }
+          T s  = f / (2.0f + f);
+          T z  = sqr(s);
+          T w  = sqr(z);
+          T t1 = w * eve::reverse_horner(w, T(0x1.999999997fa04p-2), T(0x1.c71c51d8e78afp-3), T(0x1.39a09d078c69fp-3));
+          T t2 = z * eve::reverse_horner(w, T(0x1.5555555555593p-1), T(0x1.2492494229359p-2)
+                                        , T(0x1.7466496cb03dep-3), T(0x1.2f112df3e5244p-3));
+          T R    = t2 + t1;
+          T hfsq = half(eve::as<T>()) * sqr(f);
+          //        return -(hfsq-(s*(hfsq+R))-f)*Invlog_2<T>()+dk;  // fast ?
+
+          /*
+            * f-hfsq must (for args near 1) be evaluated in extra precision
+            * to avoid a large cancellation when x is near sqrt(2) or 1/sqrt(2).
+            * This is fairly efficient since f-hfsq only depends on f, so can
+            * be evaluated in parallel with R.  Not combining hfsq with R also
+            * keeps R small (though not as small as a true `lo' term would be),
+            * so that extra precision is not needed for terms involving R.
+            *
+            * Compiler bugs involving extra precision used to break Dekker's
+            * theorem for spitting f-hfsq as hi+lo, unless double was used
+            * or the multi-precision calculations were avoided when double
+            * has extra precision.  These problems are now automatically
+            * avoided as a side effect of the optimization of combining the
+            * Dekker splitting step with the clear-low-bits step.
+            *
+            * y must (for args near sqrt(2) and 1/sqrt(2)) be added in extra
+            * precision to avoid a very large cancellation when x is very near
+            * these values.  Unlike the above cancellations, this problem is
+            * specific to base 2.  It is strange that adding +-1 is so much
+            * harder than adding +-ln2 or +-log10_2.
+            *
+            * This uses Dekker's theorem to normalize y+val_hi, so the
+            * compiler bugs are back in some configurations, sigh.  And I
+            * don't want to used double to avoid them, since that gives a
+            * pessimization and the support for avoiding the pessimization
+            * is not yet available.
+            *
+            * The multi-precision calculations for the multiplications are
+            * routine.
+            */
+
+          /* hi+lo = f - hfsq + s*(hfsq+R) ~ log(1+f) */
+
+          T Invlog_2lo = ieee_constant<-0x1.7135a80p-13f, 0x1.705fc2eefa200p-33>(eve::as<T>{});
+          T Invlog_2hi = ieee_constant<0x1.7160000p+0f, 0x1.7154765200000p+0>(eve::as<T>{});
+          T hi         = f - hfsq;
+          hi           = (hi & (allbits(eve::as<uiT>()) << 32));
+          T lo         = fma(s, hfsq + R, f - hi - hfsq);
+
+          T val_hi = hi * Invlog_2hi;
+          T val_lo = fma(lo + hi, Invlog_2lo, lo * Invlog_2hi);
+
+          T dk = convert(k, as<double>());
+          T w1 = dk + val_hi;
+          val_lo += (dk - w1) + val_hi;
+          val_hi = w1;
+          T r    = val_lo + val_hi;
+          T zz;
+          if constexpr( eve::platform::supports_infinites )
+          {
+            zz = if_else(
+              isnez, if_else(a0 == inf(eve::as<T>()), inf(eve::as<T>()), r), minf(eve::as<T>()));
+          }
+          else { zz = if_else(isnez, r, minf(eve::as<T>())); }
+          return if_else(is_ngez(a0), eve::allbits, zz);
+        }
       }
       else //scalar case
       {

--- a/include/eve/module/math/regular/powm1.hpp
+++ b/include/eve/module/math/regular/powm1.hpp
@@ -102,24 +102,20 @@ namespace eve
       }
       else
       {
-        if constexpr( has_native_abi_v<r_t> )
+        auto x = r_t(a);
+        auto y = r_t(b);
+        auto r = dec(pow(x, y));
+        auto test = (abs(y * dec(x)) < r_t(0.5) || (abs(y) < r_t(0.2)));
+        if( eve::any(test) )
         {
-          auto x = r_t(a);
-          auto y = r_t(b);
-          auto r = dec(pow(x, y));
-          auto test = (abs(y * dec(x)) < r_t(0.5) || (abs(y) < r_t(0.2)));
-          if( eve::any(test) )
-          {
-            // We don't have any good/quick approximation for log(x) * y
-            // so just try it and see:
-            auto l = y*log_abs(x);
-            auto tmp0 = expm1(l);
-            auto tmp1 = minus[is_ltz(x) && is_odd(x)](tmp0);
-            return if_else(l < T(0.5), tmp1, r);
-          }
-          else return r;
+          // We don't have any good/quick approximation for log(x) * y
+          // so just try it and see:
+          auto l = y*log_abs(x);
+          auto tmp0 = expm1(l);
+          auto tmp1 = minus[is_ltz(x) && is_odd(x)](tmp0);
+          return if_else(l < T(0.5), tmp1, r);
         }
-        else return apply_over(powm1, a, b);
+        else return r;
       }
     }
   }

--- a/include/eve/module/math/regular/quadrant.hpp
+++ b/include/eve/module/math/regular/quadrant.hpp
@@ -65,20 +65,14 @@ namespace eve
   {
 
     template<typename T, callable_options O>
-    EVE_FORCEINLINE constexpr T
-    quadrant_(EVE_REQUIRES(cpu_), O const &, T a) noexcept
+    EVE_FORCEINLINE constexpr T quadrant_(EVE_REQUIRES(cpu_), O const &, T a) noexcept
     {
-      if constexpr( has_native_abi_v<T> )
+      if constexpr( floating_value<T> )
       {
-        if constexpr( floating_value<T> )
-        {
-          T b = a * T(0.25);
-          return (b - floor(b)) * T(4);
-        }
-        else
-          return (a & T(3));
+        T b = a * T(0.25);
+        return (b - floor(b)) * T(4);
       }
-      else return apply_over(quadrant, a);
+      else return (a & T(3));
     }
   }
 }

--- a/include/eve/module/math/regular/radindeg.hpp
+++ b/include/eve/module/math/regular/radindeg.hpp
@@ -73,16 +73,11 @@ namespace eve
   namespace detail
   {
     template<floating_value T, callable_options O>
-    EVE_FORCEINLINE constexpr T
-    radindeg_(EVE_REQUIRES(cpu_), O const &, T const& a) noexcept
+    EVE_FORCEINLINE constexpr T radindeg_(EVE_REQUIRES(cpu_), O const &, T const& a) noexcept
     {
-      if constexpr( has_native_abi_v<T> )
-      {
-        auto radradindeg  = ieee_constant<0x1.ca5dc20p+5f, 0x1.ca5dc1a63c1f8p+5>(eve::as<T>{});
-        auto radradindegr = ieee_constant<0x1.670f800p-21f, 0x1.1e7ab456405f8p-49>(eve::as<T>{});
-        return fma(a, radradindegr, a * radradindeg);
-      }
-      else return apply_over(radindeg, a);
+      auto radradindeg  = ieee_constant<0x1.ca5dc20p+5f, 0x1.ca5dc1a63c1f8p+5>(eve::as<T>{});
+      auto radradindegr = ieee_constant<0x1.670f800p-21f, 0x1.1e7ab456405f8p-49>(eve::as<T>{});
+      return fma(a, radradindegr, a * radradindeg);
     }
   }
 }

--- a/include/eve/module/math/regular/radinpi.hpp
+++ b/include/eve/module/math/regular/radinpi.hpp
@@ -73,13 +73,9 @@ namespace eve
   namespace detail
   {
     template<floating_value T, callable_options O>
-    EVE_FORCEINLINE constexpr T
-    radinpi_(EVE_REQUIRES(cpu_), O const &, T const& a) noexcept
+    EVE_FORCEINLINE constexpr T radinpi_(EVE_REQUIRES(cpu_), O const &, T const& a) noexcept
     {
-      if constexpr( has_native_abi_v<T> )
-        return inv_pi(eve::as(a)) * a;
-      else
-        return apply_over(radinpi, a);
+      return inv_pi(eve::as(a)) * a;
     }
   }
 }

--- a/include/eve/module/polynomial/regular/impl/gegenbauer.hpp
+++ b/include/eve/module/polynomial/regular/impl/gegenbauer.hpp
@@ -47,30 +47,26 @@ namespace eve::detail
     else
     {
       auto xx = c_t(x);
-      if( has_native_abi_v<T> )
-      {
-        auto   y0     = one(as(xx));
-        auto iseqzn   = is_eqz(nn);
-        if( eve::all(iseqzn) ) return y0;
-        auto n  = convert(nn, as(elt_t()));
-        auto    y1 = 2 * lambda * xx;
+      auto   y0     = one(as(xx));
+      auto iseqzn   = is_eqz(nn);
+      if( eve::all(iseqzn) ) return y0;
+      auto n  = convert(nn, as(elt_t()));
+      auto    y1 = 2 * lambda * xx;
 
-        auto    yk = y1;
-        elt_t   k(2);
-        auto    k_max = n * inc(eps(as(elt_t())));
-        auto    gamma = 2 * dec(lambda);
-        auto    test  = k < k_max;
-        while( eve::any(test) )
-        {
-          yk   = if_else(test, fms((2 + gamma / k) * xx, y1, inc(gamma / k) * y0), yk);
-          y0   = y1;
-          y1   = yk;
-          k    = inc(k);
-          test = k < k_max;
-        }
-        return if_else(iseqzn, one, yk);
+      auto    yk = y1;
+      elt_t   k(2);
+      auto    k_max = n * inc(eps(as(elt_t())));
+      auto    gamma = 2 * dec(lambda);
+      auto    test  = k < k_max;
+      while( eve::any(test) )
+      {
+        yk   = if_else(test, fms((2 + gamma / k) * xx, y1, inc(gamma / k) * y0), yk);
+        y0   = y1;
+        y1   = yk;
+        k    = inc(k);
+        test = k < k_max;
       }
-      else return apply_over(gegenbauer, nn, lambda, x);
+      return if_else(iseqzn, one, yk);
     }
   };
 }

--- a/include/eve/module/polynomial/regular/impl/hermite.hpp
+++ b/include/eve/module/polynomial/regular/impl/hermite.hpp
@@ -26,21 +26,17 @@ namespace eve::detail
   {
     if constexpr(scalar_value<I>)
     {
-      if constexpr( has_native_abi_v<T> )
+      T p0 = one(as(x));
+      if( is_eqz(n) ) return p0;
+      T p1 = x + x;
+      I c  = one(as(n));
+      while( c < n )
       {
-        T p0 = one(as(x));
-        if( is_eqz(n) ) return p0;
-        T p1 = x + x;
-        I c  = one(as(n));
-        while( c < n )
-        {
-          std::swap(p0, p1);
-          p1 = hermite[successor](c, x, p0, p1);
-          ++c;
-        }
-        return p1;
+        std::swap(p0, p1);
+        p1 = hermite[successor](c, x, p0, p1);
+        ++c;
       }
-      else return apply_over(hermite, n, x);
+      return p1;
     }
     else if constexpr(simd_value<I>)
     {

--- a/include/eve/module/polynomial/regular/impl/jacobi.hpp
+++ b/include/eve/module/polynomial/regular/impl/jacobi.hpp
@@ -49,36 +49,32 @@ namespace eve::detail
       if constexpr( std::same_as<T, I> && std::same_as<T, U> && std::same_as<T, V>)
       {
         EVE_ASSERT(eve::all(is_flint(n)), "some elements of n are not flint");
-        if constexpr( has_native_abi_v<T> )
+        T    y0(1);
+        auto ap1   = inc(alpha);
+        auto apb   = alpha + beta;
+        auto a2mb2 = sqr(alpha) - sqr(beta);
+        auto y1    = fam(ap1, (apb + 2), (x - 1) * T(0.5));
+        T    yk    = y1;
+        T    k(2);
+        T    k2(4);
+        auto test = k <= n;
+        while( eve::any(test) )
         {
-          T    y0(1);
-          auto ap1   = inc(alpha);
-          auto apb   = alpha + beta;
-          auto a2mb2 = sqr(alpha) - sqr(beta);
-          auto y1    = fam(ap1, (apb + 2), (x - 1) * T(0.5));
-          T    yk    = y1;
-          T    k(2);
-          T    k2(4);
-          auto test = k <= n;
-          while( eve::any(test) )
-          {
-            T apbpk  = k + apb;
-            T apbpk2 = k + apbpk;
-            T denom  = k2 * apbpk * (apbpk2 - 2);
-            T gamma1 = (apbpk2 - 1) * fma(apbpk2 * (apbpk2 - 2), x, a2mb2);
-            T gamma0 = -2 * (k + alpha - 1) * (k + beta - 1) * apbpk2;
-            yk       = if_else(test,
-                               fma(gamma1, y1, gamma0 * y0) / denom,
-                               yk); // sum_of_prod(gamma1, y1, gamma0, y0)/denom, yk);
-            y0       = if_else(test, y1, y0);
-            y1       = if_else(test, yk, y1);
-            k        = inc(k);
-            k2 += 2;
-            test = k <= n;
-          }
-          return if_else(is_eqz(n), one, yk);
+          T apbpk  = k + apb;
+          T apbpk2 = k + apbpk;
+          T denom  = k2 * apbpk * (apbpk2 - 2);
+          T gamma1 = (apbpk2 - 1) * fma(apbpk2 * (apbpk2 - 2), x, a2mb2);
+          T gamma0 = -2 * (k + alpha - 1) * (k + beta - 1) * apbpk2;
+          yk       = if_else(test,
+                              fma(gamma1, y1, gamma0 * y0) / denom,
+                              yk); // sum_of_prod(gamma1, y1, gamma0, y0)/denom, yk);
+          y0       = if_else(test, y1, y0);
+          y1       = if_else(test, yk, y1);
+          k        = inc(k);
+          k2 += 2;
+          test = k <= n;
         }
-        else return apply_over(jacobi, n, alpha, beta, x);
+        return if_else(is_eqz(n), one, yk);
       }
       else
       {

--- a/include/eve/module/polynomial/regular/impl/legendre.hpp
+++ b/include/eve/module/polynomial/regular/impl/legendre.hpp
@@ -71,55 +71,45 @@ namespace eve::detail
       }
       else
       {
-        if constexpr( has_native_abi_v<T> )
+        if constexpr(O::contains(p_kind) || O::contains(q_kind))
         {
-          if constexpr(O::contains(p_kind) || O::contains(q_kind))
-          {
-            auto xx = r_t(x);
-            using elt_t = element_type_t<T>;
-            auto p0     = one(as(xx));
-            r_t    p00;
-            auto iseqzn       = is_eqz(l);
-            auto p1           = xx;
-            auto out_of_range = eve::abs(xx) > one(as(xx));
+          auto xx = r_t(x);
+          using elt_t = element_type_t<T>;
+          auto p0     = one(as(xx));
+          r_t    p00;
+          auto iseqzn       = is_eqz(l);
+          auto p1           = xx;
+          auto out_of_range = eve::abs(xx) > one(as(xx));
 
-            if constexpr(O::contains(p_kind))
-            {
-              if( eve::all(iseqzn) ) return if_else(out_of_range, allbits, p0);
-            }
-            else if constexpr(O::contains(q_kind))
-            {
-              p0  = atanh(xx);
-              p00 = p0;
-              if( eve::all(iseqzn) ) return if_else(out_of_range, allbits, r_t(p0));
-              p1 = fms(x, p0, one(as(xx)));
-            }
-            auto n    = convert(l, as<elt_t>());
-            auto c    = one(as(n));
-            auto test = c < n;
-            while( eve::any(test) )
-            {
-              auto p = p0;
-              p0     = p1;
-              p1     = if_else(test, legendre[successor](c, xx, p0, p), p1);
-              c      = inc(c);
-              test   = c < n;
-            }
-            if constexpr(O::contains(p_kind))
-              p1 = if_else(iseqzn, one, p1);
-            else if constexpr(O::contains(q_kind) )
-              p1 = if_else(iseqzn, p00, p1);
-            return if_else(out_of_range, allbits, p1);
-          }
-          else return apply_over(legendre[p_kind], l, r_t(x));
-        }
-        else
-        {
           if constexpr(O::contains(p_kind))
-            return apply_over(legendre[p_kind], l, r_t(x));
-          else
-            return apply_over(legendre[q_kind], l, r_t(x));
+          {
+            if( eve::all(iseqzn) ) return if_else(out_of_range, allbits, p0);
+          }
+          else if constexpr(O::contains(q_kind))
+          {
+            p0  = atanh(xx);
+            p00 = p0;
+            if( eve::all(iseqzn) ) return if_else(out_of_range, allbits, r_t(p0));
+            p1 = fms(x, p0, one(as(xx)));
+          }
+          auto n    = convert(l, as<elt_t>());
+          auto c    = one(as(n));
+          auto test = c < n;
+          while( eve::any(test) )
+          {
+            auto p = p0;
+            p0     = p1;
+            p1     = if_else(test, legendre[successor](c, xx, p0, p), p1);
+            c      = inc(c);
+            test   = c < n;
+          }
+          if constexpr(O::contains(p_kind))
+            p1 = if_else(iseqzn, one, p1);
+          else if constexpr(O::contains(q_kind) )
+            p1 = if_else(iseqzn, p00, p1);
+          return if_else(out_of_range, allbits, p1);
         }
+        else return legendre[p_kind](l, r_t(x));
       }
     }
   }
@@ -183,64 +173,60 @@ namespace eve::detail
     }
     else
     {
-      if constexpr( has_native_abi_v<T> )
+      auto iseqzm = is_eqz(m);
+      if( eve::all(iseqzm) )
       {
-        auto iseqzm = is_eqz(m);
-        if( eve::all(iseqzm) )
-        {
-          return legendre(l, x);
-        }
-        else
-        {
-          auto lpos    = is_gez(l);
-          auto mpos    = is_gez(m);
-          auto mlel    = m <= l;
-          auto inrange = eve::abs(x) <= one(as(x));
-          auto notdone_ = inrange && lpos && mpos;
-          auto r       = if_else(notdone_, zero, nan(as(x)));
-          notdone_     = notdone_ && mlel;
+        return legendre(l, x);
+      }
+      else
+      {
+        auto lpos    = is_gez(l);
+        auto mpos    = is_gez(m);
+        auto mlel    = m <= l;
+        auto inrange = eve::abs(x) <= one(as(x));
+        auto notdone_ = inrange && lpos && mpos;
+        auto r       = if_else(notdone_, zero, nan(as(x)));
+        notdone_     = notdone_ && mlel;
 
+        if( eve::any(notdone_) )
+        {
+          auto mz_case = [](auto ll, auto xx) { //(m == 0);
+            return legendre(ll, xx);
+          };
+
+          auto regular_case = [](auto ll, auto mm, auto x_, auto notdone) { // other cases
+            using elt_t          = element_type_t<T>;
+            auto ll_             = convert(ll, as<elt_t>());
+            auto mm_               = convert(mm, as<elt_t>());
+            using r_t            = decltype(x_ * ll_ * mm_);
+            auto sin_theta_power = eve::pow1p(-sqr(x_), eve::abs(mm_) / 2);
+
+            r_t p0 = convert(eve::double_factorial(convert(eve::max(2 * mm - 1, zero(as(mm))), uint_from<T>())),
+                              as<elt_t>())
+            * sin_theta_power;
+            auto p00  = p0;
+            auto p1   = x_ * (2 * mm_ + 1) * p0;
+            auto n    = if_else(notdone, inc(mm_), inc(ll_));
+            auto test = (n < ll_);
+            while( eve::any(test) )
+            {
+              auto p = p0;
+              p0     = p1;
+              p1     = if_else(test, legendre[associated][successor](n, mm_, x_, p0, p), p1);
+              n      = inc(n);
+              test   = n < ll_;
+            }
+            return if_else(mm_ == ll_, p00, p1);
+          };
+          auto mz = (m == 0);
+          notdone_ = next_interval(mz_case, notdone_, mz, r, l, x);
           if( eve::any(notdone_) )
           {
-            auto mz_case = [](auto ll, auto xx) { //(m == 0);
-              return legendre(ll, xx);
-            };
-
-            auto regular_case = [](auto ll, auto mm, auto x_, auto notdone) { // other cases
-              using elt_t          = element_type_t<T>;
-              auto ll_             = convert(ll, as<elt_t>());
-              auto mm_               = convert(mm, as<elt_t>());
-              using r_t            = decltype(x_ * ll_ * mm_);
-              auto sin_theta_power = eve::pow1p(-sqr(x_), eve::abs(mm_) / 2);
-
-              r_t p0 = convert(eve::double_factorial(convert(eve::max(2 * mm - 1, zero(as(mm))), uint_from<T>())),
-                               as<elt_t>())
-              * sin_theta_power;
-              auto p00  = p0;
-              auto p1   = x_ * (2 * mm_ + 1) * p0;
-              auto n    = if_else(notdone, inc(mm_), inc(ll_));
-              auto test = (n < ll_);
-              while( eve::any(test) )
-              {
-                auto p = p0;
-                p0     = p1;
-                p1     = if_else(test, legendre[associated][successor](n, mm_, x_, p0, p), p1);
-                n      = inc(n);
-                test   = n < ll_;
-              }
-              return if_else(mm_ == ll_, p00, p1);
-            };
-            auto mz = (m == 0);
-            notdone_ = next_interval(mz_case, notdone_, mz, r, l, x);
-            if( eve::any(notdone_) )
-            {
-              notdone_ = last_interval(regular_case, notdone_, r, l, m, x, notdone_);
-            }
+            notdone_ = last_interval(regular_case, notdone_, r, l, m, x, notdone_);
           }
-          return r;
         }
+        return r;
       }
-      else return apply_over(legendre[associated], l, m, x);
     }
   }
 }

--- a/include/eve/module/polynomial/regular/impl/tchebytchev.hpp
+++ b/include/eve/module/polynomial/regular/impl/tchebytchev.hpp
@@ -56,34 +56,30 @@ namespace eve::detail
         }
         else
         {
-          if constexpr( has_native_abi_v<T> )
+          switch( int(n) )
           {
-            switch( int(n) )
+          case 0: return one(as(x));
+          case 1: return x;
+          case 2: return fma(x, x + x, mone(as(x)));
+          case 3: return x * fms(4 * x, x, 3);
+          case 4: return inc(8 * sqr(x) * (sqr(x) - 1));
+          default:
+            auto nn   = T(n);
+            auto z    = eve::abs(x);
+            auto test = (z <= one(as(z)));
+            if( all(test) ) return cos(nn * acos(x));
+            else
             {
-            case 0: return one(as(x));
-            case 1: return x;
-            case 2: return fma(x, x + x, mone(as(x)));
-            case 3: return x * fms(4 * x, x, 3);
-            case 4: return inc(8 * sqr(x) * (sqr(x) - 1));
-            default:
-              auto nn   = T(n);
-              auto z    = eve::abs(x);
-              auto test = (z <= one(as(z)));
-              if( all(test) ) return cos(nn * acos(x));
+              auto t = cosh(nn * acosh(z));
+              if( none(test) ) return if_else(is_gez(x), t, t * sign_alternate(nn));
               else
               {
-                auto t = cosh(nn * acosh(z));
-                if( none(test) ) return if_else(is_gez(x), t, t * sign_alternate(nn));
-                else
-                {
-                  auto r0 = cos(nn * acos(x));
-                  auto r1 = if_else(is_gez(x), t, t * sign_alternate(nn));
-                  return if_else(test, r0, r1);
-                }
+                auto r0 = cos(nn * acos(x));
+                auto r1 = if_else(is_gez(x), t, t * sign_alternate(nn));
+                return if_else(test, r0, r1);
               }
             }
           }
-          else return apply_over(tchebytchev, n, x);
         }
       }
       else if constexpr(simd_value<I>)
@@ -92,7 +88,7 @@ namespace eve::detail
         {
           return tchebytchev[o](n, r_t(x));
         }
-        else if constexpr( has_native_abi_v<T> )
+        else
         {
           auto nn   = convert(n, as<eve::element_type_t<T>>());
           auto z    = eve::abs(x);
@@ -105,7 +101,6 @@ namespace eve::detail
             return if_else(test, r, if_else(is_gez(x), t, t * sign_alternate(nn)));
           }
         }
-        else return apply_over(tchebytchev, n, x);
       }
     }
     else if constexpr(O::contains(kind_2))


### PR DESCRIPTION
Remove/cleanup some calls to `map` or `apply_over` that should not be there.