### PR TITLE
Allow masked reduce with custom functions if given a neutral value

### DIFF
--- a/include/eve/module/core/regular/reduce.hpp
+++ b/include/eve/module/core/regular/reduce.hpp
@@ -153,11 +153,11 @@ namespace eve
     }
 
     template<callable_options O, simd_value T, typename Callable, typename U>
-    EVE_FORCEINLINE auto reduce_(EVE_REQUIRES(cpu_), O const& opts, T v, Callable f, U neutral) noexcept
+    EVE_FORCEINLINE auto reduce_(EVE_REQUIRES(cpu_), O const& opts, T v, Callable f, [[maybe_unused]] U neutral) noexcept
     {
       if constexpr (match_option<condition_key, O, ignore_none_>)
       {
-        return reduce.behavior(cpu_{}, opts, if_else(opts[condition_key], v, neutral), f);
+        return reduce.behavior(cpu_{}, opts, v, f);
       }
       else
       {

--- a/include/eve/module/core/regular/reduce.hpp
+++ b/include/eve/module/core/regular/reduce.hpp
@@ -87,7 +87,7 @@ namespace eve
     }
 
     template<logical_simd_value T, typename Callable, typename U>
-    EVE_FORCEINLINE element_type_t<T> operator()(T v, Callable f, U neutral) const noexcept
+    EVE_FORCEINLINE bool operator()(T v, Callable f, U neutral) const noexcept
       requires (!Options::contains(splat) && (generator<U> || std::same_as<U, bool> || std::same_as<U, element_type_t<T>>))
     {
       return EVE_DISPATCH_CALL(v, f, neutral);

--- a/include/eve/module/core/regular/reduce.hpp
+++ b/include/eve/module/core/regular/reduce.hpp
@@ -21,7 +21,7 @@ namespace eve
   template<typename Options>
   struct reduce_t : conditional_callable<reduce_t, Options, splat_option>
   {
-    template<value T, typename Callable>
+    template<arithmetic_value T, typename Callable>
     EVE_FORCEINLINE element_type_t<T> operator()(T v, Callable f) const noexcept
       requires (!Options::contains(splat))
     {
@@ -31,7 +31,17 @@ namespace eve
       return EVE_DISPATCH_CALL(v, f);
     }
 
-    template<value T>
+    template<logical_value T, typename Callable>
+    EVE_FORCEINLINE bool operator()(T v, Callable f) const noexcept
+      requires (!Options::contains(splat))
+    {
+      static_assert(detail::validate_mask_for<decltype(this->options()), T>(),
+        "[eve::reduce] - Cannot use a relative conditional expression or a simd value to mask a scalar value");
+
+      return EVE_DISPATCH_CALL(v, f);
+    }
+
+    template<arithmetic_value T>
     EVE_FORCEINLINE element_type_t<T> operator()(T v) const noexcept
       requires (!Options::contains(splat))
     {
@@ -55,16 +65,30 @@ namespace eve
       return EVE_DISPATCH_CALL(v);
     }
 
-    template<simd_value T, typename Callable, typename U>
+    template<arithmetic_simd_value T, typename Callable, typename U>
     EVE_FORCEINLINE T operator()(T v, Callable f, U neutral) const noexcept
-      requires (Options::contains(splat) && (generator<U> || std::same_as<element_type_t<T>, U>))
+      requires (Options::contains(splat) && (generator<U> || arithmetic_scalar_value<U>))
     {
       return EVE_DISPATCH_CALL(v, f, neutral);
     }
 
-    template<simd_value T, typename Callable, typename U>
+    template<arithmetic_simd_value T, typename Callable, typename U>
     EVE_FORCEINLINE element_type_t<T> operator()(T v, Callable f, U neutral) const noexcept
-      requires (!Options::contains(splat) && (generator<U> || std::same_as<element_type_t<T>, U>))
+      requires (!Options::contains(splat) && (generator<U> || arithmetic_scalar_value<U>))
+    {
+      return EVE_DISPATCH_CALL(v, f, neutral);
+    }
+
+    template<logical_simd_value T, typename Callable, typename U>
+    EVE_FORCEINLINE T operator()(T v, Callable f, U neutral) const noexcept
+      requires (Options::contains(splat) && (generator<U> || std::same_as<U, bool> || std::same_as<U, element_type_t<T>>))
+    {
+      return EVE_DISPATCH_CALL(v, f, neutral);
+    }
+
+    template<logical_simd_value T, typename Callable, typename U>
+    EVE_FORCEINLINE element_type_t<T> operator()(T v, Callable f, U neutral) const noexcept
+      requires (!Options::contains(splat) && (generator<U> || std::same_as<U, bool> || std::same_as<U, element_type_t<T>>))
     {
       return EVE_DISPATCH_CALL(v, f, neutral);
     }
@@ -159,13 +183,17 @@ namespace eve
       {
         return reduce.behavior(cpu_{}, opts, v, f);
       }
+      else if constexpr (std::same_as<U, bool>)
+      {
+        return reduce[opts.drop(condition_key)].retarget(cpu_{}, if_else(opts[condition_key], v, T { neutral }), f);
+      }
       else
       {
         return reduce[opts.drop(condition_key)].retarget(cpu_{}, if_else(opts[condition_key], v, neutral), f);
       }
     }
 
-    template<callable_options O, typename T>
+    template<callable_options O, arithmetic_value T>
     EVE_FORCEINLINE auto reduce_(EVE_REQUIRES(cpu_), O const& opts, T v) noexcept
     {
       return eve::detail::sum[opts](v);

--- a/test/unit/module/core/reduce.cpp
+++ b/test/unit/module/core/reduce.cpp
@@ -5,52 +5,86 @@
   SPDX-License-Identifier: BSL-1.0
 **/
 //==================================================================================================
-#include "test.hpp"
-
-#include <eve/module/core.hpp>
+#include "unit/module/core/reduction_test.hpp"
 
 //==================================================================================================
 // Types tests
 //==================================================================================================
-TTS_CASE_TPL("Check return types of eve::reduce(wide)", eve::test::simd::all_types)
-<typename T>(tts::type<T>)
+// TTS_CASE_TPL("Check return types of eve::reduce(wide)", eve::test::simd::all_types)
+// <typename T>(tts::type<T>)
+// {
+//   using v_t = eve::element_type_t<T>;
+//   TTS_EXPR_IS((eve::reduce(T {})), v_t);
+//   TTS_EXPR_IS((eve::reduce(T {}, eve::add)), v_t);
+//   TTS_EXPR_IS((eve::reduce[eve::splat](T {})), T);
+//   TTS_EXPR_IS((eve::reduce[eve::splat](T {}, eve::add)), T);
+// };
+
+// //==================================================================================================
+// // Arithmetic tests
+// //==================================================================================================
+// TTS_CASE_TPL("Check behavior of eve::reduce(eve::wide)", eve::test::simd::all_types)
+// <typename T>(tts::type<T>)
+// {
+//   T data = [](auto i, auto c) { return i < c / 2 ? 10 * (i + 1) : -(10 * (i + 1) + 1); };
+//   data += 1;
+
+//   typename T::value_type ref = 0;
+//   for( std::ptrdiff_t i = 0; i < T::size(); ++i ) ref += data.get(i);
+
+//   TTS_EQUAL(eve::reduce(data, [](auto a, auto b) { return a + b; }), ref);
+//   TTS_EQUAL(eve::reduce(data, eve::add), ref);
+//   TTS_EQUAL(eve::reduce(data), ref);
+
+//   TTS_EQUAL(eve::reduce[eve::splat](data, [](auto a, auto b) { return a + b; }), T(ref));
+//   TTS_EQUAL(eve::reduce[eve::splat](data, eve::add), T(ref));
+//   TTS_EQUAL(eve::reduce[eve::splat](data), T(ref));
+// };
+
+// //==================================================================================================
+// // Logical tests
+// //==================================================================================================
+// TTS_CASE_WITH("Check behavior of eve::reduce(eve::wide)",
+//               eve::test::simd::all_types,
+//               tts::generate(tts::logicals(0, 3)))
+// <typename T>(T const& a0)
+// {
+//   TTS_EQUAL(eve::reduce(a0, eve::logical_and), eve::all(a0));
+//   TTS_EQUAL(eve::reduce(a0, eve::logical_or), eve::any(a0));
+// };
+
+//==================================================================================================
+// Neutral tests
+//==================================================================================================
+struct ManualProd
 {
-  using v_t = eve::element_type_t<T>;
-  TTS_EXPR_IS((eve::reduce(T {})), v_t);
-  TTS_EXPR_IS((eve::reduce(T {}, eve::add)), v_t);
-  TTS_EXPR_IS((eve::reduce[eve::splat](T {})), T);
-  TTS_EXPR_IS((eve::reduce[eve::splat](T {}, eve::add)), T);
+  template<typename T, typename C>
+  eve::element_type_t<T> operator()(T v, C mask) const
+  {
+    auto res = eve::one(eve::as<eve::element_type_t<T>>{});
+
+    for (std::ptrdiff_t i = 0; i < v.size(); ++i)
+      if (mask_at(mask, i))
+        res *= v.get(i);
+
+    return res;
+  }
 };
 
-//==================================================================================================
-// Arithmetic tests
-//==================================================================================================
-TTS_CASE_TPL("Check behavior of eve::reduce(eve::wide)", eve::test::simd::all_types)
-<typename T>(tts::type<T>)
+namespace eve
 {
-  T data = [](auto i, auto c) { return i < c / 2 ? 10 * (i + 1) : -(10 * (i + 1) + 1); };
-  data += 1;
+  template<typename Options>
+  struct reduce_proxy_t : conditional_callable<reduce_proxy_t, Options, splat_option>
+  {
+    template <typename T>
+    EVE_FORCEINLINE auto operator()(T v) const noexcept { return eve::reduce[this->options()](v, eve::mul, eve::one); }
+  };
+}
 
-  typename T::value_type ref = 0;
-  for( std::ptrdiff_t i = 0; i < T::size(); ++i ) ref += data.get(i);
-
-  TTS_EQUAL(eve::reduce(data, [](auto a, auto b) { return a + b; }), ref);
-  TTS_EQUAL(eve::reduce(data, eve::add), ref);
-  TTS_EQUAL(eve::reduce(data), ref);
-
-  TTS_EQUAL(eve::reduce[eve::splat](data, [](auto a, auto b) { return a + b; }), T(ref));
-  TTS_EQUAL(eve::reduce[eve::splat](data, eve::add), T(ref));
-  TTS_EQUAL(eve::reduce[eve::splat](data), T(ref));
-};
-
-//==================================================================================================
-// Logical tests
-//==================================================================================================
-TTS_CASE_WITH("Check behavior of eve::reduce(eve::wide)",
-              eve::test::simd::all_types,
-              tts::generate(tts::logicals(0, 3)))
-<typename T>(T const& a0)
+TTS_CASE_WITH("Check behavior of eve::reduce with a neutral element",
+              eve::test::simd::integers,
+              tts::generate(tts::randoms(eve::valmin, eve::valmax)))
+<typename T>(T v)
 {
-  TTS_EQUAL(eve::reduce(a0, eve::logical_and), eve::all(a0));
-  TTS_EQUAL(eve::reduce(a0, eve::logical_or), eve::any(a0));
+  arithmetic_reduction_test_case<ManualProd>(eve::functor<eve::reduce_proxy_t>, v);
 };

--- a/test/unit/module/core/reduce.cpp
+++ b/test/unit/module/core/reduce.cpp
@@ -10,62 +10,78 @@
 //==================================================================================================
 // Types tests
 //==================================================================================================
-// TTS_CASE_TPL("Check return types of eve::reduce(wide)", eve::test::simd::all_types)
-// <typename T>(tts::type<T>)
-// {
-//   using v_t = eve::element_type_t<T>;
-//   TTS_EXPR_IS((eve::reduce(T {})), v_t);
-//   TTS_EXPR_IS((eve::reduce(T {}, eve::add)), v_t);
-//   TTS_EXPR_IS((eve::reduce[eve::splat](T {})), T);
-//   TTS_EXPR_IS((eve::reduce[eve::splat](T {}, eve::add)), T);
-// };
+TTS_CASE_TPL("Check return types of eve::reduce(wide)", eve::test::simd::all_types)
+<typename T>(tts::type<T>)
+{
+  using v_t = eve::element_type_t<T>;
+  TTS_EXPR_IS((eve::reduce(T {})), v_t);
+  TTS_EXPR_IS((eve::reduce(T {}, eve::add)), v_t);
+  TTS_EXPR_IS((eve::reduce[eve::splat](T {})), T);
+  TTS_EXPR_IS((eve::reduce[eve::splat](T {}, eve::add)), T);
+};
 
-// //==================================================================================================
-// // Arithmetic tests
-// //==================================================================================================
-// TTS_CASE_TPL("Check behavior of eve::reduce(eve::wide)", eve::test::simd::all_types)
-// <typename T>(tts::type<T>)
-// {
-//   T data = [](auto i, auto c) { return i < c / 2 ? 10 * (i + 1) : -(10 * (i + 1) + 1); };
-//   data += 1;
+//==================================================================================================
+// Arithmetic tests
+//==================================================================================================
+TTS_CASE_TPL("Check behavior of eve::reduce(eve::wide)", eve::test::simd::all_types)
+<typename T>(tts::type<T>)
+{
+  T data = [](auto i, auto c) { return i < c / 2 ? 10 * (i + 1) : -(10 * (i + 1) + 1); };
+  data += 1;
 
-//   typename T::value_type ref = 0;
-//   for( std::ptrdiff_t i = 0; i < T::size(); ++i ) ref += data.get(i);
+  typename T::value_type ref = 0;
+  for( std::ptrdiff_t i = 0; i < T::size(); ++i ) ref += data.get(i);
 
-//   TTS_EQUAL(eve::reduce(data, [](auto a, auto b) { return a + b; }), ref);
-//   TTS_EQUAL(eve::reduce(data, eve::add), ref);
-//   TTS_EQUAL(eve::reduce(data), ref);
+  TTS_EQUAL(eve::reduce(data, [](auto a, auto b) { return a + b; }), ref);
+  TTS_EQUAL(eve::reduce(data, eve::add), ref);
+  TTS_EQUAL(eve::reduce(data), ref);
 
-//   TTS_EQUAL(eve::reduce[eve::splat](data, [](auto a, auto b) { return a + b; }), T(ref));
-//   TTS_EQUAL(eve::reduce[eve::splat](data, eve::add), T(ref));
-//   TTS_EQUAL(eve::reduce[eve::splat](data), T(ref));
-// };
+  TTS_EQUAL(eve::reduce[eve::splat](data, [](auto a, auto b) { return a + b; }), T(ref));
+  TTS_EQUAL(eve::reduce[eve::splat](data, eve::add), T(ref));
+  TTS_EQUAL(eve::reduce[eve::splat](data), T(ref));
+};
 
-// //==================================================================================================
-// // Logical tests
-// //==================================================================================================
-// TTS_CASE_WITH("Check behavior of eve::reduce(eve::wide)",
-//               eve::test::simd::all_types,
-//               tts::generate(tts::logicals(0, 3)))
-// <typename T>(T const& a0)
-// {
-//   TTS_EQUAL(eve::reduce(a0, eve::logical_and), eve::all(a0));
-//   TTS_EQUAL(eve::reduce(a0, eve::logical_or), eve::any(a0));
-// };
+//==================================================================================================
+// Logical tests
+//==================================================================================================
+TTS_CASE_WITH("Check behavior of eve::reduce(eve::wide)",
+              eve::test::simd::all_types,
+              tts::generate(tts::logicals(0, 3)))
+<typename T>(T const& a0)
+{
+  TTS_EQUAL(eve::reduce(a0, eve::logical_and), eve::all(a0));
+  TTS_EQUAL(eve::reduce(a0, eve::logical_or), eve::any(a0));
+};
 
 //==================================================================================================
 // Neutral tests
 //==================================================================================================
-struct ManualProd
+struct ManualReduction
 {
   template<typename T, typename C>
   eve::element_type_t<T> operator()(T v, C mask) const
   {
-    auto res = eve::one(eve::as<eve::element_type_t<T>>{});
+    auto res = eve::zero(eve::as<eve::element_type_t<T>>{});
+
+    for (std::ptrdiff_t i = 0; i < v.size(); ++i)
+        res += mask_at(mask, i) ? v.get(i) : eve::one(eve::as<eve::element_type_t<T>>{});
+
+    return res;
+  }
+};
+
+struct ManualLogicalReduction
+{
+  template<typename T, typename C>
+  bool operator()(T v, C mask) const
+  {
+    auto res = false;
 
     for (std::ptrdiff_t i = 0; i < v.size(); ++i)
       if (mask_at(mask, i))
-        res *= v.get(i);
+        res = res ^ v.get(i);
+      else
+        res = res ^ true;
 
     return res;
   }
@@ -73,18 +89,43 @@ struct ManualProd
 
 namespace eve
 {
-  template<typename Options>
-  struct reduce_proxy_t : conditional_callable<reduce_proxy_t, Options, splat_option>
+  template<auto callable, auto neutral>
+  struct reduce_proxy
   {
-    template <typename T>
-    EVE_FORCEINLINE auto operator()(T v) const noexcept { return eve::reduce[this->options()](v, eve::mul, eve::one); }
+    template<typename Options>
+    struct proxy : conditional_callable<proxy, Options, splat_option>
+    {
+      template <typename T>
+      EVE_FORCEINLINE auto operator()(T v) const noexcept { return eve::reduce[this->options()](v, callable, neutral); }
+    };
+  };
+
+  template<typename Options>
+  struct reduce_proxy_scalar_logical : conditional_callable<reduce_proxy_scalar_logical, Options, splat_option>
+  {
+    template <logical_simd_value T>
+    EVE_FORCEINLINE auto operator()(T v) const noexcept
+    {
+      return eve::reduce[this->options()](v, eve::logical_xor, eve::element_type_t<T>{ true });
+    }
   };
 }
 
-TTS_CASE_WITH("Check behavior of eve::reduce with a neutral element",
+TTS_CASE_WITH("Check behavior of eve::reduce on arithmetic values with a neutral element",
               eve::test::simd::integers,
               tts::generate(tts::randoms(eve::valmin, eve::valmax)))
 <typename T>(T v)
 {
-  arithmetic_reduction_test_case<ManualProd>(eve::functor<eve::reduce_proxy_t>, v);
+  arithmetic_reduction_test_case<ManualReduction>(eve::functor<eve::reduce_proxy<eve::add, eve::one>::proxy>, v);
+  arithmetic_reduction_test_case<ManualReduction>(eve::functor<eve::reduce_proxy<eve::add, 1>::proxy>, v);
+};
+
+TTS_CASE_TPL("Check behavior of eve::reduce on logical values with a neutral element", eve::test::simd::all_types)
+<typename T>(tts::type<T>)
+{
+  auto run = [](auto f) { logical_reduction_simd_test_cases_ntb<ManualLogicalReduction>(f, eve::as<T>{}); };
+
+  run(eve::functor<eve::reduce_proxy<eve::logical_xor, eve::true_>::proxy>);
+  run(eve::functor<eve::reduce_proxy<eve::logical_xor, true>::proxy>);
+  run(eve::functor<eve::reduce_proxy_scalar_logical>);
 };

--- a/test/unit/module/core/reduction_test.hpp
+++ b/test/unit/module/core/reduction_test.hpp
@@ -45,7 +45,7 @@ struct TestRunner
   static void call_cx(Callable callable, T v, C cx);
 };
 
-template<typename TruthFn>
+template<typename TruthFn, bool SupportsTopBits>
 struct LogicalTestRunner : TestRunner<TruthFn>
 {
   template<typename Callable, typename T>
@@ -58,7 +58,7 @@ struct LogicalTestRunner : TestRunner<TruthFn>
 
     if constexpr (eve::simd_value<T>)
     {
-      TTS_EQUAL(callable(eve::top_bits{v}), manual_res);
+      if constexpr (SupportsTopBits) TTS_EQUAL(callable(eve::top_bits{v}), manual_res);
 
       if constexpr (eve::supports_options<callable, eve::splat>)
       {
@@ -81,7 +81,7 @@ struct LogicalTestRunner : TestRunner<TruthFn>
 
     if constexpr (eve::simd_value<T>)
     {
-      TTS_EQUAL(callable[cx](eve::top_bits{v}), manual_res);
+      if constexpr (SupportsTopBits)  TTS_EQUAL(callable[cx](eve::top_bits{v}), manual_res);
 
       if constexpr (eve::supports_options<callable, eve::splat>)
       {
@@ -141,8 +141,8 @@ struct ArithmeticTestRunner : TestRunner<TruthFn>
   }
 };
 
-template<typename TruthFn>
-constexpr LogicalTestRunner<TruthFn> logical_runner{};
+template<typename TruthFn, bool SupportsTopBits = true>
+constexpr LogicalTestRunner<TruthFn, SupportsTopBits> logical_runner{};
 
 template<typename TruthFn>
 constexpr ArithmeticTestRunner<TruthFn> arithmetic_runner{};
@@ -182,11 +182,11 @@ void logical_reduction_test_case(Callable callable, T v)
   reduction_test_case<TruthFn>(callable, v, runner);
 }
 
-template<typename TruthFn, typename Callable, typename T>
-void logical_reduction_simd_test_cases(Callable callable, eve::as<T> typ)
+template<typename TruthFn, typename Callable, typename T, bool SupportsTopBits>
+void logical_reduction_simd_test_cases_inner(Callable callable, eve::as<T> typ)
 {
   constexpr auto cardinal = eve::cardinal_v<T>;
-  constexpr auto runner = logical_runner<TruthFn>;
+  constexpr auto runner = logical_runner<TruthFn, SupportsTopBits>;
 
   reduction_test_case<TruthFn>(callable, eve::true_(typ), runner);
   reduction_test_case<TruthFn>(callable, eve::false_(typ), runner);
@@ -208,6 +208,18 @@ void logical_reduction_simd_test_cases(Callable callable, eve::as<T> typ)
     reduction_test_case<TruthFn>(callable, rhs3, runner);
     reduction_test_case<TruthFn>(callable, rhs4, runner);
   }
+}
+
+template<typename TruthFn, typename Callable, typename T>
+void logical_reduction_simd_test_cases(Callable callable, eve::as<T> typ)
+{
+  logical_reduction_simd_test_cases_inner<TruthFn, Callable, T, true>(callable, typ);
+}
+
+template<typename TruthFn, typename Callable, typename T>
+void logical_reduction_simd_test_cases_ntb(Callable callable, eve::as<T> typ)
+{
+  logical_reduction_simd_test_cases_inner<TruthFn, Callable, T, false>(callable, typ);
 }
 
 template<typename TruthFn, typename Callable, typename T>

--- a/test/unit/module/core/reduction_test.hpp
+++ b/test/unit/module/core/reduction_test.hpp
@@ -5,7 +5,7 @@
   SPDX-License-Identifier: BSL-1.0
 */
 //==================================================================================================
-
+#include "test.hpp"
 #include <eve/module/core.hpp>
 
 template<typename F, typename T, typename U>


### PR DESCRIPTION
Allows for things like
```c++
reduce[keep_last(2)](wide<int, fixed<4>>{ 1, 2, 3, 4 }, eve::mul, eve::one)
```