### PR TITLE
mm_shuffle_ps

### DIFF
--- a/include/eve/detail/shuffle_v2/simd/x86/idxm.hpp
+++ b/include/eve/detail/shuffle_v2/simd/x86/idxm.hpp
@@ -156,47 +156,64 @@ slide_2_left_in_16_pattern(std::ptrdiff_t g_size, std::ptrdiff_t slide)
 }
 
 template<std::ptrdiff_t g_size, std::size_t N>
+constexpr std::optional<int> x86_shuffle_ps_2(const std::array<std::ptrdiff_t, N>& repeated_part,
+                                              std::ptrdiff_t                       reg_groups);
+
+template<std::ptrdiff_t g_size, std::size_t N>
 constexpr std::optional<int>
-x86_shuffle_ps_2(std::span<const std::ptrdiff_t, N> idxs_)
+x86_shuffle_ps_2(std::span<const std::ptrdiff_t, N> repeated_part, std::ptrdiff_t reg_groups)
 {
-  auto           idxs = expand_group<g_size / 4>(idxs_);
-  std::ptrdiff_t size = std::ssize(idxs);
-  std::ptrdiff_t res  = 0;
-
-  for( std::ptrdiff_t i = 0; i != size; ++i )
+  if constexpr( g_size != 4 )
   {
-    if( idxs[i] < 0 ) { continue; }
-
-    // 2 indexes from x, 2 indexes from y
-    std::ptrdiff_t active_register_offset = (i & 2) * size / 2;
-    std::ptrdiff_t within_register_offset = i / 4;
-    std::ptrdiff_t offset                 = active_register_offset + within_register_offset;
-
-    std::ptrdiff_t selected = idxs[i] - offset;
-
-    if( selected < 0 || selected >= 4 ) { return std::nullopt; }
-
-    res |= selected << (i * 2);
+    return x86_shuffle_ps_2<4>(expand_group<g_size / 4>(repeated_part), reg_groups * g_size / 4);
   }
+  else
+  {
+    if( std::ssize(repeated_part) != 4 ) return std::nullopt;
 
-  return static_cast<int>(res);
+    int res = 0;
+
+    for( std::ptrdiff_t i = 0; i != 4; ++i )
+    {
+      std::ptrdiff_t idx = repeated_part[i];
+
+      if( idx < 0 ) { continue; }
+
+      if( i < 2 )
+      {
+        if( idx > reg_groups ) return std::nullopt;
+      }
+      else
+      {
+        if( idx < reg_groups ) return std::nullopt;
+        idx -= reg_groups;
+      }
+
+      res |= idx << (i + i);
+    }
+
+    return res;
+  }
 }
 
 template<std::ptrdiff_t g_size, std::size_t N>
 constexpr std::optional<int>
-x86_shuffle_ps_2(const std::array<std::ptrdiff_t, N> idxs)
+x86_shuffle_ps_2(const std::array<std::ptrdiff_t, N>& repeated_part, std::ptrdiff_t reg_groups)
 {
-  return x86_shuffle_ps_2<g_size>(std::span<const std::ptrdiff_t, N>(idxs));
+  return x86_shuffle_ps_2<g_size>(std::span<const std::ptrdiff_t, N>(repeated_part), reg_groups);
 }
 
-constexpr int x86_permute_pd(std::span<const std::ptrdiff_t> idxs) {
+constexpr int
+x86_permute_pd(std::span<const std::ptrdiff_t> idxs)
+{
   int res = 0;
 
   // Shuffles in pairs. For each pair 2 bits.
   // bit == 0 - take 0s element, 1 - take first.
-  for (std::ptrdiff_t i = 0; i != std::ssize(idxs); i += 2) {
-    if (idxs[i] == i + 1) res = res | (1 << i);
-    if (idxs[i + 1] == i + 1) res = res | (1 << (i + 1));
+  for( std::ptrdiff_t i = 0; i != std::ssize(idxs); i += 2 )
+  {
+    if( idxs[i] == i + 1 ) res = res | (1 << i);
+    if( idxs[i + 1] == i + 1 ) res = res | (1 << (i + 1));
   }
 
   return res;

--- a/include/eve/detail/shuffle_v2/simd/x86/shuffle_l2.hpp
+++ b/include/eve/detail/shuffle_v2/simd/x86/shuffle_l2.hpp
@@ -371,23 +371,10 @@ shuffle_l2_x86_repeated_128x2_alignr(P, fixed<G>, wide<T, N> x, wide<T, N> y)
 
 template<typename P, arithmetic_scalar_value T, typename N, std::ptrdiff_t G>
 EVE_FORCEINLINE auto
-shuffle_l2_x86_repeated_128x2(P p, fixed<G> g, wide<T, N> x, wide<T, N> y)
-{
-  if constexpr( !P::repeated_16 ) return no_matching_shuffle;
-  else if constexpr( auto r = shuffle_l2_x86_repeated_128x2_alignr(p, g, x, y);
-                     matched_shuffle<decltype(r)> )
-  {
-    return r;
-  }
-  else return no_matching_shuffle;
-}
-
-template<typename P, arithmetic_scalar_value T, typename N, std::ptrdiff_t G>
-EVE_FORCEINLINE auto
-shuffle_l2_x86_within_128x2_shuffle_ps(P, fixed<G>, wide<T, N> x, wide<T, N> y)
+shuffle_l2_x86_repeated_128x2_shuffle_ps(P, fixed<G>, wide<T, N> x, wide<T, N> y)
 {
   if constexpr( sizeof(T) < 4 || P::has_zeroes ) return no_matching_shuffle;
-  else if constexpr( constexpr auto opt_mm = idxm::x86_shuffle_ps_2<P::g_size>(P::idxs); !opt_mm )
+  else if constexpr( constexpr auto opt_mm = idxm::x86_shuffle_ps_2<P::g_size>(*P::repeated_16, P::reg_groups); !opt_mm )
   {
     return no_matching_shuffle;
   }
@@ -406,10 +393,55 @@ shuffle_l2_x86_within_128x2_shuffle_ps(P, fixed<G>, wide<T, N> x, wide<T, N> y)
 
 template<typename P, arithmetic_scalar_value T, typename N, std::ptrdiff_t G>
 EVE_FORCEINLINE auto
+shuffle_l2_x86_repeated_128x2(P p, fixed<G> g, wide<T, N> x, wide<T, N> y)
+{
+  if constexpr( !P::repeated_16 ) return no_matching_shuffle;
+  else if constexpr( auto r = shuffle_l2_x86_repeated_128x2_alignr(p, g, x, y);
+                     matched_shuffle<decltype(r)> )
+  {
+    return r;
+  }
+  else if constexpr( auto r = shuffle_l2_x86_repeated_128x2_shuffle_ps(p, g, x, y);
+                     matched_shuffle<decltype(r)> )
+  {
+    return r;
+  }
+  else return no_matching_shuffle;
+}
+
+template<typename P, arithmetic_scalar_value T, typename N, std::ptrdiff_t G>
+EVE_FORCEINLINE auto
+shuffle_l2_x86_within_128x2_shuffle_pd(P, fixed<G>, wide<T, N> x, wide<T, N> y)
+{
+  (void)x;
+  (void)y;
+  return no_matching_shuffle;
+  #if 0
+  if constexpr( P::g_size < 8 || P::g_size > 16|| P::has_zeroes ) return no_matching_shuffle;
+  else if constexpr( constexpr auto opt_mm = idxm::x86_shuffle_pd_2<P::g_size>(P::idxs); !opt_mm )
+  {
+    return no_matching_shuffle;
+  }
+  else
+  {
+    using doubles_t = eve::wide<double, eve::fixed<N::value * sizeof(T) / sizeof(double)>>;
+    auto x_f64     = bit_cast(x, eve::as<doubles_t> {});
+    auto y_f64     = bit_cast(y, eve::as<doubles_t> {});
+
+    constexpr int mm = *opt_mm;
+    if constexpr( P::reg_size == 16 ) return _mm_shuffle_ps(x_f64, y_f64, mm);
+    else if constexpr( P::reg_size == 32 ) return _mm256_shuffle_ps(x_f64, y_f64, mm);
+    else return _mm512_shuffle_ps(x_f64, y_f64, mm);
+  }
+  #endif
+}
+
+template<typename P, arithmetic_scalar_value T, typename N, std::ptrdiff_t G>
+EVE_FORCEINLINE auto
 shuffle_l2_x86_within_128x2(P p, fixed<G> g, wide<T, N> x, wide<T, N> y)
 {
   if constexpr( !idxm::shuffle_within_n(P::idxs, 16 / sizeof(T)) ) { return no_matching_shuffle; }
-  else if constexpr( auto r = shuffle_l2_x86_within_128x2_shuffle_ps(p, g, x, y);
+  else if constexpr( auto r = shuffle_l2_x86_within_128x2_shuffle_pd(p, g, x, y);
                      matched_shuffle<decltype(r)> )
   {
     return r;

--- a/test/unit/api/regular/shuffle_v2/shuffle_l2.cpp
+++ b/test/unit/api/regular/shuffle_v2/shuffle_l2.cpp
@@ -438,4 +438,67 @@ TTS_CASE("_mm_alignr_epi8(x, y)")
   run2<eve::avx512, std::uint8_t, 64>(alignr_epi8_pattern<13>);
 };
 
+TTS_CASE("_mm_shuffle_ps(x, y)")
+{
+  run2<eve::sse2, std::uint32_t, 4>(eve::pattern<0, 2, 4, 5>);
+  run2<eve::sse2, std::uint32_t, 4>(eve::pattern<1, 0, 4, 5>);
+
+  auto p0 = [](int i, int size) {
+    if (i % 4 == 0) return i + 1;
+    if (i % 4 == 1) return i - 1;
+    if (i % 4 == 2) return i + 1 + size;
+    /*if (i % 4 == 3)*/ return i - 1 + size;
+  };
+
+  auto p1 = [](int i, int size) {
+    if (i % 4 == 0) return i + 2;
+    if (i % 4 == 1) return i + 2;
+    if (i % 4 == 2) return i - 2 + size;
+    /*if (i % 4 == 3)*/ return i - 2 + size;
+  };
+
+  auto p2 = [](int i, int size) {
+    if (i % 4 == 0) return i + 2;
+    if (i % 4 == 1) return i + 2;
+    if (i % 4 == 2) return i + size;
+    /*if (i % 4 == 3)*/ return i + size;
+  };
+
+  auto p3 = [](int i, int size) {
+    if (i % 4 == 0) return i + 1;
+    if (i % 4 == 1) return i;
+    if (i % 4 == 2) return i + size;
+    /*if (i % 4 == 3)*/ return i + size;
+  };
+
+
+  run2<eve::sse2, std::uint32_t, 4>(p0);
+  run2<eve::sse2, std::uint32_t, 4>(p1);
+  run2<eve::sse2, std::uint32_t, 4>(p2);
+  run2<eve::sse2, std::uint32_t, 4>(p3);
+
+  run2<eve::avx, std::uint32_t, 8>(p0);
+  run2<eve::avx, std::uint32_t, 8>(p1);
+  run2<eve::avx, std::uint32_t, 8>(p2);
+  run2<eve::avx, std::uint32_t, 8>(p3);
+
+  run2<eve::avx512, std::uint32_t, 16>(p0);
+  run2<eve::avx512, std::uint32_t, 16>(p1);
+  run2<eve::avx512, std::uint32_t, 16>(p2);
+  run2<eve::avx512, std::uint32_t, 16>(p3);
+};
+
+#if 0
+TTS_CASE("_mm_shuffle_pd(x, y)")
+{
+//  run2<eve::sse2, std::uint64_t, 2>(eve::pattern<0, 2>);
+  run2<eve::sse2, std::uint64_t, 2>(eve::pattern<1, 2>);
+  run2<eve::sse2, std::uint64_t, 2>(eve::pattern<0, 3>);
+  run2<eve::sse2, std::uint64_t, 2>(eve::pattern<1, 3>);
+
+  run2<eve::avx, std::uint64_t, 4>(eve::pattern<0, 5, 2, 7>);
+  run2<eve::avx, std::uint64_t, 4>(eve::pattern<1, 5, 3, 7>);
+};
+#endif
+
 }


### PR DESCRIPTION
shuffle_ps was encoded incorrectly.
shuffle_ps requires the same pattern repeated in all lanes.

There is shuffle_pd that doesn't require that but I didn't have time to make that work.