### PR TITLE
Update macOS CI version

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -157,7 +157,7 @@ jobs:
   ## Mac OS X Targets
   ##################################################################################################
   macosx:
-    runs-on: [macos-14]
+    runs-on: [macos-15]
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Needed for the next translation PR as this version of the GH-hosted CI machine comes with Apple Clang 16 which implements P0960.