### PR TITLE
shuffle v2: free masking

### DIFF
--- a/include/eve/detail/shuffle_v2/native_shuffle_helpers.hpp
+++ b/include/eve/detail/shuffle_v2/native_shuffle_helpers.hpp
@@ -40,6 +40,19 @@ is_na_or_we_logical_mask(eve::pattern_t<I...> p, eve::fixed<G> g, eve::as<T> tgt
   else return is_na_or_we_mask(p, g, tgt);
 }
 
+template<std::ptrdiff_t G, std::ptrdiff_t... I, simd_value T>
+EVE_FORCEINLINE auto
+is_na_logical_mask(eve::pattern_t<I...> p, eve::fixed<G> g, eve::as<T> tgt)
+{
+  if constexpr( !logical_simd_value<T> ) return is_na_logical_mask(p, g, eve::as<logical<T>> {});
+  else if constexpr( G == 1 ) return T {I == na_ ...};
+  else
+  {
+    constexpr std::array idxs {I...};
+    return is_na_logical_mask(idxm::to_pattern<idxm::expand_group<G>(idxs)>(), eve::lane<1>, tgt);
+  }
+}
+
 template<typename T, std::ptrdiff_t... I>
 EVE_FORCEINLINE T
 make_idx_mask(eve::pattern_t<I...>, as<T>)
@@ -111,5 +124,4 @@ mask_type(eve::as<T> tgt)
   if constexpr( logical_simd_value<T> ) return eve::as<decltype(T {}.mask())> {};
   else return tgt;
 }
-
 }

--- a/include/eve/detail/shuffle_v2/simd/arm/sve/shuffle_l2.hpp
+++ b/include/eve/detail/shuffle_v2/simd/arm/sve/shuffle_l2.hpp
@@ -46,7 +46,7 @@ shuffle_l2_svrev(P, eve::fixed<G>, T x)
 
 template<typename P, typename T, typename N, std::ptrdiff_t G>
 auto
-shuffle_l2_svrevbhw(P p, eve::fixed<G> g, eve::wide<T, N> _x)
+shuffle_l2_svrevbhw(P, eve::fixed<G>, eve::wide<T, N> _x)
 {
   constexpr std::ptrdiff_t reverse_size = P::most_repeated_no_zeroes.size() * P::g_size;
   if constexpr( reverse_size > 8 ) return no_matching_shuffle;
@@ -56,28 +56,11 @@ shuffle_l2_svrevbhw(P p, eve::fixed<G> g, eve::wide<T, N> _x)
     auto x  = up_element_size_to(_x, eve::lane<reverse_size>);
     using U = decltype(x);
 
-    if constexpr( !P::has_zeroes )
-    {
-      auto m = sve_true<T>();
+    auto m = sve_true<T>();
 
-      if constexpr( P::g_size == 1 ) return U {svrevb_x(m, x)};
-      else if constexpr( P::g_size == 2 ) return U {svrevh_x(m, x)};
-      else if constexpr( P::g_size == 4 ) return U {svrevw_x(m, x)};
-    }
-    else
-    {
-      // Didn't work out of the gate for some reason.
-      (void)p;
-      (void)g;
-      return no_matching_shuffle;
-#if 0
-      auto m = is_na_or_we_mask(p, g, eve::as<eve::logical<eve::wide<T, N>>> {});
-
-      if constexpr( P::g_size == 1 ) return U {svrevb_z(m, x)};
-      else if constexpr( P::g_size == 2 ) return U {svrevh_z(m, x)};
-      else if constexpr( P::g_size == 4 ) return U {svrevw_z(m, x)};
-#endif
-    }
+    if constexpr( P::g_size == 1 ) return U {svrevb_x(m, x)};
+    else if constexpr( P::g_size == 2 ) return U {svrevh_x(m, x)};
+    else if constexpr( P::g_size == 4 ) return U {svrevw_x(m, x)};
   }
 }
 

--- a/include/eve/detail/shuffle_v2/simd/common/shuffle_v2_driver.hpp
+++ b/include/eve/detail/shuffle_v2/simd/common/shuffle_v2_driver.hpp
@@ -10,8 +10,6 @@
 #include <eve/detail/shuffle_v2/simplify_plain_shuffle.hpp>
 #include <eve/module/core/regular/if_else.hpp>
 
-#include <iostream>
-
 namespace eve::detail
 {
 

--- a/include/eve/detail/shuffle_v2/simd/x86/shuffle_l2.hpp
+++ b/include/eve/detail/shuffle_v2/simd/x86/shuffle_l2.hpp
@@ -79,10 +79,10 @@ shuffle_l2_x86_repeated_128_4_shorts(P, fixed<G>, wide<T, N> x)
 
 template<typename P, arithmetic_scalar_value T, typename N, std::ptrdiff_t G>
 EVE_FORCEINLINE auto
-shuffle_l2_x86_repeated_128_4x32(P p, fixed<G> g, wide<T, N> x)
+shuffle_l2_x86_repeated_128_4x32(P, fixed<G>, wide<T, N> x)
 {
-  if constexpr( sizeof(T) * G < 4 ) return no_matching_shuffle;
-  else if constexpr( !P::has_zeroes )
+  if constexpr( sizeof(T) * G < 4 || P::has_zeroes ) return no_matching_shuffle;
+  else
   {
     constexpr auto m = static_cast<_MM_PERM_ENUM>(idxm::x86_mm_shuffle_4(*P::repeated_16));
 
@@ -94,16 +94,6 @@ shuffle_l2_x86_repeated_128_4x32(P p, fixed<G> g, wide<T, N> x)
     }
     else if constexpr( P::reg_size == 32 ) return _mm256_shuffle_epi32(x, m);
     else return _mm512_shuffle_epi32(x, m);
-  }
-  else if constexpr( current_api < avx512 ) return no_matching_shuffle;
-  else
-  {
-    constexpr auto m    = static_cast<_MM_PERM_ENUM>(idxm::x86_mm_shuffle_4(*P::repeated_16));
-    auto           mask = is_na_or_we_logical_mask(p, g, as(x)).storage();
-
-    if constexpr( P::reg_size == 16 ) return _mm_maskz_shuffle_epi32(mask, x, m);
-    else if constexpr( P::reg_size == 32 ) return _mm256_maskz_shuffle_epi32(mask, x, m);
-    else return _mm512_maskz_shuffle_epi32(mask, x, m);
   }
 }
 
@@ -184,10 +174,10 @@ shuffle_l2_x86_128_insert_one_zero(P, fixed<G>, wide<T, N> x)
 
 template<typename P, arithmetic_scalar_value T, typename N, std::ptrdiff_t G>
 EVE_FORCEINLINE auto
-shuffle_l2_x86_repeated_256_permute4x64(P p, fixed<G> g, wide<T, N> x)
+shuffle_l2_x86_repeated_256_permute4x64(P, fixed<G>, wide<T, N> x)
 {
   if constexpr( P::g_size < 8 ) return no_matching_shuffle;
-  else if constexpr( P::has_zeroes && current_api < avx512 ) return no_matching_shuffle;
+  else if constexpr( P::has_zeroes ) return no_matching_shuffle;
   // Within lane is faster so prefer it
   else if constexpr( idxm::shuffle_within_halves(*P::repeated_32) )
   {
@@ -195,34 +185,15 @@ shuffle_l2_x86_repeated_256_permute4x64(P p, fixed<G> g, wide<T, N> x)
 
     auto x_f64 = bit_cast(x, eve::as<eve::wide<double, N>> {});
 
-    if constexpr( !P::has_zeroes )
-    {
-      if constexpr( P::reg_size == 32 ) return _mm256_permute_pd(x_f64, mm);
-      else return _mm512_permute_pd(x_f64, mm);
-    }
-    else
-    {
-      auto mask = is_na_or_we_logical_mask(p, g, as(x)).storage();
-      if constexpr( P::reg_size == 32 ) return _mm256_maskz_permute_pd(mask, x_f64, mm);
-      else return _mm256_maskz_permute_pd(mask, x_f64, mm);
-    }
+    if constexpr( P::reg_size == 32 ) return _mm256_permute_pd(x_f64, mm);
+    else return _mm512_permute_pd(x_f64, mm);
   }
   else if constexpr( current_api > avx )
   {
     constexpr int mm = idxm::x86_mm_shuffle_4(*P::repeated_32);
 
-    if constexpr( !P::has_zeroes )
-    {
-      if constexpr( P::reg_size == 32 ) return _mm256_permute4x64_epi64(x, mm);
-      else return _mm512_permutex_epi64(x, mm);
-    }
-    else
-    {
-      auto mask = is_na_or_we_logical_mask(p, g, as(x)).storage();
-
-      if constexpr( P::reg_size == 32 ) return _mm256_maskz_permutex_epi64(mask, x, mm);
-      else return _mm512_maskz_permutex_epi64(mask, x, mm);
-    }
+    if constexpr( P::reg_size == 32 ) return _mm256_permute4x64_epi64(x, mm);
+    else return _mm512_permutex_epi64(x, mm);
   }
   else return no_matching_shuffle;
 }
@@ -257,6 +228,7 @@ shuffle_l2_x86_u64x2(P p, fixed<G> g, wide<T, N> x)
   {
     constexpr int mm = idxm::x86_mm_shuffle_4(P::idxs);
 
+    // TODO(2135): this is accidentally important.
     if constexpr( !P::has_zeroes ) return _mm512_shuffle_i64x2(x, x, mm);
     else
     {
@@ -268,14 +240,14 @@ shuffle_l2_x86_u64x2(P p, fixed<G> g, wide<T, N> x)
 
 template<typename P, arithmetic_scalar_value T, typename N, std::ptrdiff_t G>
 EVE_FORCEINLINE auto
-shuffle_l2_alignr_epi32_self(P p, fixed<G> g, wide<T, N> x)
+shuffle_l2_alignr_epi32_self(P, fixed<G>, wide<T, N> x)
 {
-  if constexpr( P::g_size < 4 || current_api < avx512 ) return no_matching_shuffle;
+  if constexpr( P::g_size < 4 || current_api < avx512 || P::has_zeroes ) return no_matching_shuffle;
   else if constexpr( constexpr auto rotation = idxm::is_rotate(P::idxs_no_na); !rotation )
   {
     return no_matching_shuffle;
   }
-  else if constexpr( !P::has_zeroes )
+  else
   {
     static_assert(P::reg_size > 16, "sanity check - sse alignr is better");
 
@@ -285,35 +257,12 @@ shuffle_l2_alignr_epi32_self(P p, fixed<G> g, wide<T, N> x)
     if constexpr( P::reg_size == 32 )
     {
       if constexpr( P::g_size >= 8 ) return _mm256_alignr_epi64(x, x, shift_epi64);
-      else return _mm256_alignr_epi64(x, x, shift_epi32);
+      else return _mm256_alignr_epi32(x, x, shift_epi32);
     }
     else
     {
       if constexpr( P::g_size >= 8 ) return _mm512_alignr_epi64(x, x, shift_epi64);
       else return _mm512_alignr_epi32(x, x, shift_epi32);
-    }
-  }
-  else
-  {
-    constexpr std::ptrdiff_t shift_epi32 = (N() - *rotation) * P::g_size / 4;
-    constexpr std::ptrdiff_t shift_epi64 = (N() - *rotation) * P::g_size / 8;
-
-    auto mask = is_na_or_we_logical_mask(p, g, as(x)).storage();
-
-    if constexpr( P::reg_size == 16 )
-    {
-      if constexpr( P::g_size >= 8 ) return _mm128_maskz_alignr_epi64(mask, x, x, shift_epi64);
-      else return _mm128_maskz_alignr_epi32(mask, x, x, shift_epi32);
-    }
-    else if constexpr( P::reg_size == 32 )
-    {
-      if constexpr( P::g_size >= 8 ) return _mm256_maskz_alignr_epi64(mask, x, x, shift_epi64);
-      else return _mm256_maskz_alignr_epi32(mask, x, x, shift_epi32);
-    }
-    else
-    {
-      if constexpr( P::g_size >= 8 ) return _mm512_maskz_alignr_epi64(mask, x, x, shift_epi64);
-      else return _mm512_maskz_alignr_epi32(mask, x, x, shift_epi32);
     }
   }
 }
@@ -429,10 +378,9 @@ shuffle_l2_x86_repeated_128x2(P p, fixed<G> g, wide<T, N> x, wide<T, N> y)
 
 template<typename P, arithmetic_scalar_value T, typename N, std::ptrdiff_t G>
 EVE_FORCEINLINE auto
-shuffle_l2_x86_within_128x2_shuffle_ps(P p, fixed<G> g, wide<T, N> x, wide<T, N> y)
+shuffle_l2_x86_within_128x2_shuffle_ps(P, fixed<G>, wide<T, N> x, wide<T, N> y)
 {
-  if constexpr( sizeof(T) < 4 ) return no_matching_shuffle;
-  else if constexpr( P::has_zeroes && current_api < avx512 ) return no_matching_shuffle;
+  if constexpr( sizeof(T) < 4 || P::has_zeroes ) return no_matching_shuffle;
   else if constexpr( constexpr auto opt_mm = idxm::x86_shuffle_ps_2<P::g_size>(P::idxs); !opt_mm )
   {
     return no_matching_shuffle;
@@ -444,20 +392,9 @@ shuffle_l2_x86_within_128x2_shuffle_ps(P p, fixed<G> g, wide<T, N> x, wide<T, N>
     auto y_f32     = bit_cast(y, eve::as<floats_t> {});
 
     constexpr int mm = *opt_mm;
-    if constexpr( !P::has_zeroes )
-    {
-      if constexpr( P::reg_size == 16 ) return _mm_shuffle_ps(x_f32, y_f32, mm);
-      else if constexpr( P::reg_size == 32 ) return _mm256_shuffle_ps(x_f32, y_f32, mm);
-      else return _mm512_shuffle_ps(x_f32, y_f32, mm);
-    }
-    else
-    {
-      auto mask = is_na_or_we_logical_mask(p, g, as(x)).storage();
-
-      if constexpr( P::reg_size == 16 ) return _mm_maskz_shuffle_ps(mask, x_f32, y_f32, mm);
-      else if constexpr( P::reg_size == 32 ) return _mm256_maskz_shuffle_ps(mask, x_f32, y_f32, mm);
-      else return _mm512_maskz_shuffle_ps(mask, x_f32, y_f32, mm);
-    }
+    if constexpr( P::reg_size == 16 ) return _mm_shuffle_ps(x_f32, y_f32, mm);
+    else if constexpr( P::reg_size == 32 ) return _mm256_shuffle_ps(x_f32, y_f32, mm);
+    else return _mm512_shuffle_ps(x_f32, y_f32, mm);
   }
 }
 
@@ -489,24 +426,18 @@ shuffle_l2_x86_permute2f128(P, fixed<G>, wide<T, N> x, wide<T, N> y)
 
 template<typename P, arithmetic_scalar_value T, typename N, std::ptrdiff_t G>
 EVE_FORCEINLINE auto
-shuffle_l2_x86_shuffle_i32x4(P p, fixed<G> g, wide<T, N> x, wide<T, N> y)
+shuffle_l2_x86_shuffle_i32x4(P, fixed<G>, wide<T, N> x, wide<T, N> y)
 {
   // the _mm256_maskz_shuffle_i32x4 is not supported yet.
   if constexpr( sizeof(T) < 4 || P::reg_size < 64 ) return no_matching_shuffle;
-  else if constexpr( constexpr auto m = idxm::mm512_shuffle_i64x2_idx(P::idxs_no_na); !m )
+  else if constexpr( constexpr auto m = idxm::mm512_shuffle_i64x2_idx(P::idxs); !m )
   {
     return no_matching_shuffle;
   }
   else
   {
     constexpr int mm = *m;
-    if constexpr( !P::has_zeroes ) return _mm512_shuffle_i64x2(x, y, mm);
-    else
-    {
-      auto mask = is_na_or_we_logical_mask(p, g, as(x)).storage();
-      if constexpr( sizeof(T) >= 8 ) return _mm512_maskz_shuffle_i64x2(mask, x, y, mm);
-      else return _mm512_maskz_shuffle_i64x2(mask, x, y, mm);
-    }
+    return _mm512_shuffle_i64x2(x, y, mm);
   }
 }
 
@@ -528,7 +459,7 @@ shuffle_l2_x86_shuffle_128_2regs(P p, fixed<G> g, wide<T, N> x, wide<T, N> y)
 
 template<typename P, arithmetic_scalar_value T, typename N, std::ptrdiff_t G>
 EVE_FORCEINLINE auto
-shuffle_l2_x86_alignr_epi32(P p, fixed<G> g, wide<T, N> x, wide<T, N> y)
+shuffle_l2_x86_alignr_epi32(P, fixed<G>, wide<T, N> x, wide<T, N> y)
 {
   if constexpr( P::g_size < 4 ) return no_matching_shuffle;
   else if constexpr( current_api < avx512 ) return no_matching_shuffle;
@@ -536,7 +467,7 @@ shuffle_l2_x86_alignr_epi32(P p, fixed<G> g, wide<T, N> x, wide<T, N> y)
   {
     return no_matching_shuffle;
   }
-  else if constexpr( !P::has_zeroes )
+  else
   {
     static_assert(P::reg_size > 16, "sanity check - sse alignr is better");
 
@@ -552,29 +483,6 @@ shuffle_l2_x86_alignr_epi32(P p, fixed<G> g, wide<T, N> x, wide<T, N> y)
     {
       if constexpr( P::g_size >= 8 ) return _mm512_alignr_epi64(y, x, shift_epi64);
       else return _mm512_alignr_epi32(y, x, shift_epi32);
-    }
-  }
-  else
-  {
-    constexpr std::ptrdiff_t shift_epi32 = *starts_from * P::g_size / 4;
-    constexpr std::ptrdiff_t shift_epi64 = *starts_from * P::g_size / 8;
-
-    auto mask = is_na_or_we_logical_mask(p, g, as(x)).storage();
-
-    if constexpr( P::reg_size == 16 )
-    {
-      if constexpr( P::g_size >= 8 ) return _mm128_maskz_alignr_epi64(mask, y, x, shift_epi64);
-      else return _mm128_maskz_alignr_epi32(mask, y, x, shift_epi32);
-    }
-    else if constexpr( P::reg_size == 32 )
-    {
-      if constexpr( P::g_size >= 8 ) return _mm256_maskz_alignr_epi64(mask, y, x, shift_epi64);
-      else return _mm256_maskz_alignr_epi32(mask, y, x, shift_epi32);
-    }
-    else
-    {
-      if constexpr( P::g_size >= 8 ) return _mm512_maskz_alignr_epi64(mask, y, x, shift_epi64);
-      else return _mm512_maskz_alignr_epi32(mask, y, x, shift_epi32);
     }
   }
 }

--- a/include/eve/detail/shuffle_v2/simd/x86/shuffle_l2.hpp
+++ b/include/eve/detail/shuffle_v2/simd/x86/shuffle_l2.hpp
@@ -228,7 +228,9 @@ shuffle_l2_x86_u64x2(P p, fixed<G> g, wide<T, N> x)
   {
     constexpr int mm = idxm::x86_mm_shuffle_4(P::idxs);
 
-    // TODO(2135): this is accidentally important.
+    // TODO(2135): P should not have 0s. However while removing all other if
+    // like this one worked, this specific if lead to tests failing.
+    // Left a followup TODO.
     if constexpr( !P::has_zeroes ) return _mm512_shuffle_i64x2(x, x, mm);
     else
     {

--- a/include/eve/module/core/named_shuffles/slide.hpp
+++ b/include/eve/module/core/named_shuffles/slide.hpp
@@ -108,7 +108,8 @@ struct slide_left_impl_t
       auto mask = detail::mask_type(tgt);
       return level(mask, g, s) + 4;
     }
-    else if constexpr( current_api >= neon || current_api >= sve )
+    else if constexpr( current_api >= sve ) return 2;
+    else if constexpr( current_api >= neon )
     {
       if( reg_size <= 8 ) return 2;
       return 3;
@@ -121,7 +122,7 @@ struct slide_left_impl_t
         if( is_shift_by_4 ) return 2;
         if( reg_size <= 16 ) return 2;
         if( is_shift_by_2 ) return 3;
-        if (reg_size == 64) return 5; // this is not yet done
+        if( reg_size == 64 ) return 5; // this is not yet done
       }
       if( reg_size == 32 && is_shift_by_16 ) return 2;
       if( current_api >= avx2 && reg_size == 32 ) { return 4; }
@@ -169,8 +170,8 @@ struct slide_left_t : detail::named_shuffle_1<slide_left_impl_t>
 {};
 
 inline constexpr auto slide_left2 = slide_left_t {};
-  //================================================================================================
-  //!  @}
-  //================================================================================================
+//================================================================================================
+//!  @}
+//================================================================================================
 
 }

--- a/test/unit/api/regular/shuffle_v2/shuffle_v2_64x1.cpp
+++ b/test/unit/api/regular/shuffle_v2/shuffle_v2_64x1.cpp
@@ -23,6 +23,8 @@ TTS_CASE("shuffle_v2: 64x1")
   {
     // We can do better sometimes but not yet
     if( eve::current_api >= eve::sve ) {
+      if (idxm::matches(p, {eve::na_, 0})) return 2;
+      if (idxm::matches(p, {1, eve::na_})) return 2;
       if (idxm::matches(p, {1, 0})) return 2;
       if (idxm::matches(p, {3, 0, 1, 2})) return 2;
       if (idxm::matches(p, {1, 2, 3, 0})) return 2;

--- a/test/unit/api/regular/shuffle_v2/shuffle_v2_driver.cpp
+++ b/test/unit/api/regular/shuffle_v2/shuffle_v2_driver.cpp
@@ -328,9 +328,6 @@ TTS_CASE_TPL("free masking: zeroes", eve::test::simd::all_types)
     const T               arithmetic_in {[](int i, int) { return i + 1; }};
     const eve::logical<T> logical_in([](int i, int) { return i % 3 == 1; });
 
-    (void)free_masking;
-    (void)logical_in;
-
     // identity mixed with 0s is just propagated
     // to the shuffle.
     {

--- a/test/unit/api/regular/shuffle_v2/shuffle_v2_driver_intergration.cpp
+++ b/test/unit/api/regular/shuffle_v2/shuffle_v2_driver_intergration.cpp
@@ -37,11 +37,20 @@ TTS_CASE("integrating with fake native shuffle")
 
   using T = eve::wide<int, eve::fixed<4>>;
 
+  constexpr bool free_masking = eve::current_api >= eve::avx512 || eve::current_api >= eve::sve
+                                || eve::current_api >= eve::rvv;
+
   tst(T {3, 4, 1, 2}, eve::index<2>, T {1, 2, 3, 4}, eve::lane<2>, eve::pattern<1, 0>);
   tst(T {4, 3, 2, 1}, eve::index<4>, T {1, 2, 3, 4}, eve::pattern<3, 2, 1, 0>);
   tst(T {3, 4, 1, 2}, eve::index<2>, T {1, 2, 3, 4}, eve::pattern<2, 3, 0, 1>);
   tst(T {0, 0, 1, 2}, eve::index<1>, T {1, 2, 3, 4}, eve::lane<2>, eve::pattern<eve::we_, 0>);
-  tst(T {3, 4, 0, 0}, eve::index<2>, T {1, 2, 3, 4}, eve::lane<2>, eve::pattern<1, eve::na_>);
+  // Note masking will never actually be level 1, this is just happens here due how fake shuffle
+  // works.
+  tst(T {3, 4, 0, 0},
+      eve::index < free_masking ? 1 : 2 >,
+      T {1, 2, 3, 4},
+      eve::lane<2>,
+      eve::pattern<1, eve::na_>);
 
   // T05
   using T025 = eve::wide<int, eve::fixed<1>>;


### PR DESCRIPTION
Making masking generic. Now for avx512/sve/rvv we just generate a shuffle + blend with 0 and rely on the compiler to make blend with 0 to go away. 

The driver test could've been better but let's rely on the integration testing to extra verify this one later.
I only removed P::has_zeroes from avx512 and not everywhere as well.

The plan is, after this, to start white box  testing individual patterns in l2/l3.  