### PR TITLE
FP16 Support - FP16 scalar value manipulation

### DIFF
--- a/include/eve/arch/cpu/wide.hpp
+++ b/include/eve/arch/cpu/wide.hpp
@@ -1022,7 +1022,8 @@ namespace eve
 
         auto as_printable = [](Type v)
         {
-          if      constexpr (std::integral<Type> && sizeof(Type) == 1) return +v;
+          if constexpr (std::same_as<translate_t<Type>, detail::f16>)  return v.to_float32();
+          else if constexpr (std::integral<Type> && sizeof(Type) == 1) return +v;
           else if constexpr (requires { os << v; })                    return v;
           else                                                         return translate(v);
         };

--- a/include/eve/arch/cpu/wide.hpp
+++ b/include/eve/arch/cpu/wide.hpp
@@ -1022,7 +1022,7 @@ namespace eve
 
         auto as_printable = [](Type v)
         {
-          if constexpr (std::same_as<translate_t<Type>, eve::float16>) return static_cast<float>(translate(v));
+          if constexpr (std::same_as<translate_t<Type>, eve::float16_t>) return static_cast<float>(translate(v));
           else if constexpr (std::integral<Type> && sizeof(Type) == 1) return +v;
           else if constexpr (requires { os << v; })                    return v;
           else                                                         return translate(v);

--- a/include/eve/arch/cpu/wide.hpp
+++ b/include/eve/arch/cpu/wide.hpp
@@ -1022,7 +1022,7 @@ namespace eve
 
         auto as_printable = [](Type v)
         {
-          if constexpr (std::same_as<translate_t<Type>, detail::f16>)  return v.to_float32();
+          if constexpr (std::same_as<translate_t<Type>, eve::float16>) return static_cast<float>(translate(v));
           else if constexpr (std::integral<Type> && sizeof(Type) == 1) return +v;
           else if constexpr (requires { os << v; })                    return v;
           else                                                         return translate(v);

--- a/include/eve/arch/float16.hpp
+++ b/include/eve/arch/float16.hpp
@@ -22,11 +22,11 @@ namespace eve
 {
   namespace detail
   {
-    // taken from https://github.com/QiJune/majel/blob/master/float16.h
+    // taken from https://github.com/QiJune/majel/blob/master/float16_t.h
     static constexpr int32_t fp16_shift = 13;
     static constexpr int32_t fp16_shiftSign = 16;
     static constexpr int32_t fp16_infN = 0x7F800000;
-    // the following constant is set to 65519 instead of 56504 to emulate the rounding behaviour observed on f16 hw.
+    // the following constant is set to 65519 instead of 56504 to emulate the rounding behaviour observed on real hw.
     static constexpr int32_t fp16_maxN = 0x477FEF00; //max flt16 as flt32
     static constexpr int32_t fp16_minN = 0x38800000; //min flt16 normal as flt32
     static constexpr int32_t fp16_sigN = 0x80000000; //sign bit
@@ -149,7 +149,7 @@ namespace eve
       static constexpr bool supports_fp16_vector_ops = spy::supports::fp16::vector_ops;
     }
 
-    using float16 = _Float16;
+    using float16_t = _Float16;
   #else
     namespace detail
     {
@@ -158,7 +158,7 @@ namespace eve
       static constexpr bool supports_fp16_vector_ops = false;
     }
 
-    struct float16 {
+    struct float16_t {
       private:
         uint16_t data;
 
@@ -169,9 +169,9 @@ namespace eve
         }
 
       public:
-        constexpr float16() = default;
-        constexpr explicit float16(std::integral auto v): data(detail::emulated_int_to_fp16(v)) { }
-        constexpr explicit float16(std::floating_point auto v): data(detail::emulated_fp_to_fp16(v)) { }
+        constexpr float16_t() = default;
+        constexpr explicit float16_t(std::integral auto v): data(detail::emulated_int_to_fp16(v)) { }
+        constexpr explicit float16_t(std::floating_point auto v): data(detail::emulated_fp_to_fp16(v)) { }
 
 
         constexpr EVE_FORCEINLINE operator float()              const noexcept { return into<float>(); }
@@ -189,79 +189,82 @@ namespace eve
         constexpr EVE_FORCEINLINE operator long long()          const noexcept { return into<long long>(); }
         constexpr EVE_FORCEINLINE operator unsigned long long() const noexcept { return into<unsigned long long>(); }
 
-        // Arithmetic operators
-        constexpr EVE_FORCEINLINE float16 operator+(float16 const& other) const noexcept
+        constexpr EVE_FORCEINLINE float16_t& operator+=(float16_t const& other) noexcept
         {
-          return float16{into<float>() + static_cast<float>(other)};
-        }
-
-        constexpr EVE_FORCEINLINE float16 operator-(float16 const& other) const noexcept
-        {
-          return float16{into<float>() - static_cast<float>(other)};
-        }
-
-        constexpr EVE_FORCEINLINE float16 operator*(float16 const& other) const noexcept
-        {
-          return float16{into<float>() * static_cast<float>(other)};
-        }
-
-        constexpr EVE_FORCEINLINE float16 operator/(float16 const& other) const noexcept
-        {
-          return float16{into<float>() / static_cast<float>(other)};
-        }
-
-        constexpr EVE_FORCEINLINE float16 operator-() const noexcept
-        {
-          return float16{-into<float>()};
-        }
-
-        constexpr EVE_FORCEINLINE float16& operator+=(float16 const& other) noexcept
-        {
-          return *this = *this + other;
-        }
-
-        constexpr EVE_FORCEINLINE float16& operator-=(float16 const& other) noexcept
-        {
-          return *this = *this - other;
-        }
-
-        constexpr EVE_FORCEINLINE float16& operator*=(float16 const& other) noexcept
-        {
-          return *this = *this * other;
-        }
-
-        constexpr EVE_FORCEINLINE float16& operator/=(float16 const& other) noexcept
-        {
-          return *this = *this / other;
-        }
-
-        constexpr EVE_FORCEINLINE float16& operator++() noexcept
-        {
-          *this += float16{1.0f};
+          *this = float16_t(into<float>() + static_cast<float>(other));
           return *this;
         }
 
-        constexpr EVE_FORCEINLINE float16 operator++(int) noexcept
+        constexpr EVE_FORCEINLINE float16_t& operator-=(float16_t const& other) noexcept
         {
-          float16 tmp = *this;
+          *this = float16_t(into<float>() - static_cast<float>(other));
+          return *this;
+        }
+
+        constexpr EVE_FORCEINLINE float16_t& operator*=(float16_t const& other) noexcept
+        {
+          *this = float16_t(into<float>() * static_cast<float>(other));
+          return *this;
+        }
+
+        constexpr EVE_FORCEINLINE float16_t& operator/=(float16_t const& other) noexcept
+        {
+          *this = float16_t(into<float>() / static_cast<float>(other));
+          return *this;
+        }
+
+        constexpr EVE_FORCEINLINE float16_t operator+(float16_t const& other) const noexcept
+        {
+          return float16_t(*this) += other;
+        }
+
+        constexpr EVE_FORCEINLINE float16_t operator-(float16_t const& other) const noexcept
+        {
+          return float16_t(*this) -= other;
+        }
+
+        constexpr EVE_FORCEINLINE float16_t operator*(float16_t const& other) const noexcept
+        {
+          return float16_t(*this) *= other;
+        }
+
+        constexpr EVE_FORCEINLINE float16_t operator/(float16_t const& other) const noexcept
+        {
+          return float16_t(*this) /= other;
+        }
+
+        constexpr EVE_FORCEINLINE float16_t operator-() const noexcept
+        {
+          return float16_t{-into<float>()};
+        }
+
+        constexpr EVE_FORCEINLINE float16_t& operator++() noexcept
+        {
+          *this += float16_t{1.0f};
+          return *this;
+        }
+
+        constexpr EVE_FORCEINLINE float16_t operator++(int) noexcept
+        {
+          float16_t tmp = *this;
           ++(*this);
           return tmp;
         }
 
-        constexpr EVE_FORCEINLINE float16& operator--() noexcept
+        constexpr EVE_FORCEINLINE float16_t& operator--() noexcept
         {
-          *this -= float16{1.0f};
+          *this -= float16_t{1.0f};
           return *this;
         }
 
-        constexpr EVE_FORCEINLINE float16 operator--(int) noexcept
+        constexpr EVE_FORCEINLINE float16_t operator--(int) noexcept
         {
-          float16 tmp = *this;
+          float16_t tmp = *this;
           --(*this);
           return tmp;
         }
 
-        constexpr EVE_FORCEINLINE std::partial_ordering operator<=>(float16 const& other) const noexcept
+        constexpr EVE_FORCEINLINE std::partial_ordering operator<=>(float16_t const& other) const noexcept
         {
           return detail::emulated_fp16_compare(data, other.data);
         }
@@ -270,14 +273,9 @@ namespace eve
 
   namespace detail
   {
-    constexpr static float16 float16_from_bits(std::uint16_t bits) noexcept
+    constexpr static eve::float16_t float16_from_bits(std::uint16_t bits) noexcept
     {
-      return std::bit_cast<float16>(bits);
-    }
-
-    constexpr static std::uint16_t float16_to_bits(float16 value) noexcept
-    {
-      return std::bit_cast<std::uint16_t>(value);
+      return std::bit_cast<eve::float16_t>(bits);
     }
   }
 }

--- a/include/eve/arch/float16.hpp
+++ b/include/eve/arch/float16.hpp
@@ -174,63 +174,63 @@ namespace eve
         constexpr explicit float16_t(std::floating_point auto v): data(detail::emulated_fp_to_fp16(v)) { }
 
 
-        constexpr EVE_FORCEINLINE operator float()              const noexcept { return into<float>(); }
-        constexpr EVE_FORCEINLINE operator double()             const noexcept { return into<double>(); }
+        constexpr EVE_FORCEINLINE explicit operator float()              const noexcept { return into<float>(); }
+        constexpr EVE_FORCEINLINE explicit operator double()             const noexcept { return into<double>(); }
 
-        constexpr EVE_FORCEINLINE operator char()               const noexcept { return into<char>(); }
-        constexpr EVE_FORCEINLINE operator signed char()        const noexcept { return into<signed char>(); }
-        constexpr EVE_FORCEINLINE operator unsigned char()      const noexcept { return into<unsigned char>(); }
-        constexpr EVE_FORCEINLINE operator short()              const noexcept { return into<short>(); }
-        constexpr EVE_FORCEINLINE operator unsigned short()     const noexcept { return into<unsigned short>(); }
-        constexpr EVE_FORCEINLINE operator int()                const noexcept { return into<int>(); }
-        constexpr EVE_FORCEINLINE operator unsigned int()       const noexcept { return into<unsigned int>(); }
-        constexpr EVE_FORCEINLINE operator long()               const noexcept { return into<long>(); }
-        constexpr EVE_FORCEINLINE operator unsigned long()      const noexcept { return into<unsigned long>(); }
-        constexpr EVE_FORCEINLINE operator long long()          const noexcept { return into<long long>(); }
-        constexpr EVE_FORCEINLINE operator unsigned long long() const noexcept { return into<unsigned long long>(); }
+        constexpr EVE_FORCEINLINE explicit operator char()               const noexcept { return into<char>(); }
+        constexpr EVE_FORCEINLINE explicit operator signed char()        const noexcept { return into<signed char>(); }
+        constexpr EVE_FORCEINLINE explicit operator unsigned char()      const noexcept { return into<unsigned char>(); }
+        constexpr EVE_FORCEINLINE explicit operator short()              const noexcept { return into<short>(); }
+        constexpr EVE_FORCEINLINE explicit operator unsigned short()     const noexcept { return into<unsigned short>(); }
+        constexpr EVE_FORCEINLINE explicit operator int()                const noexcept { return into<int>(); }
+        constexpr EVE_FORCEINLINE explicit operator unsigned int()       const noexcept { return into<unsigned int>(); }
+        constexpr EVE_FORCEINLINE explicit operator long()               const noexcept { return into<long>(); }
+        constexpr EVE_FORCEINLINE explicit operator unsigned long()      const noexcept { return into<unsigned long>(); }
+        constexpr EVE_FORCEINLINE explicit operator long long()          const noexcept { return into<long long>(); }
+        constexpr EVE_FORCEINLINE explicit operator unsigned long long() const noexcept { return into<unsigned long long>(); }
 
         constexpr EVE_FORCEINLINE float16_t& operator+=(float16_t const& other) noexcept
         {
-          *this = float16_t(into<float>() + static_cast<float>(other));
+          *this = float16_t{ into<float>() + static_cast<float>(other) };
           return *this;
         }
 
         constexpr EVE_FORCEINLINE float16_t& operator-=(float16_t const& other) noexcept
         {
-          *this = float16_t(into<float>() - static_cast<float>(other));
+          *this = float16_t{ into<float>() - static_cast<float>(other) };
           return *this;
         }
 
         constexpr EVE_FORCEINLINE float16_t& operator*=(float16_t const& other) noexcept
         {
-          *this = float16_t(into<float>() * static_cast<float>(other));
+          *this = float16_t{ into<float>() * static_cast<float>(other) };
           return *this;
         }
 
         constexpr EVE_FORCEINLINE float16_t& operator/=(float16_t const& other) noexcept
         {
-          *this = float16_t(into<float>() / static_cast<float>(other));
+          *this = float16_t{ into<float>() / static_cast<float>(other) };
           return *this;
         }
 
         constexpr EVE_FORCEINLINE float16_t operator+(float16_t const& other) const noexcept
         {
-          return float16_t(*this) += other;
+          return float16_t{ *this } += other;
         }
 
         constexpr EVE_FORCEINLINE float16_t operator-(float16_t const& other) const noexcept
         {
-          return float16_t(*this) -= other;
+          return float16_t{ *this } -= other;
         }
 
         constexpr EVE_FORCEINLINE float16_t operator*(float16_t const& other) const noexcept
         {
-          return float16_t(*this) *= other;
+          return float16_t{ *this } *= other;
         }
 
         constexpr EVE_FORCEINLINE float16_t operator/(float16_t const& other) const noexcept
         {
-          return float16_t(*this) /= other;
+          return float16_t{ *this } /= other;
         }
 
         constexpr EVE_FORCEINLINE float16_t operator-() const noexcept

--- a/include/eve/arch/float16.hpp
+++ b/include/eve/arch/float16.hpp
@@ -1,0 +1,398 @@
+//==================================================================================================
+/*
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+*/
+//==================================================================================================
+#pragma once
+
+#include <eve/detail/spy.hpp>
+#include <eve/detail/meta.hpp>
+#include <eve/detail/abi.hpp>
+#include <eve/traits/translation.hpp>
+
+#include <bit>
+#include <cmath>
+#include <cstdint>
+#include <compare>
+#include <limits>
+
+namespace eve
+{
+  namespace detail
+  {
+    constexpr float emulated_fp16_to_fp32(uint16_t raw) noexcept
+    {
+      std::uint32_t sign = (raw & 0x8000) << 16;
+      std::uint32_t exp = (raw & 0x7C00) >> 10;
+      std::uint32_t mantissa = raw & 0x03FF;
+
+      if (exp == 0) {
+        if (mantissa == 0) {
+          return std::bit_cast<float>(sign);
+        } else {
+          // Subnormal - convert to normalized float32
+          int shift = 0;
+          while ((mantissa & 0x0400) == 0) {
+            mantissa <<= 1;
+            shift++;
+          }
+          mantissa &= 0x03FF;
+          exp = 127 - 15 - shift + 1;
+          return std::bit_cast<float>(sign | (exp << 23) | (mantissa << 13));
+        }
+      } else if (exp == 31) {
+        // Infinity or NaN
+        if (mantissa == 0) {
+          return std::bit_cast<float>(sign | 0x7F800000);
+        } else {
+          return std::numeric_limits<float>::quiet_NaN();
+        }
+      } else {
+        // Normal case, adjust exponent bias
+        exp = exp - 15 + 127;
+        return std::bit_cast<float>(sign | (exp << 23) | (mantissa << 13));
+      }
+    }
+
+    template <std::floating_point T>
+    constexpr std::uint16_t emulated_fp_to_fp16(T value) noexcept
+    {
+      constexpr int      F_EXP_BITS   = 11;
+      constexpr int      F_FRAC_BITS  = std::numeric_limits<double>::digits - 1;
+      constexpr int      F_BIAS       = std::numeric_limits<double>::max_exponent - 1;
+      constexpr uint32_t F_EXP_MAX    = (1u << F_EXP_BITS) - 1;
+
+      constexpr int      H_EXP_BITS   = 5;
+      constexpr int      H_FRAC_BITS  = 10;
+      constexpr int      H_BIAS       = (1 << (H_EXP_BITS - 1)) - 1;
+      constexpr uint16_t H_EXP_MAX    = (1u << H_EXP_BITS) - 1;
+
+      uint64_t bits = std::bit_cast<uint64_t>(static_cast<double>(value));
+      uint64_t sign  = bits >> 63;
+      uint64_t exp_f = (bits >> F_FRAC_BITS) & F_EXP_MAX;
+      uint64_t frac  = bits & ((1ul << F_FRAC_BITS) - 1);
+
+      // Handle NaN: always produce 0xFFFF
+      if (exp_f == F_EXP_MAX && frac != 0)
+      {
+        return 0xFFFFu;
+      }
+
+      uint16_t hsign = static_cast<uint16_t>(sign << 15);
+      uint16_t hexp;
+      uint16_t hfrac;
+
+      if (exp_f == F_EXP_MAX)
+      {
+        hexp  = H_EXP_MAX;
+        hfrac = 0;
+      }
+      else
+      {
+        int e_unbiased = static_cast<int>(exp_f) - F_BIAS;
+
+        if (e_unbiased >= H_BIAS)
+        {
+          hexp  = H_EXP_MAX;
+          hfrac = 0;
+        }
+        else if (e_unbiased < -H_BIAS - H_FRAC_BITS)
+        {
+          hexp  = 0;
+          hfrac = 0;
+        }
+        else if (e_unbiased < 1 - H_BIAS)
+        {
+          // Subnormal case: e_unbiased < -14
+          int shift = (1 - H_BIAS - e_unbiased) + (F_FRAC_BITS - H_FRAC_BITS);
+          uint64_t mant = (1ul << F_FRAC_BITS) | frac;
+
+          // Round to nearest, ties to even
+          uint64_t sub = mant >> shift;
+          if (shift > 0 && (mant >> (shift - 1)) & 1) {
+            // Check if we need to round up
+            bool round_up = true;
+            if (shift > 1) {
+              // Check if it's exactly halfway (ties to even)
+              uint64_t lower_bits = mant & ((1ul << (shift - 1)) - 1);
+              if (lower_bits == 0) {
+                // Ties to even: round up only if result would be odd
+                round_up = (sub & 1) == 1;
+              }
+            }
+            if (round_up) {
+              ++sub;
+            }
+          }
+
+          hexp  = 0;
+          hfrac = static_cast<uint16_t>(sub);
+        }
+        else
+        {
+          int newe   = e_unbiased + H_BIAS;
+          hexp       = static_cast<uint16_t>(newe);
+          uint64_t fr = frac + (1ul << (F_FRAC_BITS - H_FRAC_BITS - 1));
+          if (fr & (1ul << F_FRAC_BITS))
+          {
+            fr    = 0;
+            hexp += 1;
+            if (hexp >= H_EXP_MAX)
+            {
+              return hsign | (H_EXP_MAX << H_FRAC_BITS);
+            }
+          }
+          hfrac = static_cast<uint16_t>(fr >> (F_FRAC_BITS - H_FRAC_BITS));
+        }
+      }
+
+      return static_cast<uint16_t>(hsign | (hexp << H_FRAC_BITS) | hfrac);
+    }
+
+    template <std::integral T>
+    constexpr std::uint16_t emulated_int_to_fp16(T value) noexcept
+    {
+      return emulated_fp_to_fp16(static_cast<float>(value));
+    }
+
+    constexpr std::partial_ordering emulated_fp16_compare(std::uint16_t a_bits, std::uint16_t b_bits) noexcept
+    {
+      // Check for NaN (exp = 0x1F, mantissa != 0)
+      bool a_is_nan = ((a_bits & 0x7C00) == 0x7C00) && ((a_bits & 0x03FF) != 0);
+      bool b_is_nan = ((b_bits & 0x7C00) == 0x7C00) && ((b_bits & 0x03FF) != 0);
+
+      if (a_is_nan || b_is_nan) {
+        // NaN comparisons are unordered
+        return std::partial_ordering::unordered;
+      }
+
+      // Extract signs
+      bool a_sign = (a_bits & 0x8000) != 0;
+      bool b_sign = (b_bits & 0x8000) != 0;
+
+      // Different signs
+      if (a_sign != b_sign) {
+        // Handle zero cases: +0 == -0
+        bool a_is_zero = (a_bits & 0x7FFF) == 0;
+        bool b_is_zero = (b_bits & 0x7FFF) == 0;
+        if (a_is_zero && b_is_zero) return std::partial_ordering::equivalent;
+
+        return a_sign ? std::partial_ordering::less : std::partial_ordering::greater;
+      }
+
+      // Same signs - compare magnitudes
+      uint16_t a_mag = a_bits & 0x7FFF;
+      uint16_t b_mag = b_bits & 0x7FFF;
+
+      if (a_mag == b_mag) return std::partial_ordering::equivalent;
+
+      // For negative numbers, larger magnitude means smaller value
+      if (a_sign) {
+        return (a_mag > b_mag) ? std::partial_ordering::less : std::partial_ordering::greater;
+      } else {
+        return (a_mag < b_mag) ? std::partial_ordering::less : std::partial_ordering::greater;
+      }
+    }
+
+    struct fp16_supports_info
+    {
+  #if defined(EVE_NO_NATIVE_FP16)
+      static constexpr bool type = false;
+      static constexpr bool scalar_ops = false;
+      static constexpr bool vector_ops = false;
+  #else
+      static constexpr bool type = spy::supports::fp16::type;
+      static constexpr bool scalar_ops = spy::supports::fp16::scalar_ops;
+      static constexpr bool vector_ops = spy::supports::fp16::vector_ops;
+  #endif
+    };
+  }
+
+  namespace
+  {
+    struct from_underlying { };
+  }
+
+  template<typename Underlying>
+  struct basic_float16
+  {
+    private:
+      Underlying data;
+
+      constexpr explicit basic_float16(from_underlying, Underlying value) noexcept
+        : data(value) {}
+
+      template <std::floating_point T>
+      constexpr static Underlying make(T value) noexcept;
+
+      template <std::integral T>
+      constexpr static Underlying make(T value) noexcept;
+
+      template <typename T>
+      constexpr T into() const noexcept
+      {
+        if constexpr (supports::type) return static_cast<T>(data);
+        else                          return static_cast<T>(detail::emulated_fp16_to_fp32(data));
+      }
+
+    public:
+      using supports = detail::fp16_supports_info;
+
+      constexpr basic_float16() noexcept = default;
+      constexpr basic_float16(basic_float16 const&) noexcept = default;
+
+      constexpr explicit basic_float16(std::integral auto value) noexcept
+        : data(make(value)) {}
+
+      constexpr explicit basic_float16(std::floating_point auto value) noexcept
+        : data(make(value)) {}
+
+      constexpr EVE_FORCEINLINE static basic_float16 from_bits(std::uint16_t bits) noexcept
+      {
+        return basic_float16{ from_underlying{}, std::bit_cast<Underlying>(bits) };
+      }
+
+      constexpr EVE_FORCEINLINE std::uint16_t bits() const noexcept
+      {
+        return std::bit_cast<std::uint16_t>(data);
+      }
+
+      constexpr EVE_FORCEINLINE operator float()              const noexcept { return into<float>(); }
+      constexpr EVE_FORCEINLINE operator double()             const noexcept { return into<double>(); }
+
+      constexpr EVE_FORCEINLINE operator char()               const noexcept { return into<char>(); }
+      constexpr EVE_FORCEINLINE operator signed char()        const noexcept { return into<signed char>(); }
+      constexpr EVE_FORCEINLINE operator unsigned char()      const noexcept { return into<unsigned char>(); }
+      constexpr EVE_FORCEINLINE operator short()              const noexcept { return into<short>(); }
+      constexpr EVE_FORCEINLINE operator unsigned short()     const noexcept { return into<unsigned short>(); }
+      constexpr EVE_FORCEINLINE operator int()                const noexcept { return into<int>(); }
+      constexpr EVE_FORCEINLINE operator unsigned int()       const noexcept { return into<unsigned int>(); }
+      constexpr EVE_FORCEINLINE operator long()               const noexcept { return into<long>(); }
+      constexpr EVE_FORCEINLINE operator unsigned long()      const noexcept { return into<unsigned long>(); }
+      constexpr EVE_FORCEINLINE operator long long()          const noexcept { return into<long long>(); }
+      constexpr EVE_FORCEINLINE operator unsigned long long() const noexcept { return into<unsigned long long>(); }
+
+      // Arithmetic operators
+      constexpr EVE_FORCEINLINE basic_float16 operator+(basic_float16 const& other) const noexcept
+      {
+        if constexpr (supports::type) return basic_float16{from_underlying{}, data + other.data};
+        else                          return basic_float16{into<float>() + static_cast<float>(other)};
+      }
+
+      constexpr EVE_FORCEINLINE basic_float16 operator-(basic_float16 const& other) const noexcept
+      {
+        if constexpr (supports::type) return basic_float16{from_underlying{}, data - other.data};
+        else                          return basic_float16{into<float>() - static_cast<float>(other)};
+      }
+
+      constexpr EVE_FORCEINLINE basic_float16 operator*(basic_float16 const& other) const noexcept
+      {
+        if constexpr (supports::type) return basic_float16{from_underlying{}, data * other.data};
+        else                          return basic_float16{into<float>() * static_cast<float>(other)};
+      }
+
+      constexpr EVE_FORCEINLINE basic_float16 operator/(basic_float16 const& other) const noexcept
+      {
+        if constexpr (supports::type) return basic_float16{from_underlying{}, data / other.data};
+        else                          return basic_float16{into<float>() / static_cast<float>(other)};
+      }
+
+      constexpr EVE_FORCEINLINE basic_float16 operator-() const noexcept
+      {
+        if constexpr (supports::type) return basic_float16{from_underlying{}, -data};
+        else                          return basic_float16{-into<float>()};
+      }
+
+      constexpr EVE_FORCEINLINE basic_float16& operator+=(basic_float16 const& other) noexcept
+      {
+        return *this = *this + other;
+      }
+
+      constexpr EVE_FORCEINLINE basic_float16& operator-=(basic_float16 const& other) noexcept
+      {
+        return *this = *this - other;
+      }
+
+      constexpr EVE_FORCEINLINE basic_float16& operator*=(basic_float16 const& other) noexcept
+      {
+        return *this = *this * other;
+      }
+
+      constexpr EVE_FORCEINLINE basic_float16& operator/=(basic_float16 const& other) noexcept
+      {
+        return *this = *this / other;
+      }
+
+      constexpr EVE_FORCEINLINE basic_float16& operator++() noexcept
+      {
+        *this += basic_float16{1.0f};
+        return *this;
+      }
+
+      constexpr EVE_FORCEINLINE basic_float16 operator++(int) noexcept
+      {
+        basic_float16 tmp = *this;
+        ++(*this);
+        return tmp;
+      }
+
+      constexpr EVE_FORCEINLINE basic_float16& operator--() noexcept
+      {
+        *this -= basic_float16{1.0f};
+        return *this;
+      }
+
+      constexpr EVE_FORCEINLINE basic_float16 operator--(int) noexcept
+      {
+        basic_float16 tmp = *this;
+        --(*this);
+        return tmp;
+      }
+
+      constexpr EVE_FORCEINLINE std::partial_ordering operator<=>(basic_float16 const& other) const noexcept
+      {
+        if constexpr (supports::type) return data <=> other.data;
+        else                          return detail::emulated_fp16_compare(data, other.data);
+      }
+  };
+
+#if defined(SPY_SUPPORTS_FP16_TYPE) && !defined(EVE_NO_NATIVE_FP16)
+  using float16 = basic_float16<_Float16>;
+
+  template<>
+  struct translation_of<float16>
+  {
+    using type = _Float16;
+  };
+#else
+  using float16 = basic_float16<std::uint16_t>;
+#endif
+
+  namespace detail
+  {
+    using f16 = translate_t<float16>;
+
+    constexpr f16 f16_from_bits(std::uint16_t bits) noexcept
+    {
+      return std::bit_cast<f16>(bits);
+    }
+  }
+
+  template<typename Underlying>
+  template<std::floating_point T>
+  constexpr Underlying basic_float16<Underlying>::make(T value) noexcept
+  {
+    if constexpr (basic_float16<Underlying>::supports::type) return static_cast<Underlying>(value);
+    else                                                     return detail::emulated_fp_to_fp16(value);
+  }
+
+  template<typename Underlying>
+  template<std::integral T>
+  constexpr Underlying basic_float16<Underlying>::make(T value) noexcept
+  {
+    if constexpr (basic_float16<Underlying>::supports::type) return static_cast<Underlying>(value);
+    else                                                     return detail::emulated_int_to_fp16(value);
+  }
+}

--- a/include/eve/arch/float16.hpp
+++ b/include/eve/arch/float16.hpp
@@ -23,24 +23,24 @@ namespace eve
   namespace detail
   {
     // taken from https://github.com/QiJune/majel/blob/master/float16.h
-    static constexpr int32_t f16_shift = 13;
-    static constexpr int32_t f16_shiftSign = 16;
-    static constexpr int32_t f16_infN = 0x7F800000;
+    static constexpr int32_t fp16_shift = 13;
+    static constexpr int32_t fp16_shiftSign = 16;
+    static constexpr int32_t fp16_infN = 0x7F800000;
     // the following constant is set to 65519 instead of 56504 to emulate the rounding behaviour observed on f16 hw.
-    static constexpr int32_t f16_maxN = 0x477FEF00; //max flt16 as flt32
-    static constexpr int32_t f16_minN = 0x38800000; //min flt16 normal as flt32
-    static constexpr int32_t f16_sigN = 0x80000000; //sign bit
-    static constexpr int32_t f16_infC = f16_infN >> f16_shift;
-    static constexpr int32_t f16_nanN = (f16_infC + 1) << f16_shift; //minimum flt16 nan as float32
-    static constexpr int32_t f16_maxC = f16_maxN >> f16_shift;
-    static constexpr int32_t f16_minC = f16_minN >> f16_shift;
-    static constexpr int32_t f16_sigC = f16_sigN >> f16_shiftSign;
-    static constexpr int32_t f16_mulN = 0x52000000; //(1 << 23) / minN
-    static constexpr int32_t f16_mulC = 0x33800000; //minN / (1 << (23 - shift))
-    static constexpr int32_t f16_subC = 0x003FF; //max flt32 subnormal downshifted
-    static constexpr int32_t f16_norC = 0x00400; //min flt32 normal downshifted
-    static constexpr int32_t f16_maxD = f16_infC - f16_maxC - 1;
-    static constexpr int32_t f16_minD = f16_minC - f16_subC - 1;
+    static constexpr int32_t fp16_maxN = 0x477FEF00; //max flt16 as flt32
+    static constexpr int32_t fp16_minN = 0x38800000; //min flt16 normal as flt32
+    static constexpr int32_t fp16_sigN = 0x80000000; //sign bit
+    static constexpr int32_t fp16_infC = fp16_infN >> fp16_shift;
+    static constexpr int32_t fp16_nanN = (fp16_infC + 1) << fp16_shift; //minimum flt16 nan as float32
+    static constexpr int32_t fp16_maxC = fp16_maxN >> fp16_shift;
+    static constexpr int32_t fp16_minC = fp16_minN >> fp16_shift;
+    static constexpr int32_t fp16_sigC = fp16_sigN >> fp16_shiftSign;
+    static constexpr int32_t fp16_mulN = 0x52000000; //(1 << 23) / minN
+    static constexpr int32_t fp16_mulC = 0x33800000; //minN / (1 << (23 - shift))
+    static constexpr int32_t fp16_subC = 0x003FF; //max flt32 subnormal downshifted
+    static constexpr int32_t fp16_norC = 0x00400; //min flt32 normal downshifted
+    static constexpr int32_t fp16_maxD = fp16_infC - fp16_maxC - 1;
+    static constexpr int32_t fp16_minD = fp16_minC - fp16_subC - 1;
 
     union Bits {
         float f;
@@ -52,16 +52,16 @@ namespace eve
     {
       Bits v;
       v.ui = raw;
-      int32_t sign = v.si & f16_sigC;
+      int32_t sign = v.si & fp16_sigC;
       v.si ^= sign;
-      sign <<= f16_shiftSign;
-      v.si ^= ((v.si + f16_minD) ^ v.si) & -(v.si > f16_subC);
-      v.si ^= ((v.si + f16_maxD) ^ v.si) & -(v.si > f16_maxC);
+      sign <<= fp16_shiftSign;
+      v.si ^= ((v.si + fp16_minD) ^ v.si) & -(v.si > fp16_subC);
+      v.si ^= ((v.si + fp16_maxD) ^ v.si) & -(v.si > fp16_maxC);
       Bits s;
-      s.si = f16_mulC;
+      s.si = fp16_mulC;
       s.f *= v.si;
-      int32_t mask = -(f16_norC > v.si);
-      v.si <<= f16_shift;
+      int32_t mask = -(fp16_norC > v.si);
+      v.si <<= fp16_shift;
       v.si ^= (s.si ^ v.si) & mask;
       v.si |= sign;
       return v.f;
@@ -74,17 +74,17 @@ namespace eve
 
       Bits v, s;
       v.f = f;
-      uint32_t sign = v.si & f16_sigN;
+      uint32_t sign = v.si & fp16_sigN;
       v.si ^= sign;
-      sign >>= f16_shiftSign; // logical shift
-      s.si = f16_mulN;
+      sign >>= fp16_shiftSign; // logical shift
+      s.si = fp16_mulN;
       s.si = s.f * v.f; // correct subnormals
-      v.si ^= (s.si ^ v.si) & -(f16_minN > v.si);
-      v.si ^= (f16_infN ^ v.si) & -((f16_infN > v.si) & (v.si > f16_maxN));
-      v.si ^= (f16_nanN ^ v.si) & -((f16_nanN > v.si) & (v.si > f16_infN));
-      v.ui >>= f16_shift; // logical shift
-      v.si ^= ((v.si - f16_maxD) ^ v.si) & -(v.si > f16_maxC);
-      v.si ^= ((v.si - f16_minD) ^ v.si) & -(v.si > f16_subC);
+      v.si ^= (s.si ^ v.si) & -(fp16_minN > v.si);
+      v.si ^= (fp16_infN ^ v.si) & -((fp16_infN > v.si) & (v.si > fp16_maxN));
+      v.si ^= (fp16_nanN ^ v.si) & -((fp16_nanN > v.si) & (v.si > fp16_infN));
+      v.ui >>= fp16_shift; // logical shift
+      v.si ^= ((v.si - fp16_maxD) ^ v.si) & -(v.si > fp16_maxC);
+      v.si ^= ((v.si - fp16_minD) ^ v.si) & -(v.si > fp16_subC);
       return v.ui | sign;
     }
 
@@ -144,18 +144,18 @@ namespace eve
   #if defined(SPY_SUPPORTS_FP16_TYPE) && !defined(EVE_NO_NATIVE_FP16)
     namespace detail
     {
-      static constexpr bool supports_f16_type = spy::supports::fp16::type;
-      static constexpr bool supports_f16_scalar_ops = spy::supports::fp16::scalar_ops;
-      static constexpr bool supports_f16_vector_ops = spy::supports::fp16::vector_ops;
+      static constexpr bool supports_fp16_native_type = spy::supports::fp16::type;
+      static constexpr bool supports_fp16_scalar_ops = spy::supports::fp16::scalar_ops;
+      static constexpr bool supports_fp16_vector_ops = spy::supports::fp16::vector_ops;
     }
 
     using float16 = _Float16;
   #else
     namespace detail
     {
-      static constexpr bool supports_f16_type = false;
-      static constexpr bool supports_f16_scalar_ops = false;
-      static constexpr bool supports_f16_vector_ops = false;
+      static constexpr bool supports_fp16_native_type = false;
+      static constexpr bool supports_fp16_scalar_ops = false;
+      static constexpr bool supports_fp16_vector_ops = false;
     }
 
     struct float16 {

--- a/include/eve/concept/scalar.hpp
+++ b/include/eve/concept/scalar.hpp
@@ -25,7 +25,7 @@ template<typename T>
 constexpr bool is_plain() noexcept
 {
   return    !(std::same_as<T, bool> || std::same_as<T, long double>)
-        &&  (std::is_floating_point_v<T> || std::is_integral_v<T> || std::same_as<T, eve::float16>);
+        &&  (std::is_floating_point_v<T> || std::is_integral_v<T> || std::same_as<T, eve::float16_t>);
 }
 }
 

--- a/include/eve/concept/scalar.hpp
+++ b/include/eve/concept/scalar.hpp
@@ -11,6 +11,7 @@
 #include <eve/detail/meta.hpp>
 #include <eve/traits/translation.hpp>
 #include <eve/concept/translation.hpp>
+#include <eve/arch/float16.hpp>
 
 #include <cstddef>
 #include <cstdint>
@@ -23,8 +24,8 @@ namespace eve::detail
 template<typename T>
 constexpr bool is_plain() noexcept
 {
-  return    !(std::is_same_v<T, bool> || std::is_same_v<T, long double>)
-        &&  (std::is_floating_point_v<T> || std::is_integral_v<T>);
+  return    !(std::same_as<T, bool> || std::same_as<T, long double>)
+        &&  (std::is_floating_point_v<T> || std::is_integral_v<T> || std::same_as<T, detail::f16>);
 }
 }
 

--- a/include/eve/concept/scalar.hpp
+++ b/include/eve/concept/scalar.hpp
@@ -25,7 +25,7 @@ template<typename T>
 constexpr bool is_plain() noexcept
 {
   return    !(std::same_as<T, bool> || std::same_as<T, long double>)
-        &&  (std::is_floating_point_v<T> || std::is_integral_v<T> || std::same_as<T, detail::f16>);
+        &&  (std::is_floating_point_v<T> || std::is_integral_v<T> || std::same_as<T, eve::float16>);
 }
 }
 

--- a/include/eve/concept/value.hpp
+++ b/include/eve/concept/value.hpp
@@ -113,7 +113,9 @@ namespace eve
   //! - `double`
   //! - `eve::wide<float, eve::fixed<2>>`
   //================================================================================================
-  template<typename T> concept floating_value        = value<T> && std::floating_point<translated_element_type_t<T>>;
+  template<typename T> concept floating_value = value<T>
+                                                && (std::floating_point<translated_element_type_t<T>>
+                                                    || std::same_as<translated_element_type_t<T>, detail::f16>);
   //================================================================================================
   //! @}
   //================================================================================================

--- a/include/eve/concept/value.hpp
+++ b/include/eve/concept/value.hpp
@@ -115,7 +115,7 @@ namespace eve
   //================================================================================================
   template<typename T> concept floating_value = value<T>
                                                 && (std::floating_point<translated_element_type_t<T>>
-                                                    || std::same_as<translated_element_type_t<T>, detail::f16>);
+                                                    || std::same_as<translated_element_type_t<T>, eve::float16>);
   //================================================================================================
   //! @}
   //================================================================================================

--- a/include/eve/concept/value.hpp
+++ b/include/eve/concept/value.hpp
@@ -115,7 +115,7 @@ namespace eve
   //================================================================================================
   template<typename T> concept floating_value = value<T>
                                                 && (std::floating_point<translated_element_type_t<T>>
-                                                    || std::same_as<translated_element_type_t<T>, eve::float16>);
+                                                    || std::same_as<translated_element_type_t<T>, eve::float16_t>);
   //================================================================================================
   //! @}
   //================================================================================================

--- a/include/eve/module/core/constant/allbits.hpp
+++ b/include/eve/module/core/constant/allbits.hpp
@@ -22,7 +22,7 @@ struct allbits_t : constant_callable<allbits_t, Options, lower_option, upper_opt
   {
     constexpr auto mask = ~0ULL;
     if      constexpr(std::integral<T>       )  return T(mask);
-    else if constexpr(std::same_as<T, detail::f16>) return detail::f16_from_bits(0xFFFF);
+    else if constexpr(std::same_as<T, eve::float16>) return detail::float16_from_bits(0xFFFF);
     else if constexpr(std::same_as<T, double>)  return T(std::bit_cast<double>(~0ULL));
     else if constexpr(std::same_as<T, float >)  return T(std::bit_cast<float>(~0U));
   }

--- a/include/eve/module/core/constant/allbits.hpp
+++ b/include/eve/module/core/constant/allbits.hpp
@@ -22,6 +22,7 @@ struct allbits_t : constant_callable<allbits_t, Options, lower_option, upper_opt
   {
     constexpr auto mask = ~0ULL;
     if      constexpr(std::integral<T>       )  return T(mask);
+    else if constexpr(std::same_as<T, detail::f16>) return detail::f16_from_bits(0xFFFF);
     else if constexpr(std::same_as<T, double>)  return T(std::bit_cast<double>(~0ULL));
     else if constexpr(std::same_as<T, float >)  return T(std::bit_cast<float>(~0U));
   }

--- a/include/eve/module/core/constant/allbits.hpp
+++ b/include/eve/module/core/constant/allbits.hpp
@@ -22,7 +22,7 @@ struct allbits_t : constant_callable<allbits_t, Options, lower_option, upper_opt
   {
     constexpr auto mask = ~0ULL;
     if      constexpr(std::integral<T>       )  return T(mask);
-    else if constexpr(std::same_as<T, eve::float16>) return detail::float16_from_bits(0xFFFF);
+    else if constexpr(std::same_as<T, eve::float16_t>) return detail::float16_from_bits(0xFFFF);
     else if constexpr(std::same_as<T, double>)  return T(std::bit_cast<double>(~0ULL));
     else if constexpr(std::same_as<T, float >)  return T(std::bit_cast<float>(~0U));
   }

--- a/include/eve/module/core/constant/bitincrement.hpp
+++ b/include/eve/module/core/constant/bitincrement.hpp
@@ -20,7 +20,7 @@ struct bitincrement_t : constant_callable<bitincrement_t, Options, lower_option,
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, auto const&)
   {
     if      constexpr(std::integral<T>        ) return T(1);
-    else if constexpr(std::same_as<T, eve::float16>) return detail::float16_from_bits(0x0001);
+    else if constexpr(std::same_as<T, eve::float16_t>) return detail::float16_from_bits(0x0001);
     else if constexpr(std::same_as<T, float>  ) return T(0x1p-149);
     else if constexpr(std::same_as<T, double> ) return T(0x0.0000000000001p-1022);
   }

--- a/include/eve/module/core/constant/bitincrement.hpp
+++ b/include/eve/module/core/constant/bitincrement.hpp
@@ -20,6 +20,7 @@ struct bitincrement_t : constant_callable<bitincrement_t, Options, lower_option,
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, auto const&)
   {
     if      constexpr(std::integral<T>        ) return T(1);
+    else if constexpr(std::same_as<T, detail::f16>) return detail::f16_from_bits(0x0001);
     else if constexpr(std::same_as<T, float>  ) return T(0x1p-149);
     else if constexpr(std::same_as<T, double> ) return T(0x0.0000000000001p-1022);
   }

--- a/include/eve/module/core/constant/bitincrement.hpp
+++ b/include/eve/module/core/constant/bitincrement.hpp
@@ -20,7 +20,7 @@ struct bitincrement_t : constant_callable<bitincrement_t, Options, lower_option,
   static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, auto const&)
   {
     if      constexpr(std::integral<T>        ) return T(1);
-    else if constexpr(std::same_as<T, detail::f16>) return detail::f16_from_bits(0x0001);
+    else if constexpr(std::same_as<T, eve::float16>) return detail::float16_from_bits(0x0001);
     else if constexpr(std::same_as<T, float>  ) return T(0x1p-149);
     else if constexpr(std::same_as<T, double> ) return T(0x0.0000000000001p-1022);
   }

--- a/include/eve/module/core/constant/eps.hpp
+++ b/include/eve/module/core/constant/eps.hpp
@@ -20,7 +20,7 @@ namespace eve
     static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, auto const&)
     {
       if      constexpr(std::integral<T>        ) return T(1);
-      else if constexpr(std::same_as<T, eve::float16>) return detail::float16_from_bits(0x1400);
+      else if constexpr(std::same_as<T, eve::float16_t>) return detail::float16_from_bits(0x1400);
       else if constexpr(std::same_as<T, float>  ) return T(0x1p-23);
       else if constexpr(std::same_as<T, double> ) return T(0x1p-52);
     }

--- a/include/eve/module/core/constant/eps.hpp
+++ b/include/eve/module/core/constant/eps.hpp
@@ -20,7 +20,7 @@ namespace eve
     static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, auto const&)
     {
       if      constexpr(std::integral<T>        ) return T(1);
-      else if constexpr(std::same_as<T, detail::f16>) return detail::f16_from_bits(0x1400);
+      else if constexpr(std::same_as<T, eve::float16>) return detail::float16_from_bits(0x1400);
       else if constexpr(std::same_as<T, float>  ) return T(0x1p-23);
       else if constexpr(std::same_as<T, double> ) return T(0x1p-52);
     }

--- a/include/eve/module/core/constant/eps.hpp
+++ b/include/eve/module/core/constant/eps.hpp
@@ -20,6 +20,7 @@ namespace eve
     static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, auto const&)
     {
       if      constexpr(std::integral<T>        ) return T(1);
+      else if constexpr(std::same_as<T, detail::f16>) return detail::f16_from_bits(0x1400);
       else if constexpr(std::same_as<T, float>  ) return T(0x1p-23);
       else if constexpr(std::same_as<T, double> ) return T(0x1p-52);
     }

--- a/include/eve/module/core/constant/exponentmask.hpp
+++ b/include/eve/module/core/constant/exponentmask.hpp
@@ -20,7 +20,8 @@ namespace eve
     static EVE_FORCEINLINE constexpr auto value(eve::as<T> const&, auto const&)
     {
       using i_t = as_integer_t<T>;
-      if      constexpr(std::same_as<T, float>  ) return i_t(0x7f800000);
+      if      constexpr(std::same_as<T, detail::f16>) return i_t(0x7C00);
+      else if constexpr(std::same_as<T, float>  ) return i_t(0x7f800000);
       else if constexpr(std::same_as<T, double> ) return i_t(0x7ff0000000000000LL);
     }
 

--- a/include/eve/module/core/constant/exponentmask.hpp
+++ b/include/eve/module/core/constant/exponentmask.hpp
@@ -20,7 +20,7 @@ namespace eve
     static EVE_FORCEINLINE constexpr auto value(eve::as<T> const&, auto const&)
     {
       using i_t = as_integer_t<T>;
-      if      constexpr(std::same_as<T, eve::float16>) return i_t(0x7C00);
+      if      constexpr(std::same_as<T, eve::float16_t>) return i_t(0x7C00);
       else if constexpr(std::same_as<T, float>  ) return i_t(0x7f800000);
       else if constexpr(std::same_as<T, double> ) return i_t(0x7ff0000000000000LL);
     }

--- a/include/eve/module/core/constant/exponentmask.hpp
+++ b/include/eve/module/core/constant/exponentmask.hpp
@@ -20,7 +20,7 @@ namespace eve
     static EVE_FORCEINLINE constexpr auto value(eve::as<T> const&, auto const&)
     {
       using i_t = as_integer_t<T>;
-      if      constexpr(std::same_as<T, detail::f16>) return i_t(0x7C00);
+      if      constexpr(std::same_as<T, eve::float16>) return i_t(0x7C00);
       else if constexpr(std::same_as<T, float>  ) return i_t(0x7f800000);
       else if constexpr(std::same_as<T, double> ) return i_t(0x7ff0000000000000LL);
     }

--- a/include/eve/module/core/constant/half.hpp
+++ b/include/eve/module/core/constant/half.hpp
@@ -19,7 +19,8 @@ namespace eve
     template<typename T>
     static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, auto const&)
     {
-      if      constexpr(std::same_as<T, float> ) return T(0x1p-1);
+      if      constexpr(std::same_as<T, detail::f16>) return detail::f16_from_bits(0x3800);
+      else if constexpr(std::same_as<T, float> ) return T(0x1p-1);
       else if constexpr(std::same_as<T, double>) return T(0x1p-1f);
     }
 

--- a/include/eve/module/core/constant/half.hpp
+++ b/include/eve/module/core/constant/half.hpp
@@ -19,7 +19,7 @@ namespace eve
     template<typename T>
     static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, auto const&)
     {
-      if      constexpr(std::same_as<T, detail::f16>) return detail::f16_from_bits(0x3800);
+      if      constexpr(std::same_as<T, eve::float16>) return detail::float16_from_bits(0x3800);
       else if constexpr(std::same_as<T, float> ) return T(0x1p-1);
       else if constexpr(std::same_as<T, double>) return T(0x1p-1f);
     }

--- a/include/eve/module/core/constant/half.hpp
+++ b/include/eve/module/core/constant/half.hpp
@@ -19,7 +19,7 @@ namespace eve
     template<typename T>
     static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, auto const&)
     {
-      if      constexpr(std::same_as<T, eve::float16>) return detail::float16_from_bits(0x3800);
+      if      constexpr(std::same_as<T, eve::float16_t>) return detail::float16_from_bits(0x3800);
       else if constexpr(std::same_as<T, float> ) return T(0x1p-1);
       else if constexpr(std::same_as<T, double>) return T(0x1p-1f);
     }

--- a/include/eve/module/core/constant/inf.hpp
+++ b/include/eve/module/core/constant/inf.hpp
@@ -19,7 +19,8 @@ namespace eve
     template<typename T>
     static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, auto const&)
     {
-      return std::numeric_limits<T>::infinity();
+      if constexpr (std::same_as<T, detail::f16>) return detail::f16_from_bits(0x7C00);
+      else                                        return std::numeric_limits<T>::infinity();
     }
 
     template<floating_value T>

--- a/include/eve/module/core/constant/inf.hpp
+++ b/include/eve/module/core/constant/inf.hpp
@@ -19,7 +19,7 @@ namespace eve
     template<typename T>
     static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, auto const&)
     {
-      if constexpr (std::same_as<T, detail::f16>) return detail::f16_from_bits(0x7C00);
+      if constexpr (std::same_as<T, eve::float16>) return detail::float16_from_bits(0x7C00);
       else                                        return std::numeric_limits<T>::infinity();
     }
 

--- a/include/eve/module/core/constant/inf.hpp
+++ b/include/eve/module/core/constant/inf.hpp
@@ -19,7 +19,7 @@ namespace eve
     template<typename T>
     static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, auto const&)
     {
-      if constexpr (std::same_as<T, eve::float16>) return detail::float16_from_bits(0x7C00);
+      if constexpr (std::same_as<T, eve::float16_t>) return detail::float16_from_bits(0x7C00);
       else                                        return std::numeric_limits<T>::infinity();
     }
 

--- a/include/eve/module/core/constant/logeps.hpp
+++ b/include/eve/module/core/constant/logeps.hpp
@@ -19,7 +19,8 @@ namespace eve
     template<typename T, typename Opts>
     static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
     {
-      if      constexpr(std::same_as<T, float> ) return T(-0x1.fe2804p+3);
+      if      constexpr(std::same_as<T, detail::f16>) return detail::f16_from_bits(0xCE00);
+      else if constexpr(std::same_as<T, float> ) return T(-0x1.fe2804p+3);
       else if constexpr(std::same_as<T, double>) return T(-0x1.205966f2b4f12p+5);
     }
 

--- a/include/eve/module/core/constant/logeps.hpp
+++ b/include/eve/module/core/constant/logeps.hpp
@@ -19,7 +19,7 @@ namespace eve
     template<typename T, typename Opts>
     static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
     {
-      if      constexpr(std::same_as<T, eve::float16>) return detail::float16_from_bits(0xCE00);
+      if      constexpr(std::same_as<T, eve::float16_t>) return detail::float16_from_bits(0xCE00);
       else if constexpr(std::same_as<T, float> ) return T(-0x1.fe2804p+3);
       else if constexpr(std::same_as<T, double>) return T(-0x1.205966f2b4f12p+5);
     }

--- a/include/eve/module/core/constant/logeps.hpp
+++ b/include/eve/module/core/constant/logeps.hpp
@@ -19,7 +19,7 @@ namespace eve
     template<typename T, typename Opts>
     static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
     {
-      if      constexpr(std::same_as<T, detail::f16>) return detail::f16_from_bits(0xCE00);
+      if      constexpr(std::same_as<T, eve::float16>) return detail::float16_from_bits(0xCE00);
       else if constexpr(std::same_as<T, float> ) return T(-0x1.fe2804p+3);
       else if constexpr(std::same_as<T, double>) return T(-0x1.205966f2b4f12p+5);
     }

--- a/include/eve/module/core/constant/mantissamask.hpp
+++ b/include/eve/module/core/constant/mantissamask.hpp
@@ -21,7 +21,7 @@ namespace eve
     {
       using i_t = as_uinteger_t<T>;
 
-      if      constexpr(std::same_as<T, eve::float16>) return i_t(0x83FF);
+      if      constexpr(std::same_as<T, eve::float16_t>) return i_t(0x83FF);
       else if constexpr(std::same_as<T, float>  ) return i_t(0x807FFFFFU);
       else if constexpr(std::same_as<T, double> ) return i_t(0x800FFFFFFFFFFFFFULL);
     }

--- a/include/eve/module/core/constant/mantissamask.hpp
+++ b/include/eve/module/core/constant/mantissamask.hpp
@@ -21,7 +21,7 @@ namespace eve
     {
       using i_t = as_uinteger_t<T>;
 
-      if      constexpr(std::same_as<T, detail::f16>) return i_t(0x83FF);
+      if      constexpr(std::same_as<T, eve::float16>) return i_t(0x83FF);
       else if constexpr(std::same_as<T, float>  ) return i_t(0x807FFFFFU);
       else if constexpr(std::same_as<T, double> ) return i_t(0x800FFFFFFFFFFFFFULL);
     }

--- a/include/eve/module/core/constant/mantissamask.hpp
+++ b/include/eve/module/core/constant/mantissamask.hpp
@@ -21,7 +21,8 @@ namespace eve
     {
       using i_t = as_uinteger_t<T>;
 
-      if      constexpr(std::same_as<T, float>  ) return i_t(0x807FFFFFU);
+      if      constexpr(std::same_as<T, detail::f16>) return i_t(0x83FF);
+      else if constexpr(std::same_as<T, float>  ) return i_t(0x807FFFFFU);
       else if constexpr(std::same_as<T, double> ) return i_t(0x800FFFFFFFFFFFFFULL);
     }
 

--- a/include/eve/module/core/constant/maxexponent.hpp
+++ b/include/eve/module/core/constant/maxexponent.hpp
@@ -21,7 +21,8 @@ namespace eve
     {
       using i_t = as_integer_t<T>;
 
-      if      constexpr(std::same_as<T, float>  ) return i_t(127);
+      if      constexpr(std::same_as<T, detail::f16>) return i_t(15);
+      else if constexpr(std::same_as<T, float>  ) return i_t(127);
       else if constexpr(std::same_as<T, double> ) return i_t(1023);
     }
 

--- a/include/eve/module/core/constant/maxexponent.hpp
+++ b/include/eve/module/core/constant/maxexponent.hpp
@@ -21,7 +21,7 @@ namespace eve
     {
       using i_t = as_integer_t<T>;
 
-      if      constexpr(std::same_as<T, eve::float16>) return i_t(15);
+      if      constexpr(std::same_as<T, eve::float16_t>) return i_t(15);
       else if constexpr(std::same_as<T, float>  ) return i_t(127);
       else if constexpr(std::same_as<T, double> ) return i_t(1023);
     }

--- a/include/eve/module/core/constant/maxexponent.hpp
+++ b/include/eve/module/core/constant/maxexponent.hpp
@@ -21,7 +21,7 @@ namespace eve
     {
       using i_t = as_integer_t<T>;
 
-      if      constexpr(std::same_as<T, detail::f16>) return i_t(15);
+      if      constexpr(std::same_as<T, eve::float16>) return i_t(15);
       else if constexpr(std::same_as<T, float>  ) return i_t(127);
       else if constexpr(std::same_as<T, double> ) return i_t(1023);
     }

--- a/include/eve/module/core/constant/maxexponentm1.hpp
+++ b/include/eve/module/core/constant/maxexponentm1.hpp
@@ -21,7 +21,7 @@ namespace eve
     {
       using i_t = as_integer_t<T>;
 
-      if      constexpr(std::same_as<T, detail::f16>) return i_t(14);
+      if      constexpr(std::same_as<T, eve::float16>) return i_t(14);
       else if constexpr(std::same_as<T, float>  ) return i_t(126);
       else if constexpr(std::same_as<T, double> ) return i_t(1022);
     }

--- a/include/eve/module/core/constant/maxexponentm1.hpp
+++ b/include/eve/module/core/constant/maxexponentm1.hpp
@@ -21,7 +21,8 @@ namespace eve
     {
       using i_t = as_integer_t<T>;
 
-      if      constexpr(std::same_as<T, float>  ) return i_t(126);
+      if      constexpr(std::same_as<T, detail::f16>) return i_t(14);
+      else if constexpr(std::same_as<T, float>  ) return i_t(126);
       else if constexpr(std::same_as<T, double> ) return i_t(1022);
     }
 

--- a/include/eve/module/core/constant/maxexponentm1.hpp
+++ b/include/eve/module/core/constant/maxexponentm1.hpp
@@ -21,7 +21,7 @@ namespace eve
     {
       using i_t = as_integer_t<T>;
 
-      if      constexpr(std::same_as<T, eve::float16>) return i_t(14);
+      if      constexpr(std::same_as<T, eve::float16_t>) return i_t(14);
       else if constexpr(std::same_as<T, float>  ) return i_t(126);
       else if constexpr(std::same_as<T, double> ) return i_t(1022);
     }

--- a/include/eve/module/core/constant/maxexponentp1.hpp
+++ b/include/eve/module/core/constant/maxexponentp1.hpp
@@ -21,7 +21,8 @@ namespace eve
     {
       using i_t = as_integer_t<T>;
 
-      if      constexpr(std::same_as<T, float>  ) return  i_t(128);
+      if      constexpr(std::same_as<T, detail::f16>) return i_t(16);
+      else if constexpr(std::same_as<T, float>  ) return  i_t(128);
       else if constexpr(std::same_as<T, double> ) return  i_t(1024);
     }
 

--- a/include/eve/module/core/constant/maxexponentp1.hpp
+++ b/include/eve/module/core/constant/maxexponentp1.hpp
@@ -21,7 +21,7 @@ namespace eve
     {
       using i_t = as_integer_t<T>;
 
-      if      constexpr(std::same_as<T, detail::f16>) return i_t(16);
+      if      constexpr(std::same_as<T, eve::float16>) return i_t(16);
       else if constexpr(std::same_as<T, float>  ) return  i_t(128);
       else if constexpr(std::same_as<T, double> ) return  i_t(1024);
     }

--- a/include/eve/module/core/constant/maxexponentp1.hpp
+++ b/include/eve/module/core/constant/maxexponentp1.hpp
@@ -21,7 +21,7 @@ namespace eve
     {
       using i_t = as_integer_t<T>;
 
-      if      constexpr(std::same_as<T, eve::float16>) return i_t(16);
+      if      constexpr(std::same_as<T, eve::float16_t>) return i_t(16);
       else if constexpr(std::same_as<T, float>  ) return  i_t(128);
       else if constexpr(std::same_as<T, double> ) return  i_t(1024);
     }

--- a/include/eve/module/core/constant/maxflint.hpp
+++ b/include/eve/module/core/constant/maxflint.hpp
@@ -19,7 +19,7 @@ namespace eve
     template<typename T, typename Opts>
     static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
     {
-      if      constexpr(std::same_as<T, detail::f16>) return detail::f16_from_bits(0x6800);
+      if      constexpr(std::same_as<T, eve::float16>) return detail::float16_from_bits(0x6800);
       else if constexpr(std::same_as<T, float>  ) return T(0x1p+24);
       else if constexpr(std::same_as<T, double> ) return T(0x1p+53);
     }

--- a/include/eve/module/core/constant/maxflint.hpp
+++ b/include/eve/module/core/constant/maxflint.hpp
@@ -19,7 +19,7 @@ namespace eve
     template<typename T, typename Opts>
     static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
     {
-      if      constexpr(std::same_as<T, eve::float16>) return detail::float16_from_bits(0x6800);
+      if      constexpr(std::same_as<T, eve::float16_t>) return detail::float16_from_bits(0x6800);
       else if constexpr(std::same_as<T, float>  ) return T(0x1p+24);
       else if constexpr(std::same_as<T, double> ) return T(0x1p+53);
     }

--- a/include/eve/module/core/constant/maxflint.hpp
+++ b/include/eve/module/core/constant/maxflint.hpp
@@ -16,10 +16,11 @@ namespace eve
   template<typename Options>
   struct maxflint_t : constant_callable<maxflint_t, Options, lower_option, upper_option>
   {
-    template<typename T>
-    static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, auto const&)
+    template<typename T, typename Opts>
+    static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
     {
-      if      constexpr(std::same_as<T, float>  ) return T(0x1p+24);
+      if      constexpr(std::same_as<T, detail::f16>) return detail::f16_from_bits(0x6800);
+      else if constexpr(std::same_as<T, float>  ) return T(0x1p+24);
       else if constexpr(std::same_as<T, double> ) return T(0x1p+53);
     }
 
@@ -33,8 +34,7 @@ namespace eve
 //! @addtogroup core_constants
 //! @{
 //!   @var maxflint
-//!   @brief Computes the the greatest floating point representing an integer and
-//!   such that n != n+1.
+//!   @brief Computes the smallest floating point representing an integer such that n == n+1.
 //!
 //!   **Defined in Header**
 //!
@@ -58,6 +58,7 @@ namespace eve
 //!    **Return value**
 //!
 //!      The call `eve::maxflint(as<T>())` is semantically equivalent to:
+//!        * `T(2048.0f)` if `eve::element_type_t<T>` is float16.
 //!        * `T(16777216.0f)` if `eve::element_type_t<T>` is float.
 //!        * `T(9007199254740992.0)` if `eve::element_type_t<T>` is double.
 //!

--- a/include/eve/module/core/constant/mhalf.hpp
+++ b/include/eve/module/core/constant/mhalf.hpp
@@ -19,7 +19,7 @@ namespace eve
     template<typename T>
     static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, auto const&)
     {
-      if      constexpr(std::same_as<T, eve::float16>) return detail::float16_from_bits(0xB800);
+      if      constexpr(std::same_as<T, eve::float16_t>) return detail::float16_from_bits(0xB800);
       else if constexpr(std::same_as<T, float>  ) return T(-0x1p-1);
       else if constexpr(std::same_as<T, double> ) return T(-0x1p-1f);
     }

--- a/include/eve/module/core/constant/mhalf.hpp
+++ b/include/eve/module/core/constant/mhalf.hpp
@@ -19,7 +19,7 @@ namespace eve
     template<typename T>
     static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, auto const&)
     {
-      if      constexpr(std::same_as<T, detail::f16>) return detail::f16_from_bits(0xB800);
+      if      constexpr(std::same_as<T, eve::float16>) return detail::float16_from_bits(0xB800);
       else if constexpr(std::same_as<T, float>  ) return T(-0x1p-1);
       else if constexpr(std::same_as<T, double> ) return T(-0x1p-1f);
     }

--- a/include/eve/module/core/constant/mhalf.hpp
+++ b/include/eve/module/core/constant/mhalf.hpp
@@ -19,7 +19,8 @@ namespace eve
     template<typename T>
     static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, auto const&)
     {
-      if      constexpr(std::same_as<T, float>  ) return T(-0x1p-1);
+      if      constexpr(std::same_as<T, detail::f16>) return detail::f16_from_bits(0xB800);
+      else if constexpr(std::same_as<T, float>  ) return T(-0x1p-1);
       else if constexpr(std::same_as<T, double> ) return T(-0x1p-1f);
     }
 

--- a/include/eve/module/core/constant/mindenormal.hpp
+++ b/include/eve/module/core/constant/mindenormal.hpp
@@ -20,7 +20,7 @@ namespace eve
     static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, auto const&)
     {
       if      constexpr(std::integral<T>        ) return T(1);
-      else if constexpr(std::same_as<T, eve::float16>) return detail::float16_from_bits(0x0001);
+      else if constexpr(std::same_as<T, eve::float16_t>) return detail::float16_from_bits(0x0001);
       else if constexpr(std::same_as<T, float>  ) return T( 0x1p-149);
       else if constexpr(std::same_as<T, double> ) return T(0x0.0000000000001p-1022);
     }

--- a/include/eve/module/core/constant/mindenormal.hpp
+++ b/include/eve/module/core/constant/mindenormal.hpp
@@ -20,7 +20,7 @@ namespace eve
     static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, auto const&)
     {
       if      constexpr(std::integral<T>        ) return T(1);
-      else if constexpr(std::same_as<T, detail::f16>) return detail::f16_from_bits(0x0001);
+      else if constexpr(std::same_as<T, eve::float16>) return detail::float16_from_bits(0x0001);
       else if constexpr(std::same_as<T, float>  ) return T( 0x1p-149);
       else if constexpr(std::same_as<T, double> ) return T(0x0.0000000000001p-1022);
     }

--- a/include/eve/module/core/constant/mindenormal.hpp
+++ b/include/eve/module/core/constant/mindenormal.hpp
@@ -20,6 +20,7 @@ namespace eve
     static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, auto const&)
     {
       if      constexpr(std::integral<T>        ) return T(1);
+      else if constexpr(std::same_as<T, detail::f16>) return detail::f16_from_bits(0x0001);
       else if constexpr(std::same_as<T, float>  ) return T( 0x1p-149);
       else if constexpr(std::same_as<T, double> ) return T(0x0.0000000000001p-1022);
     }

--- a/include/eve/module/core/constant/minexponent.hpp
+++ b/include/eve/module/core/constant/minexponent.hpp
@@ -21,7 +21,7 @@ namespace eve
     {
       using i_t = as_integer_t<T>;
 
-      if      constexpr(std::same_as<T, eve::float16>) return i_t(-14);
+      if      constexpr(std::same_as<T, eve::float16_t>) return i_t(-14);
       else if constexpr(std::same_as<T, float>  ) return i_t(-126);
       else if constexpr(std::same_as<T, double> ) return i_t(-1022);
     }

--- a/include/eve/module/core/constant/minexponent.hpp
+++ b/include/eve/module/core/constant/minexponent.hpp
@@ -21,7 +21,8 @@ namespace eve
     {
       using i_t = as_integer_t<T>;
 
-      if      constexpr(std::same_as<T, float>  ) return i_t(-126);
+      if      constexpr(std::same_as<T, detail::f16>) return i_t(-14);
+      else if constexpr(std::same_as<T, float>  ) return i_t(-126);
       else if constexpr(std::same_as<T, double> ) return i_t(-1022);
     }
 

--- a/include/eve/module/core/constant/minexponent.hpp
+++ b/include/eve/module/core/constant/minexponent.hpp
@@ -21,7 +21,7 @@ namespace eve
     {
       using i_t = as_integer_t<T>;
 
-      if      constexpr(std::same_as<T, detail::f16>) return i_t(-14);
+      if      constexpr(std::same_as<T, eve::float16>) return i_t(-14);
       else if constexpr(std::same_as<T, float>  ) return i_t(-126);
       else if constexpr(std::same_as<T, double> ) return i_t(-1022);
     }

--- a/include/eve/module/core/constant/minf.hpp
+++ b/include/eve/module/core/constant/minf.hpp
@@ -19,7 +19,7 @@ namespace eve
     template<typename T>
     static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, auto const&)
     {
-      if constexpr (std::same_as<T, eve::float16>) return detail::float16_from_bits(0xFC00);
+      if constexpr (std::same_as<T, eve::float16_t>) return detail::float16_from_bits(0xFC00);
       else                                        return T(-std::numeric_limits<T>::infinity());
     }
 

--- a/include/eve/module/core/constant/minf.hpp
+++ b/include/eve/module/core/constant/minf.hpp
@@ -19,7 +19,8 @@ namespace eve
     template<typename T>
     static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, auto const&)
     {
-      return  T(-std::numeric_limits<T>::infinity());
+      if constexpr (std::same_as<T, detail::f16>) return detail::f16_from_bits(0xFC00);
+      else                                        return T(-std::numeric_limits<T>::infinity());
     }
 
     template<floating_value T>

--- a/include/eve/module/core/constant/minf.hpp
+++ b/include/eve/module/core/constant/minf.hpp
@@ -19,7 +19,7 @@ namespace eve
     template<typename T>
     static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, auto const&)
     {
-      if constexpr (std::same_as<T, detail::f16>) return detail::f16_from_bits(0xFC00);
+      if constexpr (std::same_as<T, eve::float16>) return detail::float16_from_bits(0xFC00);
       else                                        return T(-std::numeric_limits<T>::infinity());
     }
 

--- a/include/eve/module/core/constant/mone.hpp
+++ b/include/eve/module/core/constant/mone.hpp
@@ -19,7 +19,8 @@ namespace eve
     template<typename T>
     static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, auto const&)
     {
-      return T(-1);
+      if constexpr (std::same_as<T, detail::f16>) return detail::f16_from_bits(0xBC00);
+      else                                        return T(-1);
     }
 
     template<plain_value T>

--- a/include/eve/module/core/constant/mone.hpp
+++ b/include/eve/module/core/constant/mone.hpp
@@ -19,7 +19,7 @@ namespace eve
     template<typename T>
     static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, auto const&)
     {
-      if constexpr (std::same_as<T, eve::float16>) return detail::float16_from_bits(0xBC00);
+      if constexpr (std::same_as<T, eve::float16_t>) return detail::float16_from_bits(0xBC00);
       else                                        return T(-1);
     }
 

--- a/include/eve/module/core/constant/mone.hpp
+++ b/include/eve/module/core/constant/mone.hpp
@@ -19,7 +19,7 @@ namespace eve
     template<typename T>
     static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, auto const&)
     {
-      if constexpr (std::same_as<T, detail::f16>) return detail::f16_from_bits(0xBC00);
+      if constexpr (std::same_as<T, eve::float16>) return detail::float16_from_bits(0xBC00);
       else                                        return T(-1);
     }
 

--- a/include/eve/module/core/constant/mzero.hpp
+++ b/include/eve/module/core/constant/mzero.hpp
@@ -20,7 +20,7 @@ namespace eve
     static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, auto const&)
     {
       if      constexpr(std::integral<T>        ) return T(0);
-      else if constexpr(std::same_as<T, eve::float16>) return detail::float16_from_bits(0x8000);
+      else if constexpr(std::same_as<T, eve::float16_t>) return detail::float16_from_bits(0x8000);
       else if constexpr(std::same_as<T, float>  ) return T(-0.0f);
       else if constexpr(std::same_as<T, double> ) return T(-0.0);
    }

--- a/include/eve/module/core/constant/mzero.hpp
+++ b/include/eve/module/core/constant/mzero.hpp
@@ -20,6 +20,7 @@ namespace eve
     static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, auto const&)
     {
       if      constexpr(std::integral<T>        ) return T(0);
+      else if constexpr(std::same_as<T, detail::f16>) return detail::f16_from_bits(0x8000);
       else if constexpr(std::same_as<T, float>  ) return T(-0.0f);
       else if constexpr(std::same_as<T, double> ) return T(-0.0);
    }

--- a/include/eve/module/core/constant/mzero.hpp
+++ b/include/eve/module/core/constant/mzero.hpp
@@ -20,7 +20,7 @@ namespace eve
     static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, auto const&)
     {
       if      constexpr(std::integral<T>        ) return T(0);
-      else if constexpr(std::same_as<T, detail::f16>) return detail::f16_from_bits(0x8000);
+      else if constexpr(std::same_as<T, eve::float16>) return detail::float16_from_bits(0x8000);
       else if constexpr(std::same_as<T, float>  ) return T(-0.0f);
       else if constexpr(std::same_as<T, double> ) return T(-0.0);
    }

--- a/include/eve/module/core/constant/nbmantissabits.hpp
+++ b/include/eve/module/core/constant/nbmantissabits.hpp
@@ -21,7 +21,7 @@ namespace eve
     {
       using i_t = as_integer_t<T>;
 
-      if      constexpr(std::same_as<T, detail::f16>) return i_t(10);
+      if      constexpr(std::same_as<T, eve::float16>) return i_t(10);
       else if constexpr(std::same_as<T, float>  ) return  i_t(23);
       else if constexpr(std::same_as<T, double> ) return  i_t(52);
     }

--- a/include/eve/module/core/constant/nbmantissabits.hpp
+++ b/include/eve/module/core/constant/nbmantissabits.hpp
@@ -21,7 +21,7 @@ namespace eve
     {
       using i_t = as_integer_t<T>;
 
-      if      constexpr(std::same_as<T, eve::float16>) return i_t(10);
+      if      constexpr(std::same_as<T, eve::float16_t>) return i_t(10);
       else if constexpr(std::same_as<T, float>  ) return  i_t(23);
       else if constexpr(std::same_as<T, double> ) return  i_t(52);
     }

--- a/include/eve/module/core/constant/nbmantissabits.hpp
+++ b/include/eve/module/core/constant/nbmantissabits.hpp
@@ -21,7 +21,8 @@ namespace eve
     {
       using i_t = as_integer_t<T>;
 
-      if      constexpr(std::same_as<T, float>  ) return  i_t(23);
+      if      constexpr(std::same_as<T, detail::f16>) return i_t(10);
+      else if constexpr(std::same_as<T, float>  ) return  i_t(23);
       else if constexpr(std::same_as<T, double> ) return  i_t(52);
     }
 

--- a/include/eve/module/core/constant/one.hpp
+++ b/include/eve/module/core/constant/one.hpp
@@ -19,7 +19,8 @@ namespace eve
     template<typename T>
     static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, auto const&)
     {
-      return T(1);
+      if constexpr(std::same_as<T, detail::f16>) return detail::f16_from_bits(0x3C00);
+      else                                       return T(1);
     }
 
     template<plain_value T>

--- a/include/eve/module/core/constant/one.hpp
+++ b/include/eve/module/core/constant/one.hpp
@@ -19,7 +19,7 @@ namespace eve
     template<typename T>
     static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, auto const&)
     {
-      if constexpr(std::same_as<T, eve::float16>) return detail::float16_from_bits(0x3C00);
+      if constexpr(std::same_as<T, eve::float16_t>) return detail::float16_from_bits(0x3C00);
       else                                       return T(1);
     }
 

--- a/include/eve/module/core/constant/one.hpp
+++ b/include/eve/module/core/constant/one.hpp
@@ -19,7 +19,7 @@ namespace eve
     template<typename T>
     static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, auto const&)
     {
-      if constexpr(std::same_as<T, detail::f16>) return detail::f16_from_bits(0x3C00);
+      if constexpr(std::same_as<T, eve::float16>) return detail::float16_from_bits(0x3C00);
       else                                       return T(1);
     }
 

--- a/include/eve/module/core/constant/oneosqrteps.hpp
+++ b/include/eve/module/core/constant/oneosqrteps.hpp
@@ -19,7 +19,8 @@ namespace eve
     template<typename T, typename Opts>
     static EVE_FORCEINLINE constexpr T value(eve::as<T> const&,  Opts const&)
     {
-      if constexpr(std::same_as<T, float>)
+      if      constexpr(std::same_as<T, detail::f16>) return detail::f16_from_bits(0x6c00);
+      else if constexpr(std::same_as<T, float>)
       {
         if constexpr(Opts::contains(upper))        return T(0x1.6a09e8p+11f);
         else                                        return T(0x1.6a09e6p+11f);

--- a/include/eve/module/core/constant/oneosqrteps.hpp
+++ b/include/eve/module/core/constant/oneosqrteps.hpp
@@ -19,7 +19,7 @@ namespace eve
     template<typename T, typename Opts>
     static EVE_FORCEINLINE constexpr T value(eve::as<T> const&,  Opts const&)
     {
-      if      constexpr(std::same_as<T, eve::float16>) return detail::float16_from_bits(0x6c00);
+      if      constexpr(std::same_as<T, eve::float16_t>) return detail::float16_from_bits(0x6c00);
       else if constexpr(std::same_as<T, float>)
       {
         if constexpr(Opts::contains(upper))        return T(0x1.6a09e8p+11f);

--- a/include/eve/module/core/constant/oneosqrteps.hpp
+++ b/include/eve/module/core/constant/oneosqrteps.hpp
@@ -19,7 +19,7 @@ namespace eve
     template<typename T, typename Opts>
     static EVE_FORCEINLINE constexpr T value(eve::as<T> const&,  Opts const&)
     {
-      if      constexpr(std::same_as<T, detail::f16>) return detail::f16_from_bits(0x6c00);
+      if      constexpr(std::same_as<T, eve::float16>) return detail::float16_from_bits(0x6c00);
       else if constexpr(std::same_as<T, float>)
       {
         if constexpr(Opts::contains(upper))        return T(0x1.6a09e8p+11f);

--- a/include/eve/module/core/constant/signmask.hpp
+++ b/include/eve/module/core/constant/signmask.hpp
@@ -20,7 +20,7 @@ namespace eve
     template<typename T>
     static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, auto const&)
     {
-      if      constexpr( std::same_as<T, detail::f16>) return detail::f16_from_bits(0x8000);
+      if      constexpr( std::same_as<T, eve::float16>) return detail::float16_from_bits(0x8000);
       else if constexpr( std::same_as<T, float>   ) return T(-0x0p+0f);
       else if constexpr( std::same_as<T, double>  ) return T(-0x0p+0);
       else if constexpr( std::same_as<T, uint8_t> ) return T(0x80U);

--- a/include/eve/module/core/constant/signmask.hpp
+++ b/include/eve/module/core/constant/signmask.hpp
@@ -20,7 +20,7 @@ namespace eve
     template<typename T>
     static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, auto const&)
     {
-      if      constexpr( std::same_as<T, eve::float16>) return detail::float16_from_bits(0x8000);
+      if      constexpr( std::same_as<T, eve::float16_t>) return detail::float16_from_bits(0x8000);
       else if constexpr( std::same_as<T, float>   ) return T(-0x0p+0f);
       else if constexpr( std::same_as<T, double>  ) return T(-0x0p+0);
       else if constexpr( std::same_as<T, uint8_t> ) return T(0x80U);

--- a/include/eve/module/core/constant/signmask.hpp
+++ b/include/eve/module/core/constant/signmask.hpp
@@ -20,7 +20,8 @@ namespace eve
     template<typename T>
     static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, auto const&)
     {
-      if      constexpr( std::same_as<T, float>   ) return T(-0x0p+0f);
+      if      constexpr( std::same_as<T, detail::f16>) return detail::f16_from_bits(0x8000);
+      else if constexpr( std::same_as<T, float>   ) return T(-0x0p+0f);
       else if constexpr( std::same_as<T, double>  ) return T(-0x0p+0);
       else if constexpr( std::same_as<T, uint8_t> ) return T(0x80U);
       else if constexpr( std::same_as<T, uint16_t>) return T(0x8000U);

--- a/include/eve/module/core/constant/smallestposval.hpp
+++ b/include/eve/module/core/constant/smallestposval.hpp
@@ -20,7 +20,7 @@ namespace eve
     static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, auto const&)
     {
       if      constexpr(std::integral<T>       )  return T(1);
-      else if constexpr(std::same_as<T, eve::float16>) return detail::float16_from_bits(0x0400);
+      else if constexpr(std::same_as<T, eve::float16_t>) return detail::float16_from_bits(0x0400);
       else if constexpr(std::same_as<T, float> )  return T(0x1p-126);
       else if constexpr(std::same_as<T, double>)  return T(0x1p-1022);
     }

--- a/include/eve/module/core/constant/smallestposval.hpp
+++ b/include/eve/module/core/constant/smallestposval.hpp
@@ -20,6 +20,7 @@ namespace eve
     static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, auto const&)
     {
       if      constexpr(std::integral<T>       )  return T(1);
+      else if constexpr(std::same_as<T, detail::f16>) return detail::f16_from_bits(0x0400);
       else if constexpr(std::same_as<T, float> )  return T(0x1p-126);
       else if constexpr(std::same_as<T, double>)  return T(0x1p-1022);
     }

--- a/include/eve/module/core/constant/smallestposval.hpp
+++ b/include/eve/module/core/constant/smallestposval.hpp
@@ -20,7 +20,7 @@ namespace eve
     static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, auto const&)
     {
       if      constexpr(std::integral<T>       )  return T(1);
-      else if constexpr(std::same_as<T, detail::f16>) return detail::f16_from_bits(0x0400);
+      else if constexpr(std::same_as<T, eve::float16>) return detail::float16_from_bits(0x0400);
       else if constexpr(std::same_as<T, float> )  return T(0x1p-126);
       else if constexpr(std::same_as<T, double>)  return T(0x1p-1022);
     }

--- a/include/eve/module/core/constant/sqrteps.hpp
+++ b/include/eve/module/core/constant/sqrteps.hpp
@@ -19,7 +19,7 @@ namespace eve
     template<typename T, typename Opts>
     static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
     {
-      if constexpr(std::same_as<T, detail::f16>) return detail::f16_from_bits(0x2800);
+      if constexpr(std::same_as<T, eve::float16>) return detail::float16_from_bits(0x2800);
       else if constexpr(std::same_as<T, float>  )
       {
         if constexpr(Opts::contains(upper))        return T(0x1.6a09e8p-12f);

--- a/include/eve/module/core/constant/sqrteps.hpp
+++ b/include/eve/module/core/constant/sqrteps.hpp
@@ -19,7 +19,8 @@ namespace eve
     template<typename T, typename Opts>
     static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
     {
-      if constexpr(std::same_as<T, float>  )
+      if constexpr(std::same_as<T, detail::f16>) return detail::f16_from_bits(0x2800);
+      else if constexpr(std::same_as<T, float>  )
       {
         if constexpr(Opts::contains(upper))        return T(0x1.6a09e8p-12f);
         else                                        return T(0x1.6a09e6p-12f);

--- a/include/eve/module/core/constant/sqrteps.hpp
+++ b/include/eve/module/core/constant/sqrteps.hpp
@@ -19,7 +19,7 @@ namespace eve
     template<typename T, typename Opts>
     static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
     {
-      if constexpr(std::same_as<T, eve::float16>) return detail::float16_from_bits(0x2800);
+      if constexpr(std::same_as<T, eve::float16_t>) return detail::float16_from_bits(0x2800);
       else if constexpr(std::same_as<T, float>  )
       {
         if constexpr(Opts::contains(upper))        return T(0x1.6a09e8p-12f);

--- a/include/eve/module/core/constant/sqrtsmallestposval.hpp
+++ b/include/eve/module/core/constant/sqrtsmallestposval.hpp
@@ -20,6 +20,7 @@ namespace eve
     static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, auto const&)
     {
       if      constexpr(std::integral<T>        ) return T(1);
+      else if constexpr(std::same_as<T, detail::f16>) return detail::f16_from_bits(0x0C00);
       else if constexpr(std::same_as<T, float>  ) return T(0x1p-63);
       else if constexpr(std::same_as<T, double> ) return T(0x1p-511);
     }

--- a/include/eve/module/core/constant/sqrtsmallestposval.hpp
+++ b/include/eve/module/core/constant/sqrtsmallestposval.hpp
@@ -20,7 +20,7 @@ namespace eve
     static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, auto const&)
     {
       if      constexpr(std::integral<T>        ) return T(1);
-      else if constexpr(std::same_as<T, eve::float16>) return detail::float16_from_bits(0x0C00);
+      else if constexpr(std::same_as<T, eve::float16_t>) return detail::float16_from_bits(0x0C00);
       else if constexpr(std::same_as<T, float>  ) return T(0x1p-63);
       else if constexpr(std::same_as<T, double> ) return T(0x1p-511);
     }

--- a/include/eve/module/core/constant/sqrtsmallestposval.hpp
+++ b/include/eve/module/core/constant/sqrtsmallestposval.hpp
@@ -20,7 +20,7 @@ namespace eve
     static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, auto const&)
     {
       if      constexpr(std::integral<T>        ) return T(1);
-      else if constexpr(std::same_as<T, detail::f16>) return detail::f16_from_bits(0x0C00);
+      else if constexpr(std::same_as<T, eve::float16>) return detail::float16_from_bits(0x0C00);
       else if constexpr(std::same_as<T, float>  ) return T(0x1p-63);
       else if constexpr(std::same_as<T, double> ) return T(0x1p-511);
     }

--- a/include/eve/module/core/constant/sqrtvalmax.hpp
+++ b/include/eve/module/core/constant/sqrtvalmax.hpp
@@ -18,7 +18,8 @@ namespace eve
     template<typename T>
     static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, auto const&)
     {
-      if      constexpr( std::same_as<T, float>         ) return T(0x1.fffffep+63);
+      if      constexpr( std::same_as<T, detail::f16>   ) return detail::f16_from_bits(0x5bff);
+      else if constexpr( std::same_as<T, float>         ) return T(0x1.fffffep+63);
       else if constexpr( std::same_as<T, double>        ) return T(0x1.fffffffffffffp+511);
       else if constexpr( std::same_as<T, std::uint8_t>  ) return T(15);
       else if constexpr( std::same_as<T, std::uint16_t> ) return T(255);

--- a/include/eve/module/core/constant/sqrtvalmax.hpp
+++ b/include/eve/module/core/constant/sqrtvalmax.hpp
@@ -18,7 +18,7 @@ namespace eve
     template<typename T>
     static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, auto const&)
     {
-      if      constexpr( std::same_as<T, detail::f16>   ) return detail::f16_from_bits(0x5bff);
+      if      constexpr( std::same_as<T, eve::float16>   ) return detail::float16_from_bits(0x5bff);
       else if constexpr( std::same_as<T, float>         ) return T(0x1.fffffep+63);
       else if constexpr( std::same_as<T, double>        ) return T(0x1.fffffffffffffp+511);
       else if constexpr( std::same_as<T, std::uint8_t>  ) return T(15);

--- a/include/eve/module/core/constant/sqrtvalmax.hpp
+++ b/include/eve/module/core/constant/sqrtvalmax.hpp
@@ -18,7 +18,7 @@ namespace eve
     template<typename T>
     static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, auto const&)
     {
-      if      constexpr( std::same_as<T, eve::float16>   ) return detail::float16_from_bits(0x5bff);
+      if      constexpr( std::same_as<T, eve::float16_t>   ) return detail::float16_from_bits(0x5bff);
       else if constexpr( std::same_as<T, float>         ) return T(0x1.fffffep+63);
       else if constexpr( std::same_as<T, double>        ) return T(0x1.fffffffffffffp+511);
       else if constexpr( std::same_as<T, std::uint8_t>  ) return T(15);

--- a/include/eve/module/core/constant/twotonmb.hpp
+++ b/include/eve/module/core/constant/twotonmb.hpp
@@ -19,7 +19,8 @@ namespace eve
     template<typename T, typename Opts>
     static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
     {
-      if constexpr(std::same_as<T, float>)  return T(0x1p+23f);
+      if      constexpr(std::same_as<T, detail::f16>) return detail::f16_from_bits(0x549e);
+      else if constexpr(std::same_as<T, float>)  return T(0x1p+23f);
       else                                  return T(0x1p+52);
     }
 

--- a/include/eve/module/core/constant/twotonmb.hpp
+++ b/include/eve/module/core/constant/twotonmb.hpp
@@ -19,7 +19,7 @@ namespace eve
     template<typename T, typename Opts>
     static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
     {
-      if      constexpr(std::same_as<T, detail::f16>) return detail::f16_from_bits(0x549e);
+      if      constexpr(std::same_as<T, eve::float16>) return detail::float16_from_bits(0x549e);
       else if constexpr(std::same_as<T, float>)  return T(0x1p+23f);
       else                                  return T(0x1p+52);
     }

--- a/include/eve/module/core/constant/twotonmb.hpp
+++ b/include/eve/module/core/constant/twotonmb.hpp
@@ -19,7 +19,7 @@ namespace eve
     template<typename T, typename Opts>
     static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
     {
-      if      constexpr(std::same_as<T, eve::float16>) return detail::float16_from_bits(0x549e);
+      if      constexpr(std::same_as<T, eve::float16_t>) return detail::float16_from_bits(0x549e);
       else if constexpr(std::same_as<T, float>)  return T(0x1p+23f);
       else                                  return T(0x1p+52);
     }

--- a/include/eve/module/core/constant/valmax.hpp
+++ b/include/eve/module/core/constant/valmax.hpp
@@ -19,7 +19,7 @@ namespace eve
     template<typename T, typename Opts>
     static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
     {
-      if constexpr (std::same_as<T, detail::f16>) return detail::f16_from_bits(0x7BFF);
+      if constexpr (std::same_as<T, eve::float16>) return detail::float16_from_bits(0x7BFF);
       else                                        return std::numeric_limits<T>::max();
     }
 

--- a/include/eve/module/core/constant/valmax.hpp
+++ b/include/eve/module/core/constant/valmax.hpp
@@ -19,7 +19,7 @@ namespace eve
     template<typename T, typename Opts>
     static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
     {
-      if constexpr (std::same_as<T, eve::float16>) return detail::float16_from_bits(0x7BFF);
+      if constexpr (std::same_as<T, eve::float16_t>) return detail::float16_from_bits(0x7BFF);
       else                                        return std::numeric_limits<T>::max();
     }
 

--- a/include/eve/module/core/constant/valmax.hpp
+++ b/include/eve/module/core/constant/valmax.hpp
@@ -19,7 +19,8 @@ namespace eve
     template<typename T, typename Opts>
     static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
     {
-      return std::numeric_limits<T>::max();
+      if constexpr (std::same_as<T, detail::f16>) return detail::f16_from_bits(0x7BFF);
+      else                                        return std::numeric_limits<T>::max();
     }
 
     template<plain_value T>

--- a/include/eve/module/core/constant/valmin.hpp
+++ b/include/eve/module/core/constant/valmin.hpp
@@ -19,7 +19,7 @@ namespace eve
     template<typename T, typename Opts>
     static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
     {
-      if constexpr (std::same_as<T, eve::float16>) return detail::float16_from_bits(0xFBFF);
+      if constexpr (std::same_as<T, eve::float16_t>) return detail::float16_from_bits(0xFBFF);
       else                                        return std::numeric_limits<T>::lowest();
     }
 

--- a/include/eve/module/core/constant/valmin.hpp
+++ b/include/eve/module/core/constant/valmin.hpp
@@ -19,7 +19,8 @@ namespace eve
     template<typename T, typename Opts>
     static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
     {
-      return std::numeric_limits<T>::lowest();
+      if constexpr (std::same_as<T, detail::f16>) return detail::f16_from_bits(0xFBFF);
+      else                                        return std::numeric_limits<T>::lowest();
     }
 
     template<plain_value T>

--- a/include/eve/module/core/constant/valmin.hpp
+++ b/include/eve/module/core/constant/valmin.hpp
@@ -19,7 +19,7 @@ namespace eve
     template<typename T, typename Opts>
     static EVE_FORCEINLINE constexpr T value(eve::as<T> const&, Opts const&)
     {
-      if constexpr (std::same_as<T, detail::f16>) return detail::f16_from_bits(0xFBFF);
+      if constexpr (std::same_as<T, eve::float16>) return detail::float16_from_bits(0xFBFF);
       else                                        return std::numeric_limits<T>::lowest();
     }
 

--- a/test/test.hpp
+++ b/test/test.hpp
@@ -247,15 +247,12 @@ namespace eve::test::scalar
 namespace eve::test::simd
 {
   using ieee_reals        = eve::test::wides<::tts::real_types>::type;
-  using ieee_reals_wf16   = eve::test::wides<tts::concatenate_t<::tts::real_types, ::tts::types<eve::float16>>>::type;
   using signed_integers   = eve::test::wides<::tts::int_types>::type;
   using signed_types      = eve::test::wides<::tts::signed_types>::type;
-  using signed_types_wf16 = eve::test::wides<::tts::concatenate_t<::tts::signed_types, ::tts::types<eve::float16>>>::type;
   using signed_integers   = eve::test::wides<::tts::int_types>::type;
   using unsigned_integers = eve::test::wides<::tts::uint_types>::type;
   using integers          = eve::test::wides<::tts::integral_types>::type;
   using all_types         = eve::test::wides<::tts::arithmetic_types>::type;
-  using all_types_wf16    = eve::test::wides<::tts::concatenate_t<::tts::arithmetic_types, ::tts::types<eve::float16>>>::type;
 }
 
 //==================================================================================================

--- a/test/test.hpp
+++ b/test/test.hpp
@@ -233,23 +233,29 @@ namespace eve::test
 namespace eve::test::scalar
 {
   using ieee_reals        = ::tts::real_types;
+  using ieee_reals_wf16   = ::tts::concatenate_t<::tts::real_types, ::tts::types<eve::float16>>;
   using signed_integers   = ::tts::int_types;
   using signed_types      = ::tts::signed_types;
+  using signed_types_wf16 = ::tts::concatenate_t<::tts::signed_types, ::tts::types<eve::float16>>;
   using signed_integers   = ::tts::int_types;
   using unsigned_integers = ::tts::uint_types;
   using integers          = ::tts::integral_types;
   using all_types         = ::tts::arithmetic_types;
+  using all_types_wf16    = ::tts::concatenate_t<::tts::arithmetic_types, ::tts::types<eve::float16>>;
 }
 
 namespace eve::test::simd
 {
   using ieee_reals        = eve::test::wides<::tts::real_types>::type;
+  using ieee_reals_wf16   = eve::test::wides<tts::concatenate_t<::tts::real_types, ::tts::types<eve::float16>>>::type;
   using signed_integers   = eve::test::wides<::tts::int_types>::type;
   using signed_types      = eve::test::wides<::tts::signed_types>::type;
+  using signed_types_wf16 = eve::test::wides<::tts::concatenate_t<::tts::signed_types, ::tts::types<eve::float16>>>::type;
   using signed_integers   = eve::test::wides<::tts::int_types>::type;
   using unsigned_integers = eve::test::wides<::tts::uint_types>::type;
   using integers          = eve::test::wides<::tts::integral_types>::type;
   using all_types         = eve::test::wides<::tts::arithmetic_types>::type;
+  using all_types_wf16    = eve::test::wides<::tts::concatenate_t<::tts::arithmetic_types, ::tts::types<eve::float16>>>::type;
 }
 
 //==================================================================================================
@@ -339,6 +345,33 @@ namespace tts
     eve::as_wide_t<v_t, eve::cardinal_t<T>> that = eve::load(&data[0], eve::cardinal_t<T>{});
 
     return poison(that);
+  }
+
+  auto produce(type<eve::float16> const&, auto g, auto& rng, auto... args)
+  {
+    auto data = produce(type<float>{}, g, rng, args...);
+    return eve::float16{ data };
+  }
+
+  template<std::size_t N>
+  auto produce(type<std::array<eve::float16, N>> const&, auto g, auto& rng, auto... args)
+  {
+    std::array<eve::float16, N> data;
+
+    for(std::size_t i = 0; i < N; ++i)
+    {
+      data[i] = produce(type<eve::float16>{}, g, rng, args...);
+    }
+
+    return data;
+  }
+
+  template<std::ptrdiff_t N>
+  auto produce(type<eve::wide<eve::float16, eve::fixed<N>>> const&, auto g, auto& rng, auto... args)
+  {
+    auto arr = produce(type<std::array<eve::float16, N>>{}, g, rng, args...);
+
+    return poison(eve::load(arr.data(), eve::fixed<N>{}));
   }
 
   //================================================================================================

--- a/test/test.hpp
+++ b/test/test.hpp
@@ -233,15 +233,15 @@ namespace eve::test
 namespace eve::test::scalar
 {
   using ieee_reals        = ::tts::real_types;
-  using ieee_reals_wf16   = ::tts::concatenate_t<::tts::real_types, ::tts::types<eve::float16>>;
+  using ieee_reals_wf16   = ::tts::concatenate_t<::tts::real_types, ::tts::types<eve::float16_t>>;
   using signed_integers   = ::tts::int_types;
   using signed_types      = ::tts::signed_types;
-  using signed_types_wf16 = ::tts::concatenate_t<::tts::signed_types, ::tts::types<eve::float16>>;
+  using signed_types_wf16 = ::tts::concatenate_t<::tts::signed_types, ::tts::types<eve::float16_t>>;
   using signed_integers   = ::tts::int_types;
   using unsigned_integers = ::tts::uint_types;
   using integers          = ::tts::integral_types;
   using all_types         = ::tts::arithmetic_types;
-  using all_types_wf16    = ::tts::concatenate_t<::tts::arithmetic_types, ::tts::types<eve::float16>>;
+  using all_types_wf16    = ::tts::concatenate_t<::tts::arithmetic_types, ::tts::types<eve::float16_t>>;
 }
 
 namespace eve::test::simd
@@ -344,29 +344,29 @@ namespace tts
     return poison(that);
   }
 
-  auto produce(type<eve::float16> const&, auto g, auto& rng, auto... args)
+  auto produce(type<eve::float16_t> const&, auto g, auto& rng, auto... args)
   {
     auto data = produce(type<float>{}, g, rng, args...);
-    return eve::float16{ data };
+    return eve::float16_t{ data };
   }
 
   template<std::size_t N>
-  auto produce(type<std::array<eve::float16, N>> const&, auto g, auto& rng, auto... args)
+  auto produce(type<std::array<eve::float16_t, N>> const&, auto g, auto& rng, auto... args)
   {
-    std::array<eve::float16, N> data;
+    std::array<eve::float16_t, N> data;
 
     for(std::size_t i = 0; i < N; ++i)
     {
-      data[i] = produce(type<eve::float16>{}, g, rng, args...);
+      data[i] = produce(type<eve::float16_t>{}, g, rng, args...);
     }
 
     return data;
   }
 
   template<std::ptrdiff_t N>
-  auto produce(type<eve::wide<eve::float16, eve::fixed<N>>> const&, auto g, auto& rng, auto... args)
+  auto produce(type<eve::wide<eve::float16_t, eve::fixed<N>>> const&, auto g, auto& rng, auto... args)
   {
-    auto arr = produce(type<std::array<eve::float16, N>>{}, g, rng, args...);
+    auto arr = produce(type<std::array<eve::float16_t, N>>{}, g, rng, args...);
 
     return poison(eve::load(arr.data(), eve::fixed<N>{}));
   }

--- a/test/unit/internals/float16.cpp
+++ b/test/unit/internals/float16.cpp
@@ -144,16 +144,16 @@ TTS_CASE("test emulated float16 comparison")
     TTS_EXPECT(cmp(b, a) == std::partial_ordering::less);
   };
 
-  uint16_t zero = eve::detail::float16_to_bits(eve::float16{0.0f});
-  uint16_t one = eve::detail::float16_to_bits(eve::float16{1.0f});
-  uint16_t mone = eve::detail::float16_to_bits(eve::float16{-1.0f});
-  uint16_t mzero = eve::detail::float16_to_bits(eve::float16{-0.0f});
+  uint16_t zero = eve::detail::float16_to_bits(static_cast<eve::float16>(0.0f));
+  uint16_t one = eve::detail::float16_to_bits(static_cast<eve::float16>(1.0f));
+  uint16_t mone = eve::detail::float16_to_bits(static_cast<eve::float16>(-1.0f));
+  uint16_t mzero = eve::detail::float16_to_bits(static_cast<eve::float16>(-0.0f));
   uint16_t inf = eve::detail::float16_to_bits(eve::inf(eve::as<eve::float16>{}));
   uint16_t minf = eve::detail::float16_to_bits(eve::minf(eve::as<eve::float16>{}));
   uint16_t nan = eve::detail::float16_to_bits(eve::nan(eve::as<eve::float16>{}));
-  uint16_t subnorm = eve::detail::float16_to_bits(eve::float16{3e-6f});
-  uint16_t msubnorm = eve::detail::float16_to_bits(eve::float16{-1e-7f});
-  uint16_t smaller_subnorm = eve::detail::float16_to_bits(eve::float16{1e-7f});
+  uint16_t subnorm = eve::detail::float16_to_bits(static_cast<eve::float16>(3e-6f));
+  uint16_t msubnorm = eve::detail::float16_to_bits(static_cast<eve::float16>(-1e-7f));
+  uint16_t smaller_subnorm = eve::detail::float16_to_bits(static_cast<eve::float16>(1e-7f));
 
   // normal values
   expect_eq(zero, mzero);

--- a/test/unit/internals/float16.cpp
+++ b/test/unit/internals/float16.cpp
@@ -144,16 +144,16 @@ TTS_CASE("test emulated float16 comparison")
     TTS_EXPECT(cmp(b, a) == std::partial_ordering::less);
   };
 
-  uint16_t zero = eve::detail::float16_to_bits(static_cast<eve::float16>(0.0f));
-  uint16_t one = eve::detail::float16_to_bits(static_cast<eve::float16>(1.0f));
-  uint16_t mone = eve::detail::float16_to_bits(static_cast<eve::float16>(-1.0f));
-  uint16_t mzero = eve::detail::float16_to_bits(static_cast<eve::float16>(-0.0f));
-  uint16_t inf = eve::detail::float16_to_bits(eve::inf(eve::as<eve::float16>{}));
-  uint16_t minf = eve::detail::float16_to_bits(eve::minf(eve::as<eve::float16>{}));
-  uint16_t nan = eve::detail::float16_to_bits(eve::nan(eve::as<eve::float16>{}));
-  uint16_t subnorm = eve::detail::float16_to_bits(static_cast<eve::float16>(3e-6f));
-  uint16_t msubnorm = eve::detail::float16_to_bits(static_cast<eve::float16>(-1e-7f));
-  uint16_t smaller_subnorm = eve::detail::float16_to_bits(static_cast<eve::float16>(1e-7f));
+  uint16_t zero = std::bit_cast<uint16_t>(static_cast<eve::float16_t>(0.0f));
+  uint16_t one = std::bit_cast<uint16_t>(static_cast<eve::float16_t>(1.0f));
+  uint16_t mone = std::bit_cast<uint16_t>(static_cast<eve::float16_t>(-1.0f));
+  uint16_t mzero = std::bit_cast<uint16_t>(static_cast<eve::float16_t>(-0.0f));
+  uint16_t inf = std::bit_cast<uint16_t>(eve::inf(eve::as<eve::float16_t>{}));
+  uint16_t minf = std::bit_cast<uint16_t>(eve::minf(eve::as<eve::float16_t>{}));
+  uint16_t nan = std::bit_cast<uint16_t>(eve::nan(eve::as<eve::float16_t>{}));
+  uint16_t subnorm = std::bit_cast<uint16_t>(static_cast<eve::float16_t>(3e-6f));
+  uint16_t msubnorm = std::bit_cast<uint16_t>(static_cast<eve::float16_t>(-1e-7f));
+  uint16_t smaller_subnorm = std::bit_cast<uint16_t>(static_cast<eve::float16_t>(1e-7f));
 
   // normal values
   expect_eq(zero, mzero);

--- a/test/unit/internals/float16.cpp
+++ b/test/unit/internals/float16.cpp
@@ -1,0 +1,182 @@
+//==================================================================================================
+/**
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+**/
+//==================================================================================================
+#include "test.hpp"
+
+TTS_CASE_TPL("test float16 conversions - floats", tts::types<float, double>)
+<typename F>(tts::type<F>)
+{
+  auto cases = tts::limits(tts::type<float>{});
+
+  TTS_EXPECT(eve::is_nan(static_cast<float>(eve::float16{ cases.nan })));
+
+  TTS_EXPECT(eve::is_infinite(static_cast<float>(eve::float16{ cases.inf })));
+  TTS_EXPECT(eve::is_positive(static_cast<float>(eve::float16{ cases.inf })));
+
+  TTS_EXPECT(eve::is_infinite(static_cast<float>(eve::float16{ cases.minf })));
+  TTS_EXPECT(eve::is_negative(static_cast<float>(eve::float16{ cases.minf })));
+
+  TTS_EQUAL(static_cast<float>(eve::float16{ cases.mzero }), -0.0f);
+  TTS_EXPECT(eve::is_negative(static_cast<float>(eve::float16{ cases.mzero })));
+
+  TTS_EQUAL(static_cast<float>(eve::float16{ cases.zero }), 0.0f);
+  TTS_EXPECT(eve::is_positive(static_cast<float>(eve::float16{ cases.zero })));
+};
+
+TTS_CASE_TPL("test float16 conversions - integrals", eve::test::scalar::integers)
+<typename I>(tts::type<I>)
+{
+  TTS_EQUAL(static_cast<I>(eve::float16{I{0}}), I{0});
+  TTS_EQUAL(static_cast<I>(eve::float16{I{30}}), I{30});
+  if constexpr (std::is_signed_v<I>) {
+    TTS_EQUAL(static_cast<I>(eve::float16{I{-11}}), I{-11});
+  }
+
+  I max_val = std::numeric_limits<I>::max();
+  if (static_cast<long>(eve::maxflint(eve::as<eve::float16>{})) <= static_cast<long>(max_val))
+  {
+    I max_flint = static_cast<I>(eve::maxflint(eve::as<eve::float16>{}));
+    TTS_EQUAL(static_cast<I>(eve::float16{max_flint}), max_flint);
+  }
+};
+
+TTS_CASE_TPL("test emulated float16", tts::types<float, double>)
+<typename F>(tts::type<F>)
+{
+  auto cases = tts::limits(tts::type<F>{});
+
+  TTS_EXPECT(eve::is_nan(eve::detail::emulated_fp16_to_fp32(eve::detail::emulated_fp_to_fp16(cases.nan))));
+
+  TTS_EXPECT(eve::is_infinite(eve::detail::emulated_fp16_to_fp32(eve::detail::emulated_fp_to_fp16(cases.inf))));
+  TTS_EXPECT(eve::is_positive(eve::detail::emulated_fp16_to_fp32(eve::detail::emulated_fp_to_fp16(cases.inf))));
+
+  TTS_EXPECT(eve::is_infinite(eve::detail::emulated_fp16_to_fp32(eve::detail::emulated_fp_to_fp16(cases.minf))));
+  TTS_EXPECT(eve::is_negative(eve::detail::emulated_fp16_to_fp32(eve::detail::emulated_fp_to_fp16(cases.minf))));
+
+  TTS_EQUAL(eve::detail::emulated_fp16_to_fp32(eve::detail::emulated_fp_to_fp16(cases.mzero)), -0.0f);
+  TTS_EXPECT(eve::is_negative(eve::detail::emulated_fp16_to_fp32(eve::detail::emulated_fp_to_fp16(cases.mzero))));
+
+  TTS_EQUAL(eve::detail::emulated_fp16_to_fp32(eve::detail::emulated_fp_to_fp16(cases.zero)), 0.0f);
+  TTS_EXPECT(eve::is_positive(eve::detail::emulated_fp16_to_fp32(eve::detail::emulated_fp_to_fp16(cases.zero))));
+
+  // Smallest positive denormal in FP16: 2^-24 ≈ 5.960464477539063e-08
+  F smallest_denormal = 5.960464477539063e-08f;
+  std::uint16_t fp16_bits = eve::detail::emulated_fp_to_fp16(smallest_denormal);
+  F converted_back = eve::detail::emulated_fp16_to_fp32(fp16_bits);
+  TTS_EXPECT(converted_back > 0.0f);
+  TTS_EXPECT(converted_back < 6.103515625e-05f);
+
+  // Test a few denormal values
+  F denormal1 = 1.0e-07f;  // Should become denormal
+  std::uint16_t bits1 = eve::detail::emulated_fp_to_fp16(denormal1);
+  F back1 = eve::detail::emulated_fp16_to_fp32(bits1);
+  TTS_EXPECT(back1 > 0.0f);
+  TTS_EXPECT(back1 < 6.103515625e-05f);
+
+  F denormal2 = 3.0e-06f;  // Should become denormal
+  std::uint16_t bits2 = eve::detail::emulated_fp_to_fp16(denormal2);
+  F back2 = eve::detail::emulated_fp16_to_fp32(bits2);
+  TTS_EXPECT(back2 > 0.0f);
+  TTS_EXPECT(back2 < 6.103515625e-05f);
+
+  // Test negative denormals
+  F neg_denormal = -1.0e-07f;
+  std::uint16_t neg_bits = eve::detail::emulated_fp_to_fp16(neg_denormal);
+  F neg_back = eve::detail::emulated_fp16_to_fp32(neg_bits);
+  TTS_EXPECT(neg_back < 0.0f);
+  TTS_EXPECT(neg_back > -6.103515625e-05f);
+
+  // Test positive values too small to represent (should round to zero)
+  F too_small = 1.0e-10f;
+  std::uint16_t zero_bits = eve::detail::emulated_fp_to_fp16(too_small);
+  F zero_back = eve::detail::emulated_fp16_to_fp32(zero_bits);
+  TTS_EQUAL(zero_back, 0.0f);
+  TTS_EXPECT(eve::is_positive(zero_back));
+
+  // Test negative values too small to represent (should round to zero)
+  F neg_too_small = -1.0e-10f;
+  std::uint16_t neg_zero_bits = eve::detail::emulated_fp_to_fp16(neg_too_small);
+  F neg_zero_back = eve::detail::emulated_fp16_to_fp32(neg_zero_bits);
+  TTS_EQUAL(neg_zero_back, -0.0f);
+  TTS_EXPECT(eve::is_negative(neg_zero_back));
+
+  // overflow to +infinity
+  F overflow_pos = eve::detail::emulated_fp16_to_fp32(eve::detail::emulated_fp_to_fp16(65505.0f));
+  TTS_EXPECT(eve::is_infinite(overflow_pos));
+  TTS_EXPECT(eve::is_positive(overflow_pos));
+
+  // underflow to -infinity
+  F overflow_neg = eve::detail::emulated_fp16_to_fp32(eve::detail::emulated_fp_to_fp16(-65505.0f));
+  TTS_EXPECT(eve::is_infinite(overflow_neg));
+  TTS_EXPECT(eve::is_negative(overflow_neg));
+};
+
+TTS_CASE("test emulated float16 comparison")
+{
+  auto cmp = [](uint16_t a, uint16_t b) { return eve::detail::emulated_fp16_compare(a, b); };
+
+  auto expect_eq = [&](uint16_t a, uint16_t b) {
+    TTS_EXPECT(cmp(a, b) == std::partial_ordering::equivalent);
+    TTS_EXPECT(cmp(b, a) == std::partial_ordering::equivalent);
+  };
+
+  auto expect_unordered = [&](uint16_t a, uint16_t b) {
+    TTS_EQUAL(cmp(a, b), std::partial_ordering::unordered);
+    TTS_EQUAL(cmp(b, a), std::partial_ordering::unordered);
+  };
+
+  auto expect_greater = [&](uint16_t a, uint16_t b) {
+    TTS_EXPECT(cmp(a, b) == std::partial_ordering::greater);
+    TTS_EXPECT(cmp(b, a) == std::partial_ordering::less);
+  };
+
+  uint16_t zero = eve::float16{0.0f}.bits();
+  uint16_t one = eve::float16{1.0f}.bits();
+  uint16_t mone = eve::float16{-1.0f}.bits();
+  uint16_t mzero = eve::float16{-0.0f}.bits();
+  uint16_t inf = eve::inf(eve::as<eve::float16>{}).bits();
+  uint16_t minf = eve::minf(eve::as<eve::float16>{}).bits();
+  uint16_t nan = eve::nan(eve::as<eve::float16>{}).bits();
+  uint16_t subnorm = eve::float16{3e-6f}.bits();
+  uint16_t msubnorm = eve::float16{-1e-7f}.bits();
+  uint16_t smaller_subnorm = eve::float16{1e-7f}.bits();
+
+  // normal values
+  expect_eq(zero, mzero);
+
+  expect_greater(one, zero);
+  expect_greater(one, mzero);
+
+  expect_greater(zero, mone);
+  expect_greater(mzero, mone);
+
+  expect_greater(one, mone);
+
+  // infinity
+  expect_greater(inf, minf);
+  expect_greater(inf, zero);
+  expect_greater(inf, mzero);
+  expect_greater(inf, subnorm);
+  expect_greater(inf, msubnorm);
+  expect_greater(zero, minf);
+  expect_greater(mzero, minf);
+
+  // NaN
+  expect_unordered(nan, nan);
+  expect_unordered(nan, one);
+  expect_unordered(nan, zero);
+  expect_unordered(nan, mzero);
+  expect_unordered(nan, inf);
+  expect_unordered(nan, minf);
+  expect_unordered(nan, subnorm);
+  expect_unordered(nan, msubnorm);
+
+  // Subnormals
+  expect_greater(subnorm, smaller_subnorm);
+  expect_greater(subnorm, msubnorm);
+  expect_greater(smaller_subnorm, msubnorm);
+};

--- a/test/unit/internals/float16.cpp
+++ b/test/unit/internals/float16.cpp
@@ -110,7 +110,7 @@ TTS_CASE("emulated float16 conversion - f16 roundtrip")
   TTS_EXPECT(eve::is_positive(overflow_pos));
 
   // overflow to +infinity - valmax rounding edge case
-  float overflow_pos_r = eve::detail::emulated_fp16_to_fp32(eve::detail::emulated_fp_to_fp16(65505.0f));
+  float overflow_pos_r = eve::detail::emulated_fp16_to_fp32(eve::detail::emulated_fp_to_fp16(65519.0f));
   TTS_EXPECT(!eve::is_infinite(overflow_pos_r));
   TTS_EXPECT(eve::is_positive(overflow_pos_r));
 
@@ -120,7 +120,7 @@ TTS_CASE("emulated float16 conversion - f16 roundtrip")
   TTS_EXPECT(eve::is_negative(overflow_neg));
 
   // underflow to -infinity - valmax rounding edge case
-  float overflow_neg_r = eve::detail::emulated_fp16_to_fp32(eve::detail::emulated_fp_to_fp16(-65505.0f));
+  float overflow_neg_r = eve::detail::emulated_fp16_to_fp32(eve::detail::emulated_fp_to_fp16(-65519.0f));
   TTS_EXPECT(!eve::is_infinite(overflow_neg_r));
   TTS_EXPECT(eve::is_negative(overflow_neg_r));
 };
@@ -144,16 +144,16 @@ TTS_CASE("test emulated float16 comparison")
     TTS_EXPECT(cmp(b, a) == std::partial_ordering::less);
   };
 
-  uint16_t zero = eve::float16{0.0f}.bits();
-  uint16_t one = eve::float16{1.0f}.bits();
-  uint16_t mone = eve::float16{-1.0f}.bits();
-  uint16_t mzero = eve::float16{-0.0f}.bits();
-  uint16_t inf = eve::inf(eve::as<eve::float16>{}).bits();
-  uint16_t minf = eve::minf(eve::as<eve::float16>{}).bits();
-  uint16_t nan = eve::nan(eve::as<eve::float16>{}).bits();
-  uint16_t subnorm = eve::float16{3e-6f}.bits();
-  uint16_t msubnorm = eve::float16{-1e-7f}.bits();
-  uint16_t smaller_subnorm = eve::float16{1e-7f}.bits();
+  uint16_t zero = eve::detail::float16_to_bits(eve::float16{0.0f});
+  uint16_t one = eve::detail::float16_to_bits(eve::float16{1.0f});
+  uint16_t mone = eve::detail::float16_to_bits(eve::float16{-1.0f});
+  uint16_t mzero = eve::detail::float16_to_bits(eve::float16{-0.0f});
+  uint16_t inf = eve::detail::float16_to_bits(eve::inf(eve::as<eve::float16>{}));
+  uint16_t minf = eve::detail::float16_to_bits(eve::minf(eve::as<eve::float16>{}));
+  uint16_t nan = eve::detail::float16_to_bits(eve::nan(eve::as<eve::float16>{}));
+  uint16_t subnorm = eve::detail::float16_to_bits(eve::float16{3e-6f});
+  uint16_t msubnorm = eve::detail::float16_to_bits(eve::float16{-1e-7f});
+  uint16_t smaller_subnorm = eve::detail::float16_to_bits(eve::float16{1e-7f});
 
   // normal values
   expect_eq(zero, mzero);


### PR DESCRIPTION
Implement base support for FP16 in EVE.

* `std::float16_t` is only provided in C++23, and currently not implemented by clang. We cannot rely on that.
* The `_Float16` type, and associated softfloat implementations are provided by the compilers on most platforms. We still need to implement some kind of polyfills when it is not provided.

This PR adds the following:
*  A new `eve::float16` type, wrapping a `_Float16` when available with polyfill supports when the compiler does not provide this type. 
* Test changes to allow for adding fp16 to unit tests.
* FP16 constants support.
