### PR TITLE
Extract the bit_cast implementation from its callable

### DIFF
--- a/include/eve/detail/function/bit_cast.hpp
+++ b/include/eve/detail/function/bit_cast.hpp
@@ -16,13 +16,3 @@
 #if defined(EVE_INCLUDE_ARM_SVE_HEADER)
 #  include <eve/detail/function/simd/arm/sve/bit_cast.hpp>
 #endif
-
-namespace eve::detail
-{
-  template<typename T, typename Target>
-  requires (sizeof(T) == sizeof(Target))
-  EVE_FORCEINLINE constexpr Target bit_cast(T const& a, as<Target> tgt) noexcept
-  {
-    return detail::bit_cast_impl(current_api, a, tgt);
-  }
-}

--- a/include/eve/detail/function/bit_cast.hpp
+++ b/include/eve/detail/function/bit_cast.hpp
@@ -8,28 +8,21 @@
 #pragma once
 
 #include <eve/arch.hpp>
-#include <eve/traits/overload.hpp>
-
-namespace eve
-{
-  template<typename Options>
-  struct bit_cast_t : callable<bit_cast_t, Options>
-  {
-    template<typename T, typename Target>
-    requires (sizeof(T) == sizeof(Target))
-    EVE_FORCEINLINE constexpr Target operator()(T const& a, as<Target> const& tgt) const noexcept
-    {
-      return EVE_DISPATCH_CALL(a,tgt);
-    }
-
-    EVE_CALLABLE_OBJECT(bit_cast_t, bit_cast_);
-  };
-
-  inline constexpr auto bit_cast = functor<bit_cast_t>;
-}
+#include <eve/traits/overload/supports.hpp>
+#include <eve/traits/overload/default_behaviors.hpp>
 
 #include <eve/detail/function/simd/common/bit_cast.hpp>
 
 #if defined(EVE_INCLUDE_ARM_SVE_HEADER)
 #  include <eve/detail/function/simd/arm/sve/bit_cast.hpp>
 #endif
+
+namespace eve::detail
+{
+  template<typename T, typename Target>
+  requires (sizeof(T) == sizeof(Target))
+  EVE_FORCEINLINE constexpr Target bit_cast(T const& a, as<Target> tgt) noexcept
+  {
+    return detail::bit_cast_impl(current_api, a, tgt);
+  }
+}

--- a/include/eve/detail/function/simd/arm/neon/movemask.hpp
+++ b/include/eve/detail/function/simd/arm/neon/movemask.hpp
@@ -9,7 +9,7 @@
 
 #include <eve/arch/logical.hpp>
 #include <eve/detail/meta.hpp>
-#include <eve/detail/function/bit_cast.hpp>
+#include <eve/module/core/regular/bit_cast.hpp>
 #include <eve/module/core/regular/convert.hpp>
 
 namespace eve::detail

--- a/include/eve/detail/function/simd/arm/sve/bit_cast.hpp
+++ b/include/eve/detail/function/simd/arm/sve/bit_cast.hpp
@@ -13,16 +13,16 @@
 
 namespace eve::detail
 {
-  template<callable_options O, scalar_value T, typename N, scalar_value U, typename M>
+  template<scalar_value T, typename N, scalar_value U, typename M>
   requires( sve_abi<abi_t<T, N>> )
-  EVE_FORCEINLINE wide<U, M> bit_cast_(EVE_REQUIRES(sve_), O const&, wide<T,N> x, as<wide<U,M>> const&) noexcept
+  EVE_FORCEINLINE wide<U, M> bit_cast_impl(sve_, wide<T,N> x, as<wide<U,M>>) noexcept
   {
     if constexpr( std::is_same_v<wide<T, N>, wide<U, M>> ) return x;
     else
     {
       auto as_byte = [](auto v)
       {
-        constexpr auto c = categorize<eve::wide<T,N>>();
+        constexpr auto c = categorize<eve::wide<translate_t<T>, N>>();
               if constexpr(match(c, category::float64)) return svreinterpret_u8_f64(v);
         else  if constexpr(match(c, category::float32)) return svreinterpret_u8_f32(v);
         else  if constexpr(match(c, category::int64)  ) return svreinterpret_u8_s64(v);
@@ -35,7 +35,7 @@ namespace eve::detail
         else  if constexpr(match(c, category::uint8)  ) return v.storage();
       }(x);
 
-      constexpr auto d = categorize<wide<U, M>>();
+      constexpr auto d = categorize<wide<translate_t<U>, M>>();
 
               if constexpr(match(d, category::float64)) return svreinterpret_f64_u8(as_byte);
         else  if constexpr(match(d, category::float32)) return svreinterpret_f32_u8(as_byte);

--- a/include/eve/detail/function/simd/common/bit_cast.hpp
+++ b/include/eve/detail/function/simd/common/bit_cast.hpp
@@ -13,7 +13,7 @@
 namespace eve::detail
 {
   template<typename T, typename Target>
-  EVE_FORCEINLINE constexpr auto bit_cast_impl(cpu_, T const &a, as<Target>) noexcept
+  EVE_FORCEINLINE constexpr Target bit_cast_impl(cpu_, T const &a, as<Target>) noexcept
   {
     // Fixes bad codegen on some compilers
     if constexpr(std::is_same_v<T, Target>) return a;

--- a/include/eve/detail/function/simd/common/bit_cast.hpp
+++ b/include/eve/detail/function/simd/common/bit_cast.hpp
@@ -12,8 +12,8 @@
 
 namespace eve::detail
 {
-  template<callable_options O, typename T, typename Target>
-  EVE_FORCEINLINE constexpr auto bit_cast_(EVE_REQUIRES(cpu_), O const&, T const &a, as<Target> const &) noexcept
+  template<typename T, typename Target>
+  EVE_FORCEINLINE constexpr auto bit_cast_impl(cpu_, T const &a, as<Target>) noexcept
   {
     // Fixes bad codegen on some compilers
     if constexpr(std::is_same_v<T, Target>) return a;

--- a/include/eve/detail/function/simd/common/load.hpp
+++ b/include/eve/detail/function/simd/common/load.hpp
@@ -11,11 +11,11 @@
 #include <eve/concept/memory.hpp>
 #include <eve/detail/abi.hpp>
 #include <eve/detail/spy.hpp>
-#include <eve/detail/function/bit_cast.hpp>
 #include <eve/detail/implementation.hpp>
 #include <eve/memory/aligned_ptr.hpp>
 #include <eve/memory/pointer.hpp>
 #include <eve/memory/soa_ptr.hpp>
+#include <eve/module/core/regular/bit_cast.hpp>
 #include <eve/module/core/regular/replace.hpp>
 #include <eve/module/core/regular/safe.hpp>
 #include <eve/module/core/regular/unsafe.hpp>

--- a/include/eve/detail/function/simd/common/slice.hpp
+++ b/include/eve/detail/function/simd/common/slice.hpp
@@ -8,8 +8,8 @@
 #pragma once
 
 #include <eve/detail/implementation.hpp>
+#include <eve/module/core/regular/bit_cast.hpp>
 #include <eve/detail/is_native.hpp>
-#include <eve/detail/function/bit_cast.hpp>
 #include <eve/arch/platform.hpp>
 #include <eve/traits/as_wide.hpp>
 #include <eve/as.hpp>

--- a/include/eve/detail/function/simd/ppc/movemask.hpp
+++ b/include/eve/detail/function/simd/ppc/movemask.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 #include <eve/arch/logical.hpp>
-#include <eve/detail/function/bit_cast.hpp>
+#include <eve/module/core/regular/bit_cast.hpp>
 #include <utility>
 
 namespace eve::detail

--- a/include/eve/detail/function/simd/x86/interleave.hpp
+++ b/include/eve/detail/function/simd/x86/interleave.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 #include <eve/detail/abi.hpp>
-#include <eve/detail/function/bit_cast.hpp>
+#include <eve/module/core/regular/bit_cast.hpp>
 #include <eve/traits/product_type.hpp>
 
 namespace eve::detail

--- a/include/eve/detail/function/simd/x86/load.hpp
+++ b/include/eve/detail/function/simd/x86/load.hpp
@@ -12,7 +12,6 @@
 #include <eve/concept/vectorizable.hpp>
 #include <eve/detail/abi.hpp>
 #include <eve/detail/category.hpp>
-#include <eve/detail/function/bit_cast.hpp>
 #include <eve/detail/function/to_logical.hpp>
 #include <eve/detail/function/simd/common/load.hpp>
 

--- a/include/eve/module/core/regular/bit_cast.hpp
+++ b/include/eve/module/core/regular/bit_cast.hpp
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <eve/traits/overload.hpp>
-
 #include <eve/detail/function/bit_cast.hpp>
 
 namespace eve
@@ -19,7 +18,7 @@ namespace eve
     requires (sizeof(T) == sizeof(Target))
     EVE_FORCEINLINE constexpr Target operator()(T const& a, as<Target> tgt) const noexcept
     {
-      return detail::bit_cast(a, tgt);
+      return detail::bit_cast_impl(current_api, a, tgt);
     }
 
     EVE_CALLABLE_OBJECT(bit_cast_t, bit_cast_);

--- a/include/eve/module/core/regular/bit_cast.hpp
+++ b/include/eve/module/core/regular/bit_cast.hpp
@@ -6,11 +6,25 @@
 //==================================================================================================
 #pragma once
 
-#if defined(EVE_DOXYGEN_INVOKED)
 #include <eve/traits/overload.hpp>
+
+#include <eve/detail/function/bit_cast.hpp>
 
 namespace eve
 {
+  template<typename Options>
+  struct bit_cast_t : callable<bit_cast_t, Options>
+  {
+    template<typename T, typename Target>
+    requires (sizeof(T) == sizeof(Target))
+    EVE_FORCEINLINE constexpr Target operator()(T const& a, as<Target> tgt) const noexcept
+    {
+      return detail::bit_cast(a, tgt);
+    }
+
+    EVE_CALLABLE_OBJECT(bit_cast_t, bit_cast_);
+  };
+
 //================================================================================================
 //! @addtogroup core_bitops
 //! @{
@@ -65,6 +79,3 @@ namespace eve
 //! @}
 //================================================================================================
 }
-#endif
-
-#include <eve/detail/function/bit_cast.hpp>

--- a/include/eve/module/core/regular/impl/convert.hpp
+++ b/include/eve/module/core/regular/impl/convert.hpp
@@ -9,6 +9,7 @@
 
 #include <eve/module/core/regular/impl/convert_helpers.hpp>
 #include <eve/module/core/regular/is_not_finite.hpp>
+#include <eve/module/core/regular/bit_cast.hpp>
 #include <eve/detail/category.hpp>
 
 namespace eve::detail


### PR DESCRIPTION
Extract the bit_cast implementation from its callable to decouple the logic from `protocol.hpp` to prepare for translation  support.