### PR TITLE
Fix some translatable edge cases

### DIFF
--- a/include/eve/arch/cpu/logical_wide.hpp
+++ b/include/eve/arch/cpu/logical_wide.hpp
@@ -19,7 +19,6 @@
 #include <eve/detail/alias.hpp>
 #include <eve/detail/function/bit_cast.hpp>
 #include <eve/detail/function/bitmask.hpp>
-#include <eve/detail/function/combine.hpp>
 #include <eve/detail/function/fill.hpp>
 #include <eve/detail/function/friends.hpp>
 #include <eve/detail/function/load.hpp>
@@ -208,7 +207,7 @@ namespace eve
     template<logical_simd_value WL0, logical_simd_value WL1, logical_simd_value... WLs>
     EVE_FORCEINLINE logical(WL0 wl0, WL1 wl1, WLs... wls) noexcept
     requires (combinable_to<logical, WL0, WL1, WLs...>)
-      : storage_base(detail::combine(eve::current_api, wl0, wl1, wls...))
+      : storage_base(combine(wl0, wl1, wls...))
     { }
 
     //==============================================================================================

--- a/include/eve/arch/cpu/wide.hpp
+++ b/include/eve/arch/cpu/wide.hpp
@@ -18,7 +18,6 @@
 #include <eve/concept/scalar.hpp>
 #include <eve/conditional.hpp>
 #include <eve/detail/abi.hpp>
-#include <eve/detail/function/combine.hpp>
 #include <eve/detail/function/fill.hpp>
 #include <eve/detail/function/friends.hpp>
 #include <eve/detail/function/load.hpp>
@@ -254,7 +253,7 @@ namespace eve
     template<arithmetic_simd_value W0, arithmetic_simd_value W1, arithmetic_simd_value... Ws>
     EVE_FORCEINLINE wide(W0 w0, W1 w1, Ws... ws) noexcept
     requires (combinable_to<wide, W0, W1, Ws...>)
-      : storage_base(detail::combine(eve::current_api, w0, w1, ws...))
+      : storage_base(combine(w0, w1, ws...))
     {}
 
     //==============================================================================================

--- a/include/eve/detail/function/simd/common/combine.hpp
+++ b/include/eve/detail/function/simd/common/combine.hpp
@@ -38,7 +38,7 @@ namespace eve::detail
     else if constexpr( has_aggregated_abi_v<that_t> )
     {
       that_t that;
-      that.storage().assign_parts(l,h);
+      that.storage().assign_parts(translate(l), translate(h));
       return that;
     }
     else if constexpr( is_bundle_v<abi_t<T, N>> )
@@ -60,7 +60,7 @@ namespace eve::detail
     else if constexpr( has_aggregated_abi_v<that_t> )
     {
       that_t that;
-      that.storage().assign_parts(l,h);
+      that.storage().assign_parts(translate(l), translate(h));
       return that;
     }
     else

--- a/include/eve/detail/function/simd/common/combine.hpp
+++ b/include/eve/detail/function/simd/common/combine.hpp
@@ -38,7 +38,7 @@ namespace eve::detail
     else if constexpr( has_aggregated_abi_v<that_t> )
     {
       that_t that;
-      that.storage().assign_parts(translate(l), translate(h));
+      that.storage().assign_parts(l, h);
       return that;
     }
     else if constexpr( is_bundle_v<abi_t<T, N>> )
@@ -60,7 +60,7 @@ namespace eve::detail
     else if constexpr( has_aggregated_abi_v<that_t> )
     {
       that_t that;
-      that.storage().assign_parts(translate(l), translate(h));
+      that.storage().assign_parts(l, h);
       return that;
     }
     else

--- a/include/eve/detail/ptr.hpp
+++ b/include/eve/detail/ptr.hpp
@@ -1,0 +1,27 @@
+//==================================================================================================
+/*
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+*/
+//==================================================================================================
+#pragma once
+
+#include <type_traits>
+
+namespace eve::detail
+{
+  template<typename Src, typename Tgt>
+  struct copy_qualifiers
+  {
+  private:
+      using R = std::remove_pointer_t<Tgt>;
+      using U1 = std::conditional_t<std::is_const<R>::value, std::add_const_t<Src>, Src>;
+      using U2 = std::conditional_t<std::is_volatile<R>::value, std::add_volatile_t<U1>, U1>;
+  public:
+      using type = U2;
+  };
+
+  template<typename Src, typename Tgt>
+  using copy_qualifiers_t = typename copy_qualifiers<Src, Tgt>::type;
+}

--- a/include/eve/module/core/regular/combine.hpp
+++ b/include/eve/module/core/regular/combine.hpp
@@ -9,6 +9,7 @@
 #include <eve/concept/value.hpp>
 #include <eve/detail/function/combine.hpp>
 #include <eve/detail/overload.hpp>
+#include <eve/traits/as_translation.hpp>
 
 namespace eve
 {
@@ -18,7 +19,9 @@ namespace eve
     template<simd_value T>
     constexpr EVE_FORCEINLINE typename T::combined_type operator()(T a, T b) const noexcept
     {
-      return detail::combine(eve::current_api, a, b);
+      return translate_into(
+        detail::combine(eve::current_api, translate(a), translate(b)),
+        as<typename T::combined_type>{});
     }
 
     template<simd_value T0, simd_value T1, simd_value T2, simd_value... Ts>
@@ -26,7 +29,9 @@ namespace eve
     operator()(T0 a, T1 b, T2 c, Ts... ts) const noexcept
       requires (combinable<T0, T1, T2, Ts...>)
     {
-      return detail::combine(eve::current_api, a, b, c, ts...);
+      return translate_into(
+        detail::combine(eve::current_api, translate(a), translate(b), translate(c), translate(ts)...),
+        as<typename T0::template rescale<fixed<(T0::size() * (3 + sizeof...(Ts)))>>>{});
     }
   };
 

--- a/include/eve/traits/as_translation.hpp
+++ b/include/eve/traits/as_translation.hpp
@@ -126,7 +126,7 @@ namespace eve
   //! @endcode
   //================================================================================================
   template <typename Dst, translatable_into<Dst> Src>
-  constexpr auto translate_into(Src const& val, as<Dst>)
+  constexpr Dst translate_into(Src const& val, as<Dst>)
   {
     return std::bit_cast<Dst>(val);
   }

--- a/include/eve/traits/as_translation.hpp
+++ b/include/eve/traits/as_translation.hpp
@@ -9,6 +9,7 @@
 
 #include <eve/concept/translation.hpp>
 #include <eve/detail/wide_forward.hpp>
+#include <eve/detail/ptr.hpp>
 #include <eve/memory/pointer.hpp>
 #include <eve/traits/value_type.hpp>
 
@@ -27,6 +28,20 @@ namespace eve
   constexpr translate_t<V> translate(V const& val)
   {
     if constexpr (has_plain_translation<element_type_t<V>>) return std::bit_cast<translate_t<V>>(val);
+    else                                                    return val;
+  }
+
+  //================================================================================================
+  //! @brief Translates an `std::array` to an `std::array` of its translated value type and the same size.
+  //!
+  //! @param T The element type of the array to translate
+  //! @param N The size of the array to translate
+  //! @return The translated array of type `std::array<translate_t<V>, N>`
+  //================================================================================================
+  template <typename T, size_t N>
+  constexpr std::array<translate_t<T>, N> translate(std::array<T, N> val)
+  {
+    if constexpr (has_plain_translation<element_type_t<T>>) return std::bit_cast<std::array<translate_t<T>, N>>(val);
     else                                                    return val;
   }
 
@@ -79,7 +94,7 @@ namespace eve
   {
     if constexpr (has_plain_translation<value_type_t<Ptr>>)
     {
-      using trans_t = translate_t<value_type_t<Ptr>>;
+      using trans_t = detail::copy_qualifiers_t<translated_value_type_t<Ptr>, Ptr>;
 
       if constexpr (std::is_pointer_v<Ptr>)
       {
@@ -87,8 +102,7 @@ namespace eve
       }
       else
       {
-        using r_t = typename Ptr::template rebind<trans_t>;
-        return r_t { translate_ptr(ptr.get()) };
+        return std::bit_cast<typename Ptr::template rebind<trans_t>>(ptr);
       }
     }
     else

--- a/include/eve/traits/translation.hpp
+++ b/include/eve/traits/translation.hpp
@@ -106,4 +106,11 @@ namespace eve
   requires (std::is_enum_v<T>)
   struct translation_of<T>: std::underlying_type<T>
   { };
+
+  // If `T` can be translated to `U`, then `std::array<T, N>` can be translated to `std::array<U, N>`.
+  template <typename T, size_t N>
+  struct translation_of<std::array<T, N>>
+  {
+    using type = std::array<translate_t<T>, N>;
+  };
 }

--- a/test/unit/api/translation/ptr.cpp
+++ b/test/unit/api/translation/ptr.cpp
@@ -1,0 +1,62 @@
+//==================================================================================================
+/**
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+**/
+//==================================================================================================
+#include "unit/api/translation/common.hpp"
+
+TTS_CASE_TPL("Translatable - ptr", eve::test::scalar::all_types)
+<typename T>(tts::type<T>)
+{
+  using trans_t = BaseStruct<T>;
+
+  // basic
+  {
+    trans_t value { 42 };
+    trans_t* ptr = &value;
+    T* translated = eve::translate_ptr(ptr);
+
+    TTS_EQUAL(*translated, T{42});
+
+    TTS_EXPECT_NOT((std::is_const_v<std::remove_pointer_t<decltype(translated)>>));
+    TTS_EXPECT_NOT((std::is_volatile_v<std::remove_pointer_t<decltype(translated)>>));
+  }
+
+  // const
+  {
+    trans_t value { 42 };
+    const trans_t* const_ptr = &value;
+    const T* translated_const = eve::translate_ptr(const_ptr);
+
+    TTS_EQUAL(*translated_const, T{42});
+
+    TTS_EXPECT((std::is_const_v<std::remove_pointer_t<decltype(translated_const)>>));
+    TTS_EXPECT_NOT((std::is_volatile_v<std::remove_pointer_t<decltype(translated_const)>>));
+  }
+
+  // volatile
+  {
+    trans_t value { 42 };
+    volatile trans_t* volatile_ptr = &value;
+    volatile T* translated_volatile = eve::translate_ptr(volatile_ptr);
+
+    TTS_EQUAL(*translated_volatile, T{42});
+
+    TTS_EXPECT_NOT((std::is_const_v<std::remove_pointer_t<decltype(translated_volatile)>>));
+    TTS_EXPECT((std::is_volatile_v<std::remove_pointer_t<decltype(translated_volatile)>>));
+  }
+
+  // const volatile
+  {
+    trans_t value { 42 };
+    const volatile trans_t* const_volatile_ptr = &value;
+    const volatile T* translated_const_volatile = eve::translate_ptr(const_volatile_ptr);
+
+    TTS_EQUAL(*translated_const_volatile, T{42});
+
+    TTS_EXPECT((std::is_const_v<std::remove_pointer_t<decltype(translated_const_volatile)>>));
+    TTS_EXPECT((std::is_volatile_v<std::remove_pointer_t<decltype(translated_const_volatile)>>));
+  }
+};

--- a/test/unit/api/translation/slicecombine.cpp
+++ b/test/unit/api/translation/slicecombine.cpp
@@ -1,0 +1,169 @@
+//==================================================================================================
+/**
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+**/
+//==================================================================================================
+#include "unit/api/translation/common.hpp"
+
+TTS_CASE_TPL("Translatable wide - slice", eve::test::simd::all_types)
+<typename W>(tts::type<W>)
+{
+  using T = eve::element_type_t<W>;
+  using trans_t = BaseStruct<T>;
+  using WT = eve::as_wide_as_t<trans_t, W>;
+
+  if constexpr (W::size() > 1)
+  {
+    if constexpr (std::integral<T>)
+    {
+      enum class E: T { };
+      using WE = eve::as_wide_as_t<E, W>;
+
+      W wr_enum = [](auto i, auto) { return static_cast<T>(i + 1); };
+      WE wt_enum = [](auto i, auto) { return static_cast<E>(i + 1); };
+
+      TTS_EQUAL(eve::translate(wt_enum), wr_enum);
+
+      auto [wr_lo_enum, wr_hi_enum] = wr_enum.slice();
+      auto [wt_lo_enum, wt_hi_enum] = wt_enum.slice();
+
+      TTS_EQUAL(eve::translate(wt_lo_enum), wr_lo_enum);
+      TTS_EQUAL(eve::translate(wt_hi_enum), wr_hi_enum);
+
+      auto wr_lower_enum = wr_enum.slice(eve::lower_);
+      auto wt_lower_enum = wt_enum.slice(eve::lower_);
+
+      TTS_EQUAL(eve::translate(wt_lower_enum), wr_lower_enum);
+
+      auto wr_upper_enum = wr_enum.slice(eve::upper_);
+      auto wt_upper_enum = wt_enum.slice(eve::upper_);
+
+      TTS_EQUAL(eve::translate(wt_upper_enum), wr_upper_enum);
+    }
+
+    W wr = [](auto i, auto) { return static_cast<T>(i + 1); };
+    WT wt = [](auto i, auto) { return trans_t { static_cast<T>(i + 1) }; };
+
+    TTS_EQUAL(eve::translate(wt), wr);
+
+    auto [wr_lo, wr_hi] = wr.slice();
+    auto [wt_lo, wt_hi] = wt.slice();
+
+    TTS_EQUAL(eve::translate(wt_lo), wr_lo);
+    TTS_EQUAL(eve::translate(wt_hi), wr_hi);
+
+    auto wr_lower = wr.slice(eve::lower_);
+    auto wt_lower = wt.slice(eve::lower_);
+
+    TTS_EQUAL(eve::translate(wt_lower), wr_lower);
+
+    auto wr_upper = wr.slice(eve::upper_);
+    auto wt_upper = wt.slice(eve::upper_);
+
+    TTS_EQUAL(eve::translate(wt_upper), wr_upper);
+  }
+};
+
+TTS_CASE_TPL("Translatable wide - combine", eve::test::simd::all_types)
+<typename W>(tts::type<W>)
+{
+  using T = eve::element_type_t<W>;
+  using trans_t = BaseStruct<T>;
+  using WT = eve::as_wide_as_t<trans_t, W>;
+
+  if constexpr (std::integral<T>)
+  {
+    enum class E: T { };
+    using WE = eve::as_wide_as_t<E, W>;
+
+    W wr1 = [](auto i, auto) { return static_cast<T>(i + 1); };
+    W wr2 = [](auto i, auto) { return static_cast<T>(i * 2 + 3); };
+    WE wt1 = [](auto i, auto) { return static_cast<E>(i + 1); };
+    WE wt2 = [](auto i, auto) { return static_cast<E>(i * 2 + 3); };
+
+    auto wr_combined = eve::combine(wr1, wr2);
+    auto wt_combined = eve::combine(wt1, wt2);
+
+    TTS_EQUAL(eve::translate(wt_combined), wr_combined);
+  }
+
+  W wr1 = [](auto i, auto) { return static_cast<T>(i + 1); };
+  W wr2 = [](auto i, auto) { return static_cast<T>(i * 2 + 3); };
+  WT wt1 = [](auto i, auto) { return trans_t { static_cast<T>(i + 1) }; };
+  WT wt2 = [](auto i, auto) { return trans_t { static_cast<T>(i * 2 + 3) }; };
+
+  auto wr_combined = eve::combine(wr1, wr2);
+  auto wt_combined = eve::combine(wt1, wt2);
+
+  TTS_EQUAL(eve::translate(wt_combined), wr_combined);
+};
+
+TTS_CASE_TPL("Translatable wide - combine constructor", eve::test::simd::all_types)
+<typename W>(tts::type<W>)
+{
+  using T = eve::element_type_t<W>;
+  using trans_t = BaseStruct<T>;
+  using WT = eve::as_wide_as_t<trans_t, W>;
+
+  if constexpr (std::integral<T>)
+  {
+    enum class E: T { };
+    using WE = eve::as_wide_as_t<E, W>;
+
+    W wr1 = [](auto i, auto) { return static_cast<T>(i + 1); };
+    W wr2 = [](auto i, auto) { return static_cast<T>(i * 2 + 3); };
+    WE wt1 = [](auto i, auto) { return static_cast<E>(i + 1); };
+    WE wt2 = [](auto i, auto) { return static_cast<E>(i * 2 + 3); };
+
+    typename W::combined_type wr_combined { wr1, wr2 };
+    typename WE::combined_type wt_combined { wt1, wt2 };
+
+    TTS_EQUAL(eve::translate(wt_combined), wr_combined);
+  }
+
+  W wr1 = [](auto i, auto) { return static_cast<T>(i + 1); };
+  W wr2 = [](auto i, auto) { return static_cast<T>(i * 2 + 3); };
+  WT wt1 = [](auto i, auto) { return trans_t { static_cast<T>(i + 1) }; };
+  WT wt2 = [](auto i, auto) { return trans_t { static_cast<T>(i * 2 + 3) }; };
+
+  typename W::combined_type wr_combined { wr1, wr2 };
+  typename WT::combined_type wt_combined { wt1, wt2 };
+
+  TTS_EQUAL(eve::translate(wt_combined), wr_combined);
+};
+
+TTS_CASE_TPL("Translatable logical wide - combine constructor", eve::test::simd::all_types)
+<typename W>(tts::type<W>)
+{
+  using T = eve::element_type_t<W>;
+  using trans_t = eve::logical<BaseStruct<T>>;
+  using WT = eve::as_wide_as_t<trans_t, W>;
+
+  if constexpr (std::integral<T>)
+  {
+    enum class E: T { };
+    using WE = eve::as_wide_as_t<eve::logical<E>, W>;
+
+    eve::logical<W> wr1 = [](auto i, auto) { return (i % 2) == 0; };
+    eve::logical<W> wr2 = [](auto i, auto) { return (i % 3) == 0; };
+    WE wt1 = [](auto i, auto) { return eve::logical<E>((i % 2) == 0); };
+    WE wt2 = [](auto i, auto) { return eve::logical<E>((i % 3) == 0); };
+
+    typename eve::logical<W>::combined_type wr_combined { wr1, wr2 };
+    typename WE::combined_type wt_combined { wt1, wt2 };
+
+    TTS_EQUAL(eve::translate(wt_combined), wr_combined);
+  }
+
+  eve::logical<W> wr1 = [](auto i, auto) { return (i % 2) == 0; };
+  eve::logical<W> wr2 = [](auto i, auto) { return (i % 3) == 0; };
+  WT wt1 = [](auto i, auto) { return trans_t((i % 2) == 0); };
+  WT wt2 = [](auto i, auto) { return trans_t((i % 3) == 0); };
+
+  typename eve::logical<W>::combined_type wr_combined { wr1, wr2 };
+  typename WT::combined_type wt_combined { wt1, wt2 };
+
+  TTS_EQUAL(eve::translate(wt_combined), wr_combined);
+};


### PR DESCRIPTION
Fix the following translatable edge cases :
- fix `combine`: didn't work well with translatable values in some cases
- fix `slice`: `std::array<T, N>` is now translatable by default to `std::array<U, N>` if `T` is translatable into `U`.
- fix `translate_ptr`: no longer discard qualifiers in some cases. Added a new `copy_qualifiers_t` helper type that will also be used for the undergoing fp16 work (specifically when translating `[qals] _Float16*` to `[quals] __fp16*` on ARM.

\+ added some tests