### PR TITLE
Improved logical_xxx testing + SVE optimizations

### DIFF
--- a/include/eve/detail/validate_mask.hpp
+++ b/include/eve/detail/validate_mask.hpp
@@ -1,0 +1,40 @@
+//==================================================================================================
+/*
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+*/
+//==================================================================================================
+#pragma once
+
+#include <eve/concept/value.hpp>
+#include <eve/concept/options.hpp>
+#include <eve/concept/conditional.hpp>
+#include <eve/deps/raberu/raberu.hpp>
+
+#include <concepts>
+
+namespace eve::detail
+{
+  template<typename C, typename T>
+  EVE_FORCEINLINE constexpr bool validate_mask_for() noexcept
+  {
+    if constexpr (scalar_value<T>)
+    {
+      if constexpr (std::same_as<C, ignore_none_>) return true;
+      else if constexpr (C::has_alternative)       return validate_mask_for<typename C::conditional_type, T>();
+      else                                         return !(relative_conditional_expr<C> || simd_value<C>);
+    }
+    else
+    {
+      return true;
+    }
+  }
+
+  template<callable_options O, typename T>
+  constexpr EVE_FORCEINLINE bool validate_mask_for() noexcept
+  {
+    if constexpr (O::contains(condition_key)) return validate_mask_for<rbr::result::fetch_t<condition_key, O>, T>();
+    else                                      return true;
+  }
+}

--- a/include/eve/module/core/regular/impl/logical_notand.hpp
+++ b/include/eve/module/core/regular/impl/logical_notand.hpp
@@ -10,12 +10,19 @@
 #include <eve/concept/value.hpp>
 #include <eve/detail/implementation.hpp>
 #include <eve/detail/overload.hpp>
+#include <eve/module/core/regular/logical_andnot.hpp>
 
 namespace eve::detail
 {
   template<callable_options O, relaxed_logical_value T>
-  EVE_FORCEINLINE constexpr T logical_notand_(EVE_REQUIRES(cpu_), O const&, T a, T b) noexcept
+  EVE_FORCEINLINE constexpr T logical_notand_(EVE_REQUIRES(cpu_), O const& opts, T a, T b) noexcept
   {
-    return !a && b;
+    return logical_andnot(b, a);
+  }
+
+  template<callable_options O, conditional_expr C, relaxed_logical_value T>
+  EVE_FORCEINLINE constexpr T logical_notand_(EVE_REQUIRES(cpu_), C const& cx, O const&, T a, T b) noexcept
+  {
+    return logical_andnot[cx](b, a);
   }
 }

--- a/include/eve/module/core/regular/impl/logical_notor.hpp
+++ b/include/eve/module/core/regular/impl/logical_notor.hpp
@@ -10,12 +10,19 @@
 #include <eve/concept/value.hpp>
 #include <eve/detail/implementation.hpp>
 #include <eve/detail/overload.hpp>
+#include <eve/module/core/regular/logical_ornot.hpp>
 
 namespace eve::detail
 {
   template<callable_options O, relaxed_logical_value T>
   EVE_FORCEINLINE constexpr T logical_notor_(EVE_REQUIRES(cpu_), O const&, T a, T b) noexcept
   {
-    return !a || b;
+    return logical_ornot(b, a);
+  }
+
+  template<callable_options O, conditional_expr C, relaxed_logical_value T>
+  EVE_FORCEINLINE constexpr T logical_notor_(EVE_REQUIRES(cpu_), C const& cx, O const&, T a, T b) noexcept
+  {
+    return logical_ornot[cx](b, a);
   }
 }

--- a/include/eve/module/core/regular/impl/simd/arm/sve/logical_andnot.hpp
+++ b/include/eve/module/core/regular/impl/simd/arm/sve/logical_andnot.hpp
@@ -14,16 +14,17 @@
 namespace eve::detail
 {
   template<callable_options O, typename T, typename N>
-  EVE_FORCEINLINE logical<wide<T, N>> logical_or_(EVE_REQUIRES(sve_), O const&, logical<wide<T, N>> a, logical<wide<T, N>> b) noexcept
+  EVE_FORCEINLINE logical<wide<T, N>> logical_andnot_(EVE_REQUIRES(sve_), O const&, logical<wide<T, N>> a, logical<wide<T, N>> b) noexcept
     requires sve_abi<abi_t<T, N>>
   {
-    return svorr_z(expand_mask(keep_first(N::value), as(a)), a, b);
+    return svbic_z(expand_mask(keep_first(N::value), as(a)), a, b);
   }
 
   template<callable_options O, conditional_expr C, typename T, typename N>
-  EVE_FORCEINLINE logical<wide<T, N>> logical_or_(EVE_REQUIRES(sve_), C const& cx, O const&, logical<wide<T, N>> a, logical<wide<T, N>> b) noexcept
+  EVE_FORCEINLINE logical<wide<T, N>> logical_andnot_(EVE_REQUIRES(sve_), C const& cx, O const&, logical<wide<T, N>> a, logical<wide<T, N>> b) noexcept
     requires sve_abi<abi_t<T, N>>
   {
-    return svorr_z(expand_mask(cx, as(a)), a, b);
+    return svbic_z(expand_mask(cx, as(a)), a, b);
   }
 }
+

--- a/include/eve/module/core/regular/impl/simd/arm/sve/logical_not.hpp
+++ b/include/eve/module/core/regular/impl/simd/arm/sve/logical_not.hpp
@@ -16,9 +16,16 @@
 namespace eve::detail
 {
   template<callable_options O, arithmetic_scalar_value T, typename N>
-  EVE_FORCEINLINE logical<wide<T, N>> logical_not_(EVE_REQUIRES(sve_), O const&, logical<wide<T, N>> v) noexcept
+  EVE_FORCEINLINE logical<wide<T, N>> logical_not_(EVE_REQUIRES(sve_), O const&, logical<wide<T, N>> a) noexcept
     requires sve_abi<abi_t<T, N>>
   {
-    return svnot_z(sve_true<T>(), v);
+    return svnot_z(expand_mask(keep_first(N::value), as(a)), a);
+  }
+
+  template<callable_options O, conditional_expr C, typename T, typename N>
+  EVE_FORCEINLINE logical<wide<T, N>> logical_not_(EVE_REQUIRES(sve_), C const& cx, O const&, logical<wide<T, N>> a) noexcept
+    requires(sve_abi<abi_t<T, N>>)
+  {
+    return svnot_z(expand_mask(cx, as(a)), a);
   }
 }

--- a/include/eve/module/core/regular/impl/simd/arm/sve/logical_ornot.hpp
+++ b/include/eve/module/core/regular/impl/simd/arm/sve/logical_ornot.hpp
@@ -14,16 +14,16 @@
 namespace eve::detail
 {
   template<callable_options O, typename T, typename N>
-  EVE_FORCEINLINE logical<wide<T, N>> logical_or_(EVE_REQUIRES(sve_), O const&, logical<wide<T, N>> a, logical<wide<T, N>> b) noexcept
+  EVE_FORCEINLINE logical<wide<T, N>> logical_ornot_(EVE_REQUIRES(sve_), O const&, logical<wide<T, N>> a, logical<wide<T, N>> b) noexcept
     requires sve_abi<abi_t<T, N>>
   {
-    return svorr_z(expand_mask(keep_first(N::value), as(a)), a, b);
+    return svorn_z(expand_mask(keep_first(N::value), as(a)), a, b);
   }
 
   template<callable_options O, conditional_expr C, typename T, typename N>
-  EVE_FORCEINLINE logical<wide<T, N>> logical_or_(EVE_REQUIRES(sve_), C const& cx, O const&, logical<wide<T, N>> a, logical<wide<T, N>> b) noexcept
+  EVE_FORCEINLINE logical<wide<T, N>> logical_ornot_(EVE_REQUIRES(sve_), C const& cx, O const&, logical<wide<T, N>> a, logical<wide<T, N>> b) noexcept
     requires sve_abi<abi_t<T, N>>
   {
-    return svorr_z(expand_mask(cx, as(a)), a, b);
+    return svorn_z(expand_mask(cx, as(a)), a, b);
   }
 }

--- a/include/eve/module/core/regular/impl/simd/arm/sve/logical_xor.hpp
+++ b/include/eve/module/core/regular/impl/simd/arm/sve/logical_xor.hpp
@@ -14,16 +14,16 @@
 namespace eve::detail
 {
   template<callable_options O, typename T, typename N>
-  EVE_FORCEINLINE logical<wide<T, N>> logical_or_(EVE_REQUIRES(sve_), O const&, logical<wide<T, N>> a, logical<wide<T, N>> b) noexcept
+  EVE_FORCEINLINE logical<wide<T, N>> logical_xor_(EVE_REQUIRES(sve_), O const&, logical<wide<T, N>> a, logical<wide<T, N>> b) noexcept
     requires sve_abi<abi_t<T, N>>
   {
-    return svorr_z(expand_mask(keep_first(N::value), as(a)), a, b);
+    return sveor_z(expand_mask(keep_first(N::value), as(a)), a, b);
   }
 
-  template<callable_options O, conditional_expr C, typename T, typename N>
-  EVE_FORCEINLINE logical<wide<T, N>> logical_or_(EVE_REQUIRES(sve_), C const& cx, O const&, logical<wide<T, N>> a, logical<wide<T, N>> b) noexcept
+  template<callable_options O, typename T, typename N>
+  EVE_FORCEINLINE logical<wide<T, N>> logical_xor_(EVE_REQUIRES(sve_), auto const& cx, O const&, logical<wide<T, N>> a, logical<wide<T, N>> b) noexcept
     requires sve_abi<abi_t<T, N>>
   {
-    return svorr_z(expand_mask(cx, as(a)), a, b);
+    return sveor_z(expand_mask(cx, as(a)), a, b);
   }
 }

--- a/include/eve/module/core/regular/logical_andnot.hpp
+++ b/include/eve/module/core/regular/logical_andnot.hpp
@@ -74,3 +74,7 @@ namespace eve
 }
 
 #include <eve/module/core/regular/impl/logical_andnot.hpp>
+
+#if defined(EVE_INCLUDE_ARM_SVE_HEADER)
+#  include <eve/module/core/regular/impl/simd/arm/sve/logical_andnot.hpp>
+#endif

--- a/include/eve/module/core/regular/logical_ornot.hpp
+++ b/include/eve/module/core/regular/logical_ornot.hpp
@@ -72,3 +72,7 @@ namespace eve
 }
 
 #include <eve/module/core/regular/impl/logical_ornot.hpp>
+
+#if defined(EVE_INCLUDE_ARM_SVE_HEADER)
+#  include <eve/module/core/regular/impl/simd/arm/sve/logical_ornot.hpp>
+#endif

--- a/include/eve/module/core/regular/logical_xor.hpp
+++ b/include/eve/module/core/regular/logical_xor.hpp
@@ -72,6 +72,10 @@ namespace eve
 
 #include <eve/module/core/regular/impl/logical_xor.hpp>
 
+#if defined(EVE_INCLUDE_ARM_SVE_HEADER)
+#  include <eve/module/core/regular/impl/simd/arm/sve/logical_xor.hpp>
+#endif
+
 #if defined(EVE_INCLUDE_X86_HEADER)
 #  include <eve/module/core/regular/impl/simd/x86/logical_xor.hpp>
 #endif

--- a/include/eve/traits/overload/impl/conditional.hpp
+++ b/include/eve/traits/overload/impl/conditional.hpp
@@ -8,33 +8,12 @@
 #pragma once
 
 #include <eve/traits/overload/impl/callable.hpp>
+#include <eve/detail/validate_mask.hpp>
 
 namespace eve
 {
   namespace detail
   {
-    template<typename C, typename T>
-    constexpr EVE_FORCEINLINE bool validate_mask_for() noexcept
-    {
-      if constexpr (scalar_value<T>)
-      {
-        if constexpr (std::same_as<C, ignore_none_>) return true;
-        else if constexpr (C::has_alternative)       return validate_mask_for<typename C::conditional_type, T>();
-        else                                         return !(relative_conditional_expr<C> || simd_value<C>);
-      }
-      else
-      {
-        return true;
-      }
-    }
-
-    template<callable_options O, typename T>
-    constexpr EVE_FORCEINLINE bool validate_mask_for() noexcept
-    {
-      if constexpr (O::contains(condition_key)) return validate_mask_for<rbr::result::fetch_t<condition_key, O>, T>();
-      else                                      return true;
-    }
-
     template< template<typename> class Func
     , typename OptionsValues
     , typename... Options

--- a/include/eve/traits/overload/impl/strict_elementwise.hpp
+++ b/include/eve/traits/overload/impl/strict_elementwise.hpp
@@ -9,6 +9,7 @@
 
 #include <eve/detail/has_abi.hpp>
 #include <eve/detail/skeleton.hpp>
+#include <eve/detail/validate_mask.hpp>
 #include <eve/traits/overload/impl/conditional.hpp>
 
 namespace eve
@@ -55,7 +56,7 @@ namespace eve
         [[maybe_unused]] Func<decltype(rmv_cond)> const f{rmv_cond};
 
         // Check that the mask and the value are of same kind if simd
-        constexpr bool compatible_mask = !(simd_value<decltype(cond.mask(as(x0)))> && (scalar_value<T> && ... && scalar_value<Ts>));
+        constexpr bool compatible_mask = detail::validate_mask_for<cond_t, decltype(f(x0, xs...))>();
         static_assert(compatible_mask, "[EVE] - Scalar values can't be masked by SIMD logicals.");
 
         // Shush any other cascading errors

--- a/test/unit/internals/options.cpp
+++ b/test/unit/internals/options.cpp
@@ -41,7 +41,7 @@ namespace eve
   template<typename Options>
   struct ew_drop_func_t : strict_elementwise_callable<ew_drop_func_t, Options>
   {
-    auto operator()() const { return EVE_DISPATCH_CALL(eve::wide<int>{}); }
+    auto operator()(int a) const { return EVE_DISPATCH_CALL(a); }
     EVE_CALLABLE_OBJECT(ew_drop_func_t, ew_drop_func_);
   };
 
@@ -69,17 +69,17 @@ namespace eve::detail
   }
 
   template<eve::callable_options O, eve::conditional_expr C>
-  auto ew_drop_func_(EVE_REQUIRES(cpu_), C const&, O const&, eve::wide<int>)
+  auto ew_drop_func_(EVE_REQUIRES(cpu_), C const&, O const&, int)
   {
     TTS_EXPECT(!O::contains(condition_key));
-    return OverloadType::masked;
+    return wide<int>{ (int) OverloadType::masked };
   }
 
   template<eve::callable_options O>
-  auto ew_drop_func_(EVE_REQUIRES(cpu_), O const&, eve::wide<int>)
+  auto ew_drop_func_(EVE_REQUIRES(cpu_), O const&, int)
   {
     TTS_EXPECT(!O::contains(condition_key));
-    return OverloadType::regular;
+    return eve::wide<int>{ (int) OverloadType::regular };
   }
 }
 
@@ -125,8 +125,8 @@ TTS_CASE("Check callable always have conditional_key when chained")
 
 TTS_CASE("Check elementwise callable condition_key drop")
 {
-  TTS_EQUAL(eve::ew_drop_func(), OverloadType::regular);
-  TTS_EQUAL(eve::ew_drop_func[eve::ignore_none](), OverloadType::regular);
-  TTS_EQUAL(eve::ew_drop_func[true](), OverloadType::masked);
-  TTS_EQUAL(eve::ew_drop_func[eve::ignore_all](), OverloadType::masked);
+  TTS_EQUAL(eve::ew_drop_func(3011).get(0), (int) OverloadType::regular);
+  TTS_EQUAL(eve::ew_drop_func[eve::ignore_none](3011).get(0), (int) OverloadType::regular);
+  TTS_EQUAL(eve::ew_drop_func[true](3011).get(0), (int) OverloadType::masked);
+  TTS_EQUAL(eve::ew_drop_func[eve::ignore_all](3011).get(0), (int) OverloadType::masked);
 };

--- a/test/unit/module/core/logical_not.cpp
+++ b/test/unit/module/core/logical_not.cpp
@@ -35,4 +35,24 @@ TTS_CASE_WITH("Check behavior of eve::logical_not(simd)",
   TTS_EQUAL(eve::logical_not(a0), tts::map([](auto e) -> v_t { return !e; }, a0));
   TTS_EQUAL(eve::logical_not(true), false);
   TTS_EQUAL(eve::logical_not(false), true);
+
+  auto alt = eve::false_(eve::as<T>{});
+  auto base = eve::logical_not(a0);
+
+  TTS_EQUAL(eve::logical_not[eve::ignore_all](a0), alt);
+  TTS_EQUAL(eve::logical_not[eve::ignore_none](a0), base);
+  TTS_EQUAL(eve::logical_not[false](a0), alt);
+  TTS_EQUAL(eve::logical_not[true](a0), base);
+
+  T m = tts::poison(T{ [](auto i, auto) { return i % 2 == 0; } });
+  TTS_EQUAL(eve::logical_not[m](a0), eve::if_else(m, base, alt));
+
+  constexpr auto cardinal = eve::cardinal_v<T>;
+
+  if constexpr (cardinal >= 2)
+  {
+    TTS_EQUAL(eve::logical_not[eve::ignore_extrema(1, 1)](a0), eve::if_else(eve::ignore_extrema(1, 1), base, alt));
+    TTS_EQUAL(eve::logical_not[eve::ignore_extrema(cardinal / 2, cardinal / 2)](a0), eve::if_else(eve::ignore_extrema(cardinal / 2, cardinal / 2), base, alt));
+    TTS_EQUAL(eve::logical_not[eve::ignore_extrema(cardinal / 4, cardinal / 4)](a0), eve::if_else(eve::ignore_extrema(cardinal / 4, cardinal / 4), base, alt));
+  }
 };

--- a/test/unit/module/core/logical_xor.cpp
+++ b/test/unit/module/core/logical_xor.cpp
@@ -47,7 +47,7 @@ TTS_CASE_TPL("Check behavior of eve::logical_xor(invalid)", eve::test::scalar::a
 TTS_CASE_WITH("Check behavior of eve::logical_xor(logical<wide>)",
               eve::test::simd::all_types,
               tts::generate(tts::logicals(0, 3), tts::logicals(1, 2), tts::randoms(0, 2)))
-<typename M, typename T>(M const& l0, [[maybe_unused]] M const& l1, [[maybe_unused]] T const& a0)
+<typename M, typename T>(M const& l0, M const& l1, T const& a0)
 {
   using l_t = eve::element_type_t<M>;
 


### PR DESCRIPTION
* Added tests for masked calls to the logical_xxx family of callables.

* Modified the way `strict_elementwise_callable` checks for valid masks:
  - It now uses `eve::detail::validate_mask` to ensure that the mask is valid for the operation.
  - This is now based on the return type of the callable, not its first parameter.

* Slight SVE optimizations :
  - Implemented `logical_andnot`, `logical_ornot`, and `logical_xor` for sve. (compilers are not able to merge `and`+`not` and `orr`+`not`, (as well as combining the operation with the condition merging in the masked versions) in most cases)
  - Only touch active lanes in the unmasked versions of the logical_xxx callables. (This is always free on SVE because we need to generate a predicate mask anyway, but using a more appropriate predicate can help in predicate register reusing [1]).
  - Changed `logical_notand` and `logical_notor` to use `logical_andnot` and `logical_ornot` respectively, granting the same SVE optimizations to these callables.

[1] resulting codegen improvement for `all[mask](logical<int, fixed<4>>)` (`not`+`orr` merging and predicate register reusing): before:
```asm
ptrue   p3.s, vl8
ptrue   p2.s, vl4
not     p1.b, p3/z, p1.b
orr     p3.b, p3/z, p0.b, p1.b
cntp    x0, p2, p3.s
cmp     x0, 4
cset    w0, eq
ret
```
after:
```asm
ptrue   p3.s, vl4
orn     p0.b, p3/z, p0.b, p1.b
cntp    x0, p3, p0.s
cmp     x0, 4
cset    w0, eq
ret
```

Other codegen improvements:
<details>
<summary>logical_ornot</summary>

before:

```asm
test0(eve::logical<eve::arm_sve256_v0::wide<int, eve::fixed<4l>>>, eve::logical<eve::arm_sve256_v0::wide<int, eve::fixed<4l>>>):
        ptrue   p3.s, vl8
        not     p1.b, p3/z, p1.b
        orr     p0.b, p3/z, p0.b, p1.b
        and     p0.b, p2/z, p0.b, p0.b
        ret
test1(eve::logical<eve::arm_sve256_v0::wide<int, eve::fixed<4l>>>, eve::logical<eve::arm_sve256_v0::wide<int, eve::fixed<4l>>>, eve::logical<eve::arm_sve256_v0::wide<int, eve::fixed<4l>>>):
        ptrue   p3.s, vl8
        not     p1.b, p3/z, p1.b
        orr     p0.b, p3/z, p0.b, p1.b
        and     p0.b, p2/z, p0.b, p0.b
        ret
test2(eve::logical<eve::arm_sve256_v0::wide<int, eve::fixed<4l>>>, eve::logical<eve::arm_sve256_v0::wide<int, eve::fixed<4l>>>, eve::keep_first):
        ptrue   p3.s, vl8
        whilelt p2.s, wzr, w0
        not     p1.b, p3/z, p1.b
        orr     p0.b, p3/z, p0.b, p1.b
        and     p0.b, p0/z, p2.b, p2.b
        ret
```

after:

```asm
test(eve::logical<eve::arm_sve256_v0::wide<int, eve::fixed<4l>>>, eve::logical<eve::arm_sve256_v0::wide<int, eve::fixed<4l>>>):
        ptrue   p3.s, vl4
        orn     p0.b, p3/z, p0.b, p1.b
        ret
test_mask(eve::logical<eve::arm_sve256_v0::wide<int, eve::fixed<4l>>>, eve::logical<eve::arm_sve256_v0::wide<int, eve::fixed<4l>>>, eve::logical<eve::arm_sve256_v0::wide<int, eve::fixed<4l>>>):
        orn     p0.b, p2/z, p0.b, p1.b
        ret
test_mask_relative(eve::logical<eve::arm_sve256_v0::wide<int, eve::fixed<4l>>>, eve::logical<eve::arm_sve256_v0::wide<int, eve::fixed<4l>>>, eve::keep_first):
        whilelt p3.s, wzr, w0
        orn     p0.b, p3/z, p0.b, p1.b
        ret
```
</details>

<details>
<summary>logical_xor</summary>
before:
```asm
test(eve::logical<eve::arm_sve256_v0::wide<int, eve::fixed<4l>>>, eve::logical<eve::arm_sve256_v0::wide<int, eve::fixed<4l>>>):
        ptrue   p3.s, vl8
        orr     p0.b, p3/z, p0.b, p1.b
        ret
test_mask(eve::logical<eve::arm_sve256_v0::wide<int, eve::fixed<4l>>>, eve::logical<eve::arm_sve256_v0::wide<int, eve::fixed<4l>>>, eve::logical<eve::arm_sve256_v0::wide<int, eve::fixed<4l>>>):
        ptrue   p3.s, vl8
        orr     p0.b, p3/z, p0.b, p1.b
        and     p0.b, p2/z, p0.b, p0.b
        ret
test_mask_relative(eve::logical<eve::arm_sve256_v0::wide<int, eve::fixed<4l>>>, eve::logical<eve::arm_sve256_v0::wide<int, eve::fixed<4l>>>, eve::keep_first):
        ptrue   p3.s, vl8
        whilelt p2.s, wzr, w0
        orr     p0.b, p3/z, p0.b, p1.b
        and     p0.b, p0/z, p2.b, p2.b
        ret

```
after:
```asm
test(eve::logical<eve::arm_sve256_v0::wide<int, eve::fixed<4l>>>, eve::logical<eve::arm_sve256_v0::wide<int, eve::fixed<4l>>>):
        ptrue   p3.s, vl4
        orr     p0.b, p3/z, p0.b, p1.b
        ret
test_mask(eve::logical<eve::arm_sve256_v0::wide<int, eve::fixed<4l>>>, eve::logical<eve::arm_sve256_v0::wide<int, eve::fixed<4l>>>, eve::logical<eve::arm_sve256_v0::wide<int, eve::fixed<4l>>>):
        orr     p0.b, p2/z, p0.b, p1.b
        ret
test_mask_relative(eve::logical<eve::arm_sve256_v0::wide<int, eve::fixed<4l>>>, eve::logical<eve::arm_sve256_v0::wide<int, eve::fixed<4l>>>, eve::keep_first):
        whilelt p3.s, wzr, w0
        orr     p0.b, p3/z, p0.b, p1.b
        ret
```
</details>