### PR TITLE
as_register: return type info through eve::as

### DIFF
--- a/include/eve/arch/arm/neon/as_register.hpp
+++ b/include/eve/arch/arm/neon/as_register.hpp
@@ -10,6 +10,8 @@
 #include <eve/arch/arm/predef.hpp>
 #include <eve/arch/float16.hpp>
 #include <eve/traits/as_integer.hpp>
+#include <eve/as.hpp>
+
 #include <type_traits>
 
 namespace eve
@@ -27,33 +29,33 @@ namespace eve
   {
     if constexpr (std::same_as<T, eve::float16_t> && (N::value <= 4))
     {
-      return float16x4_t{};
+      return as<float16x4_t>{};
     }
     else if constexpr (std::same_as<T, float> && (N::value <= 2))
     {
-      return float32x2_t{};
+      return as<float32x2_t>{};
     }
     else if constexpr (std::same_as<T, double> && (N::value <= 1))
     {
       #if defined(SPY_SIMD_IS_ARM_ASIMD)
-      return float64x1_t{};
+      return as<float64x1_t>{};
       #else
-      return emulated_{};
+      static_assert(false, "unreachable");
       #endif
     }
     else if constexpr (std::signed_integral<T>)
     {
-      if      constexpr((sizeof(T) == 1) && (N::value <= 8)) return int8x8_t{};
-      else if constexpr((sizeof(T) == 2) && (N::value <= 4)) return int16x4_t{};
-      else if constexpr((sizeof(T) == 4) && (N::value <= 2)) return int32x2_t{};
-      else if constexpr((sizeof(T) == 8) && (N::value <= 1)) return int64x1_t{};
+      if      constexpr((sizeof(T) == 1) && (N::value <= 8)) return as<int8x8_t>{};
+      else if constexpr((sizeof(T) == 2) && (N::value <= 4)) return as<int16x4_t>{};
+      else if constexpr((sizeof(T) == 4) && (N::value <= 2)) return as<int32x2_t>{};
+      else if constexpr((sizeof(T) == 8) && (N::value <= 1)) return as<int64x1_t>{};
     }
     else if constexpr (std::unsigned_integral<T>)
     {
-      if      constexpr((sizeof(T) == 1) && (N::value <= 8)) return uint8x8_t{};
-      else if constexpr((sizeof(T) == 2) && (N::value <= 4)) return uint16x4_t{};
-      else if constexpr((sizeof(T) == 4) && (N::value <= 2)) return uint32x2_t{};
-      else if constexpr((sizeof(T) == 8) && (N::value <= 1)) return uint64x1_t{};
+      if      constexpr((sizeof(T) == 1) && (N::value <= 8)) return as<uint8x8_t>{};
+      else if constexpr((sizeof(T) == 2) && (N::value <= 4)) return as<uint16x4_t>{};
+      else if constexpr((sizeof(T) == 4) && (N::value <= 2)) return as<uint32x2_t>{};
+      else if constexpr((sizeof(T) == 8) && (N::value <= 1)) return as<uint64x1_t>{};
     }
   }
 
@@ -64,33 +66,33 @@ namespace eve
   {
     if constexpr (std::same_as<T, eve::float16_t>)
     {
-      return float16x8_t{};
+      return as<float16x8_t>{};
     }
     else if constexpr (std::same_as<T, float>)
     {
-      return float32x4_t{};
+      return as<float32x4_t>{};
     }
     else if constexpr (std::same_as<T, double>)
     {
       #if defined(SPY_SIMD_IS_ARM_ASIMD)
-      return float64x2_t{};
+      return as<float64x2_t>{};
       #else
-      return emulated_{};
+      static_assert(false, "unreachable");
       #endif
     }
     else if constexpr (std::signed_integral<T>)
     {
-      if      constexpr ((sizeof(T) == 1) && (N::value == 16)) return int8x16_t{};
-      else if constexpr ((sizeof(T) == 2) && (N::value == 8 )) return int16x8_t{};
-      else if constexpr ((sizeof(T) == 4) && (N::value == 4 )) return int32x4_t{};
-      else if constexpr ((sizeof(T) == 8) && (N::value == 2 )) return int64x2_t{};
+      if      constexpr ((sizeof(T) == 1) && (N::value == 16)) return as<int8x16_t>{};
+      else if constexpr ((sizeof(T) == 2) && (N::value == 8 )) return as<int16x8_t>{};
+      else if constexpr ((sizeof(T) == 4) && (N::value == 4 )) return as<int32x4_t>{};
+      else if constexpr ((sizeof(T) == 8) && (N::value == 2 )) return as<int64x2_t>{};
     }
     else if constexpr (std::unsigned_integral<T>)
     {
-      if      constexpr ((sizeof(T) == 1) && (N::value == 16)) return uint8x16_t{};
-      else if constexpr ((sizeof(T) == 2) && (N::value == 8 )) return uint16x8_t{};
-      else if constexpr ((sizeof(T) == 4) && (N::value == 4 )) return uint32x4_t{};
-      else if constexpr ((sizeof(T) == 8) && (N::value == 2 )) return uint64x2_t{};
+      if      constexpr ((sizeof(T) == 1) && (N::value == 16)) return as<uint8x16_t>{};
+      else if constexpr ((sizeof(T) == 2) && (N::value == 8 )) return as<uint16x8_t>{};
+      else if constexpr ((sizeof(T) == 4) && (N::value == 4 )) return as<uint32x4_t>{};
+      else if constexpr ((sizeof(T) == 8) && (N::value == 2 )) return as<uint64x2_t>{};
     }
   }
 

--- a/include/eve/arch/arm/sve/as_register.hpp
+++ b/include/eve/arch/arm/sve/as_register.hpp
@@ -10,6 +10,8 @@
 #include <eve/arch/arm/predef.hpp>
 #include <eve/arch/float16.hpp>
 #include <eve/traits/as_integer.hpp>
+#include <eve/as.hpp>
+
 #include <type_traits>
 
 namespace eve
@@ -30,39 +32,39 @@ namespace eve
       if constexpr (std::same_as<T, eve::float16_t>)
       {
         using type = svfloat16_t __attribute__((arm_sve_vector_bits(__ARM_FEATURE_SVE_BITS)));
-        return type{};
+        return as<type>{};
       }
       else if constexpr (std::same_as<T, float>)
       {
         using type = svfloat32_t __attribute__((arm_sve_vector_bits(__ARM_FEATURE_SVE_BITS)));
-        return type{};
+        return as<type>{};
       }
       else if constexpr (std::same_as<T, double>)
       {
         using type = svfloat64_t __attribute__((arm_sve_vector_bits(__ARM_FEATURE_SVE_BITS)));
-        return type{};
+        return as<type>{};
       }
       else if constexpr (std::signed_integral<T>)
       {
         if constexpr (sizeof(T) == 1)
         {
           using type = svint8_t __attribute__((arm_sve_vector_bits(__ARM_FEATURE_SVE_BITS)));
-          return type{};
+          return as<type>{};
         }
         else if constexpr (sizeof(T) == 2)
         {
           using type = svint16_t __attribute__((arm_sve_vector_bits(__ARM_FEATURE_SVE_BITS)));
-          return type{};
+          return as<type>{};
         }
         else if constexpr (sizeof(T) == 4)
         {
           using type = svint32_t __attribute__((arm_sve_vector_bits(__ARM_FEATURE_SVE_BITS)));
-          return type{};
+          return as<type>{};
         }
         else if constexpr (sizeof(T) == 8)
         {
           using type = svint64_t __attribute__((arm_sve_vector_bits(__ARM_FEATURE_SVE_BITS)));
-          return type{};
+          return as<type>{};
         }
       }
       else if constexpr (std::unsigned_integral<T>)
@@ -70,22 +72,22 @@ namespace eve
         if constexpr (sizeof(T) == 1)
         {
           using type = svuint8_t __attribute__((arm_sve_vector_bits(__ARM_FEATURE_SVE_BITS)));
-          return type{};
+          return as<type>{};
         }
         else if constexpr (sizeof(T) == 2)
         {
           using type = svuint16_t __attribute__((arm_sve_vector_bits(__ARM_FEATURE_SVE_BITS)));
-          return type{};
+          return as<type>{};
         }
         else if constexpr (sizeof(T) == 4)
         {
           using type = svuint32_t __attribute__((arm_sve_vector_bits(__ARM_FEATURE_SVE_BITS)));
-          return type{};
+          return as<type>{};
         }
         else if constexpr (sizeof(T) == 8)
         {
           using type = svuint64_t __attribute__((arm_sve_vector_bits(__ARM_FEATURE_SVE_BITS)));
-          return type{};
+          return as<type>{};
         }
       }
     }
@@ -101,7 +103,7 @@ namespace eve
     if constexpr (width <= __ARM_FEATURE_SVE_BITS)
     {
       using type = svbool_t __attribute__((arm_sve_vector_bits(__ARM_FEATURE_SVE_BITS)));
-      return type{};
+      return as<type>{};
     }
   }
 }

--- a/include/eve/arch/as_register.hpp
+++ b/include/eve/arch/as_register.hpp
@@ -38,7 +38,7 @@ namespace eve
   }
 
   template<typename T, typename N, typename ABI>
-  using as_register_t = decltype(as_register(as<T>{}, N{}, ABI{}));
+  using as_register_t = typename decltype(as_register(as<T>{}, N{}, ABI{}))::type;
 
   template<typename T, typename N, typename ABI>
   consteval auto as_logical_register(as<T> t, N n, ABI abi)
@@ -51,5 +51,5 @@ namespace eve
   }
 
   template<typename T, typename N, typename ABI>
-  using as_logical_register_t = decltype(as_logical_register(as<T>{}, N{}, ABI{}));
+  using as_logical_register_t = typename decltype(as_logical_register(as<T>{}, N{}, ABI{}))::type;
 }

--- a/include/eve/arch/cpu/as_register.hpp
+++ b/include/eve/arch/cpu/as_register.hpp
@@ -21,13 +21,13 @@ namespace eve
   template<typename T, typename N>
   consteval auto find_register_type(as<T>, N, eve::emulated_)
   {
-    return std::array<T, N::value>{};
+    return as<std::array<T, N::value>>{};
   }
 
   template<typename T, typename N>
   consteval auto find_logical_register_type(as<T>, N, eve::emulated_)
   {
-    return std::array<logical<T>, N::value>{};
+    return as<std::array<logical<T>, N::value>>{};
   }
 
   //================================================================================================
@@ -47,7 +47,7 @@ namespace eve
   consteval auto find_register_type(as<T>, N, eve::bundle_)
     requires (kumi::product_type<T>)
   {
-    return kumi::as_tuple_t<T, detail::apply_as_wide<N>::template type>{};
+    return as<kumi::as_tuple_t<T, detail::apply_as_wide<N>::template type>>{};
   }
 
   namespace detail
@@ -117,13 +117,13 @@ namespace eve
   template<typename T, typename N>
   consteval auto find_register_type(as<T>, N, eve::aggregated_)
   {
-    return detail::blob<T, N>{};
+    return as<detail::blob<T, N>>{};
   }
 
   template<typename T, typename N>
   consteval auto find_logical_register_type(as<T>, N, eve::aggregated_)
   {
-    return detail::blob<logical<T>, N>{};
+    return as<detail::blob<logical<T>, N>>{};
   }
 }
 

--- a/include/eve/arch/ppc/as_register.hpp
+++ b/include/eve/arch/ppc/as_register.hpp
@@ -8,6 +8,8 @@
 #pragma once
 
 #include <eve/arch/ppc/predef.hpp>
+#include <eve/as.hpp>
+
 #include <type_traits>
 
 namespace eve
@@ -36,40 +38,34 @@ namespace eve
 
     if constexpr (std::same_as<T, float> && (N::value <= 4))
     {
-      return wrap<__vector float>{}; 
+      return as<wrap<__vector float>>{};
     }
     else if constexpr (std::same_as<T, double> && (N::value <= 2))
     {
-      if constexpr (spy::simd_instruction_set >= spy::vsx_) return wrap<__vector double>{};
-      else                                                  return emulated_{};
+      if constexpr (spy::simd_instruction_set >= spy::vsx_) return as<wrap<__vector double>>{};
+      else                                                  static_assert(false, "unreachable");
     }
     else if constexpr (std::signed_integral<T>)
     {
-      if      constexpr (size_check(1, 16)) return wrap<__vector signed char>{};
-      else if constexpr (size_check(2,  8)) return wrap<__vector signed short>{};
-      else if constexpr (size_check(4,  4)) return wrap<__vector signed int>{};
+      if      constexpr (size_check(1, 16)) return as<wrap<__vector signed char>>{};
+      else if constexpr (size_check(2,  8)) return as<wrap<__vector signed short>>{};
+      else if constexpr (size_check(4,  4)) return as<wrap<__vector signed int>>{};
       else if constexpr (spy::simd_instruction_set >= spy::vsx_)
       {
-        if constexpr (size_check(8, 2)) return wrap<__vector signed long>{};
+        if constexpr (size_check(8, 2))     return as<wrap<__vector signed long>>{};
       }
-      else
-      {
-        if constexpr (size_check(8, 1)) return emulated_{};
-      }
+      else                                  static_assert(false, "unreachable");
     }
     else if constexpr (std::unsigned_integral<T>)
     {
-      if      constexpr (size_check(1, 16)) return wrap<__vector unsigned char>{};
-      else if constexpr (size_check(2,  8)) return wrap<__vector unsigned short>{};
-      else if constexpr (size_check(4,  4)) return wrap<__vector unsigned int>{};
+      if      constexpr (size_check(1, 16)) return as<wrap<__vector unsigned char>>{};
+      else if constexpr (size_check(2,  8)) return as<wrap<__vector unsigned short>>{};
+      else if constexpr (size_check(4,  4)) return as<wrap<__vector unsigned int>>{};
       else if constexpr (spy::simd_instruction_set >= spy::vsx_)
       {
-        if constexpr (size_check(8, 2)) return wrap<__vector unsigned long>{};
+        if constexpr (size_check(8, 2))     return as<wrap<__vector unsigned long>>{};
       }
-      else
-      {
-        if constexpr (size_check(8, 1)) return emulated_{};
-      }
+      else                                  static_assert(false, "unreachable");
     }
   }
 
@@ -85,25 +81,25 @@ namespace eve
 
     if constexpr (std::is_same_v<T, float> && (N::value <= 4))
     {
-      return wrap<__vector __bool int>{};
+      return as<wrap<__vector __bool int>>{};
     }
     else if constexpr (std::is_same_v<T, double> && (N::value <= 2))
     {
-      if constexpr (spy::simd_instruction_set >= spy::vsx_) return wrap<__vector __bool long>{};
-      else                                                  return emulated_{};
+      if constexpr (spy::simd_instruction_set >= spy::vsx_) return as<wrap<__vector __bool long>>{};
+      else                                                  static_assert(false, "unreachable");
     }
     else if constexpr (std::integral<T>)
     {
-      if      constexpr (size_check(1, 16))  return wrap<__vector __bool char>{};
-      else if constexpr (size_check(2, 8 ))  return wrap<__vector __bool short>{};
-      else if constexpr (size_check(4, 4 ))  return wrap<__vector __bool int>{};
+      if      constexpr (size_check(1, 16))  return as<wrap<__vector __bool char>>{};
+      else if constexpr (size_check(2, 8 ))  return as<wrap<__vector __bool short>>{};
+      else if constexpr (size_check(4, 4 ))  return as<wrap<__vector __bool int>>{};
       else if constexpr (spy::simd_instruction_set >= spy::vsx_)
       {
-        if constexpr (size_check(8,2))  return wrap<__vector __bool long>{};
+        if constexpr (size_check(8,2))  return as<wrap<__vector __bool long>>{};
       }
       else
       {
-        if constexpr (size_check(8, 2)) return emulated_{};
+        if constexpr (size_check(8, 2)) static_assert(false, "unreachable");
       }
     }
   }

--- a/include/eve/arch/riscv/as_register.hpp
+++ b/include/eve/arch/riscv/as_register.hpp
@@ -10,6 +10,7 @@
 #include <eve/arch/riscv/predef.hpp>
 #include <eve/arch/riscv/rvv_utils.hpp>
 #include <eve/traits/as_integer.hpp>
+#include <eve/as.hpp>
 
 #include <type_traits>
 
@@ -53,32 +54,32 @@ namespace eve
     {
       if constexpr (lmul == 1)
       {
-        if      constexpr (element_bit_size == 16) return wrap<EVE_RVV_M(vfloat16m1_t, 1)>{};
-        else if constexpr (element_bit_size == 32) return wrap<EVE_RVV_M(vfloat32m1_t, 1)>{};
-        else if constexpr (element_bit_size == 64) return wrap<EVE_RVV_M(vfloat64m1_t, 1)>{};
+        if      constexpr (element_bit_size == 16) return as<wrap<EVE_RVV_M(vfloat16m1_t, 1)>>{};
+        else if constexpr (element_bit_size == 32) return as<wrap<EVE_RVV_M(vfloat32m1_t, 1)>>{};
+        else if constexpr (element_bit_size == 64) return as<wrap<EVE_RVV_M(vfloat64m1_t, 1)>>{};
       }
       else if constexpr (lmul == 2)
       {
-        if      constexpr (element_bit_size == 16) return wrap<EVE_RVV_M(vfloat16m2_t, 2)>{};
-        else if constexpr (element_bit_size == 32) return wrap<EVE_RVV_M(vfloat32m2_t, 2)>{};
-        else if constexpr (element_bit_size == 64) return wrap<EVE_RVV_M(vfloat64m2_t, 2)>{};
+        if      constexpr (element_bit_size == 16) return as<wrap<EVE_RVV_M(vfloat16m2_t, 2)>>{};
+        else if constexpr (element_bit_size == 32) return as<wrap<EVE_RVV_M(vfloat32m2_t, 2)>>{};
+        else if constexpr (element_bit_size == 64) return as<wrap<EVE_RVV_M(vfloat64m2_t, 2)>>{};
       }
       else if constexpr (lmul == 4)
       {
-        if      constexpr (element_bit_size == 16) return wrap<EVE_RVV_M(vfloat16m4_t, 4)>{};
-        else if constexpr (element_bit_size == 32) return wrap<EVE_RVV_M(vfloat32m4_t, 4)>{};
-        else if constexpr (element_bit_size == 64) return wrap<EVE_RVV_M(vfloat64m4_t, 4)>{};
+        if      constexpr (element_bit_size == 16) return as<wrap<EVE_RVV_M(vfloat16m4_t, 4)>>{};
+        else if constexpr (element_bit_size == 32) return as<wrap<EVE_RVV_M(vfloat32m4_t, 4)>>{};
+        else if constexpr (element_bit_size == 64) return as<wrap<EVE_RVV_M(vfloat64m4_t, 4)>>{};
       }
       else if constexpr (lmul == 8)
       {
-        if      constexpr (element_bit_size == 16) return wrap<EVE_RVV_M(vfloat16m8_t, 8)>{};
-        else if constexpr (element_bit_size == 32) return wrap<EVE_RVV_M(vfloat32m8_t, 8)>{};
-        else if constexpr (element_bit_size == 64) return wrap<EVE_RVV_M(vfloat64m8_t, 8)>{};
+        if      constexpr (element_bit_size == 16) return as<wrap<EVE_RVV_M(vfloat16m8_t, 8)>>{};
+        else if constexpr (element_bit_size == 32) return as<wrap<EVE_RVV_M(vfloat32m8_t, 8)>>{};
+        else if constexpr (element_bit_size == 64) return as<wrap<EVE_RVV_M(vfloat64m8_t, 8)>>{};
       }
       else if constexpr (lmul == -2)
       {
-        if      constexpr (element_bit_size == 16) return wrap<EVE_RVV_MF(vfloat16mf2_t, 2)>{};
-        else if constexpr (element_bit_size == 32) return wrap<EVE_RVV_MF(vfloat32mf2_t, 2)>{};
+        if      constexpr (element_bit_size == 16) return as<wrap<EVE_RVV_MF(vfloat16mf2_t, 2)>>{};
+        else if constexpr (element_bit_size == 32) return as<wrap<EVE_RVV_MF(vfloat32mf2_t, 2)>>{};
       }
       // MF8, MF4 for float not supported.
     }
@@ -86,92 +87,92 @@ namespace eve
     {
       if constexpr (lmul == 1)
       {
-        if      constexpr (element_bit_size == 8 ) return wrap<EVE_RVV_M(vint8m1_t, 1)>{};
-        else if constexpr (element_bit_size == 16) return wrap<EVE_RVV_M(vint16m1_t, 1)>{};
-        else if constexpr (element_bit_size == 32) return wrap<EVE_RVV_M(vint32m1_t, 1)>{};
-        else if constexpr (element_bit_size == 64) return wrap<EVE_RVV_M(vint64m1_t, 1)>{};
+        if      constexpr (element_bit_size == 8 ) return as<wrap<EVE_RVV_M(vint8m1_t, 1)>>{};
+        else if constexpr (element_bit_size == 16) return as<wrap<EVE_RVV_M(vint16m1_t, 1)>>{};
+        else if constexpr (element_bit_size == 32) return as<wrap<EVE_RVV_M(vint32m1_t, 1)>>{};
+        else if constexpr (element_bit_size == 64) return as<wrap<EVE_RVV_M(vint64m1_t, 1)>>{};
       }
       else if constexpr (lmul == 2)
       {
-        if      constexpr (element_bit_size == 8 ) return wrap<EVE_RVV_M(vint8m2_t, 2)>{};
-        else if constexpr (element_bit_size == 16) return wrap<EVE_RVV_M(vint16m2_t, 2)>{};
-        else if constexpr (element_bit_size == 32) return wrap<EVE_RVV_M(vint32m2_t, 2)>{};
-        else if constexpr (element_bit_size == 64) return wrap<EVE_RVV_M(vint64m2_t, 2)>{};
+        if      constexpr (element_bit_size == 8 ) return as<wrap<EVE_RVV_M(vint8m2_t, 2)>>{};
+        else if constexpr (element_bit_size == 16) return as<wrap<EVE_RVV_M(vint16m2_t, 2)>>{};
+        else if constexpr (element_bit_size == 32) return as<wrap<EVE_RVV_M(vint32m2_t, 2)>>{};
+        else if constexpr (element_bit_size == 64) return as<wrap<EVE_RVV_M(vint64m2_t, 2)>>{};
       }
       else if constexpr (lmul == 4)
       {
-        if      constexpr (element_bit_size == 8 ) return wrap<EVE_RVV_M(vint8m4_t, 4)>{};
-        else if constexpr (element_bit_size == 16) return wrap<EVE_RVV_M(vint16m4_t, 4)>{};
-        else if constexpr (element_bit_size == 32) return wrap<EVE_RVV_M(vint32m4_t, 4)>{};
-        else if constexpr (element_bit_size == 64) return wrap<EVE_RVV_M(vint64m4_t, 4)>{};
+        if      constexpr (element_bit_size == 8 ) return as<wrap<EVE_RVV_M(vint8m4_t, 4)>>{};
+        else if constexpr (element_bit_size == 16) return as<wrap<EVE_RVV_M(vint16m4_t, 4)>>{};
+        else if constexpr (element_bit_size == 32) return as<wrap<EVE_RVV_M(vint32m4_t, 4)>>{};
+        else if constexpr (element_bit_size == 64) return as<wrap<EVE_RVV_M(vint64m4_t, 4)>>{};
       }
       else if constexpr (lmul == 8)
       {
-        if      constexpr (element_bit_size == 8 ) return wrap<EVE_RVV_M(vint8m8_t, 8)>{};
-        else if constexpr (element_bit_size == 16) return wrap<EVE_RVV_M(vint16m8_t, 8)>{};
-        else if constexpr (element_bit_size == 32) return wrap<EVE_RVV_M(vint32m8_t, 8)>{};
-        else if constexpr (element_bit_size == 64) return wrap<EVE_RVV_M(vint64m8_t, 8)>{};
+        if      constexpr (element_bit_size == 8 ) return as<wrap<EVE_RVV_M(vint8m8_t, 8)>>{};
+        else if constexpr (element_bit_size == 16) return as<wrap<EVE_RVV_M(vint16m8_t, 8)>>{};
+        else if constexpr (element_bit_size == 32) return as<wrap<EVE_RVV_M(vint32m8_t, 8)>>{};
+        else if constexpr (element_bit_size == 64) return as<wrap<EVE_RVV_M(vint64m8_t, 8)>>{};
       }
       else if constexpr (lmul == -2)
       {
-        if      constexpr (element_bit_size == 8 ) return wrap<EVE_RVV_MF(vint8mf2_t, 2)>{};
-        else if constexpr (element_bit_size == 16) return wrap<EVE_RVV_MF(vint16mf2_t, 2)>{};
-        else if constexpr (element_bit_size == 32) return wrap<EVE_RVV_MF(vint32mf2_t, 2)>{};
+        if      constexpr (element_bit_size == 8 ) return as<wrap<EVE_RVV_MF(vint8mf2_t, 2)>>{};
+        else if constexpr (element_bit_size == 16) return as<wrap<EVE_RVV_MF(vint16mf2_t, 2)>>{};
+        else if constexpr (element_bit_size == 32) return as<wrap<EVE_RVV_MF(vint32mf2_t, 2)>>{};
       }
       else if constexpr (lmul == -4)
       {
-        if      constexpr (element_bit_size == 8 ) return wrap<EVE_RVV_MF(vint8mf4_t, 4)>{};
-        else if constexpr (element_bit_size == 16) return wrap<EVE_RVV_MF(vint16mf4_t, 4)>{};
+        if      constexpr (element_bit_size == 8 ) return as<wrap<EVE_RVV_MF(vint8mf4_t, 4)>>{};
+        else if constexpr (element_bit_size == 16) return as<wrap<EVE_RVV_MF(vint16mf4_t, 4)>>{};
       }
       else if constexpr (lmul == -8)
       {
-        if      constexpr (element_bit_size == 8 ) return wrap<EVE_RVV_MF(vint8mf8_t, 8)>{};
+        if      constexpr (element_bit_size == 8 ) return as<wrap<EVE_RVV_MF(vint8mf8_t, 8)>>{};
       }
     }
     else if constexpr (std::unsigned_integral<T>)
     {
       if constexpr (lmul == 1)
       {
-        if      constexpr (element_bit_size == 8 ) return wrap<EVE_RVV_M(vuint8m1_t, 1)>{};
-        else if constexpr (element_bit_size == 16) return wrap<EVE_RVV_M(vuint16m1_t, 1)>{};
-        else if constexpr (element_bit_size == 32) return wrap<EVE_RVV_M(vuint32m1_t, 1)>{};
-        else if constexpr (element_bit_size == 64) return wrap<EVE_RVV_M(vuint64m1_t, 1)>{};
+        if      constexpr (element_bit_size == 8 ) return as<wrap<EVE_RVV_M(vuint8m1_t, 1)>>{};
+        else if constexpr (element_bit_size == 16) return as<wrap<EVE_RVV_M(vuint16m1_t, 1)>>{};
+        else if constexpr (element_bit_size == 32) return as<wrap<EVE_RVV_M(vuint32m1_t, 1)>>{};
+        else if constexpr (element_bit_size == 64) return as<wrap<EVE_RVV_M(vuint64m1_t, 1)>>{};
       }
       else if constexpr (lmul == 2)
       {
-        if      constexpr (element_bit_size == 8 ) return wrap<EVE_RVV_M(vuint8m2_t, 2)>{};
-        else if constexpr (element_bit_size == 16) return wrap<EVE_RVV_M(vuint16m2_t, 2)>{};
-        else if constexpr (element_bit_size == 32) return wrap<EVE_RVV_M(vuint32m2_t, 2)>{};
-        else if constexpr (element_bit_size == 64) return wrap<EVE_RVV_M(vuint64m2_t, 2)>{};
+        if      constexpr (element_bit_size == 8 ) return as<wrap<EVE_RVV_M(vuint8m2_t, 2)>>{};
+        else if constexpr (element_bit_size == 16) return as<wrap<EVE_RVV_M(vuint16m2_t, 2)>>{};
+        else if constexpr (element_bit_size == 32) return as<wrap<EVE_RVV_M(vuint32m2_t, 2)>>{};
+        else if constexpr (element_bit_size == 64) return as<wrap<EVE_RVV_M(vuint64m2_t, 2)>>{};
       }
       else if constexpr (lmul == 4)
       {
-        if      constexpr (element_bit_size == 8 ) return wrap<EVE_RVV_M(vuint8m4_t, 4)>{};
-        else if constexpr (element_bit_size == 16) return wrap<EVE_RVV_M(vuint16m4_t, 4)>{};
-        else if constexpr (element_bit_size == 32) return wrap<EVE_RVV_M(vuint32m4_t, 4)>{};
-        else if constexpr (element_bit_size == 64) return wrap<EVE_RVV_M(vuint64m4_t, 4)>{};
+        if      constexpr (element_bit_size == 8 ) return as<wrap<EVE_RVV_M(vuint8m4_t, 4)>>{};
+        else if constexpr (element_bit_size == 16) return as<wrap<EVE_RVV_M(vuint16m4_t, 4)>>{};
+        else if constexpr (element_bit_size == 32) return as<wrap<EVE_RVV_M(vuint32m4_t, 4)>>{};
+        else if constexpr (element_bit_size == 64) return as<wrap<EVE_RVV_M(vuint64m4_t, 4)>>{};
       }
       else if constexpr (lmul == 8)
       {
-        if      constexpr (element_bit_size == 8 ) return wrap<EVE_RVV_M(vuint8m8_t, 8)>{};
-        else if constexpr (element_bit_size == 16) return wrap<EVE_RVV_M(vuint16m8_t, 8)>{};
-        else if constexpr (element_bit_size == 32) return wrap<EVE_RVV_M(vuint32m8_t, 8)>{};
-        else if constexpr (element_bit_size == 64) return wrap<EVE_RVV_M(vuint64m8_t, 8)>{};
+        if      constexpr (element_bit_size == 8 ) return as<wrap<EVE_RVV_M(vuint8m8_t, 8)>>{};
+        else if constexpr (element_bit_size == 16) return as<wrap<EVE_RVV_M(vuint16m8_t, 8)>>{};
+        else if constexpr (element_bit_size == 32) return as<wrap<EVE_RVV_M(vuint32m8_t, 8)>>{};
+        else if constexpr (element_bit_size == 64) return as<wrap<EVE_RVV_M(vuint64m8_t, 8)>>{};
       }
       else if constexpr (lmul == -2)
       {
-        if      constexpr (element_bit_size == 8 ) return wrap<EVE_RVV_MF(vuint8mf2_t, 2)>{};
-        else if constexpr (element_bit_size == 16) return wrap<EVE_RVV_MF(vuint16mf2_t, 2)>{};
-        else if constexpr (element_bit_size == 32) return wrap<EVE_RVV_MF(vuint32mf2_t, 2)>{};
+        if      constexpr (element_bit_size == 8 ) return as<wrap<EVE_RVV_MF(vuint8mf2_t, 2)>>{};
+        else if constexpr (element_bit_size == 16) return as<wrap<EVE_RVV_MF(vuint16mf2_t, 2)>>{};
+        else if constexpr (element_bit_size == 32) return as<wrap<EVE_RVV_MF(vuint32mf2_t, 2)>>{};
       }
       else if constexpr (lmul == -4)
       {
-        if      constexpr (element_bit_size == 8 ) return wrap<EVE_RVV_MF(vuint8mf4_t, 4)>{};
-        else if constexpr (element_bit_size == 16) return wrap<EVE_RVV_MF(vuint16mf4_t, 4)>{};
+        if      constexpr (element_bit_size == 8 ) return as<wrap<EVE_RVV_MF(vuint8mf4_t, 4)>>{};
+        else if constexpr (element_bit_size == 16) return as<wrap<EVE_RVV_MF(vuint16mf4_t, 4)>>{};
       }
       else if constexpr (lmul == -8)
       {
-        if      constexpr (element_bit_size == 8 ) return wrap<EVE_RVV_MF(vuint8mf8_t, 8)>{};
+        if      constexpr (element_bit_size == 8 ) return as<wrap<EVE_RVV_MF(vuint8mf8_t, 8)>>{};
       }
     }
   }
@@ -185,13 +186,13 @@ namespace eve
 
     constexpr size_t ratio = detail::rvv_logical_ratio_v<T, N>;
 
-    if      constexpr (ratio == 1 ) return wrap<EVE_RVV_MF(vbool1_t, 1)>{};
-    else if constexpr (ratio == 2 ) return wrap<EVE_RVV_MF(vbool2_t, 2)>{};
-    else if constexpr (ratio == 4 ) return wrap<EVE_RVV_MF(vbool4_t, 4)>{};
-    else if constexpr (ratio == 8 ) return wrap<EVE_RVV_MF(vbool8_t, 8)>{};
-    else if constexpr (ratio == 16) return wrap<EVE_RVV_MF(vbool16_t, 16)>{};
-    else if constexpr (ratio == 32) return wrap<EVE_RVV_MF(vbool32_t, 32)>{};
-    else if constexpr (ratio == 64) return wrap<EVE_RVV_MF(vbool64_t, 64)>{};
+    if      constexpr (ratio == 1 ) return as<wrap<EVE_RVV_MF(vbool1_t, 1)>>{};
+    else if constexpr (ratio == 2 ) return as<wrap<EVE_RVV_MF(vbool2_t, 2)>>{};
+    else if constexpr (ratio == 4 ) return as<wrap<EVE_RVV_MF(vbool4_t, 4)>>{};
+    else if constexpr (ratio == 8 ) return as<wrap<EVE_RVV_MF(vbool8_t, 8)>>{};
+    else if constexpr (ratio == 16) return as<wrap<EVE_RVV_MF(vbool16_t, 16)>>{};
+    else if constexpr (ratio == 32) return as<wrap<EVE_RVV_MF(vbool32_t, 32)>>{};
+    else if constexpr (ratio == 64) return as<wrap<EVE_RVV_MF(vbool64_t, 64)>>{};
   }
 }
 

--- a/include/eve/arch/x86/as_register.hpp
+++ b/include/eve/arch/x86/as_register.hpp
@@ -9,6 +9,8 @@
 
 #include <eve/arch/x86/predef.hpp>
 #include <eve/arch/float16.hpp>
+#include <eve/as.hpp>
+
 #include <compare>
 #include <type_traits>
 #include <ostream>
@@ -32,30 +34,30 @@ namespace eve
     {
       if constexpr (width <= 16)
       {
-             if constexpr (std::same_as<T, double>)         return __m128d{};
-        else if constexpr (std::same_as<T, float >)         return __m128{};
-        else if constexpr (std::same_as<T, eve::float16_t>) return __m128h{};
-        else if constexpr (std::is_integral_v<T>  )         return __m128i{};
+        if      constexpr (std::same_as<T, double>)         return as<__m128d>{};
+        else if constexpr (std::same_as<T, float >)         return as<__m128>{};
+        else if constexpr (std::same_as<T, eve::float16_t>) return as<__m128h>{};
+        else if constexpr (std::is_integral_v<T>  )         return as<__m128i>{};
       }
     }
     else if constexpr (std::same_as<ABI, x86_256_>)
     {
       if constexpr (width <= 32)
       {
-             if constexpr (std::same_as<T, double>)         return __m256d{};
-        else if constexpr (std::same_as<T, float >)         return __m256{};
-        else if constexpr (std::same_as<T, eve::float16_t>) return __m256h{};
-        else if constexpr (std::is_integral_v<T>  )         return __m256i{};
+        if      constexpr (std::same_as<T, double>)         return as<__m256d>{};
+        else if constexpr (std::same_as<T, float >)         return as<__m256>{};
+        else if constexpr (std::same_as<T, eve::float16_t>) return as<__m256h>{};
+        else if constexpr (std::is_integral_v<T>  )         return as<__m256i>{};
       }
     }
     else if constexpr (std::same_as<ABI, x86_512_>)
     {
       if constexpr (width <= 64)
       {
-        if      constexpr (std::same_as<T, double>)         return __m512d{};
-        else if constexpr (std::same_as<T, float >)         return __m512{};
-        else if constexpr (std::same_as<T, eve::float16_t>) return __m512h{};
-        else if constexpr (std::is_integral_v<T>  )         return __m512i{};
+        if      constexpr (std::same_as<T, double>)         return as<__m512d>{};
+        else if constexpr (std::same_as<T, float >)         return as<__m512>{};
+        else if constexpr (std::same_as<T, eve::float16_t>) return as<__m512h>{};
+        else if constexpr (std::is_integral_v<T>  )         return as<__m512i>{};
       }
     }
   }
@@ -138,18 +140,18 @@ namespace eve
 
     if constexpr (std::same_as<ABI, x86_512_> && (width == 64))
     {
-      return detail::as_mask_t<64 / sizeof(T)>{};
+      return as<detail::as_mask_t<64 / sizeof(T)>>{};
     }
     else if constexpr (std::same_as<ABI, x86_256_> && (width == 32))
     {
-      if constexpr (N::value <= 8 ) return detail::mask8{};
-      if constexpr (N::value == 16) return detail::mask16{};
-      if constexpr (N::value == 32) return detail::mask32{};
+      if constexpr (N::value <= 8 ) return as<detail::mask8>{};
+      if constexpr (N::value == 16) return as<detail::mask16>{};
+      if constexpr (N::value == 32) return as<detail::mask32>{};
     }
     else if constexpr (std::same_as<ABI, x86_128_> && (width <= 16))
     {
-      if constexpr (sizeof(T) == 1) return detail::mask16{};
-      else                          return detail::mask8{};
+      if constexpr (sizeof(T) == 1) return as<detail::mask16>{};
+      else                          return as<detail::mask8>{};
     }
   }
 # else


### PR DESCRIPTION
This will be needed for a later change to `as_register` with emulated ABI.