### PR TITLE
Fix memory tests not found

### DIFF
--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -43,10 +43,11 @@ glob_unit("unit" ${unit_root} "internals/*.cpp")
 ##==================================================================================================
 add_custom_target(unit.memory.exe         )
 add_dependencies(unit.exe unit.memory.exe )
-glob_unit("unit" ${unit_root} "memory/*.cpp"               )
-glob_unit("unit" ${unit_root} "memory/load/*.cpp"          )
-glob_unit("unit" ${unit_root} "memory/store/*.cpp"         )
-glob_unit("unit" ${unit_root} "memory/compress_store/*.cpp")
+glob_unit("unit" ${unit_root} "memory/*.cpp"                )
+glob_unit("unit" ${unit_root} "memory/load/*.cpp"           )
+glob_unit("unit" ${unit_root} "memory/load/aligned/*.cpp"   )
+glob_unit("unit" ${unit_root} "memory/load/unaligned/*.cpp" )
+glob_unit("unit" ${unit_root} "memory/store/*.cpp"          )
 
 ##==================================================================================================
 ## GLOB and process meta unit tests


### PR DESCRIPTION
The memory load aligned/unaligned tests were not globbed by the cmakefile and were not run for 3 years.