### PR TITLE
Improve SVE ignore_none mask generation in sve_true(as) for sub-cardinals

### DIFF
--- a/include/eve/arch/arm/sve/sve_true.hpp
+++ b/include/eve/arch/arm/sve/sve_true.hpp
@@ -41,8 +41,8 @@ EVE_FORCEINLINE T sve_true(C cond, as<T> tgt)
       half_t half = sve_true(cond, eve::as<half_t>{});
       return T{half, half};
     }
-    else if constexpr(T::size() == fc_t::value )      return sve_true<v_t>();
-    else return bit_cast(keep_first(T::size()).mask(as<as_wide_t<v_t, fc_t>>{}), tgt);
+    else if constexpr (T::size() == fc_t::value) return sve_true<v_t>();
+    else                                         return keep_first(T::size()).mask(tgt);
   }
   else
   {


### PR DESCRIPTION
Improve ignore_none mask generation in `sve_true(as)` in cases where the vector cardinal is lower than the expected cardinal for the architecture.

Exemple codegen from the #2076 PR: 
baseline: 
```asm
test(eve::logical<eve::arm_sve256_v0::wide<int, eve::fixed<4l> > >):  
  =>    index   z31.s, #0, #1
  =>    ptrue   p2.b, vl32
        sub     sp, sp, #16
  =>    cmplt   p3.s, p2/z, z31.s, #4
        mov     w1, 0
        ptest   p3, p0.b
        b.none  .L2
        mov     w1, 1
        ptrue   p3.s, vl8
        brkb    p3.b, p3/z, p0.b
        cntp    x0, p2, p3.s
.L2:
        strb    w1, [sp, 8]
        ldr     x1, [sp, 8]
        add     sp, sp, 16
        ret
```
this PR:
```asm
test(eve::logical<eve::arm_sve256_v0::wide<int, eve::fixed<4l> > >):
  =>    ptrue   p3.s, vl4
        sub     sp, sp, #16
        mov     w1, 0
        ptest   p3, p0.b
        b.none  .L2
        mov     w1, 1
        ptrue   p3.s, vl8
        ptrue   p2.b, vl32
        brkb    p3.b, p3/z, p0.b
        cntp    x0, p2, p3.s
.L2:
        strb    w1, [sp, 8]
        ldr     x1, [sp, 8]
        add     sp, sp, 16
        ret
```

In this example, the group of highlighted lines  create a logical mask with the first `4s` (or `32b`) lanes in the enabled state.
The code using this PR relies on the mask generation optimizations made in the #2064 PR, and produces the optimal code in this case (a `ptrue` instruction with a size parameter matching the required lane count).

This should improve the codegen for most sve functions calling the parametrized form of the `sve_true` function.