### PR TITLE
Fix misuse of kumi::max_flat

### DIFF
--- a/include/eve/module/algo/algo/traits.hpp
+++ b/include/eve/module/algo/algo/traits.hpp
@@ -514,7 +514,7 @@ namespace eve::algo
   template<typename RorI>
   constexpr auto default_index_type_to_use() {
     using T = eve::value_type_t<RorI>;
-    constexpr std::size_t max_size = kumi::max_flat( T{}, [](auto m) { return sizeof(m); });
+    constexpr std::size_t max_size = max_scalar_size_v<T>;
          if constexpr (max_size <= 2U) return std::type_identity<std::uint16_t>{};
     else if constexpr (max_size == 4U) return std::type_identity<std::uint32_t>{};
     else                               return std::type_identity<std::uint64_t>{};


### PR DESCRIPTION
@DenisYaroshevskiy `default_index_type_to_use` is passing scalar values to `kumi::max_flat`. This used to work but was an undocumented behaviour and is no longer supported by kumi.

There is already an helper in `traits/max_scalar_size.hpp` that wraps `kumi::max_flat` to achieve this.