### PR TITLE
Fix map handling of fp16

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -26,8 +26,8 @@ jobs:
       fail-fast: false
       matrix:
         cfg:
-        - { comp: clang, arch: x86    , opts: "-mavx2 -O3 -DEVE_SPECIAL_TESTS" }
-        - { comp: gcc  , arch: x86    , opts: "-mavx2 -O3 -DEVE_SPECIAL_TESTS" }
+        - { comp: clang, arch: x86    , opts: "-march=native -O3 -DEVE_SPECIAL_TESTS" }
+        - { comp: gcc  , arch: x86    , opts: "-march=native -O3 -DEVE_SPECIAL_TESTS" }
     steps:
       - name: Print Runner Info
         run: |
@@ -226,12 +226,12 @@ jobs:
           cmake .. -G Ninja -DEVE_RUNNER_SCRIPT=${{ matrix.cfg.runner }} -DEVE_OPTIONS="${{ matrix.cfg.opts }}" -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchain/${{ matrix.cfg.comp }}.${{ matrix.cfg.arch }}.cmake
       - name: Compiling Unit Tests
         run: |
-          cd build 
+          cd build
           ninja unit.meta.exe unit.arch.exe unit.core.bit_cast.exe unit.api.regular.wide.exe unit.core.simd_cast.exe unit.core.count_true.exe unit.memory.store.exe unit.memory.store_equivalent.exe -j 4
           ctest --output-on-failure -j 4 --timeout 3600 -R "^unit.meta.*.exe|^unit.arch.*.exe|unit.core.bit_cast.exe|unit.api.regular.wide.exe|unit.core.simd_cast.exe|unit.core.count_true.exe|unit.memory.store.*"
-          ninja clean 
+          ninja clean
       - name: Compiling Big Unit Tests
-        run: | 
+        run: |
           cd build
           ninja unit.api.compress.exe -j 2
           ctest -R "^unit.api.compress.*"

--- a/cmake/config/compiler.cmake
+++ b/cmake/config/compiler.cmake
@@ -15,7 +15,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
   target_compile_options( eve_test INTERFACE /bigobj /W3 /EHsc /wd4267 /wd4244 /wd4146)
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   target_compile_options( eve_test INTERFACE -Werror -Wshadow -Wall -Wpedantic -Wextra -fcolor-diagnostics
-                          -ftemplate-backtrace-limit=0
+                          -ftemplate-backtrace-limit=0 -Wno-c2y-extensions
                         )
 else()
   target_compile_options( eve_test INTERFACE  -Werror -Wshadow -Wall -Wpedantic -Wextra -fdiagnostics-color=always

--- a/include/eve/arch/cpu/tags.hpp
+++ b/include/eve/arch/cpu/tags.hpp
@@ -108,7 +108,7 @@ namespace eve
 
   //================================================================================================
   // Dispatching tag for emulated SIMD implementation
-  struct emulated_ : cpu_
+  struct emulated_
   {
     static constexpr std::size_t bits                     = 128;
     static constexpr std::size_t bytes                    = 16;

--- a/include/eve/arch/float16.hpp
+++ b/include/eve/arch/float16.hpp
@@ -56,7 +56,7 @@ namespace eve
       return std::bit_cast<float>(result);
     }
 
-    EVE_NOINLINE constexpr uint16_t emulated_fp_to_fp16(float value) noexcept
+    EVE_NOINLINE constexpr uint16_t emulated_fp32_to_fp16(float value) noexcept
     {
         uint32_t bits = std::bit_cast<uint32_t>(value);
         uint32_t sign = (bits & 0x80000000u) >> 16;
@@ -123,7 +123,7 @@ namespace eve
     template <std::integral T>
     constexpr std::uint16_t emulated_int_to_fp16(T value) noexcept
     {
-      return emulated_fp_to_fp16(static_cast<float>(value));
+      return emulated_fp32_to_fp16(static_cast<float>(value));
     }
 
     constexpr std::partial_ordering emulated_fp16_compare(std::uint16_t a_bits, std::uint16_t b_bits) noexcept
@@ -199,7 +199,7 @@ namespace eve
       public:
         constexpr float16_t() = default;
         constexpr float16_t(std::integral auto v): data(detail::emulated_int_to_fp16(v)) { }
-        constexpr float16_t(std::floating_point auto v): data(detail::emulated_fp_to_fp16(v)) { }
+        constexpr float16_t(std::floating_point auto v): data(detail::emulated_fp32_to_fp16(v)) { }
 
         constexpr EVE_FORCEINLINE explicit operator bool()               const noexcept { return into<bool>(); }
 

--- a/include/eve/arch/float16.hpp
+++ b/include/eve/arch/float16.hpp
@@ -22,7 +22,7 @@ namespace eve
 {
   namespace detail
   {
-    constexpr float emulated_fp16_to_fp32(uint16_t raw) noexcept
+    EVE_NOINLINE constexpr float emulated_fp16_to_fp32(uint16_t raw) noexcept
     {
       uint32_t sign     = (raw & 0x8000u) << 16;
       uint32_t exponent = (raw & 0x7C00u) >> 10;
@@ -56,7 +56,7 @@ namespace eve
       return std::bit_cast<float>(result);
     }
 
-    constexpr uint16_t emulated_fp_to_fp16(float value) noexcept
+    EVE_NOINLINE constexpr uint16_t emulated_fp_to_fp16(float value) noexcept
     {
         uint32_t bits = std::bit_cast<uint32_t>(value);
         uint32_t sign = (bits & 0x80000000u) >> 16;

--- a/include/eve/arch/simdfloat16.hpp
+++ b/include/eve/arch/simdfloat16.hpp
@@ -1,0 +1,109 @@
+//==================================================================================================
+/*
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+*/
+//==================================================================================================
+#pragma once
+
+#include <eve/arch/float16.hpp>
+#include <eve/module/core/regular/convert.hpp>
+#include <eve/module/core/regular/countl_zero.hpp>
+#include <eve/module/core/regular/bit_cast.hpp>
+#include <eve/module/core/regular/if_else.hpp>
+
+namespace eve::detail
+{
+  template<typename N>
+  EVE_NOINLINE auto emulated_simd_fp16_to_fp32(wide<eve::float16_t, N> v) noexcept
+  {
+    auto u16      = bit_cast(v, as<wide<uint16_t, N>>{});
+    auto u32      = convert(u16, as<uint32_t>{});
+    auto sign     = (u32 & 0x8000u) << 16;
+    auto exponent = (u32 & 0x7C00u) >> 10;
+    auto mantissa = (u32 & 0x03FFu);
+
+    // Normal
+    auto normal_res = sign | ((exponent + 112) << 23) | (mantissa << 13);
+
+    // Denormal / Zero
+    auto shift = convert(countl_zero(mantissa), as<uint32_t>{}) - 21;
+    auto denorm_mantissa = (mantissa << shift) & 0x03FFu;
+    auto denorm_exp = 113 - shift;
+    auto denorm_res = sign | (denorm_exp << 23) | (denorm_mantissa << 13);
+    denorm_res = if_else(mantissa == 0, sign, denorm_res);
+
+    // Inf / NaN
+    auto inf_nan_res = sign | 0x7F800000u | (mantissa << 13);
+    inf_nan_res = if_else(mantissa != 0, inf_nan_res | 0x400000u, inf_nan_res);
+
+    auto result = if_else(exponent == 31, inf_nan_res,
+                  if_else(exponent == 0, denorm_res, normal_res));
+
+    return bit_cast(result, as<wide<float, N>>{});
+  }
+
+  template<typename N>
+  EVE_NOINLINE auto emulated_simd_fp32_to_fp16(wide<float, N> v) noexcept
+  {
+    auto bits     = bit_cast(v, as<wide<uint32_t, N>>{});
+    auto sign     = (bits & 0x80000000u) >> 16;
+    auto mantissa = bits & 0x7FFFFFu;
+    auto exponent = bit_cast((bits >> 23) & 0xFF, as<wide<int32_t, N>>{}) - 127;
+
+    auto is_inf_nan = (bits & 0x7F800000u) == 0x7F800000u;
+    auto is_nan     = is_inf_nan && (mantissa != 0);
+
+    auto nan_payload = mantissa >> 13;
+    nan_payload = if_else(nan_payload != 0, nan_payload, 1u);
+    auto nan_res = sign | 0x7C00u | nan_payload;
+    auto inf_res = sign | 0x7C00u;
+    auto inf_nan_res = if_else(is_nan, nan_res, inf_res);
+
+    auto is_overflow = exponent > 15;
+    auto res_overflow = sign | 0x7C00u;
+
+    auto is_tiny = exponent < -25;
+
+    // Denormal handling
+    auto mant_hidden = mantissa | 0x800000u;
+    auto raw_shift   = -exponent - 1;
+    auto safe_shift  = if_else(exponent <= -15, min(raw_shift, 24), 24);
+
+    auto rounded_denorm    = mant_hidden >> safe_shift;
+    auto one_v = one(as<wide<uint32_t, N>>{});
+    auto remainder_denorm  = mant_hidden & ((one_v << safe_shift) - one_v);
+
+    auto threshold_denorm  = one_v << (safe_shift - 1);
+    auto should_inc_denorm = (remainder_denorm > threshold_denorm) ||
+                             ((remainder_denorm == threshold_denorm) && ((rounded_denorm & 1u) != 0));
+
+    rounded_denorm += if_else(should_inc_denorm, 1u, 0u);
+    auto res_denorm = sign | rounded_denorm;
+
+    // Normal handling
+    auto fp16_exp_norm = convert(exponent + 15, as<uint32_t>{}) << 10;
+    auto mant_norm     = mantissa >> 13;
+    auto round_bits    = mantissa & 0x1FFFu;
+
+    auto should_inc_norm = (round_bits > 0x1000u) || ((round_bits == 0x1000u) && ((mant_norm & 1u) != 0));
+    mant_norm += if_else(should_inc_norm, 1u, 0u);
+
+    auto norm_overflow = mant_norm == 0x0400u;
+    mant_norm = if_else(norm_overflow, 0u, mant_norm);
+    fp16_exp_norm += if_else(norm_overflow, 0x0400u, 0u);
+
+    auto is_inf_post_round = (fp16_exp_norm >> 10) >= 31u;
+    auto result_norm = if_else(is_inf_post_round, sign | 0x7C00u, sign | fp16_exp_norm | (mant_norm & 0x3FFu));
+
+    auto res = if_else(exponent <= -15,
+                       if_else(is_tiny, sign, res_denorm),
+                       result_norm);
+
+    res = if_else(is_overflow, res_overflow, res);
+    res = if_else(is_inf_nan, inf_nan_res, res);
+
+    return bit_cast(convert(res, as<uint16_t>{}), as<wide<eve::float16_t, N>>{});
+  }
+}

--- a/include/eve/detail/skeleton.hpp
+++ b/include/eve/detail/skeleton.hpp
@@ -104,10 +104,6 @@ namespace eve::detail
                 }
               );
     }
-    else if constexpr (fp16_should_apply<w_t>)
-    {
-      return call_convert(apply_fp16_as_fp32(EVE_FWD(f), EVE_FWD(ts)...), as<element_type_t<w_t>>{});
-    }
     else
     {
       return apply<cardinal_v<w_t>>([&](auto... I) { return w_t{map_{}( EVE_FWD(f), I, EVE_FWD(ts)...)...}; } );
@@ -244,9 +240,14 @@ namespace eve::detail
         }
       };
 
-      if      constexpr (has_emulated_abi_v<wide_t>)   return kumi::apply([](auto... m) { return wide_t{m...}; }, rewrap(inner_output));
-      else if constexpr (has_aggregated_abi_v<wide_t>) return wide_t { storage_t { rewrap(inner_output) } };
-      else                                             return rewrap(inner_output);
+      const auto out = rewrap(inner_output);
+
+      if constexpr (has_emulated_abi_v<wide_t> && product_type<decltype(out)>)
+        return kumi::apply([](auto... m) { return wide_t{m...}; }, out);
+      else if constexpr (has_aggregated_abi_v<wide_t>)
+        return wide_t { storage_t { out } };
+      else
+        return out;
     }
     else
     {

--- a/include/eve/detail/skeleton.hpp
+++ b/include/eve/detail/skeleton.hpp
@@ -12,6 +12,7 @@
 #include <eve/traits/element_type.hpp>
 #include <eve/traits/as_wide.hpp>
 #include <eve/traits/cardinal.hpp>
+#include <eve/traits/apply_fp16.hpp>
 #include <eve/arch/cpu/as_register.hpp>
 #include <type_traits>
 #include <algorithm>
@@ -102,6 +103,10 @@ namespace eve::detail
                   return rebuild<w_t>(map_{}(EVE_FWD(f), I, EVE_FWD(ts)...)...);
                 }
               );
+    }
+    else if constexpr (fp16_should_apply<w_t>)
+    {
+      return call_convert(apply_fp16_as_fp32(EVE_FWD(f), EVE_FWD(ts)...), as<element_type_t<w_t>>{});
     }
     else
     {

--- a/include/eve/forward.hpp
+++ b/include/eve/forward.hpp
@@ -59,7 +59,7 @@ template <typename From, typename To>
 To call_simd_cast(From, as<To>);
 
 // This is an inderect wrapper of eve::convert to avoid cycling dependencies
-template <simd_value Src, typename Tgt>
+template <typename Src, typename Tgt>
 as_wide_as_t<Tgt, Src> call_convert(Src, as<Tgt>);
 
 // This is an inderect wrapper of eve::detail::butterfly_reduction to avoid cycling dependencies

--- a/include/eve/module/core/regular/add.hpp
+++ b/include/eve/module/core/regular/add.hpp
@@ -13,6 +13,7 @@
 #include <eve/traits/updown.hpp>
 #include <eve/module/core/detail/tolerance.hpp>
 #include <eve/module/core/constant/zero.hpp>
+#include <eve/traits/apply_fp16.hpp>
 
 namespace eve
 {

--- a/include/eve/module/core/regular/average.hpp
+++ b/include/eve/module/core/regular/average.hpp
@@ -11,7 +11,6 @@
 #include <eve/traits/overload.hpp>
 #include <eve/module/core/decorator/core.hpp>
 #include <eve/traits/updown.hpp>
-#include <eve/traits/apply_fp16.hpp>
 
 namespace eve
 {

--- a/include/eve/module/core/regular/average.hpp
+++ b/include/eve/module/core/regular/average.hpp
@@ -11,6 +11,7 @@
 #include <eve/traits/overload.hpp>
 #include <eve/module/core/decorator/core.hpp>
 #include <eve/traits/updown.hpp>
+#include <eve/traits/apply_fp16.hpp>
 
 namespace eve
 {
@@ -19,7 +20,6 @@ namespace eve
                                     lower_option, strict_option, kahan_option,
                                     widen_option>
   {
-
     template<value... Ts>
     requires(sizeof...(Ts) !=  0 && eve::same_lanes_or_scalar<Ts...>)
       EVE_FORCEINLINE constexpr eve::upgrade_if_t<Options, common_value_t<Ts...>>

--- a/include/eve/module/core/regular/convert.hpp
+++ b/include/eve/module/core/regular/convert.hpp
@@ -89,7 +89,7 @@ namespace eve
   namespace detail
   {
     // This function is forward declared wrapper around convert, so that internally we can call it anywhere.
-    template<simd_value Src, typename Tgt>
+    template<typename Src, typename Tgt>
     EVE_FORCEINLINE as_wide_as_t<Tgt, Src> call_convert(Src x, as<Tgt> tgt)
     {
       return convert(x, tgt);

--- a/include/eve/module/core/regular/cosine_similarity.hpp
+++ b/include/eve/module/core/regular/cosine_similarity.hpp
@@ -85,7 +85,7 @@ namespace eve
   namespace detail
   {
     template<callable_options O, typename... Ts>
-    EVE_FORCEINLINE constexpr auto cosine_similarity_(EVE_REQUIRES(emulated_), O const & o, Ts... ts) noexcept
+    EVE_FORCEINLINE constexpr auto cosine_similarity_(EVE_REQUIRES(strict_elementwise_emulated_), O const & o, Ts... ts) noexcept
     requires (O::contains(widen) && detail::fp16_should_apply<common_value_t<Ts...>>)
     {
       return cosine_similarity[o.drop(widen)](upgrade(ts)...);

--- a/include/eve/module/core/regular/cosine_similarity.hpp
+++ b/include/eve/module/core/regular/cosine_similarity.hpp
@@ -13,12 +13,13 @@
 #include <eve/module/core/regular/sum_of_squares.hpp>
 #include <eve/module/core/regular/rsqrt.hpp>
 #include <eve/module/core/decorator/core.hpp>
+#include <eve/traits/apply_fp16.hpp>
+
 namespace eve
 {
   template<typename Options>
   struct cosine_similarity_t : tuple_callable<cosine_similarity_t, Options, kahan_option, widen_option, unbiased_option>
   {
-
     template<value Tup1, value Tup2>
     requires(eve::product_type<element_type_t<Tup1>> && eve::product_type<element_type_t<Tup2>> && Options::contains(widen))
     EVE_FORCEINLINE constexpr
@@ -83,6 +84,13 @@ namespace eve
 
   namespace detail
   {
+    template<callable_options O, typename... Ts>
+    EVE_FORCEINLINE constexpr auto cosine_similarity_(EVE_REQUIRES(emulated_), O const & o, Ts... ts) noexcept
+    requires (O::contains(widen) && detail::fp16_should_apply<common_value_t<Ts...>>)
+    {
+      return cosine_similarity[o.drop(widen)](upgrade(ts)...);
+    }
+
     template<eve::non_empty_product_type PT1,
              eve::non_empty_product_type PT2, callable_options O>
     EVE_FORCEINLINE constexpr auto cosine_similarity_(EVE_REQUIRES(cpu_), O const & o, PT1 f, PT2 s) noexcept

--- a/include/eve/module/core/regular/cosine_similarity.hpp
+++ b/include/eve/module/core/regular/cosine_similarity.hpp
@@ -85,7 +85,7 @@ namespace eve
   namespace detail
   {
     template<callable_options O, typename... Ts>
-    EVE_FORCEINLINE constexpr auto cosine_similarity_(EVE_REQUIRES(strict_elementwise_emulated_), O const & o, Ts... ts) noexcept
+    EVE_FORCEINLINE constexpr auto cosine_similarity_(EVE_REQUIRES(emulated_), O const & o, Ts... ts) noexcept
     requires (O::contains(widen) && detail::fp16_should_apply<common_value_t<Ts...>>)
     {
       return cosine_similarity[o.drop(widen)](upgrade(ts)...);

--- a/include/eve/module/core/regular/covariance.hpp
+++ b/include/eve/module/core/regular/covariance.hpp
@@ -11,6 +11,8 @@
 #include <eve/detail/overload.hpp>
 #include <eve/module/core/regular/dot.hpp>
 #include <eve/module/core/decorator/core.hpp>
+#include <eve/traits/apply_fp16.hpp>
+
 namespace eve
 {
   template<typename Options>
@@ -89,6 +91,13 @@ namespace eve
 
   namespace detail
   {
+    template<callable_options O, typename... Ts>
+    EVE_FORCEINLINE constexpr auto covariance_(EVE_REQUIRES(emulated_), O const & o, Ts... ts) noexcept
+    requires (O::contains(widen) && detail::fp16_should_apply<common_value_t<Ts...>>)
+    {
+      return covariance[o.drop(widen)](upgrade(ts)...);
+    }
+
     template<eve::non_empty_product_type PT1, eve::non_empty_product_type PT2, callable_options O>
     EVE_FORCEINLINE constexpr auto covariance_(EVE_REQUIRES(cpu_), O const & o, PT1 f, PT2 s) noexcept
     requires (kumi::as_tuple_t<PT1>::size() == kumi::as_tuple_t<PT2>::size())

--- a/include/eve/module/core/regular/covariance.hpp
+++ b/include/eve/module/core/regular/covariance.hpp
@@ -92,7 +92,7 @@ namespace eve
   namespace detail
   {
     template<callable_options O, typename... Ts>
-    EVE_FORCEINLINE constexpr auto covariance_(EVE_REQUIRES(strict_elementwise_emulated_), O const & o, Ts... ts) noexcept
+    EVE_FORCEINLINE constexpr auto covariance_(EVE_REQUIRES(emulated_), O const & o, Ts... ts) noexcept
     requires (O::contains(widen) && detail::fp16_should_apply<common_value_t<Ts...>>)
     {
       return covariance[o.drop(widen)](upgrade(ts)...);

--- a/include/eve/module/core/regular/covariance.hpp
+++ b/include/eve/module/core/regular/covariance.hpp
@@ -92,7 +92,7 @@ namespace eve
   namespace detail
   {
     template<callable_options O, typename... Ts>
-    EVE_FORCEINLINE constexpr auto covariance_(EVE_REQUIRES(emulated_), O const & o, Ts... ts) noexcept
+    EVE_FORCEINLINE constexpr auto covariance_(EVE_REQUIRES(strict_elementwise_emulated_), O const & o, Ts... ts) noexcept
     requires (O::contains(widen) && detail::fp16_should_apply<common_value_t<Ts...>>)
     {
       return covariance[o.drop(widen)](upgrade(ts)...);

--- a/include/eve/module/core/regular/dec.hpp
+++ b/include/eve/module/core/regular/dec.hpp
@@ -17,6 +17,7 @@
 #include <eve/module/core/regular/all.hpp>
 #include <eve/module/core/regular/convert.hpp>
 #include <eve/module/core/detail/modular.hpp>
+#include <eve/traits/apply_fp16.hpp>
 
 namespace eve
 {
@@ -112,6 +113,14 @@ namespace eve
 
   namespace detail
   {
+    template<value T, callable_options O>
+    EVE_FORCEINLINE constexpr auto dec_(EVE_REQUIRES(strict_elementwise_emulated_), O const& o, T v) noexcept
+      requires(detail::fp16_should_apply<T>)
+    {
+      if constexpr (O::contains(upper) || O::contains(lower)) return detail::map(dec[o], v);
+      else                                                    return apply_fp16_as_fp32(dec[o], v);
+    }
+
     template<value T, callable_options O>
     EVE_FORCEINLINE constexpr T dec_(EVE_REQUIRES(cpu_), O const& o, T const& a) noexcept
     {

--- a/include/eve/module/core/regular/dec.hpp
+++ b/include/eve/module/core/regular/dec.hpp
@@ -114,7 +114,7 @@ namespace eve
   namespace detail
   {
     template<value T, callable_options O>
-    EVE_FORCEINLINE constexpr auto dec_(EVE_REQUIRES(strict_elementwise_emulated_), O const& o, T v) noexcept
+    EVE_FORCEINLINE constexpr auto dec_(EVE_REQUIRES(emulated_), O const& o, T v) noexcept
       requires(detail::fp16_should_apply<T>)
     {
       if constexpr (O::contains(upper) || O::contains(lower)) return detail::map(dec[o], v);

--- a/include/eve/module/core/regular/diff_of_prod.hpp
+++ b/include/eve/module/core/regular/diff_of_prod.hpp
@@ -14,6 +14,7 @@
 #include <eve/module/core/regular/fma.hpp>
 #include <eve/module/core/regular/fms.hpp>
 #include <eve/module/core/regular/fnma.hpp>
+#include <eve/traits/apply_fp16.hpp>
 
 namespace eve
 {
@@ -87,6 +88,14 @@ namespace eve
 
   namespace detail
   {
+    template<callable_options O, typename... Ts>
+    EVE_FORCEINLINE constexpr auto diff_of_prod_(EVE_REQUIRES(strict_elementwise_emulated_), O const & o, Ts const&... ts) noexcept
+      requires(detail::fp16_should_apply<common_value_t<Ts...>>)
+    {
+      if constexpr(O::contains(upper) || O::contains(lower)) return detail::map(diff_of_prod[o], ts...);
+      else                                                   return apply_fp16_as_fp32(diff_of_prod[o], ts...);
+    }
+
     template<typename T, callable_options O>
     EVE_FORCEINLINE constexpr auto
     diff_of_prod_(EVE_REQUIRES(cpu_), O const & o,

--- a/include/eve/module/core/regular/diff_of_prod.hpp
+++ b/include/eve/module/core/regular/diff_of_prod.hpp
@@ -92,8 +92,8 @@ namespace eve
     EVE_FORCEINLINE constexpr auto diff_of_prod_(EVE_REQUIRES(strict_elementwise_emulated_), O const & o, Ts const&... ts) noexcept
       requires(detail::fp16_should_apply<common_value_t<Ts...>>)
     {
-      if constexpr(O::contains(upper) || O::contains(lower)) return detail::map(diff_of_prod[o], ts...);
-      else                                                   return apply_fp16_as_fp32(diff_of_prod[o], ts...);
+      if constexpr(O::contains(upper) || O::contains(lower) || O::contains(pedantic)) return detail::map(diff_of_prod[o], ts...);
+      else                                                                            return apply_fp16_as_fp32(diff_of_prod[o], ts...);
     }
 
     template<typename T, callable_options O>

--- a/include/eve/module/core/regular/diff_of_prod.hpp
+++ b/include/eve/module/core/regular/diff_of_prod.hpp
@@ -89,7 +89,7 @@ namespace eve
   namespace detail
   {
     template<callable_options O, typename... Ts>
-    EVE_FORCEINLINE constexpr auto diff_of_prod_(EVE_REQUIRES(strict_elementwise_emulated_), O const & o, Ts const&... ts) noexcept
+    EVE_FORCEINLINE constexpr auto diff_of_prod_(EVE_REQUIRES(emulated_), O const & o, Ts const&... ts) noexcept
       requires(detail::fp16_should_apply<common_value_t<Ts...>>)
     {
       if constexpr(O::contains(upper) || O::contains(lower) || O::contains(pedantic)) return detail::map(diff_of_prod[o], ts...);

--- a/include/eve/module/core/regular/dist.hpp
+++ b/include/eve/module/core/regular/dist.hpp
@@ -17,6 +17,7 @@
 #include <eve/module/core/regular/min.hpp>
 #include <eve/module/core/constant/valmax.hpp>
 #include <eve/module/core/constant/inf.hpp>
+#include <eve/traits/apply_fp16.hpp>
 
 namespace eve
 {
@@ -89,6 +90,14 @@ namespace eve
 
   namespace detail
   {
+    template<value T, callable_options O>
+    EVE_FORCEINLINE constexpr auto dist_(EVE_REQUIRES(strict_elementwise_emulated_), O const& o, T a, T b)
+      requires(detail::fp16_should_apply<T>)
+    {
+      if constexpr(O::contains(upper) || O::contains(lower)) return detail::map(dist[o], a, b);
+      else                                                   return apply_fp16_as_fp32(dist[o], a, b);
+    }
+
     template<value T, callable_options O>
     constexpr T dist_(EVE_REQUIRES(cpu_), O const& o, T a, T b)
     {

--- a/include/eve/module/core/regular/dist.hpp
+++ b/include/eve/module/core/regular/dist.hpp
@@ -91,7 +91,7 @@ namespace eve
   namespace detail
   {
     template<value T, callable_options O>
-    EVE_FORCEINLINE constexpr auto dist_(EVE_REQUIRES(strict_elementwise_emulated_), O const& o, T a, T b)
+    EVE_FORCEINLINE constexpr auto dist_(EVE_REQUIRES(emulated_), O const& o, T a, T b)
       requires(detail::fp16_should_apply<T>)
     {
       if constexpr(O::contains(upper) || O::contains(lower)) return detail::map(dist[o], a, b);

--- a/include/eve/module/core/regular/dot.hpp
+++ b/include/eve/module/core/regular/dot.hpp
@@ -97,7 +97,7 @@ namespace eve
   namespace detail
   {
     template<callable_options O, typename... Ts>
-    EVE_FORCEINLINE constexpr auto dot_(EVE_REQUIRES(emulated_), O const & o, Ts... ts) noexcept
+    EVE_FORCEINLINE constexpr auto dot_(EVE_REQUIRES(strict_elementwise_emulated_), O const & o, Ts... ts) noexcept
     requires (O::contains(widen) && detail::fp16_should_apply<common_value_t<Ts...>>)
     {
       return dot[o.drop(widen)](upgrade(ts)...);

--- a/include/eve/module/core/regular/dot.hpp
+++ b/include/eve/module/core/regular/dot.hpp
@@ -97,7 +97,7 @@ namespace eve
   namespace detail
   {
     template<callable_options O, typename... Ts>
-    EVE_FORCEINLINE constexpr auto dot_(EVE_REQUIRES(strict_elementwise_emulated_), O const & o, Ts... ts) noexcept
+    EVE_FORCEINLINE constexpr auto dot_(EVE_REQUIRES(emulated_), O const & o, Ts... ts) noexcept
     requires (O::contains(widen) && detail::fp16_should_apply<common_value_t<Ts...>>)
     {
       return dot[o.drop(widen)](upgrade(ts)...);

--- a/include/eve/module/core/regular/dot.hpp
+++ b/include/eve/module/core/regular/dot.hpp
@@ -13,13 +13,13 @@
 #include <eve/traits/updown.hpp>
 #include <eve/module/core/regular/two_fma_approx.hpp>
 #include <eve/module/core/regular/mul.hpp>
+#include <eve/traits/apply_fp16.hpp>
 
 namespace eve
 {
   template<typename Options>
   struct dot_t : tuple_callable<dot_t, Options, kahan_option, widen_option>
   {
-
     template<eve::value T0, value T1, value... Ts>
     requires(eve::same_lanes_or_scalar<T0, T1, Ts...>)
     EVE_FORCEINLINE upgrade_if_t<Options, common_value_t<T0, T1, Ts... >>
@@ -96,6 +96,13 @@ namespace eve
 
   namespace detail
   {
+    template<callable_options O, typename... Ts>
+    EVE_FORCEINLINE constexpr auto dot_(EVE_REQUIRES(emulated_), O const & o, Ts... ts) noexcept
+    requires (O::contains(widen) && detail::fp16_should_apply<common_value_t<Ts...>>)
+    {
+      return dot[o.drop(widen)](upgrade(ts)...);
+    }
+
     template<typename... Ts, callable_options O>
     EVE_FORCEINLINE constexpr auto dot_(EVE_REQUIRES(cpu_), O const & o, Ts... args) noexcept
     requires(sizeof...(Ts) > 1  && sizeof...(Ts)%2 == 0)

--- a/include/eve/module/core/regular/epsilon.hpp
+++ b/include/eve/module/core/regular/epsilon.hpp
@@ -9,6 +9,7 @@
 
 #include <eve/arch.hpp>
 #include <eve/traits/overload.hpp>
+#include <eve/traits/apply_fp16.hpp>
 #include <eve/module/core/decorator/core.hpp>
 #include <eve/module/core/regular/abs.hpp>
 #include <eve/module/core/regular/dist.hpp>
@@ -93,6 +94,13 @@ namespace eve
 
   namespace detail
   {
+    template<callable_options O, typename... Ts>
+    EVE_FORCEINLINE constexpr auto epsilon_(EVE_REQUIRES(strict_elementwise_emulated_), O const& o, Ts... ts) noexcept
+      requires (detail::fp16_should_apply<common_value_t<Ts...>>)
+    {
+      return detail::map(epsilon[o], ts...);
+    }
+
     template<typename T, callable_options O>
     EVE_FORCEINLINE constexpr auto epsilon_(EVE_REQUIRES(cpu_), O const& o, T const& a0)
     {

--- a/include/eve/module/core/regular/epsilon.hpp
+++ b/include/eve/module/core/regular/epsilon.hpp
@@ -95,7 +95,7 @@ namespace eve
   namespace detail
   {
     template<callable_options O, typename... Ts>
-    EVE_FORCEINLINE constexpr auto epsilon_(EVE_REQUIRES(strict_elementwise_emulated_), O const& o, Ts... ts) noexcept
+    EVE_FORCEINLINE constexpr auto epsilon_(EVE_REQUIRES(emulated_), O const& o, Ts... ts) noexcept
       requires (detail::fp16_should_apply<common_value_t<Ts...>>)
     {
       return detail::map(epsilon[o], ts...);

--- a/include/eve/module/core/regular/fanm.hpp
+++ b/include/eve/module/core/regular/fanm.hpp
@@ -91,10 +91,10 @@ namespace eve
   {
     template<typename T, typename U, typename V, callable_options O>
     EVE_FORCEINLINE constexpr auto fanm_(EVE_REQUIRES(strict_elementwise_emulated_), O const& o, T const& a, U const& b, V const& c)
-      requires(detail::fp16_should_apply<common_value_t<T, U, V>>)
+      requires (detail::fp16_should_apply<common_value_t<T, U, V>>)
     {
-      if constexpr(O::contains(upper) || O::contains(lower)) return detail::map(fanm[o], a, b, c);
-      else                                                   return apply_fp16_as_fp32(fanm[o], a, b, c);
+      if constexpr(O::contains(upper) || O::contains(lower) || O::contains(pedantic)) return detail::map(fanm[o], a, b, c);
+      else                                                                            return apply_fp16_as_fp32(fanm[o], a, b, c);
     }
 
     template<typename T, typename U, typename V, callable_options O>

--- a/include/eve/module/core/regular/fanm.hpp
+++ b/include/eve/module/core/regular/fanm.hpp
@@ -90,7 +90,7 @@ namespace eve
   namespace detail
   {
     template<typename T, typename U, typename V, callable_options O>
-    EVE_FORCEINLINE constexpr auto fanm_(EVE_REQUIRES(strict_elementwise_emulated_), O const& o, T const& a, U const& b, V const& c)
+    EVE_FORCEINLINE constexpr auto fanm_(EVE_REQUIRES(emulated_), O const& o, T const& a, U const& b, V const& c)
       requires (detail::fp16_should_apply<common_value_t<T, U, V>>)
     {
       if constexpr(O::contains(upper) || O::contains(lower) || O::contains(pedantic)) return detail::map(fanm[o], a, b, c);

--- a/include/eve/module/core/regular/fanm.hpp
+++ b/include/eve/module/core/regular/fanm.hpp
@@ -12,6 +12,7 @@
 #include <eve/module/core/decorator/core.hpp>
 #include <eve/module/core/regular/fnma.hpp>
 #include <eve/module/core/detail/fmx_utils.hpp>
+#include <eve/traits/apply_fp16.hpp>
 
 namespace eve
 {
@@ -88,6 +89,14 @@ namespace eve
 
   namespace detail
   {
+    template<typename T, typename U, typename V, callable_options O>
+    EVE_FORCEINLINE constexpr auto fanm_(EVE_REQUIRES(strict_elementwise_emulated_), O const& o, T const& a, U const& b, V const& c)
+      requires(detail::fp16_should_apply<common_value_t<T, U, V>>)
+    {
+      if constexpr(O::contains(upper) || O::contains(lower)) return detail::map(fanm[o], a, b, c);
+      else                                                   return apply_fp16_as_fp32(fanm[o], a, b, c);
+    }
+
     template<typename T, typename U, typename V, callable_options O>
     EVE_FORCEINLINE constexpr auto fanm_(EVE_REQUIRES(cpu_), O const& o, T const& a, U const& b, V const& c)
     {

--- a/include/eve/module/core/regular/fnma.hpp
+++ b/include/eve/module/core/regular/fnma.hpp
@@ -94,12 +94,12 @@ namespace eve
 
   namespace detail
   {
-    template<typename T, typename U, typename V, callable_options O>
-    EVE_FORCEINLINE constexpr auto fnma_(EVE_REQUIRES(strict_elementwise_emulated_), O const& o, T const& a, U const& b, V const& c)
-      requires(detail::fp16_should_apply<common_value_t<T, U, V>>)
+    template<callable_options O, simd_value... Ts>
+    EVE_FORCEINLINE constexpr auto fnma_(EVE_REQUIRES(strict_elementwise_emulated_), O const& o, Ts const&... ts)
+      requires (detail::fp16_should_apply<Ts> && ...)
     {
-      if constexpr(O::contains(upper) || O::contains(lower)) return detail::map(fnma[o], a, b, c);
-      else                                                   return apply_fp16_as_fp32(fnma[o], a, b, c);
+      if constexpr(O::contains(upper) || O::contains(lower) || O::contains(pedantic)) return detail::map(fnma[o], ts...);
+      else                                                                            return apply_fp16_as_fp32(fnma[o], ts...);
     }
 
     template<typename T, typename U, typename V, callable_options O>

--- a/include/eve/module/core/regular/fnma.hpp
+++ b/include/eve/module/core/regular/fnma.hpp
@@ -13,6 +13,7 @@
 #include <eve/module/core/regular/fma.hpp>
 #include <eve/module/core/regular/minus.hpp>
 #include <eve/module/core/detail/fmx_utils.hpp>
+#include <eve/traits/apply_fp16.hpp>
 
 namespace eve
 {
@@ -93,6 +94,14 @@ namespace eve
 
   namespace detail
   {
+    template<typename T, typename U, typename V, callable_options O>
+    EVE_FORCEINLINE constexpr auto fnma_(EVE_REQUIRES(strict_elementwise_emulated_), O const& o, T const& a, U const& b, V const& c)
+      requires(detail::fp16_should_apply<common_value_t<T, U, V>>)
+    {
+      if constexpr(O::contains(upper) || O::contains(lower)) return detail::map(fnma[o], a, b, c);
+      else                                                   return apply_fp16_as_fp32(fnma[o], a, b, c);
+    }
+
     template<typename T, typename U, typename V, callable_options O>
     EVE_FORCEINLINE constexpr auto fnma_(EVE_REQUIRES(cpu_), O const& o, T const& a, U const& b, V const& c)
     {

--- a/include/eve/module/core/regular/fnma.hpp
+++ b/include/eve/module/core/regular/fnma.hpp
@@ -95,7 +95,7 @@ namespace eve
   namespace detail
   {
     template<callable_options O, simd_value... Ts>
-    EVE_FORCEINLINE constexpr auto fnma_(EVE_REQUIRES(strict_elementwise_emulated_), O const& o, Ts const&... ts)
+    EVE_FORCEINLINE constexpr auto fnma_(EVE_REQUIRES(emulated_), O const& o, Ts const&... ts)
       requires (detail::fp16_should_apply<Ts> && ...)
     {
       if constexpr(O::contains(upper) || O::contains(lower) || O::contains(pedantic)) return detail::map(fnma[o], ts...);

--- a/include/eve/module/core/regular/fnms.hpp
+++ b/include/eve/module/core/regular/fnms.hpp
@@ -94,7 +94,7 @@ namespace eve
   {
 
     template<callable_options O, simd_value... Ts>
-    EVE_FORCEINLINE constexpr auto fnms_(EVE_REQUIRES(strict_elementwise_emulated_), O const& o, Ts const&... ts)
+    EVE_FORCEINLINE constexpr auto fnms_(EVE_REQUIRES(emulated_), O const& o, Ts const&... ts)
       requires (detail::fp16_should_apply<Ts> && ...)
     {
       if constexpr(O::contains(upper) || O::contains(lower) || O::contains(pedantic)) return detail::map(fnms[o], ts...);

--- a/include/eve/module/core/regular/fnms.hpp
+++ b/include/eve/module/core/regular/fnms.hpp
@@ -12,6 +12,7 @@
 #include <eve/module/core/decorator/core.hpp>
 #include <eve/module/core/regular/minus.hpp>
 #include <eve/module/core/detail/fmx_utils.hpp>
+#include <eve/traits/apply_fp16.hpp>
 
 namespace eve
 {
@@ -91,6 +92,14 @@ namespace eve
 
   namespace detail
   {
+
+    template<typename T, typename U, typename V, callable_options O>
+    EVE_FORCEINLINE constexpr auto fnms_(EVE_REQUIRES(strict_elementwise_emulated_), O const& o, T const& a, U const& b, V const& c)
+      requires(detail::fp16_should_apply<common_value_t<T, U, V>>)
+    {
+      if constexpr(O::contains(upper) || O::contains(lower)) return detail::map(fnms[o], a, b, c);
+      else                                                   return apply_fp16_as_fp32(fnms[o], a, b, c);
+    }
 
     template<typename T, typename U, typename V, callable_options O>
     EVE_FORCEINLINE constexpr auto fnms_(EVE_REQUIRES(cpu_), O const& o, T const& a, U const& b, V const& c)

--- a/include/eve/module/core/regular/fnms.hpp
+++ b/include/eve/module/core/regular/fnms.hpp
@@ -93,12 +93,12 @@ namespace eve
   namespace detail
   {
 
-    template<typename T, typename U, typename V, callable_options O>
-    EVE_FORCEINLINE constexpr auto fnms_(EVE_REQUIRES(strict_elementwise_emulated_), O const& o, T const& a, U const& b, V const& c)
-      requires(detail::fp16_should_apply<common_value_t<T, U, V>>)
+    template<callable_options O, simd_value... Ts>
+    EVE_FORCEINLINE constexpr auto fnms_(EVE_REQUIRES(strict_elementwise_emulated_), O const& o, Ts const&... ts)
+      requires (detail::fp16_should_apply<Ts> && ...)
     {
-      if constexpr(O::contains(upper) || O::contains(lower)) return detail::map(fnms[o], a, b, c);
-      else                                                   return apply_fp16_as_fp32(fnms[o], a, b, c);
+      if constexpr(O::contains(upper) || O::contains(lower) || O::contains(pedantic)) return detail::map(fnms[o], ts...);
+      else                                                                            return apply_fp16_as_fp32(fnms[o], ts...);
     }
 
     template<typename T, typename U, typename V, callable_options O>

--- a/include/eve/module/core/regular/frac.hpp
+++ b/include/eve/module/core/regular/frac.hpp
@@ -88,7 +88,7 @@ namespace eve
   namespace detail
   {
     template<callable_options O, typename... Ts>
-    EVE_FORCEINLINE constexpr auto frac_(EVE_REQUIRES(strict_elementwise_emulated_), O const& o, Ts... ts) noexcept
+    EVE_FORCEINLINE constexpr auto frac_(EVE_REQUIRES(emulated_), O const& o, Ts... ts) noexcept
       requires (detail::fp16_should_apply<common_value_t<Ts...>>)
     {
       return detail::map(frac[o], ts...);

--- a/include/eve/module/core/regular/frac.hpp
+++ b/include/eve/module/core/regular/frac.hpp
@@ -87,6 +87,13 @@ namespace eve
 
   namespace detail
   {
+    template<callable_options O, typename... Ts>
+    EVE_FORCEINLINE constexpr auto frac_(EVE_REQUIRES(strict_elementwise_emulated_), O const& o, Ts... ts) noexcept
+      requires (detail::fp16_should_apply<common_value_t<Ts...>>)
+    {
+      return detail::map(frac[o], ts...);
+    }
+
     template<typename T, callable_options O>
     EVE_FORCEINLINE constexpr T
     frac_(EVE_REQUIRES(cpu_), O const& o, T const& a) noexcept

--- a/include/eve/module/core/regular/fsm.hpp
+++ b/include/eve/module/core/regular/fsm.hpp
@@ -92,12 +92,12 @@ struct fsm_t : strict_elementwise_callable<fsm_t, Options, pedantic_option, prom
 
   namespace detail
   {
-    template<typename T, typename U, typename V, callable_options O>
-    EVE_FORCEINLINE constexpr auto fsm_(EVE_REQUIRES(strict_elementwise_emulated_), O const& o, T const& a, U const& b, V const& c)
-      requires(detail::fp16_should_apply<common_value_t<T, U, V>>)
+    template<callable_options O, simd_value... Ts>
+    EVE_FORCEINLINE constexpr auto fsm_(EVE_REQUIRES(strict_elementwise_emulated_), O const& o, Ts const&... ts)
+      requires (detail::fp16_should_apply<Ts> && ...)
     {
-      if constexpr(O::contains(upper) || O::contains(lower)) return detail::map(fsm[o], a, b, c);
-      else                                                   return apply_fp16_as_fp32(fsm[o], a, b, c);
+      if constexpr(O::contains(upper) || O::contains(lower) || O::contains(pedantic)) return detail::map(fsm[o], ts...);
+      else                                                                            return apply_fp16_as_fp32(fsm[o], ts...);
     }
 
     template<typename T, typename U, typename V, callable_options O>
@@ -105,7 +105,6 @@ struct fsm_t : strict_elementwise_callable<fsm_t, Options, pedantic_option, prom
     {
       return fms[o](b, c, a);
     }
-
   }
 }
 

--- a/include/eve/module/core/regular/fsm.hpp
+++ b/include/eve/module/core/regular/fsm.hpp
@@ -93,7 +93,7 @@ struct fsm_t : strict_elementwise_callable<fsm_t, Options, pedantic_option, prom
   namespace detail
   {
     template<callable_options O, simd_value... Ts>
-    EVE_FORCEINLINE constexpr auto fsm_(EVE_REQUIRES(strict_elementwise_emulated_), O const& o, Ts const&... ts)
+    EVE_FORCEINLINE constexpr auto fsm_(EVE_REQUIRES(emulated_), O const& o, Ts const&... ts)
       requires (detail::fp16_should_apply<Ts> && ...)
     {
       if constexpr(O::contains(upper) || O::contains(lower) || O::contains(pedantic)) return detail::map(fsm[o], ts...);

--- a/include/eve/module/core/regular/fsm.hpp
+++ b/include/eve/module/core/regular/fsm.hpp
@@ -12,6 +12,7 @@
 #include <eve/module/core/decorator/core.hpp>
 #include <eve/module/core/regular/fma.hpp>
 #include <eve/module/core/detail/fmx_utils.hpp>
+#include <eve/traits/apply_fp16.hpp>
 
 namespace eve
 {
@@ -91,6 +92,14 @@ struct fsm_t : strict_elementwise_callable<fsm_t, Options, pedantic_option, prom
 
   namespace detail
   {
+    template<typename T, typename U, typename V, callable_options O>
+    EVE_FORCEINLINE constexpr auto fsm_(EVE_REQUIRES(strict_elementwise_emulated_), O const& o, T const& a, U const& b, V const& c)
+      requires(detail::fp16_should_apply<common_value_t<T, U, V>>)
+    {
+      if constexpr(O::contains(upper) || O::contains(lower)) return detail::map(fsm[o], a, b, c);
+      else                                                   return apply_fp16_as_fp32(fsm[o], a, b, c);
+    }
+
     template<typename T, typename U, typename V, callable_options O>
     EVE_FORCEINLINE constexpr auto fsm_(EVE_REQUIRES(cpu_), O const& o, T const& a, U const& b, V const& c)
     {

--- a/include/eve/module/core/regular/fsnm.hpp
+++ b/include/eve/module/core/regular/fsnm.hpp
@@ -93,12 +93,12 @@ namespace eve
 
   namespace detail
   {
-    template<typename T, typename U, typename V, callable_options O>
-    EVE_FORCEINLINE constexpr auto fsnm_(EVE_REQUIRES(strict_elementwise_emulated_), O const& o, T const& a, U const& b, V const& c)
-      requires(detail::fp16_should_apply<common_value_t<T, U, V>>)
+    template<callable_options O, simd_value... Ts>
+    EVE_FORCEINLINE constexpr auto fsnm_(EVE_REQUIRES(strict_elementwise_emulated_), O const& o, Ts const&... ts)
+      requires (detail::fp16_should_apply<Ts> && ...)
     {
-      if constexpr(O::contains(upper) || O::contains(lower)) return detail::map(fsnm[o], a, b, c);
-      else                                                   return apply_fp16_as_fp32(fsnm[o], a, b, c);
+      if constexpr(O::contains(upper) || O::contains(lower) || O::contains(pedantic)) return detail::map(fsnm[o], ts...);
+      else                                                                            return apply_fp16_as_fp32(fsnm[o], ts...);
     }
 
     template<typename T, typename U, typename V, callable_options O>

--- a/include/eve/module/core/regular/fsnm.hpp
+++ b/include/eve/module/core/regular/fsnm.hpp
@@ -94,7 +94,7 @@ namespace eve
   namespace detail
   {
     template<callable_options O, simd_value... Ts>
-    EVE_FORCEINLINE constexpr auto fsnm_(EVE_REQUIRES(strict_elementwise_emulated_), O const& o, Ts const&... ts)
+    EVE_FORCEINLINE constexpr auto fsnm_(EVE_REQUIRES(emulated_), O const& o, Ts const&... ts)
       requires (detail::fp16_should_apply<Ts> && ...)
     {
       if constexpr(O::contains(upper) || O::contains(lower) || O::contains(pedantic)) return detail::map(fsnm[o], ts...);

--- a/include/eve/module/core/regular/fsnm.hpp
+++ b/include/eve/module/core/regular/fsnm.hpp
@@ -12,6 +12,7 @@
 #include <eve/module/core/decorator/core.hpp>
 #include <eve/module/core/regular/fnms.hpp>
 #include <eve/module/core/detail/fmx_utils.hpp>
+#include <eve/traits/apply_fp16.hpp>
 
 namespace eve
 {
@@ -92,6 +93,14 @@ namespace eve
 
   namespace detail
   {
+    template<typename T, typename U, typename V, callable_options O>
+    EVE_FORCEINLINE constexpr auto fsnm_(EVE_REQUIRES(strict_elementwise_emulated_), O const& o, T const& a, U const& b, V const& c)
+      requires(detail::fp16_should_apply<common_value_t<T, U, V>>)
+    {
+      if constexpr(O::contains(upper) || O::contains(lower)) return detail::map(fsnm[o], a, b, c);
+      else                                                   return apply_fp16_as_fp32(fsnm[o], a, b, c);
+    }
+
     template<typename T, typename U, typename V, callable_options O>
     EVE_FORCEINLINE constexpr auto fsnm_(EVE_REQUIRES(cpu_), O const& o, T const& a, U const& b, V const& c)
     {

--- a/include/eve/module/core/regular/impl/add.hpp
+++ b/include/eve/module/core/regular/impl/add.hpp
@@ -29,7 +29,7 @@
 namespace eve::detail
 {
   template<callable_options O, typename... Ts>
-  EVE_FORCEINLINE constexpr auto add_(EVE_REQUIRES(strict_elementwise_emulated_), O const& o, Ts... ts) noexcept
+  EVE_FORCEINLINE constexpr auto add_(EVE_REQUIRES(emulated_), O const& o, Ts... ts) noexcept
     requires (detail::fp16_should_apply<common_value_t<Ts...>>)
   {
     if      constexpr (O::contains(widen))                       return add[o.drop(widen)](upgrade(ts)...);

--- a/include/eve/module/core/regular/impl/add.hpp
+++ b/include/eve/module/core/regular/impl/add.hpp
@@ -29,7 +29,7 @@
 namespace eve::detail
 {
   template<callable_options O, typename... Ts>
-  EVE_FORCEINLINE constexpr auto add_(EVE_REQUIRES(emulated_), O const& o, Ts... ts) noexcept
+  EVE_FORCEINLINE constexpr auto add_(EVE_REQUIRES(strict_elementwise_emulated_), O const& o, Ts... ts) noexcept
     requires (detail::fp16_should_apply<common_value_t<Ts...>>)
   {
     if      constexpr (O::contains(widen))                       return add[o.drop(widen)](upgrade(ts)...);

--- a/include/eve/module/core/regular/impl/add.hpp
+++ b/include/eve/module/core/regular/impl/add.hpp
@@ -25,9 +25,17 @@
 #include <eve/module/core/regular/fnma.hpp>
 #include <eve/module/core/regular/next.hpp>
 #include <eve/module/core/regular/prev.hpp>
-//#include <eve/detail/function/sum.hpp>
+
 namespace eve::detail
 {
+  template<callable_options O, typename... Ts>
+  EVE_FORCEINLINE constexpr auto add_(EVE_REQUIRES(emulated_), O const& o, Ts... ts) noexcept
+    requires (detail::fp16_should_apply<common_value_t<Ts...>>)
+  {
+    if      constexpr (O::contains(widen))                       return add[o.drop(widen)](upgrade(ts)...);
+    else if constexpr (O::contains(upper) || O::contains(lower)) return detail::map(add[o], ts...);
+    else                                                         return apply_fp16_as_fp32(add[o], ts...);
+  }
 
   template<callable_options O, typename T0, typename T1>
   EVE_FORCEINLINE constexpr auto add_(EVE_REQUIRES(cpu_), O const& o, T0 a0, T1 b0) noexcept

--- a/include/eve/module/core/regular/impl/average.hpp
+++ b/include/eve/module/core/regular/impl/average.hpp
@@ -23,11 +23,12 @@ namespace eve::detail
   EVE_FORCEINLINE constexpr auto average_(EVE_REQUIRES(strict_elementwise_emulated_), O const & o, Ts... ts) noexcept
     requires (detail::fp16_should_apply<common_value_t<Ts...>>)
   {
-    if      constexpr (O::contains(widen))                       return average[o.drop(widen)](upgrade(ts)...);
-    else if constexpr (O::contains(upper) || O::contains(lower)) {
-      return average_(EVE_TARGETS(cpu_), o, ts...);
-    }
-    else                                                         return apply_fp16_as_fp32(average[o], ts...);
+    if constexpr (O::contains(widen))
+      return average[o.drop(widen)](upgrade(ts)...);
+    else if constexpr ((O::contains(upper) || O::contains(lower)) && O::contains(strict))
+      return detail::map(average[o], ts...);
+    else
+      return apply_fp16_as_fp32(average[o], ts...);
   }
 
   template<value T0, value ... Ts, callable_options O>

--- a/include/eve/module/core/regular/impl/average.hpp
+++ b/include/eve/module/core/regular/impl/average.hpp
@@ -18,6 +18,14 @@
 
 namespace eve::detail
 {
+  template<callable_options O, typename... Ts>
+  EVE_FORCEINLINE constexpr auto average_(EVE_REQUIRES(emulated_), O const & o, Ts... ts) noexcept
+    requires (detail::fp16_should_apply<common_value_t<Ts...>>)
+  {
+    if      constexpr (O::contains(widen))                       return average[o.drop(widen)](upgrade(ts)...);
+    else if constexpr (O::contains(upper) || O::contains(lower)) return detail::map(average[o], ts...);
+    else                                                         return apply_fp16_as_fp32(average[o], ts...);
+  }
 
   template<value T0, value ... Ts, callable_options O>
   EVE_FORCEINLINE constexpr auto

--- a/include/eve/module/core/regular/impl/average.hpp
+++ b/include/eve/module/core/regular/impl/average.hpp
@@ -15,6 +15,7 @@
 #include <eve/module/core/regular/fma.hpp>
 #include <eve/module/core/regular/rec.hpp>
 #include <eve/module/core/regular/two_fma_approx.hpp>
+#include <eve/traits/apply_fp16.hpp>
 
 namespace eve::detail
 {
@@ -23,7 +24,9 @@ namespace eve::detail
     requires (detail::fp16_should_apply<common_value_t<Ts...>>)
   {
     if      constexpr (O::contains(widen))                       return average[o.drop(widen)](upgrade(ts)...);
-    else if constexpr (O::contains(upper) || O::contains(lower)) return detail::map(average[o], ts...);
+    else if constexpr (O::contains(upper) || O::contains(lower)) {
+      return average_(EVE_TARGETS(cpu_), o, ts...);
+    }
     else                                                         return apply_fp16_as_fp32(average[o], ts...);
   }
 

--- a/include/eve/module/core/regular/impl/average.hpp
+++ b/include/eve/module/core/regular/impl/average.hpp
@@ -20,7 +20,7 @@
 namespace eve::detail
 {
   template<callable_options O, typename... Ts>
-  EVE_FORCEINLINE constexpr auto average_(EVE_REQUIRES(strict_elementwise_emulated_), O const & o, Ts... ts) noexcept
+  EVE_FORCEINLINE constexpr auto average_(EVE_REQUIRES(emulated_), O const & o, Ts... ts) noexcept
     requires (detail::fp16_should_apply<common_value_t<Ts...>>)
   {
     if constexpr (O::contains(widen))

--- a/include/eve/module/core/regular/impl/average.hpp
+++ b/include/eve/module/core/regular/impl/average.hpp
@@ -19,7 +19,7 @@
 namespace eve::detail
 {
   template<callable_options O, typename... Ts>
-  EVE_FORCEINLINE constexpr auto average_(EVE_REQUIRES(emulated_), O const & o, Ts... ts) noexcept
+  EVE_FORCEINLINE constexpr auto average_(EVE_REQUIRES(strict_elementwise_emulated_), O const & o, Ts... ts) noexcept
     requires (detail::fp16_should_apply<common_value_t<Ts...>>)
   {
     if      constexpr (O::contains(widen))                       return average[o.drop(widen)](upgrade(ts)...);

--- a/include/eve/module/core/regular/impl/ceil.hpp
+++ b/include/eve/module/core/regular/impl/ceil.hpp
@@ -15,6 +15,13 @@
 
 namespace eve::detail
 {
+  template<callable_options O, typename... Ts>
+  EVE_FORCEINLINE constexpr auto ceil_(EVE_REQUIRES(strict_elementwise_emulated_), O const& o, Ts const&... ts) noexcept
+    requires(detail::fp16_should_apply<common_value_t<Ts...>>)
+  {
+    if constexpr (O::contains(almost)) return detail::map(ceil[o], ts...);
+    else                               return apply_fp16_as_fp32(ceil[o], ts...);
+  }
 
   template<typename T, callable_options O>
   EVE_FORCEINLINE constexpr T

--- a/include/eve/module/core/regular/impl/ceil.hpp
+++ b/include/eve/module/core/regular/impl/ceil.hpp
@@ -16,7 +16,7 @@
 namespace eve::detail
 {
   template<callable_options O, typename... Ts>
-  EVE_FORCEINLINE constexpr auto ceil_(EVE_REQUIRES(strict_elementwise_emulated_), O const& o, Ts const&... ts) noexcept
+  EVE_FORCEINLINE constexpr auto ceil_(EVE_REQUIRES(emulated_), O const& o, Ts const&... ts) noexcept
     requires(detail::fp16_should_apply<common_value_t<Ts...>>)
   {
     if constexpr (O::contains(almost)) return detail::map(ceil[o], ts...);

--- a/include/eve/module/core/regular/impl/convert.hpp
+++ b/include/eve/module/core/regular/impl/convert.hpp
@@ -42,14 +42,14 @@ namespace eve::detail
 
   template<callable_options O, typename U, typename N>
   EVE_NOINLINE auto convert_(EVE_REQUIRES(cpu_), O const&, wide<eve::float16_t, N> v, as<U>) noexcept
-    requires (!detail::supports_fp16_vector_conversion)
+    requires (!detail::supports_fp16_vector_conversion && !std::same_as<U, eve::float16_t>)
   {
     return convert(detail::emulated_simd_fp16_to_fp32(v), as<U>{});
   }
 
   template<callable_options O, typename T, typename N>
   EVE_FORCEINLINE auto convert_(EVE_REQUIRES(cpu_), O const&, wide<T, N> v, as<eve::float16_t>) noexcept
-    requires (!detail::supports_fp16_vector_conversion)
+    requires (!detail::supports_fp16_vector_conversion && !std::same_as<T, eve::float16_t>)
   {
     return detail::emulated_simd_fp32_to_fp16(convert(v, as<float>{}));
   }

--- a/include/eve/module/core/regular/impl/convert.hpp
+++ b/include/eve/module/core/regular/impl/convert.hpp
@@ -44,6 +44,8 @@ namespace eve::detail
   EVE_FORCEINLINE auto convert_(EVE_REQUIRES(cpu_), O const&, wide<eve::float16_t, N> v, as<U>) noexcept
     requires (!detail::supports_fp16_vector_conversion && !std::same_as<U, eve::float16_t>)
   {
+    // Because we currently only have conversion routine through floats, we make sure that we convert to/from chunks of
+    // proper cardinality to keep the code size of `emulated_simd_fp16_to_fp32` under control.
     if constexpr( has_aggregated_abi_v<wide<float,N>> )
     {
       using card_t = expected_cardinal_t<float>;

--- a/include/eve/module/core/regular/impl/convert.hpp
+++ b/include/eve/module/core/regular/impl/convert.hpp
@@ -15,6 +15,7 @@
 #include <eve/module/core/regular/if_else.hpp>
 #include <eve/module/core/constant/one.hpp>
 #include <eve/detail/category.hpp>
+#include <eve/arch/simdfloat16.hpp>
 
 namespace eve::detail
 {
@@ -39,112 +40,18 @@ namespace eve::detail
     }
   }
 
-  template<callable_options O, typename N>
-  EVE_NOINLINE auto convert_(EVE_REQUIRES(cpu_), O const&, wide<eve::float16_t, N> v, as<float>) noexcept
-    requires (!detail::supports_fp16_vector_ops)
+  template<callable_options O, typename U, typename N>
+  EVE_NOINLINE auto convert_(EVE_REQUIRES(cpu_), O const&, wide<eve::float16_t, N> v, as<U>) noexcept
+    requires (!detail::supports_fp16_vector_conversion)
   {
-    auto u16      = bit_cast(v, as<wide<uint16_t, N>>{});
-    auto u32      = convert(u16, as<uint32_t>{});
-    auto sign     = (u32 & 0x8000u) << 16;
-    auto exponent = (u32 & 0x7C00u) >> 10;
-    auto mantissa = (u32 & 0x03FFu);
-
-    // Normal
-    auto normal_res = sign | ((exponent + 112) << 23) | (mantissa << 13);
-
-    // Denormal / Zero
-    auto shift = convert(countl_zero(mantissa), as<uint32_t>{}) - 21;
-    auto denorm_mantissa = (mantissa << shift) & 0x03FFu;
-    auto denorm_exp = 113 - shift;
-    auto denorm_res = sign | (denorm_exp << 23) | (denorm_mantissa << 13);
-    denorm_res = if_else(mantissa == 0, sign, denorm_res);
-
-    // Inf / NaN
-    auto inf_nan_res = sign | 0x7F800000u | (mantissa << 13);
-    inf_nan_res = if_else(mantissa != 0, inf_nan_res | 0x400000u, inf_nan_res);
-
-    auto result = if_else(exponent == 31, inf_nan_res,
-                  if_else(exponent == 0, denorm_res, normal_res));
-
-    return bit_cast(result, as<wide<float, N>>{});
-  }
-
-  template<callable_options O, typename N, typename U>
-  EVE_FORCEINLINE auto convert_(EVE_REQUIRES(cpu_), O const&, wide<eve::float16_t, N> v, as<U> tgt) noexcept
-    requires (!std::same_as<U, float> && !std::same_as<U, eve::float16_t> && !detail::supports_fp16_vector_ops)
-  {
-    return convert(convert(v, as<float>{}), tgt);
-  }
-
-  template<callable_options O, typename N>
-  EVE_NOINLINE auto convert_(EVE_REQUIRES(cpu_), O const&, wide<float, N> v, as<eve::float16_t>) noexcept
-    requires (!detail::supports_fp16_vector_ops)
-  {
-    auto bits     = bit_cast(v, as<wide<uint32_t, N>>{});
-    auto sign     = (bits & 0x80000000u) >> 16;
-    auto mantissa = bits & 0x7FFFFFu;
-    auto exponent = bit_cast((bits >> 23) & 0xFF, as<wide<int32_t, N>>{}) - 127;
-
-    auto is_inf_nan = (bits & 0x7F800000u) == 0x7F800000u;
-    auto is_nan     = is_inf_nan && (mantissa != 0);
-
-    auto nan_payload = mantissa >> 13;
-    nan_payload = if_else(nan_payload != 0, nan_payload, 1u);
-    auto nan_res = sign | 0x7C00u | nan_payload;
-    auto inf_res = sign | 0x7C00u;
-    auto inf_nan_res = if_else(is_nan, nan_res, inf_res);
-
-    auto is_overflow = exponent > 15;
-    auto res_overflow = sign | 0x7C00u;
-
-    auto is_tiny = exponent < -25;
-
-    // Denormal handling
-    auto mant_hidden = mantissa | 0x800000u;
-    auto raw_shift   = -exponent - 1;
-    auto safe_shift  = if_else(exponent <= -15, min(raw_shift, 24), 24);
-
-    auto rounded_denorm    = mant_hidden >> safe_shift;
-    auto one_v = one(as<wide<uint32_t, N>>{});
-    auto remainder_denorm  = mant_hidden & ((one_v << safe_shift) - one_v);
-
-    auto threshold_denorm  = one_v << (safe_shift - 1);
-    auto should_inc_denorm = (remainder_denorm > threshold_denorm) ||
-                             ((remainder_denorm == threshold_denorm) && ((rounded_denorm & 1u) != 0));
-
-    rounded_denorm += if_else(should_inc_denorm, 1u, 0u);
-    auto res_denorm = sign | rounded_denorm;
-
-    // Normal handling
-    auto fp16_exp_norm = convert(exponent + 15, as<uint32_t>{}) << 10;
-    auto mant_norm     = mantissa >> 13;
-    auto round_bits    = mantissa & 0x1FFFu;
-
-    auto should_inc_norm = (round_bits > 0x1000u) || ((round_bits == 0x1000u) && ((mant_norm & 1u) != 0));
-    mant_norm += if_else(should_inc_norm, 1u, 0u);
-
-    auto norm_overflow = mant_norm == 0x0400u;
-    mant_norm = if_else(norm_overflow, 0u, mant_norm);
-    fp16_exp_norm += if_else(norm_overflow, 0x0400u, 0u);
-
-    auto is_inf_post_round = (fp16_exp_norm >> 10) >= 31u;
-    auto result_norm = if_else(is_inf_post_round, sign | 0x7C00u, sign | fp16_exp_norm | (mant_norm & 0x3FFu));
-
-    auto res = if_else(exponent <= -15,
-                       if_else(is_tiny, sign, res_denorm),
-                       result_norm);
-
-    res = if_else(is_overflow, res_overflow, res);
-    res = if_else(is_inf_nan, inf_nan_res, res);
-
-    return bit_cast(convert(res, as<uint16_t>{}), as<wide<eve::float16_t, N>>{});
+    return convert(detail::emulated_simd_fp16_to_fp32(v), as<U>{});
   }
 
   template<callable_options O, typename T, typename N>
   EVE_FORCEINLINE auto convert_(EVE_REQUIRES(cpu_), O const&, wide<T, N> v, as<eve::float16_t>) noexcept
-    requires (!std::same_as<T, float> && !std::same_as<T, eve::float16_t> && !detail::supports_fp16_vector_ops)
+    requires (!detail::supports_fp16_vector_conversion)
   {
-    return convert(convert(v, as<float>{}), as<eve::float16_t>{});
+    return detail::emulated_simd_fp32_to_fp16(convert(v, as<float>{}));
   }
 
   template<callable_options O, value In, scalar_value Out>

--- a/include/eve/module/core/regular/impl/convert.hpp
+++ b/include/eve/module/core/regular/impl/convert.hpp
@@ -10,6 +10,10 @@
 #include <eve/module/core/regular/impl/convert_helpers.hpp>
 #include <eve/module/core/regular/is_finite.hpp>
 #include <eve/module/core/regular/bit_cast.hpp>
+#include <eve/module/core/regular/countl_zero.hpp>
+#include <eve/module/core/regular/min.hpp>
+#include <eve/module/core/regular/if_else.hpp>
+#include <eve/module/core/constant/one.hpp>
 #include <eve/detail/category.hpp>
 
 namespace eve::detail
@@ -33,6 +37,114 @@ namespace eve::detail
 
       return res;
     }
+  }
+
+  template<callable_options O, typename N>
+  EVE_NOINLINE auto convert_(EVE_REQUIRES(cpu_), O const&, wide<eve::float16_t, N> v, as<float>) noexcept
+    requires (!detail::supports_fp16_vector_ops)
+  {
+    auto u16      = bit_cast(v, as<wide<uint16_t, N>>{});
+    auto u32      = convert(u16, as<uint32_t>{});
+    auto sign     = (u32 & 0x8000u) << 16;
+    auto exponent = (u32 & 0x7C00u) >> 10;
+    auto mantissa = (u32 & 0x03FFu);
+
+    // Normal
+    auto normal_res = sign | ((exponent + 112) << 23) | (mantissa << 13);
+
+    // Denormal / Zero
+    auto shift = convert(countl_zero(mantissa), as<uint32_t>{}) - 21;
+    auto denorm_mantissa = (mantissa << shift) & 0x03FFu;
+    auto denorm_exp = 113 - shift;
+    auto denorm_res = sign | (denorm_exp << 23) | (denorm_mantissa << 13);
+    denorm_res = if_else(mantissa == 0, sign, denorm_res);
+
+    // Inf / NaN
+    auto inf_nan_res = sign | 0x7F800000u | (mantissa << 13);
+    inf_nan_res = if_else(mantissa != 0, inf_nan_res | 0x400000u, inf_nan_res);
+
+    auto result = if_else(exponent == 31, inf_nan_res,
+                  if_else(exponent == 0, denorm_res, normal_res));
+
+    return bit_cast(result, as<wide<float, N>>{});
+  }
+
+  template<callable_options O, typename N, typename U>
+  EVE_FORCEINLINE auto convert_(EVE_REQUIRES(cpu_), O const&, wide<eve::float16_t, N> v, as<U> tgt) noexcept
+    requires (!std::same_as<U, float> && !std::same_as<U, eve::float16_t> && !detail::supports_fp16_vector_ops)
+  {
+    return convert(convert(v, as<float>{}), tgt);
+  }
+
+  template<callable_options O, typename N>
+  EVE_NOINLINE auto convert_(EVE_REQUIRES(cpu_), O const&, wide<float, N> v, as<eve::float16_t>) noexcept
+    requires (!detail::supports_fp16_vector_ops)
+  {
+    auto bits     = bit_cast(v, as<wide<uint32_t, N>>{});
+    auto sign     = (bits & 0x80000000u) >> 16;
+    auto mantissa = bits & 0x7FFFFFu;
+    auto exponent = bit_cast((bits >> 23) & 0xFF, as<wide<int32_t, N>>{}) - 127;
+
+    auto is_inf_nan = (bits & 0x7F800000u) == 0x7F800000u;
+    auto is_nan     = is_inf_nan && (mantissa != 0);
+
+    auto nan_payload = mantissa >> 13;
+    nan_payload = if_else(nan_payload != 0, nan_payload, 1u);
+    auto nan_res = sign | 0x7C00u | nan_payload;
+    auto inf_res = sign | 0x7C00u;
+    auto inf_nan_res = if_else(is_nan, nan_res, inf_res);
+
+    auto is_overflow = exponent > 15;
+    auto res_overflow = sign | 0x7C00u;
+
+    auto is_tiny = exponent < -25;
+
+    // Denormal handling
+    auto mant_hidden = mantissa | 0x800000u;
+    auto raw_shift   = -exponent - 1;
+    auto safe_shift  = if_else(exponent <= -15, min(raw_shift, 24), 24);
+
+    auto rounded_denorm    = mant_hidden >> safe_shift;
+    auto one_v = one(as<wide<uint32_t, N>>{});
+    auto remainder_denorm  = mant_hidden & ((one_v << safe_shift) - one_v);
+
+    auto threshold_denorm  = one_v << (safe_shift - 1);
+    auto should_inc_denorm = (remainder_denorm > threshold_denorm) ||
+                             ((remainder_denorm == threshold_denorm) && ((rounded_denorm & 1u) != 0));
+
+    rounded_denorm += if_else(should_inc_denorm, 1u, 0u);
+    auto res_denorm = sign | rounded_denorm;
+
+    // Normal handling
+    auto fp16_exp_norm = convert(exponent + 15, as<uint32_t>{}) << 10;
+    auto mant_norm     = mantissa >> 13;
+    auto round_bits    = mantissa & 0x1FFFu;
+
+    auto should_inc_norm = (round_bits > 0x1000u) || ((round_bits == 0x1000u) && ((mant_norm & 1u) != 0));
+    mant_norm += if_else(should_inc_norm, 1u, 0u);
+
+    auto norm_overflow = mant_norm == 0x0400u;
+    mant_norm = if_else(norm_overflow, 0u, mant_norm);
+    fp16_exp_norm += if_else(norm_overflow, 0x0400u, 0u);
+
+    auto is_inf_post_round = (fp16_exp_norm >> 10) >= 31u;
+    auto result_norm = if_else(is_inf_post_round, sign | 0x7C00u, sign | fp16_exp_norm | (mant_norm & 0x3FFu));
+
+    auto res = if_else(exponent <= -15,
+                       if_else(is_tiny, sign, res_denorm),
+                       result_norm);
+
+    res = if_else(is_overflow, res_overflow, res);
+    res = if_else(is_inf_nan, inf_nan_res, res);
+
+    return bit_cast(convert(res, as<uint16_t>{}), as<wide<eve::float16_t, N>>{});
+  }
+
+  template<callable_options O, typename T, typename N>
+  EVE_FORCEINLINE auto convert_(EVE_REQUIRES(cpu_), O const&, wide<T, N> v, as<eve::float16_t>) noexcept
+    requires (!std::same_as<T, float> && !std::same_as<T, eve::float16_t> && !detail::supports_fp16_vector_ops)
+  {
+    return convert(convert(v, as<float>{}), as<eve::float16_t>{});
   }
 
   template<callable_options O, value In, scalar_value Out>

--- a/include/eve/module/core/regular/impl/convert.hpp
+++ b/include/eve/module/core/regular/impl/convert.hpp
@@ -44,7 +44,18 @@ namespace eve::detail
   EVE_FORCEINLINE auto convert_(EVE_REQUIRES(cpu_), O const&, wide<eve::float16_t, N> v, as<U>) noexcept
     requires (!detail::supports_fp16_vector_conversion && !std::same_as<U, eve::float16_t>)
   {
-    return convert(detail::emulated_simd_fp16_to_fp32(v), as<U>{});
+    if constexpr( has_aggregated_abi_v<wide<float,N>> )
+    {
+      using card_t = expected_cardinal_t<float>;
+      using base  = typename wide<eve::float16_t, N>::template rescale<card_t>;
+      auto parts  = kumi::map([](auto m) { return std::bit_cast<base>(m); }, kumi::chunks<card_t::value>(v.storage()));
+      auto cvt    = kumi::map([](auto p) { return convert(p, as<float>{}); }, parts);
+      return kumi::apply([&](auto... m) { return wide<U, N>{m...}; }, cvt);
+    }
+    else
+    {
+      return convert(detail::emulated_simd_fp16_to_fp32(v), as<U>{});
+    }
   }
 
   template<callable_options O, typename T, typename N>

--- a/include/eve/module/core/regular/impl/convert.hpp
+++ b/include/eve/module/core/regular/impl/convert.hpp
@@ -41,7 +41,7 @@ namespace eve::detail
   }
 
   template<callable_options O, typename U, typename N>
-  EVE_NOINLINE auto convert_(EVE_REQUIRES(cpu_), O const&, wide<eve::float16_t, N> v, as<U>) noexcept
+  EVE_FORCEINLINE auto convert_(EVE_REQUIRES(cpu_), O const&, wide<eve::float16_t, N> v, as<U>) noexcept
     requires (!detail::supports_fp16_vector_conversion && !std::same_as<U, eve::float16_t>)
   {
     return convert(detail::emulated_simd_fp16_to_fp32(v), as<U>{});

--- a/include/eve/module/core/regular/impl/convert.hpp
+++ b/include/eve/module/core/regular/impl/convert.hpp
@@ -49,7 +49,7 @@ namespace eve::detail
       using card_t = expected_cardinal_t<float>;
       using base  = typename wide<eve::float16_t, N>::template rescale<card_t>;
       auto parts  = kumi::map([](auto m) { return std::bit_cast<base>(m); }, kumi::chunks<card_t::value>(v.storage()));
-      auto cvt    = kumi::map([](auto p) { return convert(p, as<float>{}); }, parts);
+      auto cvt    = kumi::map([](auto p) { return convert(p, as<U>{}); }, parts);
       return kumi::apply([&](auto... m) { return wide<U, N>{m...}; }, cvt);
     }
     else

--- a/include/eve/module/core/regular/impl/convert_helpers.hpp
+++ b/include/eve/module/core/regular/impl/convert_helpers.hpp
@@ -91,14 +91,15 @@ EVE_FORCEINLINE auto convert_impl(EVE_REQUIRES(cpu_), In v0, as<Out> tgt) noexce
 {
   using out_t = as_wide_t<Out, cardinal_t<In>>;
 
-  if constexpr( has_aggregated_abi_v<In> )
+  if constexpr( has_aggregated_abi_v<In> && !has_emulated_abi_v<out_t> )
   {
     // If input is aggregated, we can slice and combine without lose of performance
     return out_t {eve::convert(v0.slice(lower_), tgt), eve::convert(v0.slice(upper_), tgt)};
   }
   else
   {
-    return map(convert, v0, tgt);
+    // prevent map circular calls for FP16
+    return apply<cardinal_v<out_t>>([&](auto... I) { return out_t{ convert(v0.get(I), tgt)... }; } );
   }
 }
 

--- a/include/eve/module/core/regular/impl/div.hpp
+++ b/include/eve/module/core/regular/impl/div.hpp
@@ -42,23 +42,25 @@
 
 namespace eve::detail
 {
-  template<callable_options O, typename T0, typename... Ts>
-  EVE_FORCEINLINE constexpr auto div_(EVE_REQUIRES(strict_elementwise_emulated_), O const& o, T0 t0, T0 t1, Ts... ts) noexcept
+  template<callable_options O, typename... Ts>
+  EVE_FORCEINLINE constexpr auto div_(EVE_REQUIRES(strict_elementwise_emulated_), O const& o, Ts... ts) noexcept
     requires (detail::fp16_should_apply<common_value_t<Ts...>>)
   {
     if constexpr (O::contains(upper) || O::contains(lower) || O::contains(upward) || O::contains(downward) || O::contains(to_nearest))
     {
-      return detail::map(div[o], t0, t1, ts...);
+      return detail::map(div[o], ts...);
     }
-    else if constexpr (sizeof...(Ts) > 0)
+    else if constexpr (sizeof...(Ts) > 2)
     {
-      auto den = t1;
-      ((den = apply_fp16_as_fp32(mul[o], den, ts)), ...);
-       return apply_fp16_as_fp32(div[o], t0, den);
+      return [&](auto t0, auto t1, auto... rest) {
+        auto den = t1;
+        ((den = apply_fp16_as_fp32(mul[o], den, rest)), ...);
+        return apply_fp16_as_fp32(div[o], t0, den);
+      }(ts...);
     }
     else
     {
-      return apply_fp16_as_fp32(div[o], t0, t1, ts...);
+      return apply_fp16_as_fp32(div[o], ts...);
     }
   }
 

--- a/include/eve/module/core/regular/impl/div.hpp
+++ b/include/eve/module/core/regular/impl/div.hpp
@@ -42,6 +42,28 @@
 
 namespace eve::detail
 {
+  template<callable_options O, typename... Ts>
+  EVE_FORCEINLINE constexpr auto div_(EVE_REQUIRES(emulated_), O const& o, Ts... ts) noexcept
+    requires (detail::fp16_should_apply<common_value_t<Ts...>>)
+  {
+    if constexpr (sizeof...(Ts) > 2)
+    {
+      return [&o]<typename T0, typename T1, typename... Us>(T0 x0, T1 x1, Us... xs)
+      {
+        auto den = x1;
+        ((den = apply_fp16_as_fp32(mul[o], den, xs)), ...);
+        return apply_fp16_as_fp32(div[o], x0, den);
+      }(ts...);
+    }
+    else if constexpr (O::contains(upper) || O::contains(lower))
+    {
+      return detail::map(div[o], ts...);
+    }
+    else
+    {
+      return apply_fp16_as_fp32(div[o], ts...);
+    }
+  }
 
   template<callable_options O, typename T>
   EVE_FORCEINLINE constexpr T div_(EVE_REQUIRES(cpu_), O const& o, T a, T b) noexcept

--- a/include/eve/module/core/regular/impl/div.hpp
+++ b/include/eve/module/core/regular/impl/div.hpp
@@ -42,17 +42,23 @@
 
 namespace eve::detail
 {
-  template<callable_options O, typename... Ts>
-  EVE_FORCEINLINE constexpr auto div_(EVE_REQUIRES(strict_elementwise_emulated_), O const& o, Ts... ts) noexcept
+  template<callable_options O, typename T0, typename... Ts>
+  EVE_FORCEINLINE constexpr auto div_(EVE_REQUIRES(strict_elementwise_emulated_), O const& o, T0 t0, T0 t1, Ts... ts) noexcept
     requires (detail::fp16_should_apply<common_value_t<Ts...>>)
   {
     if constexpr (O::contains(upper) || O::contains(lower) || O::contains(upward) || O::contains(downward) || O::contains(to_nearest))
     {
-      return detail::map(div[o], ts...);
+      return detail::map(div[o], t0, t1, ts...);
+    }
+    else if constexpr (sizeof...(Ts) > 0)
+    {
+      auto den = t1;
+      ((den = apply_fp16_as_fp32(mul[o], den, ts)), ...);
+       return apply_fp16_as_fp32(div[o], t0, den);
     }
     else
     {
-      return apply_fp16_as_fp32(div[o], ts...);
+      return apply_fp16_as_fp32(div[o], t0, t1, ts...);
     }
   }
 

--- a/include/eve/module/core/regular/impl/div.hpp
+++ b/include/eve/module/core/regular/impl/div.hpp
@@ -43,7 +43,7 @@
 namespace eve::detail
 {
   template<callable_options O, typename... Ts>
-  EVE_FORCEINLINE constexpr auto div_(EVE_REQUIRES(emulated_), O const& o, Ts... ts) noexcept
+  EVE_FORCEINLINE constexpr auto div_(EVE_REQUIRES(strict_elementwise_emulated_), O const& o, Ts... ts) noexcept
     requires (detail::fp16_should_apply<common_value_t<Ts...>>)
   {
     if constexpr (sizeof...(Ts) > 2)

--- a/include/eve/module/core/regular/impl/div.hpp
+++ b/include/eve/module/core/regular/impl/div.hpp
@@ -43,7 +43,7 @@
 namespace eve::detail
 {
   template<callable_options O, typename... Ts>
-  EVE_FORCEINLINE constexpr auto div_(EVE_REQUIRES(strict_elementwise_emulated_), O const& o, Ts... ts) noexcept
+  EVE_FORCEINLINE constexpr auto div_(EVE_REQUIRES(emulated_), O const& o, Ts... ts) noexcept
     requires (detail::fp16_should_apply<common_value_t<Ts...>>)
   {
     if constexpr (O::contains(upper) || O::contains(lower) || O::contains(upward) || O::contains(downward) || O::contains(to_nearest))

--- a/include/eve/module/core/regular/impl/div.hpp
+++ b/include/eve/module/core/regular/impl/div.hpp
@@ -46,16 +46,7 @@ namespace eve::detail
   EVE_FORCEINLINE constexpr auto div_(EVE_REQUIRES(strict_elementwise_emulated_), O const& o, Ts... ts) noexcept
     requires (detail::fp16_should_apply<common_value_t<Ts...>>)
   {
-    if constexpr (sizeof...(Ts) > 2)
-    {
-      return [&o]<typename T0, typename T1, typename... Us>(T0 x0, T1 x1, Us... xs)
-      {
-        auto den = x1;
-        ((den = apply_fp16_as_fp32(mul[o], den, xs)), ...);
-        return apply_fp16_as_fp32(div[o], x0, den);
-      }(ts...);
-    }
-    else if constexpr (O::contains(upper) || O::contains(lower))
+    if constexpr (O::contains(upper) || O::contains(lower) || O::contains(upward) || O::contains(downward) || O::contains(to_nearest))
     {
       return detail::map(div[o], ts...);
     }

--- a/include/eve/module/core/regular/impl/fam.hpp
+++ b/include/eve/module/core/regular/impl/fam.hpp
@@ -16,7 +16,7 @@
 namespace eve::detail
 {
   template<callable_options O, simd_value... Ts>
-  EVE_FORCEINLINE constexpr auto fam_(EVE_REQUIRES(strict_elementwise_emulated_), O const& o, Ts const&... ts) noexcept
+  EVE_FORCEINLINE constexpr auto fam_(EVE_REQUIRES(emulated_), O const& o, Ts const&... ts) noexcept
     requires (detail::fp16_should_apply<Ts> && ...)
   {
     if constexpr (O::contains(upper) || O::contains(lower) || O::contains(pedantic)) return detail::map(fam[o], ts...);

--- a/include/eve/module/core/regular/impl/fam.hpp
+++ b/include/eve/module/core/regular/impl/fam.hpp
@@ -11,9 +11,18 @@
 #include <eve/concept/value.hpp>
 #include <eve/detail/implementation.hpp>
 #include <eve/module/core/regular/fma.hpp>
+#include <eve/traits/apply_fp16.hpp>
 
 namespace eve::detail
 {
+  template<callable_options O, typename... Ts>
+  EVE_FORCEINLINE constexpr auto fam_(EVE_REQUIRES(strict_elementwise_emulated_), O const& o, Ts const&... ts) noexcept
+    requires(detail::fp16_should_apply<common_value_t<Ts...>>)
+  {
+    if constexpr (O::contains(upper) || O::contains(lower)) return detail::map(fam[o], ts...);
+    else                                                    return apply_fp16_as_fp32(fam[o], ts...);
+  }
+
   template<typename T, typename U, typename V, callable_options O>
   EVE_FORCEINLINE constexpr auto fam_(EVE_REQUIRES(cpu_), O const& o, T const& a, U const& b, V const& c)
   {

--- a/include/eve/module/core/regular/impl/fam.hpp
+++ b/include/eve/module/core/regular/impl/fam.hpp
@@ -15,12 +15,12 @@
 
 namespace eve::detail
 {
-  template<callable_options O, typename... Ts>
+  template<callable_options O, simd_value... Ts>
   EVE_FORCEINLINE constexpr auto fam_(EVE_REQUIRES(strict_elementwise_emulated_), O const& o, Ts const&... ts) noexcept
-    requires(detail::fp16_should_apply<common_value_t<Ts...>>)
+    requires (detail::fp16_should_apply<Ts> && ...)
   {
-    if constexpr (O::contains(upper) || O::contains(lower)) return detail::map(fam[o], ts...);
-    else                                                    return apply_fp16_as_fp32(fam[o], ts...);
+    if constexpr (O::contains(upper) || O::contains(lower) || O::contains(pedantic)) return detail::map(fam[o], ts...);
+    else                                                                             return apply_fp16_as_fp32(fam[o], ts...);
   }
 
   template<typename T, typename U, typename V, callable_options O>
@@ -77,7 +77,12 @@ namespace eve::detail
    // PEDANTIC ---------------------
     else if constexpr(O::contains(pedantic))
     {
-      if constexpr( std::same_as<element_type_t<T>, float> )
+      if constexpr( std::same_as<element_type_t<T>, eve::float16_t> )
+      {
+        constexpr auto tgt = as<float>{};
+        return convert(convert(a,tgt) + convert(b,tgt) * convert(c,tgt), as_element(a));
+      }
+      else if constexpr( std::same_as<element_type_t<T>, float> )
       {
         constexpr auto tgt = as<double>{};
         return convert(convert(a,tgt) + convert(b,tgt) * convert(c,tgt), as_element(a));

--- a/include/eve/module/core/regular/impl/floor.hpp
+++ b/include/eve/module/core/regular/impl/floor.hpp
@@ -30,7 +30,7 @@
 namespace eve::detail
 {
   template<callable_options O, typename... Ts>
-  EVE_FORCEINLINE constexpr auto floor_(EVE_REQUIRES(strict_elementwise_emulated_), O const& o, Ts const&... ts) noexcept
+  EVE_FORCEINLINE constexpr auto floor_(EVE_REQUIRES(emulated_), O const& o, Ts const&... ts) noexcept
     requires(detail::fp16_should_apply<common_value_t<Ts...>>)
   {
     if constexpr (O::contains(almost)) return detail::map(floor[o], ts...);

--- a/include/eve/module/core/regular/impl/floor.hpp
+++ b/include/eve/module/core/regular/impl/floor.hpp
@@ -10,6 +10,7 @@
 #include <eve/concept/value.hpp>
 #include <eve/detail/apply_over.hpp>
 #include <eve/detail/implementation.hpp>
+#include <eve/traits/apply_fp16.hpp>
 #include <eve/module/core/regular/dec.hpp>
 #include <eve/module/core/regular/is_greater.hpp>
 #include <eve/module/core/regular/is_not_less_equal.hpp>
@@ -28,6 +29,14 @@
 
 namespace eve::detail
 {
+  template<callable_options O, typename... Ts>
+  EVE_FORCEINLINE constexpr auto floor_(EVE_REQUIRES(strict_elementwise_emulated_), O const& o, Ts const&... ts) noexcept
+    requires(detail::fp16_should_apply<common_value_t<Ts...>>)
+  {
+    if constexpr (O::contains(almost)) return detail::map(floor[o], ts...);
+    else                               return apply_fp16_as_fp32(floor[o], ts...);
+  }
+
   template<typename T, callable_options O>
   EVE_FORCEINLINE constexpr T
   floor_(EVE_REQUIRES(cpu_), O const& o, T const& a0) noexcept

--- a/include/eve/module/core/regular/impl/fma.hpp
+++ b/include/eve/module/core/regular/impl/fma.hpp
@@ -26,7 +26,7 @@
 namespace eve::detail
 {
   template<callable_options O, typename... Ts>
-  EVE_FORCEINLINE constexpr auto fma_(EVE_REQUIRES(emulated_), O const& o, Ts... ts) noexcept
+  EVE_FORCEINLINE constexpr auto fma_(EVE_REQUIRES(strict_elementwise_emulated_), O const& o, Ts... ts) noexcept
     requires (detail::fp16_should_apply<common_value_t<Ts...>>)
   {
     if constexpr (O::contains(upper) || O::contains(lower)) return detail::map(fma[o], ts...);

--- a/include/eve/module/core/regular/impl/fma.hpp
+++ b/include/eve/module/core/regular/impl/fma.hpp
@@ -25,6 +25,14 @@
 
 namespace eve::detail
 {
+  template<callable_options O, typename... Ts>
+  EVE_FORCEINLINE constexpr auto fma_(EVE_REQUIRES(emulated_), O const& o, Ts... ts) noexcept
+    requires (detail::fp16_should_apply<common_value_t<Ts...>>)
+  {
+    if constexpr (O::contains(upper) || O::contains(lower)) return detail::map(fma[o], ts...);
+    else                                                    return apply_fp16_as_fp32(fma[o], ts...);
+  }
+
   template<typename T, typename U, typename V, callable_options O>
   EVE_FORCEINLINE constexpr auto fma_(EVE_REQUIRES(cpu_), O const& o, T const& a, U const& b, V const& c)
   {

--- a/include/eve/module/core/regular/impl/fma.hpp
+++ b/include/eve/module/core/regular/impl/fma.hpp
@@ -27,7 +27,7 @@
 namespace eve::detail
 {
   template<callable_options O, simd_value... Ts>
-  EVE_FORCEINLINE constexpr auto fma_(EVE_REQUIRES(strict_elementwise_emulated_), O const& o, Ts... ts) noexcept
+  EVE_FORCEINLINE constexpr auto fma_(EVE_REQUIRES(emulated_), O const& o, Ts... ts) noexcept
     requires (detail::fp16_should_apply<Ts> && ...)
   {
     if constexpr (O::contains(upper) || O::contains(lower) || O::contains(pedantic)) return detail::map(fma[o], ts...);

--- a/include/eve/module/core/regular/impl/fma.hpp
+++ b/include/eve/module/core/regular/impl/fma.hpp
@@ -21,16 +21,17 @@
 #include <eve/module/core/regular/three_fma.hpp>
 #include <eve/traits/as_integer.hpp>
 #include <eve/traits/common_value.hpp>
+#include <eve/traits/apply_fp16.hpp>
 #include <cmath>
 
 namespace eve::detail
 {
-  template<callable_options O, typename... Ts>
+  template<callable_options O, simd_value... Ts>
   EVE_FORCEINLINE constexpr auto fma_(EVE_REQUIRES(strict_elementwise_emulated_), O const& o, Ts... ts) noexcept
-    requires (detail::fp16_should_apply<common_value_t<Ts...>>)
+    requires (detail::fp16_should_apply<Ts> && ...)
   {
-    if constexpr (O::contains(upper) || O::contains(lower)) return detail::map(fma[o], ts...);
-    else                                                    return apply_fp16_as_fp32(fma[o], ts...);
+    if constexpr (O::contains(upper) || O::contains(lower) || O::contains(pedantic)) return detail::map(fma[o], ts...);
+    else                                                                             return apply_fp16_as_fp32(fma[o], ts...);
   }
 
   template<typename T, typename U, typename V, callable_options O>

--- a/include/eve/module/core/regular/impl/fms.hpp
+++ b/include/eve/module/core/regular/impl/fms.hpp
@@ -27,12 +27,12 @@
 
 namespace eve::detail
 {
-  template<callable_options O, typename... Ts>
+  template<callable_options O, simd_value... Ts>
   EVE_FORCEINLINE constexpr auto fms_(EVE_REQUIRES(strict_elementwise_emulated_), O const& o, Ts const&... ts) noexcept
-    requires(detail::fp16_should_apply<common_value_t<Ts...>>)
+    requires (detail::fp16_should_apply<Ts> && ...)
   {
-    if constexpr (O::contains(upper) || O::contains(lower)) return detail::map(fms[o], ts...);
-    else                                                    return apply_fp16_as_fp32(fms[o], ts...);
+    if constexpr (O::contains(upper) || O::contains(lower) || O::contains(pedantic)) return detail::map(fms[o], ts...);
+    else                                                                             return apply_fp16_as_fp32(fms[o], ts...);
   }
 
   template<typename T, typename U, typename V, callable_options O>
@@ -106,7 +106,12 @@ namespace eve::detail
     // PEDANTIC ---------------------
     else if constexpr(O::contains(pedantic))
     {
-      if constexpr( std::same_as<element_type_t<T>, float> )
+      if constexpr( std::same_as<element_type_t<T>, eve::float16_t> )
+      {
+        constexpr auto tgt = as<float>{};
+        return convert(convert(a,tgt) * convert(b,tgt) - convert(c,tgt), as_element(a));
+      }
+      else if constexpr( std::same_as<element_type_t<T>, float> )
       {
         constexpr auto tgt = as<double>{};
         return convert(convert(a,tgt) * convert(b,tgt) - convert(c,tgt), as_element(a));

--- a/include/eve/module/core/regular/impl/fms.hpp
+++ b/include/eve/module/core/regular/impl/fms.hpp
@@ -22,10 +22,19 @@
 #include <eve/module/core/regular/three_fma.hpp>
 #include <eve/traits/as_integer.hpp>
 #include <eve/traits/common_value.hpp>
+#include <eve/traits/apply_fp16.hpp>
 #include <cmath>
 
 namespace eve::detail
 {
+  template<callable_options O, typename... Ts>
+  EVE_FORCEINLINE constexpr auto fms_(EVE_REQUIRES(strict_elementwise_emulated_), O const& o, Ts const&... ts) noexcept
+    requires(detail::fp16_should_apply<common_value_t<Ts...>>)
+  {
+    if constexpr (O::contains(upper) || O::contains(lower)) return detail::map(fms[o], ts...);
+    else                                                    return apply_fp16_as_fp32(fms[o], ts...);
+  }
+
   template<typename T, typename U, typename V, callable_options O>
   EVE_FORCEINLINE constexpr auto fms_(EVE_REQUIRES(cpu_), O const& o, T const& a, U const& b, V const& c)
   {

--- a/include/eve/module/core/regular/impl/fms.hpp
+++ b/include/eve/module/core/regular/impl/fms.hpp
@@ -28,7 +28,7 @@
 namespace eve::detail
 {
   template<callable_options O, simd_value... Ts>
-  EVE_FORCEINLINE constexpr auto fms_(EVE_REQUIRES(strict_elementwise_emulated_), O const& o, Ts const&... ts) noexcept
+  EVE_FORCEINLINE constexpr auto fms_(EVE_REQUIRES(emulated_), O const& o, Ts const&... ts) noexcept
     requires (detail::fp16_should_apply<Ts> && ...)
   {
     if constexpr (O::contains(upper) || O::contains(lower) || O::contains(pedantic)) return detail::map(fms[o], ts...);

--- a/include/eve/module/core/regular/impl/maxabs.hpp
+++ b/include/eve/module/core/regular/impl/maxabs.hpp
@@ -14,7 +14,7 @@
 namespace eve::detail
 {
   template<callable_options O, typename... Ts>
-  EVE_FORCEINLINE constexpr auto maxabs_(EVE_REQUIRES(emulated_), O const & o, Ts... ts) noexcept
+  EVE_FORCEINLINE constexpr auto maxabs_(EVE_REQUIRES(strict_elementwise_emulated_), O const & o, Ts... ts) noexcept
     requires (O::contains(widen) && detail::fp16_should_apply<common_value_t<Ts...>>)
   {
     return maxabs[o.drop(widen)](upgrade(ts)...);

--- a/include/eve/module/core/regular/impl/maxabs.hpp
+++ b/include/eve/module/core/regular/impl/maxabs.hpp
@@ -14,7 +14,7 @@
 namespace eve::detail
 {
   template<callable_options O, typename... Ts>
-  EVE_FORCEINLINE constexpr auto maxabs_(EVE_REQUIRES(strict_elementwise_emulated_), O const & o, Ts... ts) noexcept
+  EVE_FORCEINLINE constexpr auto maxabs_(EVE_REQUIRES(emulated_), O const & o, Ts... ts) noexcept
     requires (O::contains(widen) && detail::fp16_should_apply<common_value_t<Ts...>>)
   {
     return maxabs[o.drop(widen)](upgrade(ts)...);

--- a/include/eve/module/core/regular/impl/maxabs.hpp
+++ b/include/eve/module/core/regular/impl/maxabs.hpp
@@ -13,6 +13,13 @@
 
 namespace eve::detail
 {
+  template<callable_options O, typename... Ts>
+  EVE_FORCEINLINE constexpr auto maxabs_(EVE_REQUIRES(emulated_), O const & o, Ts... ts) noexcept
+    requires (O::contains(widen) && detail::fp16_should_apply<common_value_t<Ts...>>)
+  {
+    return maxabs[o.drop(widen)](upgrade(ts)...);
+  }
+
   template<typename T0, typename... Ts, callable_options O>
   EVE_FORCEINLINE constexpr auto
   maxabs_(EVE_REQUIRES(cpu_), O const & o, T0 t0, Ts... as) noexcept

--- a/include/eve/module/core/regular/impl/minabs.hpp
+++ b/include/eve/module/core/regular/impl/minabs.hpp
@@ -12,6 +12,13 @@
 
 namespace eve::detail
 {
+  template<callable_options O, typename... Ts>
+  EVE_FORCEINLINE constexpr auto minabs_(EVE_REQUIRES(emulated_), O const & o, Ts... ts) noexcept
+    requires (O::contains(widen) && detail::fp16_should_apply<common_value_t<Ts...>>)
+  {
+    return minabs[o.drop(widen)](upgrade(ts)...);
+  }
+
   template<typename T0, typename... Ts, callable_options O>
   EVE_FORCEINLINE constexpr common_value_t<T0, Ts...>
   minabs_(EVE_REQUIRES(cpu_), O const & o, T0 t0, Ts... as) noexcept

--- a/include/eve/module/core/regular/impl/minabs.hpp
+++ b/include/eve/module/core/regular/impl/minabs.hpp
@@ -13,7 +13,7 @@
 namespace eve::detail
 {
   template<callable_options O, typename... Ts>
-  EVE_FORCEINLINE constexpr auto minabs_(EVE_REQUIRES(strict_elementwise_emulated_), O const & o, Ts... ts) noexcept
+  EVE_FORCEINLINE constexpr auto minabs_(EVE_REQUIRES(emulated_), O const & o, Ts... ts) noexcept
     requires (O::contains(widen) && detail::fp16_should_apply<common_value_t<Ts...>>)
   {
     return minabs[o.drop(widen)](upgrade(ts)...);

--- a/include/eve/module/core/regular/impl/minabs.hpp
+++ b/include/eve/module/core/regular/impl/minabs.hpp
@@ -13,7 +13,7 @@
 namespace eve::detail
 {
   template<callable_options O, typename... Ts>
-  EVE_FORCEINLINE constexpr auto minabs_(EVE_REQUIRES(emulated_), O const & o, Ts... ts) noexcept
+  EVE_FORCEINLINE constexpr auto minabs_(EVE_REQUIRES(strict_elementwise_emulated_), O const & o, Ts... ts) noexcept
     requires (O::contains(widen) && detail::fp16_should_apply<common_value_t<Ts...>>)
   {
     return minabs[o.drop(widen)](upgrade(ts)...);

--- a/include/eve/module/core/regular/impl/mul.hpp
+++ b/include/eve/module/core/regular/impl/mul.hpp
@@ -34,7 +34,7 @@
 namespace eve::detail
 {
   template<callable_options O, typename... Ts>
-  EVE_FORCEINLINE constexpr auto mul_(EVE_REQUIRES(strict_elementwise_emulated_), O const& o, Ts... ts) noexcept
+  EVE_FORCEINLINE constexpr auto mul_(EVE_REQUIRES(emulated_), O const& o, Ts... ts) noexcept
     requires (detail::fp16_should_apply<common_value_t<Ts...>>)
   {
     if constexpr (O::contains(widen))

--- a/include/eve/module/core/regular/impl/mul.hpp
+++ b/include/eve/module/core/regular/impl/mul.hpp
@@ -34,7 +34,7 @@
 namespace eve::detail
 {
   template<callable_options O, typename... Ts>
-  EVE_FORCEINLINE constexpr auto mul_(EVE_REQUIRES(emulated_), O const& o, Ts... ts) noexcept
+  EVE_FORCEINLINE constexpr auto mul_(EVE_REQUIRES(strict_elementwise_emulated_), O const& o, Ts... ts) noexcept
     requires (detail::fp16_should_apply<common_value_t<Ts...>>)
   {
     if constexpr (O::contains(widen))

--- a/include/eve/module/core/regular/impl/mul.hpp
+++ b/include/eve/module/core/regular/impl/mul.hpp
@@ -33,6 +33,31 @@
 
 namespace eve::detail
 {
+  template<callable_options O, typename... Ts>
+  EVE_FORCEINLINE constexpr auto mul_(EVE_REQUIRES(emulated_), O const& o, Ts... ts) noexcept
+    requires (detail::fp16_should_apply<common_value_t<Ts...>>)
+  {
+    if constexpr (O::contains(widen))
+    {
+      return mul[o.drop(widen)](upgrade(ts)...);
+    }
+    else if constexpr (sizeof...(Ts) > 2)
+    {
+      using r_t = common_value_t<Ts...>;
+      auto r0 = eve::one(as<r_t>{});
+      ((r0 = mul[o](r0, ts)), ...);
+      return r0;
+    }
+    else if constexpr (O::contains(upper) || O::contains(lower))
+    {
+      return detail::map(mul[o], ts...);
+    }
+    else
+    {
+      return apply_fp16_as_fp32(mul[o], ts...);
+    }
+  }
+
   template<callable_options O, typename T, typename U>
   EVE_FORCEINLINE constexpr auto mul_(EVE_REQUIRES(cpu_), O const& opts, T a, U b) noexcept
   {

--- a/include/eve/module/core/regular/impl/rec.hpp
+++ b/include/eve/module/core/regular/impl/rec.hpp
@@ -24,6 +24,15 @@
 namespace eve::detail
 {
 
+  template<callable_options O, typename T>
+  EVE_FORCEINLINE constexpr auto rec_(EVE_REQUIRES(emulated_), O const& o, T a) noexcept
+    requires (detail::fp16_should_apply<common_value_t<T>>)
+  {
+    if      constexpr (O::contains(widen))                       return rec[o.drop(widen)](upgrade(a));
+    else if constexpr (O::contains(upper) || O::contains(lower)) return detail::map(rec[o], a);
+    else                                                         return apply_fp16_as_fp32(rec[o], a);
+  }
+
   template<value T, callable_options O>
   constexpr T  rec_(EVE_REQUIRES(cpu_), O const& o, T const& a) noexcept
   requires(!O::contains(mod))

--- a/include/eve/module/core/regular/impl/rec.hpp
+++ b/include/eve/module/core/regular/impl/rec.hpp
@@ -25,7 +25,7 @@ namespace eve::detail
 {
 
   template<callable_options O, typename T>
-  EVE_FORCEINLINE constexpr auto rec_(EVE_REQUIRES(emulated_), O const& o, T a) noexcept
+  EVE_FORCEINLINE constexpr auto rec_(EVE_REQUIRES(strict_elementwise_emulated_), O const& o, T a) noexcept
     requires (detail::fp16_should_apply<common_value_t<T>>)
   {
     if      constexpr (O::contains(widen))                       return rec[o.drop(widen)](upgrade(a));

--- a/include/eve/module/core/regular/impl/rec.hpp
+++ b/include/eve/module/core/regular/impl/rec.hpp
@@ -25,7 +25,7 @@ namespace eve::detail
 {
 
   template<callable_options O, typename T>
-  EVE_FORCEINLINE constexpr auto rec_(EVE_REQUIRES(strict_elementwise_emulated_), O const& o, T a) noexcept
+  EVE_FORCEINLINE constexpr auto rec_(EVE_REQUIRES(emulated_), O const& o, T a) noexcept
     requires (detail::fp16_should_apply<common_value_t<T>>)
   {
     if      constexpr (O::contains(widen))                       return rec[o.drop(widen)](upgrade(a));

--- a/include/eve/module/core/regular/impl/sqrt.hpp
+++ b/include/eve/module/core/regular/impl/sqrt.hpp
@@ -22,6 +22,14 @@
 namespace eve::detail
 {
   template<typename T, callable_options O>
+  EVE_FORCEINLINE constexpr auto sqrt_(EVE_REQUIRES(strict_elementwise_emulated_), O const& o, T const& a0) noexcept
+    requires(detail::fp16_should_apply<T>)
+  {
+    if constexpr(O::contains(lower) || O::contains(upper)) return detail::map(sqrt[o], a0);
+    else                                                   return apply_fp16_as_fp32(sqrt[o], a0);
+  }
+
+  template<typename T, callable_options O>
   EVE_FORCEINLINE constexpr T sqrt_(EVE_REQUIRES(cpu_),
                                     O const& o,
                                     T const& a0) noexcept

--- a/include/eve/module/core/regular/impl/sqrt.hpp
+++ b/include/eve/module/core/regular/impl/sqrt.hpp
@@ -22,7 +22,7 @@
 namespace eve::detail
 {
   template<typename T, callable_options O>
-  EVE_FORCEINLINE constexpr auto sqrt_(EVE_REQUIRES(strict_elementwise_emulated_), O const& o, T const& a0) noexcept
+  EVE_FORCEINLINE constexpr auto sqrt_(EVE_REQUIRES(emulated_), O const& o, T const& a0) noexcept
     requires(detail::fp16_should_apply<T>)
   {
     if constexpr(O::contains(lower) || O::contains(upper)) return detail::map(sqrt[o], a0);

--- a/include/eve/module/core/regular/impl/sub.hpp
+++ b/include/eve/module/core/regular/impl/sub.hpp
@@ -25,6 +25,15 @@
 
 namespace eve::detail
 {
+  template<callable_options O, typename... Ts>
+  EVE_FORCEINLINE constexpr auto sub_(EVE_REQUIRES(emulated_), O const& o, Ts... ts) noexcept
+    requires (detail::fp16_should_apply<common_value_t<Ts...>>)
+  {
+    if      constexpr (O::contains(widen))                       return sub[o.drop(widen)](upgrade(ts)...);
+    else if constexpr (O::contains(upper) || O::contains(lower)) return detail::map(sub[o], ts...);
+    else                                                         return apply_fp16_as_fp32(sub[o], ts...);
+  }
+
   template<callable_options O, typename T0>
   EVE_FORCEINLINE constexpr auto sub_(EVE_REQUIRES(cpu_), O const&, T0 a) noexcept
   {

--- a/include/eve/module/core/regular/impl/sub.hpp
+++ b/include/eve/module/core/regular/impl/sub.hpp
@@ -26,7 +26,7 @@
 namespace eve::detail
 {
   template<callable_options O, typename... Ts>
-  EVE_FORCEINLINE constexpr auto sub_(EVE_REQUIRES(emulated_), O const& o, Ts... ts) noexcept
+  EVE_FORCEINLINE constexpr auto sub_(EVE_REQUIRES(strict_elementwise_emulated_), O const& o, Ts... ts) noexcept
     requires (detail::fp16_should_apply<common_value_t<Ts...>>)
   {
     if      constexpr (O::contains(widen))                       return sub[o.drop(widen)](upgrade(ts)...);

--- a/include/eve/module/core/regular/impl/sub.hpp
+++ b/include/eve/module/core/regular/impl/sub.hpp
@@ -26,7 +26,7 @@
 namespace eve::detail
 {
   template<callable_options O, typename... Ts>
-  EVE_FORCEINLINE constexpr auto sub_(EVE_REQUIRES(strict_elementwise_emulated_), O const& o, Ts... ts) noexcept
+  EVE_FORCEINLINE constexpr auto sub_(EVE_REQUIRES(emulated_), O const& o, Ts... ts) noexcept
     requires (detail::fp16_should_apply<common_value_t<Ts...>>)
   {
     if      constexpr (O::contains(widen))                       return sub[o.drop(widen)](upgrade(ts)...);

--- a/include/eve/module/core/regular/impl/trunc.hpp
+++ b/include/eve/module/core/regular/impl/trunc.hpp
@@ -21,7 +21,7 @@
 namespace eve::detail
 {
   template<callable_options O, typename... Ts>
-  EVE_FORCEINLINE constexpr auto trunc_(EVE_REQUIRES(strict_elementwise_emulated_), O const& o, Ts const&... ts) noexcept
+  EVE_FORCEINLINE constexpr auto trunc_(EVE_REQUIRES(emulated_), O const& o, Ts const&... ts) noexcept
     requires(detail::fp16_should_apply<common_value_t<Ts...>>)
   {
     if constexpr (O::contains(almost)) return detail::map(trunc[o], ts...);

--- a/include/eve/module/core/regular/impl/trunc.hpp
+++ b/include/eve/module/core/regular/impl/trunc.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <eve/concept/value.hpp>
+#include <eve/traits/apply_fp16.hpp>
 #include <eve/module/core/constant/maxflint.hpp>
 #include <eve/module/core/regular/abs.hpp>
 #include <eve/module/core/regular/convert.hpp>
@@ -19,6 +20,13 @@
 
 namespace eve::detail
 {
+  template<callable_options O, typename... Ts>
+  EVE_FORCEINLINE constexpr auto trunc_(EVE_REQUIRES(strict_elementwise_emulated_), O const& o, Ts const&... ts) noexcept
+    requires(detail::fp16_should_apply<common_value_t<Ts...>>)
+  {
+    if constexpr (O::contains(almost)) return detail::map(trunc[o], ts...);
+    else                               return apply_fp16_as_fp32(trunc[o], ts...);
+  }
 
   template<typename T, callable_options O>
   EVE_FORCEINLINE constexpr T

--- a/include/eve/module/core/regular/inc.hpp
+++ b/include/eve/module/core/regular/inc.hpp
@@ -15,6 +15,7 @@
 #include <eve/module/core/regular/add.hpp>
 #include <eve/module/core/regular/convert.hpp>
 #include <eve/module/core/detail/modular.hpp>
+#include <eve/traits/apply_fp16.hpp>
 
 namespace eve
 {
@@ -111,6 +112,14 @@ namespace eve
 
   namespace detail
   {
+    template<callable_options O, typename T>
+    EVE_FORCEINLINE constexpr auto inc_(EVE_REQUIRES(strict_elementwise_emulated_), O const& o, T v) noexcept
+      requires (detail::fp16_should_apply<common_value_t<T>>)
+    {
+      if constexpr (O::contains(upper) || O::contains(lower)) return detail::map(inc[o], v);
+      else                                                    return apply_fp16_as_fp32(inc[o], v);
+    }
+
     template<value T, callable_options O>
     EVE_FORCEINLINE constexpr T inc_(EVE_REQUIRES(cpu_), O const& o, T const& a) noexcept
     {

--- a/include/eve/module/core/regular/inc.hpp
+++ b/include/eve/module/core/regular/inc.hpp
@@ -113,7 +113,7 @@ namespace eve
   namespace detail
   {
     template<callable_options O, typename T>
-    EVE_FORCEINLINE constexpr auto inc_(EVE_REQUIRES(strict_elementwise_emulated_), O const& o, T v) noexcept
+    EVE_FORCEINLINE constexpr auto inc_(EVE_REQUIRES(emulated_), O const& o, T v) noexcept
       requires (detail::fp16_should_apply<common_value_t<T>>)
     {
       if constexpr (O::contains(upper) || O::contains(lower)) return detail::map(inc[o], v);

--- a/include/eve/module/core/regular/manhattan.hpp
+++ b/include/eve/module/core/regular/manhattan.hpp
@@ -23,6 +23,7 @@ namespace eve
   struct manhattan_t : tuple_callable<manhattan_t, Options, raw_option, pedantic_option, saturated_option, lower_option,
                                 upper_option, strict_option, widen_option, kahan_option>
   {
+
     template<value... Ts>
     requires(eve::same_lanes_or_scalar<Ts...> && (sizeof...(Ts) != 0))
       EVE_FORCEINLINE upgrade_if_t<Options, common_value_t<Ts...>>
@@ -117,6 +118,7 @@ namespace eve
     manhattan_(EVE_REQUIRES(cpu_), O const & o, Ts... args) noexcept
     {
       using r_t = common_value_t<Ts...>;
+      using e_t = element_type_t<r_t>;
       if constexpr(O::contains(widen))
         return manhattan[o.drop(widen)](upgrade(args)...);
       else if constexpr(std::same_as<e_t, eve::float16_t>)

--- a/include/eve/module/core/regular/manhattan.hpp
+++ b/include/eve/module/core/regular/manhattan.hpp
@@ -104,7 +104,7 @@ namespace eve
   namespace detail
   {
     template<callable_options O, typename... Ts>
-    EVE_FORCEINLINE constexpr auto manhattan_(EVE_REQUIRES(strict_elementwise_emulated_), O const& o, Ts... ts) noexcept
+    EVE_FORCEINLINE constexpr auto manhattan_(EVE_REQUIRES(emulated_), O const& o, Ts... ts) noexcept
       requires (detail::fp16_should_apply<common_value_t<Ts...>>)
     {
       if      constexpr (O::contains(widen))                       return manhattan[o.drop(widen)](upgrade(ts)...);

--- a/include/eve/module/core/regular/manhattan.hpp
+++ b/include/eve/module/core/regular/manhattan.hpp
@@ -23,7 +23,6 @@ namespace eve
   struct manhattan_t : tuple_callable<manhattan_t, Options, raw_option, pedantic_option, saturated_option, lower_option,
                                 upper_option, strict_option, widen_option, kahan_option>
   {
-
     template<value... Ts>
     requires(eve::same_lanes_or_scalar<Ts...> && (sizeof...(Ts) != 0))
       EVE_FORCEINLINE upgrade_if_t<Options, common_value_t<Ts...>>
@@ -104,12 +103,20 @@ namespace eve
 
   namespace detail
   {
+    template<callable_options O, typename... Ts>
+    EVE_FORCEINLINE constexpr auto manhattan_(EVE_REQUIRES(emulated_), O const& o, Ts... ts) noexcept
+      requires (detail::fp16_should_apply<common_value_t<Ts...>>)
+    {
+      if      constexpr (O::contains(widen))                       return manhattan[o.drop(widen)](upgrade(ts)...);
+      else if constexpr (O::contains(upper) || O::contains(lower)) return detail::map(manhattan[o], ts...);
+      else                                                         return apply_fp16_as_fp32(manhattan[o], ts...);
+    }
+
     template<typename... Ts, callable_options O>
     EVE_FORCEINLINE constexpr auto
     manhattan_(EVE_REQUIRES(cpu_), O const & o, Ts... args) noexcept
     {
       using r_t = common_value_t<Ts...>;
-      using e_t = element_type_t<r_t>;
       if constexpr(O::contains(widen))
         return manhattan[o.drop(widen)](upgrade(args)...);
       else if constexpr(std::same_as<e_t, eve::float16_t>)

--- a/include/eve/module/core/regular/manhattan.hpp
+++ b/include/eve/module/core/regular/manhattan.hpp
@@ -104,7 +104,7 @@ namespace eve
   namespace detail
   {
     template<callable_options O, typename... Ts>
-    EVE_FORCEINLINE constexpr auto manhattan_(EVE_REQUIRES(emulated_), O const& o, Ts... ts) noexcept
+    EVE_FORCEINLINE constexpr auto manhattan_(EVE_REQUIRES(strict_elementwise_emulated_), O const& o, Ts... ts) noexcept
       requires (detail::fp16_should_apply<common_value_t<Ts...>>)
     {
       if      constexpr (O::contains(widen))                       return manhattan[o.drop(widen)](upgrade(ts)...);

--- a/include/eve/module/core/regular/maxabs.hpp
+++ b/include/eve/module/core/regular/maxabs.hpp
@@ -19,7 +19,6 @@ namespace eve
   struct maxabs_t : tuple_callable<maxabs_t, Options, drastic_option, numeric_option, pedantic_option,
                                                       saturated_option, widen_option>
   {
-
     template<value... Ts>
     requires(eve::same_lanes_or_scalar<Ts...>)
     EVE_FORCEINLINE constexpr upgrade_if_t<Options, common_value_t<Ts...>> operator()(Ts...ts) const noexcept

--- a/include/eve/module/core/regular/next.hpp
+++ b/include/eve/module/core/regular/next.hpp
@@ -111,6 +111,13 @@ namespace eve
 
   namespace detail
   {
+    template<callable_options O, typename... Ts>
+    EVE_FORCEINLINE constexpr auto next_(EVE_REQUIRES(strict_elementwise_emulated_), O const& o, Ts... ts) noexcept
+      requires (detail::fp16_should_apply<common_value_t<Ts...>>)
+    {
+      return detail::map(next[o], ts...);
+    }
+
     template<typename T, callable_options O>
     EVE_FORCEINLINE constexpr T next_(EVE_REQUIRES(cpu_), O const &, T a) noexcept
     requires(!O::contains(pedantic) || !floating_value<T>)

--- a/include/eve/module/core/regular/next.hpp
+++ b/include/eve/module/core/regular/next.hpp
@@ -112,7 +112,7 @@ namespace eve
   namespace detail
   {
     template<callable_options O, typename... Ts>
-    EVE_FORCEINLINE constexpr auto next_(EVE_REQUIRES(strict_elementwise_emulated_), O const& o, Ts... ts) noexcept
+    EVE_FORCEINLINE constexpr auto next_(EVE_REQUIRES(emulated_), O const& o, Ts... ts) noexcept
       requires (detail::fp16_should_apply<common_value_t<Ts...>>)
     {
       return next_(EVE_TARGETS(cpu_), o, ts...);

--- a/include/eve/module/core/regular/next.hpp
+++ b/include/eve/module/core/regular/next.hpp
@@ -115,7 +115,7 @@ namespace eve
     EVE_FORCEINLINE constexpr auto next_(EVE_REQUIRES(strict_elementwise_emulated_), O const& o, Ts... ts) noexcept
       requires (detail::fp16_should_apply<common_value_t<Ts...>>)
     {
-      return detail::map(next[o], ts...);
+      return next_(EVE_TARGETS(cpu_), o, ts...);
     }
 
     template<typename T, callable_options O>

--- a/include/eve/module/core/regular/nextafter.hpp
+++ b/include/eve/module/core/regular/nextafter.hpp
@@ -81,7 +81,7 @@ namespace eve
   namespace detail
   {
     template<callable_options O, typename... Ts>
-    EVE_FORCEINLINE constexpr auto nextafter_(EVE_REQUIRES(strict_elementwise_emulated_), O const& o, Ts... ts) noexcept
+    EVE_FORCEINLINE constexpr auto nextafter_(EVE_REQUIRES(emulated_), O const& o, Ts... ts) noexcept
       requires (detail::fp16_should_apply<common_value_t<Ts...>>)
     {
       return detail::map(nextafter[o], ts...);

--- a/include/eve/module/core/regular/nextafter.hpp
+++ b/include/eve/module/core/regular/nextafter.hpp
@@ -80,6 +80,13 @@ namespace eve
 
   namespace detail
   {
+    template<callable_options O, typename... Ts>
+    EVE_FORCEINLINE constexpr auto nextafter_(EVE_REQUIRES(strict_elementwise_emulated_), O const& o, Ts... ts) noexcept
+      requires (detail::fp16_should_apply<common_value_t<Ts...>>)
+    {
+      return detail::map(nextafter[o], ts...);
+    }
+
     template<typename T, callable_options O>
     EVE_FORCEINLINE constexpr auto
     nextafter_(EVE_REQUIRES(cpu_), O const& o, T const& a, T const & b) noexcept

--- a/include/eve/module/core/regular/oneminus.hpp
+++ b/include/eve/module/core/regular/oneminus.hpp
@@ -18,6 +18,7 @@
 #include <eve/module/core/constant/valmin.hpp>
 #include <eve/module/core/constant/one.hpp>
 #include <eve/module/core/detail/modular.hpp>
+#include <eve/traits/apply_fp16.hpp>
 
 namespace eve
 {
@@ -102,6 +103,15 @@ namespace eve
 
   namespace detail
   {
+    template<typename T, callable_options O>
+    EVE_FORCEINLINE constexpr auto
+    oneminus_(EVE_REQUIRES(strict_elementwise_emulated_), O const & o, T v) noexcept
+      requires(detail::fp16_should_apply<T>)
+    {
+      if constexpr (O::contains(upper) || O::contains(lower)) return detail::map(oneminus[o], v);
+      else                                                    return apply_fp16_as_fp32(oneminus[o], v);
+    }
+
     template<typename T, callable_options O>
     EVE_FORCEINLINE constexpr T
     oneminus_(EVE_REQUIRES(cpu_), O const & o, T v) noexcept

--- a/include/eve/module/core/regular/oneminus.hpp
+++ b/include/eve/module/core/regular/oneminus.hpp
@@ -105,7 +105,7 @@ namespace eve
   {
     template<typename T, callable_options O>
     EVE_FORCEINLINE constexpr auto
-    oneminus_(EVE_REQUIRES(strict_elementwise_emulated_), O const & o, T v) noexcept
+    oneminus_(EVE_REQUIRES(emulated_), O const & o, T v) noexcept
       requires(detail::fp16_should_apply<T>)
     {
       if constexpr (O::contains(upper) || O::contains(lower)) return detail::map(oneminus[o], v);

--- a/include/eve/module/core/regular/prev.hpp
+++ b/include/eve/module/core/regular/prev.hpp
@@ -110,7 +110,7 @@ namespace eve
     EVE_FORCEINLINE constexpr auto prev_(EVE_REQUIRES(strict_elementwise_emulated_), O const& o, Ts... ts) noexcept
       requires (detail::fp16_should_apply<common_value_t<Ts...>>)
     {
-      return detail::map(prev[o], ts...);
+      return prev_(EVE_TARGETS(cpu_), o, ts...);
     }
 
     template<typename T, callable_options O>

--- a/include/eve/module/core/regular/prev.hpp
+++ b/include/eve/module/core/regular/prev.hpp
@@ -106,6 +106,13 @@ namespace eve
 
   namespace detail
   {
+    template<callable_options O, typename... Ts>
+    EVE_FORCEINLINE constexpr auto prev_(EVE_REQUIRES(strict_elementwise_emulated_), O const& o, Ts... ts) noexcept
+      requires (detail::fp16_should_apply<common_value_t<Ts...>>)
+    {
+      return detail::map(prev[o], ts...);
+    }
+
     template<typename T, callable_options O>
     EVE_FORCEINLINE constexpr T
     prev_(EVE_REQUIRES(cpu_), O const &, T a) noexcept

--- a/include/eve/module/core/regular/prev.hpp
+++ b/include/eve/module/core/regular/prev.hpp
@@ -107,7 +107,7 @@ namespace eve
   namespace detail
   {
     template<callable_options O, typename... Ts>
-    EVE_FORCEINLINE constexpr auto prev_(EVE_REQUIRES(strict_elementwise_emulated_), O const& o, Ts... ts) noexcept
+    EVE_FORCEINLINE constexpr auto prev_(EVE_REQUIRES(emulated_), O const& o, Ts... ts) noexcept
       requires (detail::fp16_should_apply<common_value_t<Ts...>>)
     {
       return prev_(EVE_TARGETS(cpu_), o, ts...);

--- a/include/eve/module/core/regular/rec.hpp
+++ b/include/eve/module/core/regular/rec.hpp
@@ -11,6 +11,7 @@
 #include <eve/traits/overload.hpp>
 #include <eve/module/core/decorator/core.hpp>
 #include <eve/module/core/detail/modular.hpp>
+#include <eve/traits/apply_fp16.hpp>
 
 namespace eve
 {

--- a/include/eve/module/core/regular/sqr.hpp
+++ b/include/eve/module/core/regular/sqr.hpp
@@ -15,6 +15,7 @@
 #include <eve/module/core/regular/mul.hpp>
 #include <eve/module/core/regular/abs.hpp>
 #include <eve/module/core/regular/if_else.hpp>
+#include <eve/traits/apply_fp16.hpp>
 
 
 namespace eve
@@ -101,6 +102,15 @@ struct sqr_t : elementwise_callable<sqr_t, Options, saturated_option, lower_opti
 
   namespace detail
   {
+
+    template<typename T, callable_options O>
+    EVE_FORCEINLINE constexpr auto
+    sqr_(EVE_REQUIRES(strict_elementwise_emulated_), O const &o, T const &a0) noexcept
+      requires(detail::fp16_should_apply<T>)
+    {
+      if constexpr (O::contains(upper) || O::contains(lower)) return detail::map(sqr[o], a0);
+      else                                                    return apply_fp16_as_fp32(sqr[o], a0);
+    }
 
     template<typename T, callable_options O>
     EVE_FORCEINLINE constexpr T

--- a/include/eve/module/core/regular/sqr.hpp
+++ b/include/eve/module/core/regular/sqr.hpp
@@ -105,7 +105,7 @@ struct sqr_t : elementwise_callable<sqr_t, Options, saturated_option, lower_opti
 
     template<typename T, callable_options O>
     EVE_FORCEINLINE constexpr auto
-    sqr_(EVE_REQUIRES(strict_elementwise_emulated_), O const &o, T const &a0) noexcept
+    sqr_(EVE_REQUIRES(emulated_), O const &o, T const &a0) noexcept
       requires(detail::fp16_should_apply<T>)
     {
       if constexpr (O::contains(upper) || O::contains(lower)) return detail::map(sqr[o], a0);

--- a/include/eve/module/core/regular/sub.hpp
+++ b/include/eve/module/core/regular/sub.hpp
@@ -11,6 +11,7 @@
 #include <eve/traits/overload.hpp>
 #include <eve/traits/updown.hpp>
 #include <eve/module/core/decorator/core.hpp>
+#include <eve/traits/apply_fp16.hpp>
 
 namespace eve
 {
@@ -19,7 +20,6 @@ namespace eve
                                 upper_option, strict_option, widen_option, left_option,
                                 right_option, mod_option>
   {
-
     template<eve::value T0, value... Ts>
     requires(eve::same_lanes_or_scalar<T0, Ts...>)
       EVE_FORCEINLINE upgrade_if_t<Options, common_value_t<T0, Ts...>>

--- a/include/eve/module/core/regular/sum_of_prod.hpp
+++ b/include/eve/module/core/regular/sum_of_prod.hpp
@@ -96,8 +96,8 @@ namespace eve
     EVE_FORCEINLINE constexpr auto sum_of_prod_(EVE_REQUIRES(strict_elementwise_emulated_), O const & o, Ts const&... ts) noexcept
       requires(detail::fp16_should_apply<common_value_t<Ts...>>)
     {
-      if constexpr(O::contains(upper) || O::contains(lower)) return detail::map(sum_of_prod[o], ts...);
-      else                                                   return apply_fp16_as_fp32(sum_of_prod[o], ts...);
+      if constexpr(O::contains(upper) || O::contains(lower) || O::contains(pedantic)) return detail::map(sum_of_prod[o], ts...);
+      else                                                                            return apply_fp16_as_fp32(sum_of_prod[o], ts...);
     }
 
     template<typename T, callable_options O>

--- a/include/eve/module/core/regular/sum_of_prod.hpp
+++ b/include/eve/module/core/regular/sum_of_prod.hpp
@@ -19,6 +19,7 @@
 #include <eve/module/core/regular/fnma.hpp>
 #include <eve/module/core/regular/prev.hpp>
 #include <eve/module/core/regular/next.hpp>
+#include <eve/traits/apply_fp16.hpp>
 
 namespace eve
 {
@@ -91,6 +92,14 @@ namespace eve
 
   namespace detail
   {
+    template<callable_options O, typename... Ts>
+    EVE_FORCEINLINE constexpr auto sum_of_prod_(EVE_REQUIRES(strict_elementwise_emulated_), O const & o, Ts const&... ts) noexcept
+      requires(detail::fp16_should_apply<common_value_t<Ts...>>)
+    {
+      if constexpr(O::contains(upper) || O::contains(lower)) return detail::map(sum_of_prod[o], ts...);
+      else                                                   return apply_fp16_as_fp32(sum_of_prod[o], ts...);
+    }
+
     template<typename T, callable_options O>
     EVE_FORCEINLINE constexpr auto
     sum_of_prod_(EVE_REQUIRES(cpu_), O const & o,

--- a/include/eve/module/core/regular/sum_of_prod.hpp
+++ b/include/eve/module/core/regular/sum_of_prod.hpp
@@ -93,7 +93,7 @@ namespace eve
   namespace detail
   {
     template<callable_options O, typename... Ts>
-    EVE_FORCEINLINE constexpr auto sum_of_prod_(EVE_REQUIRES(strict_elementwise_emulated_), O const & o, Ts const&... ts) noexcept
+    EVE_FORCEINLINE constexpr auto sum_of_prod_(EVE_REQUIRES(emulated_), O const & o, Ts const&... ts) noexcept
       requires(detail::fp16_should_apply<common_value_t<Ts...>>)
     {
       if constexpr(O::contains(upper) || O::contains(lower) || O::contains(pedantic)) return detail::map(sum_of_prod[o], ts...);

--- a/include/eve/module/core/regular/sum_of_squares.hpp
+++ b/include/eve/module/core/regular/sum_of_squares.hpp
@@ -95,7 +95,7 @@ namespace eve
   namespace detail
   {
     template<callable_options O, typename... Ts>
-    EVE_FORCEINLINE constexpr auto sum_of_squares_(EVE_REQUIRES(strict_elementwise_emulated_), O const & o, Ts... ts) noexcept
+    EVE_FORCEINLINE constexpr auto sum_of_squares_(EVE_REQUIRES(emulated_), O const & o, Ts... ts) noexcept
     requires (detail::fp16_should_apply<common_value_t<Ts...>>)
     {
       if      constexpr(O::contains(widen))                        return sum_of_squares[o.drop(widen)](upgrade(ts)...);

--- a/include/eve/module/core/regular/sum_of_squares.hpp
+++ b/include/eve/module/core/regular/sum_of_squares.hpp
@@ -25,7 +25,6 @@ namespace eve
                                            saturated_option, lower_option, upper_option,
                                            strict_option, widen_option, kahan_option>
   {
-
     template<value... Ts>
     requires(eve::same_lanes_or_scalar<Ts...>)
       EVE_FORCEINLINE upgrade_if_t<Options, common_value_t<Ts... >>
@@ -95,6 +94,15 @@ namespace eve
 
   namespace detail
   {
+    template<callable_options O, typename... Ts>
+    EVE_FORCEINLINE constexpr auto sum_of_squares_(EVE_REQUIRES(emulated_), O const & o, Ts... ts) noexcept
+    requires (detail::fp16_should_apply<common_value_t<Ts...>>)
+    {
+      if      constexpr(O::contains(widen))                        return sum_of_squares[o.drop(widen)](upgrade(ts)...);
+      else if constexpr(O::contains(upper) || O::contains(lower))  return detail::map(sum_of_squares[o], ts...);
+      else                                                          return apply_fp16_as_fp32(sum_of_squares[o], ts...);
+    }
+
     template<value... Ts, callable_options O>
     EVE_FORCEINLINE constexpr auto
     sum_of_squares_(EVE_REQUIRES(cpu_), O const & o ,Ts... args) noexcept

--- a/include/eve/module/core/regular/sum_of_squares.hpp
+++ b/include/eve/module/core/regular/sum_of_squares.hpp
@@ -95,7 +95,7 @@ namespace eve
   namespace detail
   {
     template<callable_options O, typename... Ts>
-    EVE_FORCEINLINE constexpr auto sum_of_squares_(EVE_REQUIRES(emulated_), O const & o, Ts... ts) noexcept
+    EVE_FORCEINLINE constexpr auto sum_of_squares_(EVE_REQUIRES(strict_elementwise_emulated_), O const & o, Ts... ts) noexcept
     requires (detail::fp16_should_apply<common_value_t<Ts...>>)
     {
       if      constexpr(O::contains(widen))                        return sum_of_squares[o.drop(widen)](upgrade(ts)...);

--- a/include/eve/module/core/regular/three_fma.hpp
+++ b/include/eve/module/core/regular/three_fma.hpp
@@ -87,7 +87,7 @@ namespace eve
   namespace detail
   {
     template<callable_options O, simd_value... Ts>
-    EVE_FORCEINLINE constexpr auto three_fma_(EVE_REQUIRES(strict_elementwise_emulated_), O const& o, Ts... ts) noexcept
+    EVE_FORCEINLINE constexpr auto three_fma_(EVE_REQUIRES(emulated_), O const& o, Ts... ts) noexcept
       requires (detail::fp16_should_apply<Ts> && ...)
     {
       return detail::map(three_fma[o], ts...);

--- a/include/eve/module/core/regular/three_fma.hpp
+++ b/include/eve/module/core/regular/three_fma.hpp
@@ -86,6 +86,13 @@ namespace eve
 {
   namespace detail
   {
+    template<callable_options O, simd_value... Ts>
+    EVE_FORCEINLINE constexpr auto three_fma_(EVE_REQUIRES(strict_elementwise_emulated_), O const& o, Ts... ts) noexcept
+      requires (detail::fp16_should_apply<Ts> && ...)
+    {
+      return detail::map(three_fma[o], ts...);
+    }
+
     template<typename T, callable_options O>
     EVE_FORCEINLINE auto three_fma_(EVE_REQUIRES(cpu_), O const&, T a, T x, T y) noexcept
     {

--- a/include/eve/module/core/regular/trapz.hpp
+++ b/include/eve/module/core/regular/trapz.hpp
@@ -122,7 +122,7 @@ namespace eve
   namespace detail
   {
     template<callable_options O, typename... Ts>
-    EVE_FORCEINLINE constexpr auto trapz_(EVE_REQUIRES(strict_elementwise_emulated_), O const & o, Ts... ts) noexcept
+    EVE_FORCEINLINE constexpr auto trapz_(EVE_REQUIRES(emulated_), O const & o, Ts... ts) noexcept
     requires (O::contains(widen) && detail::fp16_should_apply<common_value_t<Ts...>>)
     {
       return trapz[o.drop(widen)](upgrade(ts)...);

--- a/include/eve/module/core/regular/trapz.hpp
+++ b/include/eve/module/core/regular/trapz.hpp
@@ -122,7 +122,7 @@ namespace eve
   namespace detail
   {
     template<callable_options O, typename... Ts>
-    EVE_FORCEINLINE constexpr auto trapz_(EVE_REQUIRES(emulated_), O const & o, Ts... ts) noexcept
+    EVE_FORCEINLINE constexpr auto trapz_(EVE_REQUIRES(strict_elementwise_emulated_), O const & o, Ts... ts) noexcept
     requires (O::contains(widen) && detail::fp16_should_apply<common_value_t<Ts...>>)
     {
       return trapz[o.drop(widen)](upgrade(ts)...);

--- a/include/eve/module/core/regular/trapz.hpp
+++ b/include/eve/module/core/regular/trapz.hpp
@@ -22,7 +22,6 @@ namespace eve
   template<typename Options>
   struct trapz_t : callable<trapz_t, Options, widen_option, kahan_option>
   {
-
     template<floating_value... Ts>
     requires(eve::same_lanes_or_scalar<Ts...> && (sizeof...(Ts) > 1))
       EVE_FORCEINLINE eve::upgrade_if_t<Options, common_value_t<Ts...>>
@@ -122,6 +121,13 @@ namespace eve
 
   namespace detail
   {
+    template<callable_options O, typename... Ts>
+    EVE_FORCEINLINE constexpr auto trapz_(EVE_REQUIRES(emulated_), O const & o, Ts... ts) noexcept
+    requires (O::contains(widen) && detail::fp16_should_apply<common_value_t<Ts...>>)
+    {
+      return trapz[o.drop(widen)](upgrade(ts)...);
+    }
+
     template<eve::non_empty_product_type PT , callable_options O>
      EVE_FORCEINLINE constexpr auto
     trapz_(EVE_REQUIRES(cpu_), O const & o, PT tup) noexcept

--- a/include/eve/module/core/regular/ulpdist.hpp
+++ b/include/eve/module/core/regular/ulpdist.hpp
@@ -84,7 +84,7 @@ namespace eve
   namespace detail
   {
     template<callable_options O, typename... Ts>
-    EVE_FORCEINLINE constexpr auto ulpdist_(EVE_REQUIRES(strict_elementwise_emulated_), O const& o, Ts... ts) noexcept
+    EVE_FORCEINLINE constexpr auto ulpdist_(EVE_REQUIRES(emulated_), O const& o, Ts... ts) noexcept
       requires (detail::fp16_should_apply<common_value_t<Ts...>>)
     {
       return detail::map(ulpdist[o], ts...);

--- a/include/eve/module/core/regular/ulpdist.hpp
+++ b/include/eve/module/core/regular/ulpdist.hpp
@@ -83,6 +83,13 @@ namespace eve
 
   namespace detail
   {
+    template<callable_options O, typename... Ts>
+    EVE_FORCEINLINE constexpr auto ulpdist_(EVE_REQUIRES(strict_elementwise_emulated_), O const& o, Ts... ts) noexcept
+      requires (detail::fp16_should_apply<common_value_t<Ts...>>)
+    {
+      return detail::map(ulpdist[o], ts...);
+    }
+
     template<typename T, callable_options O>
     constexpr T ulpdist_(EVE_REQUIRES(cpu_), O const&, T a, T b)
     {

--- a/include/eve/module/core/regular/variance.hpp
+++ b/include/eve/module/core/regular/variance.hpp
@@ -119,7 +119,7 @@ namespace eve::detail
 {
 
   template<callable_options O, typename... Ts>
-  EVE_FORCEINLINE constexpr auto variance_(EVE_REQUIRES(strict_elementwise_emulated_), O const & o, Ts... ts) noexcept
+  EVE_FORCEINLINE constexpr auto variance_(EVE_REQUIRES(emulated_), O const & o, Ts... ts) noexcept
   requires (O::contains(widen) && detail::fp16_should_apply<common_value_t<Ts...>>)
   {
     return variance[o.drop(widen)](upgrade(ts)...);

--- a/include/eve/module/core/regular/variance.hpp
+++ b/include/eve/module/core/regular/variance.hpp
@@ -26,7 +26,6 @@ namespace eve
   struct variance_t : tuple_callable<variance_t, Options, raw_option, kahan_option,
                                      widen_option, unbiased_option>
   {
-
     template<value... Ts>
     requires(sizeof...(Ts) !=  0 && eve::same_lanes_or_scalar<Ts...>)
       EVE_FORCEINLINE constexpr eve::upgrade_if_t<Options, common_value_t<Ts...>>
@@ -118,6 +117,13 @@ namespace eve
 
 namespace eve::detail
 {
+
+  template<callable_options O, typename... Ts>
+  EVE_FORCEINLINE constexpr auto variance_(EVE_REQUIRES(emulated_), O const & o, Ts... ts) noexcept
+  requires (O::contains(widen) && detail::fp16_should_apply<common_value_t<Ts...>>)
+  {
+    return variance[o.drop(widen)](upgrade(ts)...);
+  }
 
   template<value T0, value ... Ts, callable_options O>
   EVE_FORCEINLINE constexpr auto

--- a/include/eve/module/core/regular/variance.hpp
+++ b/include/eve/module/core/regular/variance.hpp
@@ -119,7 +119,7 @@ namespace eve::detail
 {
 
   template<callable_options O, typename... Ts>
-  EVE_FORCEINLINE constexpr auto variance_(EVE_REQUIRES(emulated_), O const & o, Ts... ts) noexcept
+  EVE_FORCEINLINE constexpr auto variance_(EVE_REQUIRES(strict_elementwise_emulated_), O const & o, Ts... ts) noexcept
   requires (O::contains(widen) && detail::fp16_should_apply<common_value_t<Ts...>>)
   {
     return variance[o.drop(widen)](upgrade(ts)...);

--- a/include/eve/module/core/regular/welford_average.hpp
+++ b/include/eve/module/core/regular/welford_average.hpp
@@ -44,7 +44,6 @@ namespace eve
   template<typename Options>
   struct welford_average_t : callable<welford_average_t, Options, widen_option>
   {
-
 //     template<typename... Ts>
 //     requires(sizeof...(Ts) !=  0 && eve::same_lanes_or_scalar<detail::internal_welford_t<Ts>...>  && !Options::contains(widen))
 //       EVE_FORCEINLINE constexpr detail::welford_result<common_value_t<detail::internal_welford_t<Ts>...>>
@@ -141,6 +140,13 @@ namespace eve
 
 namespace eve::detail
 {
+
+  template<callable_options O, typename... Ts>
+  EVE_FORCEINLINE constexpr auto welford_average_(EVE_REQUIRES(emulated_), O const & o, Ts... ts) noexcept
+  requires (O::contains(widen) && detail::fp16_should_apply<common_value_t<Ts...>>)
+  {
+    return welford_average[o.drop(widen)](upgrade(ts)...);
+  }
 
   template<scalar_value T0, scalar_value ... Ts, callable_options O>
   EVE_FORCEINLINE constexpr auto

--- a/include/eve/module/core/regular/welford_average.hpp
+++ b/include/eve/module/core/regular/welford_average.hpp
@@ -142,7 +142,7 @@ namespace eve::detail
 {
 
   template<callable_options O, typename... Ts>
-  EVE_FORCEINLINE constexpr auto welford_average_(EVE_REQUIRES(emulated_), O const & o, Ts... ts) noexcept
+  EVE_FORCEINLINE constexpr auto welford_average_(EVE_REQUIRES(strict_elementwise_emulated_), O const & o, Ts... ts) noexcept
   requires (O::contains(widen) && detail::fp16_should_apply<common_value_t<Ts...>>)
   {
     return welford_average[o.drop(widen)](upgrade(ts)...);

--- a/include/eve/module/core/regular/welford_average.hpp
+++ b/include/eve/module/core/regular/welford_average.hpp
@@ -142,7 +142,7 @@ namespace eve::detail
 {
 
   template<callable_options O, typename... Ts>
-  EVE_FORCEINLINE constexpr auto welford_average_(EVE_REQUIRES(strict_elementwise_emulated_), O const & o, Ts... ts) noexcept
+  EVE_FORCEINLINE constexpr auto welford_average_(EVE_REQUIRES(emulated_), O const & o, Ts... ts) noexcept
   requires (O::contains(widen) && detail::fp16_should_apply<common_value_t<Ts...>>)
   {
     return welford_average[o.drop(widen)](upgrade(ts)...);

--- a/include/eve/module/core/regular/welford_covariance.hpp
+++ b/include/eve/module/core/regular/welford_covariance.hpp
@@ -51,7 +51,6 @@ namespace eve
   template<typename Options>
   struct welford_covariance_t : callable<welford_covariance_t, Options, widen_option, unbiased_option>
   {
-
     template<typename... Ts>
     requires((detail::is_welford_covariance_result_v<Ts> && ...))
       EVE_FORCEINLINE constexpr detail::welford_covariance_result<upgrade_if_t<Options, common_value_t<detail::internal_welford_covariance_t<Ts>...>>>
@@ -142,6 +141,13 @@ namespace eve
 
   namespace detail
   {
+    template<callable_options O, typename... Ts>
+    EVE_FORCEINLINE constexpr auto welford_covariance_(EVE_REQUIRES(emulated_), O const & o, Ts... ts) noexcept
+    requires (O::contains(widen) && detail::fp16_should_apply<common_value_t<Ts...>>)
+    {
+      return welford_covariance[o.drop(widen)](upgrade(ts)...);
+    }
+
     template<eve::non_empty_product_type PT1, eve::non_empty_product_type PT2, callable_options O>
     EVE_FORCEINLINE constexpr auto welford_covariance_(EVE_REQUIRES(cpu_), O const & o, PT1 f, PT2 s) noexcept
     requires (kumi::as_tuple_t<PT1>::size() == kumi::as_tuple_t<PT2>::size())

--- a/include/eve/module/core/regular/welford_covariance.hpp
+++ b/include/eve/module/core/regular/welford_covariance.hpp
@@ -142,7 +142,7 @@ namespace eve
   namespace detail
   {
     template<callable_options O, typename... Ts>
-    EVE_FORCEINLINE constexpr auto welford_covariance_(EVE_REQUIRES(strict_elementwise_emulated_), O const & o, Ts... ts) noexcept
+    EVE_FORCEINLINE constexpr auto welford_covariance_(EVE_REQUIRES(emulated_), O const & o, Ts... ts) noexcept
     requires (O::contains(widen) && detail::fp16_should_apply<common_value_t<Ts...>>)
     {
       return welford_covariance[o.drop(widen)](upgrade(ts)...);

--- a/include/eve/module/core/regular/welford_covariance.hpp
+++ b/include/eve/module/core/regular/welford_covariance.hpp
@@ -142,7 +142,7 @@ namespace eve
   namespace detail
   {
     template<callable_options O, typename... Ts>
-    EVE_FORCEINLINE constexpr auto welford_covariance_(EVE_REQUIRES(emulated_), O const & o, Ts... ts) noexcept
+    EVE_FORCEINLINE constexpr auto welford_covariance_(EVE_REQUIRES(strict_elementwise_emulated_), O const & o, Ts... ts) noexcept
     requires (O::contains(widen) && detail::fp16_should_apply<common_value_t<Ts...>>)
     {
       return welford_covariance[o.drop(widen)](upgrade(ts)...);

--- a/include/eve/module/core/regular/welford_variance.hpp
+++ b/include/eve/module/core/regular/welford_variance.hpp
@@ -48,7 +48,6 @@ namespace eve
   template<typename Options>
   struct welford_variance_t : callable<welford_variance_t, Options, unbiased_option, widen_option>
   {
-
  //    template<typename... Ts>
 //     requires(sizeof...(Ts) !=  0 && eve::same_lanes_or_scalar<detail::internal_welford_variance_t<Ts>...>  && !Options::contains(widen))
 //       EVE_FORCEINLINE constexpr detail::welford_variance_result<common_value_t<detail::internal_welford_variance_t<Ts>...>>
@@ -148,6 +147,13 @@ namespace eve
 
 namespace eve::detail
 {
+
+  template<callable_options O, typename... Ts>
+  EVE_FORCEINLINE constexpr auto welford_variance_(EVE_REQUIRES(emulated_), O const & o, Ts... ts) noexcept
+  requires (O::contains(widen) && detail::fp16_should_apply<common_value_t<Ts...>>)
+  {
+    return welford_variance[o.drop(widen)](upgrade(ts)...);
+  }
 
   template<scalar_value T0, scalar_value ... Ts, callable_options O>
   EVE_FORCEINLINE constexpr auto

--- a/include/eve/module/core/regular/welford_variance.hpp
+++ b/include/eve/module/core/regular/welford_variance.hpp
@@ -149,7 +149,7 @@ namespace eve::detail
 {
 
   template<callable_options O, typename... Ts>
-  EVE_FORCEINLINE constexpr auto welford_variance_(EVE_REQUIRES(emulated_), O const & o, Ts... ts) noexcept
+  EVE_FORCEINLINE constexpr auto welford_variance_(EVE_REQUIRES(strict_elementwise_emulated_), O const & o, Ts... ts) noexcept
   requires (O::contains(widen) && detail::fp16_should_apply<common_value_t<Ts...>>)
   {
     return welford_variance[o.drop(widen)](upgrade(ts)...);

--- a/include/eve/module/core/regular/welford_variance.hpp
+++ b/include/eve/module/core/regular/welford_variance.hpp
@@ -149,7 +149,7 @@ namespace eve::detail
 {
 
   template<callable_options O, typename... Ts>
-  EVE_FORCEINLINE constexpr auto welford_variance_(EVE_REQUIRES(strict_elementwise_emulated_), O const & o, Ts... ts) noexcept
+  EVE_FORCEINLINE constexpr auto welford_variance_(EVE_REQUIRES(emulated_), O const & o, Ts... ts) noexcept
   requires (O::contains(widen) && detail::fp16_should_apply<common_value_t<Ts...>>)
   {
     return welford_variance[o.drop(widen)](upgrade(ts)...);

--- a/include/eve/module/math/regular/geommean.hpp
+++ b/include/eve/module/math/regular/geommean.hpp
@@ -97,7 +97,7 @@ namespace eve
   namespace detail
   {
     template<callable_options O, typename... Ts>
-    EVE_FORCEINLINE constexpr auto geommean_(EVE_REQUIRES(emulated_), O const & o, Ts... ts) noexcept
+    EVE_FORCEINLINE constexpr auto geommean_(EVE_REQUIRES(strict_elementwise_emulated_), O const & o, Ts... ts) noexcept
     requires (O::contains(widen) && detail::fp16_should_apply<common_value_t<Ts...>>)
     {
       return geommean[o.drop(widen)](upgrade(ts)...);

--- a/include/eve/module/math/regular/geommean.hpp
+++ b/include/eve/module/math/regular/geommean.hpp
@@ -19,7 +19,6 @@ namespace eve
   struct geommean_t : strict_tuple_callable<geommean_t, Options, pedantic_option, widen_option,
                                      kahan_option>
   {
-
     template<value... Ts>
     requires(eve::same_lanes_or_scalar<Ts...>)
       EVE_FORCEINLINE upgrade_if_t<Options, common_value_t<Ts...>>
@@ -97,6 +96,13 @@ namespace eve
 
   namespace detail
   {
+    template<callable_options O, typename... Ts>
+    EVE_FORCEINLINE constexpr auto geommean_(EVE_REQUIRES(emulated_), O const & o, Ts... ts) noexcept
+    requires (O::contains(widen) && detail::fp16_should_apply<common_value_t<Ts...>>)
+    {
+      return geommean[o.drop(widen)](upgrade(ts)...);
+    }
+
     template<typename T0, typename... Ts, callable_options O>
     EVE_FORCEINLINE constexpr auto
     geommean_(EVE_REQUIRES(cpu_), O const & o, T0 a0, Ts... args) noexcept

--- a/include/eve/module/math/regular/geommean.hpp
+++ b/include/eve/module/math/regular/geommean.hpp
@@ -97,7 +97,7 @@ namespace eve
   namespace detail
   {
     template<callable_options O, typename... Ts>
-    EVE_FORCEINLINE constexpr auto geommean_(EVE_REQUIRES(strict_elementwise_emulated_), O const & o, Ts... ts) noexcept
+    EVE_FORCEINLINE constexpr auto geommean_(EVE_REQUIRES(emulated_), O const & o, Ts... ts) noexcept
     requires (O::contains(widen) && detail::fp16_should_apply<common_value_t<Ts...>>)
     {
       return geommean[o.drop(widen)](upgrade(ts)...);

--- a/include/eve/module/math/regular/harmmean.hpp
+++ b/include/eve/module/math/regular/harmmean.hpp
@@ -96,7 +96,7 @@ namespace eve
   namespace detail
   {
     template<callable_options O, typename... Ts>
-    EVE_FORCEINLINE constexpr auto harmmean_(EVE_REQUIRES(emulated_), O const & o, Ts... ts) noexcept
+    EVE_FORCEINLINE constexpr auto harmmean_(EVE_REQUIRES(strict_elementwise_emulated_), O const & o, Ts... ts) noexcept
     requires (O::contains(widen) && detail::fp16_should_apply<common_value_t<Ts...>>)
     {
       return harmmean[o.drop(widen)](upgrade(ts)...);

--- a/include/eve/module/math/regular/harmmean.hpp
+++ b/include/eve/module/math/regular/harmmean.hpp
@@ -95,6 +95,13 @@ namespace eve
 
   namespace detail
   {
+    template<callable_options O, typename... Ts>
+    EVE_FORCEINLINE constexpr auto harmmean_(EVE_REQUIRES(emulated_), O const & o, Ts... ts) noexcept
+    requires (O::contains(widen) && detail::fp16_should_apply<common_value_t<Ts...>>)
+    {
+      return harmmean[o.drop(widen)](upgrade(ts)...);
+    }
+
     template<typename T0, typename... Ts, callable_options O>
     EVE_FORCEINLINE constexpr auto
     harmmean_(EVE_REQUIRES(cpu_), O const & o, T0 a0, Ts... args) noexcept

--- a/include/eve/module/math/regular/harmmean.hpp
+++ b/include/eve/module/math/regular/harmmean.hpp
@@ -96,7 +96,7 @@ namespace eve
   namespace detail
   {
     template<callable_options O, typename... Ts>
-    EVE_FORCEINLINE constexpr auto harmmean_(EVE_REQUIRES(strict_elementwise_emulated_), O const & o, Ts... ts) noexcept
+    EVE_FORCEINLINE constexpr auto harmmean_(EVE_REQUIRES(emulated_), O const & o, Ts... ts) noexcept
     requires (O::contains(widen) && detail::fp16_should_apply<common_value_t<Ts...>>)
     {
       return harmmean[o.drop(widen)](upgrade(ts)...);

--- a/include/eve/module/math/regular/horner.hpp
+++ b/include/eve/module/math/regular/horner.hpp
@@ -124,6 +124,13 @@ namespace eve
 
   namespace detail
   {
+    template<callable_options O, typename... Ts>
+    EVE_FORCEINLINE constexpr auto horner_(EVE_REQUIRES(emulated_), O const & o, Ts... ts) noexcept
+    requires (O::contains(widen) && detail::fp16_should_apply<common_value_t<Ts...>>)
+    {
+      return horner[o.drop(widen)](upgrade(ts)...);
+    }
+
     template<value X, callable_options O>
     EVE_FORCEINLINE constexpr auto
     horner_(EVE_REQUIRES(cpu_), O const &, X ) noexcept

--- a/include/eve/module/math/regular/horner.hpp
+++ b/include/eve/module/math/regular/horner.hpp
@@ -125,7 +125,7 @@ namespace eve
   namespace detail
   {
     template<callable_options O, typename... Ts>
-    EVE_FORCEINLINE constexpr auto horner_(EVE_REQUIRES(emulated_), O const & o, Ts... ts) noexcept
+    EVE_FORCEINLINE constexpr auto horner_(EVE_REQUIRES(strict_elementwise_emulated_), O const & o, Ts... ts) noexcept
     requires (O::contains(widen) && detail::fp16_should_apply<common_value_t<Ts...>>)
     {
       return horner[o.drop(widen)](upgrade(ts)...);

--- a/include/eve/module/math/regular/horner.hpp
+++ b/include/eve/module/math/regular/horner.hpp
@@ -125,7 +125,7 @@ namespace eve
   namespace detail
   {
     template<callable_options O, typename... Ts>
-    EVE_FORCEINLINE constexpr auto horner_(EVE_REQUIRES(strict_elementwise_emulated_), O const & o, Ts... ts) noexcept
+    EVE_FORCEINLINE constexpr auto horner_(EVE_REQUIRES(emulated_), O const & o, Ts... ts) noexcept
     requires (O::contains(widen) && detail::fp16_should_apply<common_value_t<Ts...>>)
     {
       return horner[o.drop(widen)](upgrade(ts)...);

--- a/include/eve/module/math/regular/hypot.hpp
+++ b/include/eve/module/math/regular/hypot.hpp
@@ -101,7 +101,7 @@ namespace eve
   namespace detail
   {
     template<callable_options O, typename... Ts>
-    EVE_FORCEINLINE constexpr auto hypot_(EVE_REQUIRES(strict_elementwise_emulated_), O const & o, Ts... ts) noexcept
+    EVE_FORCEINLINE constexpr auto hypot_(EVE_REQUIRES(emulated_), O const & o, Ts... ts) noexcept
     requires (O::contains(widen) && detail::fp16_should_apply<common_value_t<Ts...>>)
     {
       return hypot[o.drop(widen)](upgrade(ts)...);

--- a/include/eve/module/math/regular/hypot.hpp
+++ b/include/eve/module/math/regular/hypot.hpp
@@ -101,7 +101,7 @@ namespace eve
   namespace detail
   {
     template<callable_options O, typename... Ts>
-    EVE_FORCEINLINE constexpr auto hypot_(EVE_REQUIRES(emulated_), O const & o, Ts... ts) noexcept
+    EVE_FORCEINLINE constexpr auto hypot_(EVE_REQUIRES(strict_elementwise_emulated_), O const & o, Ts... ts) noexcept
     requires (O::contains(widen) && detail::fp16_should_apply<common_value_t<Ts...>>)
     {
       return hypot[o.drop(widen)](upgrade(ts)...);

--- a/include/eve/module/math/regular/hypot.hpp
+++ b/include/eve/module/math/regular/hypot.hpp
@@ -17,7 +17,6 @@ namespace eve
   template<typename Options>
   struct hypot_t : tuple_callable<hypot_t, Options, raw_option, pedantic_option, kahan_option, widen_option>
   {
-
     template<value... Ts>
     requires((sizeof...(Ts) !=  0) && eve::same_lanes_or_scalar<Ts...>)
       EVE_FORCEINLINE constexpr upgrade_if_t<Options, common_value_t<Ts...>> operator()(Ts...ts) const noexcept
@@ -101,6 +100,13 @@ namespace eve
 
   namespace detail
   {
+    template<callable_options O, typename... Ts>
+    EVE_FORCEINLINE constexpr auto hypot_(EVE_REQUIRES(emulated_), O const & o, Ts... ts) noexcept
+    requires (O::contains(widen) && detail::fp16_should_apply<common_value_t<Ts...>>)
+    {
+      return hypot[o.drop(widen)](upgrade(ts)...);
+    }
+
     template<typename T0, callable_options O>
     EVE_FORCEINLINE constexpr auto
     hypot_(EVE_REQUIRES(cpu_), O const &, T0 a0) noexcept

--- a/include/eve/module/math/regular/kolmmean.hpp
+++ b/include/eve/module/math/regular/kolmmean.hpp
@@ -96,7 +96,7 @@ namespace eve
   namespace detail
   {
     template<callable_options O, typename... Ts>
-    EVE_FORCEINLINE constexpr auto kolmmean_(EVE_REQUIRES(strict_elementwise_emulated_), O const & o, Ts... ts) noexcept
+    EVE_FORCEINLINE constexpr auto kolmmean_(EVE_REQUIRES(emulated_), O const & o, Ts... ts) noexcept
     requires (O::contains(widen) && detail::fp16_should_apply<common_value_t<Ts...>>)
     {
       return kolmmean[o.drop(widen)](upgrade(ts)...);

--- a/include/eve/module/math/regular/kolmmean.hpp
+++ b/include/eve/module/math/regular/kolmmean.hpp
@@ -95,6 +95,13 @@ namespace eve
 
   namespace detail
   {
+    template<callable_options O, typename... Ts>
+    EVE_FORCEINLINE constexpr auto kolmmean_(EVE_REQUIRES(emulated_), O const & o, Ts... ts) noexcept
+    requires (O::contains(widen) && detail::fp16_should_apply<common_value_t<Ts...>>)
+    {
+      return kolmmean[o.drop(widen)](upgrade(ts)...);
+    }
+
     template<typename F, typename G, floating_value... Ts, callable_options O>
     EVE_FORCEINLINE constexpr auto
     kolmmean_(EVE_REQUIRES(cpu_), O const & o, F f, G g, Ts... args) noexcept

--- a/include/eve/module/math/regular/kolmmean.hpp
+++ b/include/eve/module/math/regular/kolmmean.hpp
@@ -96,7 +96,7 @@ namespace eve
   namespace detail
   {
     template<callable_options O, typename... Ts>
-    EVE_FORCEINLINE constexpr auto kolmmean_(EVE_REQUIRES(emulated_), O const & o, Ts... ts) noexcept
+    EVE_FORCEINLINE constexpr auto kolmmean_(EVE_REQUIRES(strict_elementwise_emulated_), O const & o, Ts... ts) noexcept
     requires (O::contains(widen) && detail::fp16_should_apply<common_value_t<Ts...>>)
     {
       return kolmmean[o.drop(widen)](upgrade(ts)...);

--- a/include/eve/module/math/regular/lpnorm.hpp
+++ b/include/eve/module/math/regular/lpnorm.hpp
@@ -100,7 +100,7 @@ namespace eve
   namespace detail
   {
     template<callable_options O, typename... Ts>
-    EVE_FORCEINLINE constexpr auto lpnorm_(EVE_REQUIRES(emulated_), O const & o, Ts... ts) noexcept
+    EVE_FORCEINLINE constexpr auto lpnorm_(EVE_REQUIRES(strict_elementwise_emulated_), O const & o, Ts... ts) noexcept
     requires (O::contains(widen) && detail::fp16_should_apply<common_value_t<Ts...>>)
     {
       return lpnorm[o.drop(widen)](upgrade(ts)...);

--- a/include/eve/module/math/regular/lpnorm.hpp
+++ b/include/eve/module/math/regular/lpnorm.hpp
@@ -100,7 +100,7 @@ namespace eve
   namespace detail
   {
     template<callable_options O, typename... Ts>
-    EVE_FORCEINLINE constexpr auto lpnorm_(EVE_REQUIRES(strict_elementwise_emulated_), O const & o, Ts... ts) noexcept
+    EVE_FORCEINLINE constexpr auto lpnorm_(EVE_REQUIRES(emulated_), O const & o, Ts... ts) noexcept
     requires (O::contains(widen) && detail::fp16_should_apply<common_value_t<Ts...>>)
     {
       return lpnorm[o.drop(widen)](upgrade(ts)...);

--- a/include/eve/module/math/regular/lpnorm.hpp
+++ b/include/eve/module/math/regular/lpnorm.hpp
@@ -99,6 +99,12 @@ namespace eve
 
   namespace detail
   {
+    template<callable_options O, typename... Ts>
+    EVE_FORCEINLINE constexpr auto lpnorm_(EVE_REQUIRES(emulated_), O const & o, Ts... ts) noexcept
+    requires (O::contains(widen) && detail::fp16_should_apply<common_value_t<Ts...>>)
+    {
+      return lpnorm[o.drop(widen)](upgrade(ts)...);
+    }
 
     template<typename P, floating_value... Ts, callable_options O>
     EVE_NOINLINE constexpr auto

--- a/include/eve/module/math/regular/radinpi.hpp
+++ b/include/eve/module/math/regular/radinpi.hpp
@@ -76,7 +76,7 @@ namespace eve
     EVE_FORCEINLINE constexpr T radinpi_(EVE_REQUIRES(cpu_), O const &o, T const& a) noexcept
     {
       if constexpr(std::same_as<eve::element_type_t<T>, eve::float16_t>)
-        return eve::detail::apply_fp16_as_fp32(eve::radindeg[o], a);
+        return eve::detail::apply_fp16_as_fp32(eve::radinpi[o], a);
       else if constexpr(O::contains(kahan))
       {
         auto pi_h = eve::inv_pi(eve::as<T>());

--- a/include/eve/module/math/regular/reverse_horner.hpp
+++ b/include/eve/module/math/regular/reverse_horner.hpp
@@ -123,7 +123,7 @@ namespace eve
   {
 
     template<callable_options O, typename... Ts>
-    EVE_FORCEINLINE constexpr auto reverse_horner_(EVE_REQUIRES(emulated_), O const & o, Ts... ts) noexcept
+    EVE_FORCEINLINE constexpr auto reverse_horner_(EVE_REQUIRES(strict_elementwise_emulated_), O const & o, Ts... ts) noexcept
     requires (O::contains(widen) && detail::fp16_should_apply<common_value_t<Ts...>>)
     {
       return reverse_horner[o.drop(widen)](upgrade(ts)...);

--- a/include/eve/module/math/regular/reverse_horner.hpp
+++ b/include/eve/module/math/regular/reverse_horner.hpp
@@ -123,7 +123,7 @@ namespace eve
   {
 
     template<callable_options O, typename... Ts>
-    EVE_FORCEINLINE constexpr auto reverse_horner_(EVE_REQUIRES(strict_elementwise_emulated_), O const & o, Ts... ts) noexcept
+    EVE_FORCEINLINE constexpr auto reverse_horner_(EVE_REQUIRES(emulated_), O const & o, Ts... ts) noexcept
     requires (O::contains(widen) && detail::fp16_should_apply<common_value_t<Ts...>>)
     {
       return reverse_horner[o.drop(widen)](upgrade(ts)...);

--- a/include/eve/module/math/regular/reverse_horner.hpp
+++ b/include/eve/module/math/regular/reverse_horner.hpp
@@ -21,7 +21,6 @@ namespace eve
   struct reverse_horner_t : callable<reverse_horner_t, Options, pedantic_option,
                                      kahan_option, widen_option>
   {
-
     template<floating_value X, value ... Ts>
     requires(eve::same_lanes_or_scalar<X, Ts...>)
     EVE_FORCEINLINE constexpr upgrade_if_t<Options, common_value_t<X, Ts...>>
@@ -122,6 +121,13 @@ namespace eve
 
   namespace detail
   {
+
+    template<callable_options O, typename... Ts>
+    EVE_FORCEINLINE constexpr auto reverse_horner_(EVE_REQUIRES(emulated_), O const & o, Ts... ts) noexcept
+    requires (O::contains(widen) && detail::fp16_should_apply<common_value_t<Ts...>>)
+    {
+      return reverse_horner[o.drop(widen)](upgrade(ts)...);
+    }
 
     template<value X, callable_options O>
     EVE_FORCEINLINE constexpr auto

--- a/include/eve/module/polynomial/regular/tchebsum.hpp
+++ b/include/eve/module/polynomial/regular/tchebsum.hpp
@@ -126,7 +126,7 @@ namespace eve
 namespace eve::detail
 {
   template<callable_options O, typename... Ts>
-  EVE_FORCEINLINE constexpr auto tchebsum_(EVE_REQUIRES(emulated_), O const & o, Ts... ts) noexcept
+  EVE_FORCEINLINE constexpr auto tchebsum_(EVE_REQUIRES(strict_elementwise_emulated_), O const & o, Ts... ts) noexcept
   requires (O::contains(widen) && detail::fp16_should_apply<common_value_t<Ts...>>)
   {
     return tchebsum[o.drop(widen)](upgrade(ts)...);

--- a/include/eve/module/polynomial/regular/tchebsum.hpp
+++ b/include/eve/module/polynomial/regular/tchebsum.hpp
@@ -126,7 +126,7 @@ namespace eve
 namespace eve::detail
 {
   template<callable_options O, typename... Ts>
-  EVE_FORCEINLINE constexpr auto tchebsum_(EVE_REQUIRES(strict_elementwise_emulated_), O const & o, Ts... ts) noexcept
+  EVE_FORCEINLINE constexpr auto tchebsum_(EVE_REQUIRES(emulated_), O const & o, Ts... ts) noexcept
   requires (O::contains(widen) && detail::fp16_should_apply<common_value_t<Ts...>>)
   {
     return tchebsum[o.drop(widen)](upgrade(ts)...);

--- a/include/eve/module/polynomial/regular/tchebsum.hpp
+++ b/include/eve/module/polynomial/regular/tchebsum.hpp
@@ -125,6 +125,12 @@ namespace eve
 
 namespace eve::detail
 {
+  template<callable_options O, typename... Ts>
+  EVE_FORCEINLINE constexpr auto tchebsum_(EVE_REQUIRES(emulated_), O const & o, Ts... ts) noexcept
+  requires (O::contains(widen) && detail::fp16_should_apply<common_value_t<Ts...>>)
+  {
+    return tchebsum[o.drop(widen)](upgrade(ts)...);
+  }
 
   template<value T, typename... Cs, callable_options O>
   constexpr auto

--- a/include/eve/traits/apply_fp16.hpp
+++ b/include/eve/traits/apply_fp16.hpp
@@ -11,7 +11,7 @@
 #include <eve/arch/float16.hpp>
 #include <eve/traits/element_type.hpp>
 #include <eve/concept/same_lanes.hpp>
-#include <eve/module/core/regular/convert.hpp>
+#include <eve/forward.hpp>
 
 #include <type_traits>
 
@@ -22,11 +22,11 @@ namespace eve::detail
                                   || (simd_value<T> && std::same_as<element_type_t<T>, eve::float16_t> && !detail::supports_fp16_vector_ops);
 
   template <typename Func, typename Arg0, typename... Args>
-  constexpr EVE_FORCEINLINE auto apply_fp16_as_fp32(Func&& f, Arg0 arg0, Args... args)
+  EVE_NOINLINE constexpr auto apply_fp16_as_fp32(Func&& f, Arg0 arg0, Args... args)
   {
     constexpr auto cvt_args = [](auto v) {
       if constexpr (std::same_as<element_type_t<decltype(v)>, eve::float16_t>)
-        return convert(v, as<float>{});
+        return detail::call_convert(v, as<float>{});
       else
         return v;
     };
@@ -34,13 +34,13 @@ namespace eve::detail
     auto r = f(cvt_args(arg0), cvt_args(args)...);
     using r_t = decltype(r);
 
-    if      constexpr (logical_value<r_t>)                       return convert(r, as<logical<eve::float16_t>>{});
-    else if constexpr (std::same_as<element_type_t<r_t>, float>) return convert(r, as<eve::float16_t>{});
+    if      constexpr (logical_value<r_t>)                       return detail::call_convert(r, as<logical<eve::float16_t>>{});
+    else if constexpr (std::same_as<element_type_t<r_t>, float>) return detail::call_convert(r, as<eve::float16_t>{});
     else                                                         return r;
   }
 
   template <typename Func, typename C, typename Arg0, typename... Args>
-  constexpr EVE_FORCEINLINE auto apply_fp16_as_fp32_masked(Func&& f, C const& cx, Arg0 arg0, Args... args)
+  EVE_NOINLINE constexpr auto apply_fp16_as_fp32_masked(Func&& f, C const& cx, Arg0 arg0, Args... args)
   {
     if constexpr (relative_conditional_expr<C>)
     {
@@ -48,19 +48,19 @@ namespace eve::detail
     }
     else if constexpr (C::has_alternative)
     {
-      const auto nc = convert(expand_mask(cx, as(arg0)), as<logical<float>>{});
-      const auto na = convert(cx.alternative, as<float>{});
+      const auto nc = detail::call_convert(expand_mask(cx, as(arg0)), as<logical<float>>{});
+      const auto na = detail::call_convert(cx.alternative, as<float>{});
       return apply_fp16_as_fp32(f[if_(nc).else_(na)], arg0, args...);
     }
     else
     {
-      auto m = convert(expand_mask(cx, as(arg0)), as<logical<float>>{});
+      auto m = detail::call_convert(expand_mask(cx, as(arg0)), as<logical<float>>{});
       return apply_fp16_as_fp32(f[m], arg0, args...);
     }
   }
 
   template <typename Func, typename Arg0, typename... Args>
-  constexpr EVE_FORCEINLINE auto apply_fp16_as_u16(Func&& f, Arg0 arg0, Args... args)
+  EVE_NOINLINE constexpr auto apply_fp16_as_u16(Func&& f, Arg0 arg0, Args... args)
   {
     constexpr auto cast_args = [](auto v) {
       if constexpr (std::same_as<element_type_t<decltype(v)>, eve::float16_t>)

--- a/include/eve/traits/apply_fp16.hpp
+++ b/include/eve/traits/apply_fp16.hpp
@@ -22,11 +22,13 @@ namespace eve::detail
                                   || (simd_value<T> && std::same_as<element_type_t<T>, eve::float16_t> && !detail::supports_fp16_vector_ops);
 
   template <typename Func, typename Arg0, typename... Args>
-  EVE_NOINLINE constexpr auto apply_fp16_as_fp32(Func&& f, Arg0 arg0, Args... args)
+  EVE_FORCEINLINE constexpr auto apply_fp16_as_fp32(Func&& f, Arg0 arg0, Args... args)
   {
     constexpr auto cvt_args = [](auto v) {
       if constexpr (std::same_as<element_type_t<decltype(v)>, eve::float16_t>)
         return detail::call_convert(v, as<float>{});
+      else if constexpr (std::same_as<element_type_t<decltype(v)>, eve::logical<eve::float16_t>>)
+        return detail::call_convert(v, as<eve::logical<float>>{});
       else
         return v;
     };
@@ -40,7 +42,7 @@ namespace eve::detail
   }
 
   template <typename Func, typename C, typename Arg0, typename... Args>
-  EVE_NOINLINE constexpr auto apply_fp16_as_fp32_masked(Func&& f, C const& cx, Arg0 arg0, Args... args)
+  EVE_FORCEINLINE constexpr auto apply_fp16_as_fp32_masked(Func&& f, C const& cx, Arg0 arg0, Args... args)
   {
     if constexpr (relative_conditional_expr<C>)
     {
@@ -60,7 +62,7 @@ namespace eve::detail
   }
 
   template <typename Func, typename Arg0, typename... Args>
-  EVE_NOINLINE constexpr auto apply_fp16_as_u16(Func&& f, Arg0 arg0, Args... args)
+  EVE_FORCEINLINE constexpr auto apply_fp16_as_u16(Func&& f, Arg0 arg0, Args... args)
   {
     constexpr auto cast_args = [](auto v) {
       if constexpr (std::same_as<element_type_t<decltype(v)>, eve::float16_t>)

--- a/include/eve/traits/apply_fp16.hpp
+++ b/include/eve/traits/apply_fp16.hpp
@@ -12,6 +12,7 @@
 #include <eve/traits/element_type.hpp>
 #include <eve/concept/same_lanes.hpp>
 #include <eve/forward.hpp>
+#include <eve/module/core/regular/bit_cast.hpp>
 
 #include <type_traits>
 
@@ -66,14 +67,14 @@ namespace eve::detail
   {
     constexpr auto cast_args = [](auto v) {
       if constexpr (std::same_as<element_type_t<decltype(v)>, eve::float16_t>)
-        return bit_cast(v, as<as_wide_as_t<uint16_t, decltype(v)>>{});
+        return eve::bit_cast(v, as<as_wide_as_t<uint16_t, decltype(v)>>{});
       else
         return v;
     };
 
     auto r = f(cast_args(arg0), cast_args(args)...);
 
-    if constexpr (logical_value<decltype(r)>) return bit_cast(r, as<as_wide_as_t<logical<eve::float16_t>, decltype(r)>>{});
-    else                                      return bit_cast(r, as<as_wide_as_t<eve::float16_t, decltype(r)>>{});
+    if constexpr (logical_value<decltype(r)>) return eve::bit_cast(r, as<as_wide_as_t<logical<eve::float16_t>, decltype(r)>>{});
+    else                                      return eve::bit_cast(r, as<as_wide_as_t<eve::float16_t, decltype(r)>>{});
   }
 }

--- a/include/eve/traits/overload/impl/strict_elementwise.hpp
+++ b/include/eve/traits/overload/impl/strict_elementwise.hpp
@@ -40,14 +40,14 @@ namespace eve
     {
       constexpr bool has_implementation          = requires{ func_t::deferred_call(a, o, x, xs...); };
       constexpr bool has_emulated_implementation = requires{ func_t::deferred_call(emulated_{}, o, x, xs...); };
-      constexpr bool supports_map_no_conversion  = requires{ this->derived().map(x, xs...); };
+      constexpr bool supports_map_no_conversion  = requires{ this->map(x, xs...); };
       constexpr bool any_emulated                = (has_emulated_abi_v<T> || ... || has_emulated_abi_v<Ts>);
       constexpr bool any_aggregated              = (has_aggregated_abi_v<T> || ... || has_aggregated_abi_v<Ts>);
 
 
       if      constexpr(any_aggregated)                              return aggregate(this->derived(), x, xs...);
       else if constexpr(any_emulated && has_emulated_implementation) return func_t::deferred_call(emulated_{}, o, x, xs...);
-      else if constexpr(any_emulated && supports_map_no_conversion)  return this->derived().map(x, xs...);
+      else if constexpr(any_emulated && supports_map_no_conversion)  return this->map(x, xs...);
       else if constexpr(has_implementation)                          return func_t::deferred_call(a, o, x, xs...);
       else                                                           return detail::ignore{};
     }

--- a/include/eve/traits/overload/impl/strict_elementwise.hpp
+++ b/include/eve/traits/overload/impl/strict_elementwise.hpp
@@ -15,8 +15,6 @@
 
 namespace eve
 {
-  struct strict_elementwise_emulated_ {};
-
   template< template<typename> class Func
         , typename OptionsValues
         , typename... Options
@@ -41,14 +39,14 @@ namespace eve
     constexpr EVE_FORCEINLINE auto adapt_call(auto a, O const& o, T x, Ts... xs) const
     {
       constexpr bool has_implementation          = requires{ func_t::deferred_call(a, o, x, xs...); };
-      constexpr bool has_emulated_implementation = requires{ func_t::deferred_call(strict_elementwise_emulated_{}, o, x, xs...); };
+      constexpr bool has_emulated_implementation = requires{ func_t::deferred_call(emulated_{}, o, x, xs...); };
       constexpr bool supports_map_no_conversion  = requires{ this->derived().map(x, xs...); };
       constexpr bool any_emulated                = (has_emulated_abi_v<T> || ... || has_emulated_abi_v<Ts>);
       constexpr bool any_aggregated              = (has_aggregated_abi_v<T> || ... || has_aggregated_abi_v<Ts>);
 
 
       if      constexpr(any_aggregated)                              return aggregate(this->derived(), x, xs...);
-      else if constexpr(any_emulated && has_emulated_implementation) return func_t::deferred_call(strict_elementwise_emulated_{}, o, x, xs...);
+      else if constexpr(any_emulated && has_emulated_implementation) return func_t::deferred_call(emulated_{}, o, x, xs...);
       else if constexpr(any_emulated && supports_map_no_conversion)  return this->derived().map(x, xs...);
       else if constexpr(has_implementation)                          return func_t::deferred_call(a, o, x, xs...);
       else                                                           return detail::ignore{};

--- a/include/eve/traits/overload/impl/strict_elementwise.hpp
+++ b/include/eve/traits/overload/impl/strict_elementwise.hpp
@@ -11,9 +11,12 @@
 #include <eve/detail/skeleton.hpp>
 #include <eve/detail/validate_mask.hpp>
 #include <eve/traits/overload/impl/conditional.hpp>
+#include <eve/traits/apply_fp16.hpp>
 
 namespace eve
 {
+  struct strict_elementwise_emulated_ {};
+
   template< template<typename> class Func
         , typename OptionsValues
         , typename... Options
@@ -23,19 +26,30 @@ namespace eve
     using base_t = conditional_callable<Func, OptionsValues, Options...>;
     using func_t =  Func<OptionsValues>;
 
+    template<typename... Ts>
+    constexpr EVE_FORCEINLINE typename detail::wide_result<func_t, Ts...>::type map(Ts... ts) const noexcept
+    {
+      using R = typename detail::wide_result<func_t, Ts...>::type;
+
+      if constexpr (detail::fp16_should_apply<R> && (detail::fp16_should_apply<Ts> && ...))
+        return detail::apply_fp16_as_fp32(this->derived(), ts...);
+      else
+        return detail::map(this->derived(), ts...);
+    }
+
     template<callable_options O, typename T, typename... Ts>
     constexpr EVE_FORCEINLINE auto adapt_call(auto a, O const& o, T x, Ts... xs) const
     {
       constexpr bool has_implementation          = requires{ func_t::deferred_call(a, o, x, xs...); };
-      constexpr bool has_emulated_implementation = requires{ func_t::deferred_call(emulated_{}, o, x, xs...); };
-      constexpr bool supports_map_no_conversion  = requires{ detail::map(this->derived(), x, xs...); };
+      constexpr bool has_emulated_implementation = requires{ func_t::deferred_call(strict_elementwise_emulated_{}, o, x, xs...); };
+      constexpr bool supports_map_no_conversion  = requires{ this->derived().map(x, xs...); };
       constexpr bool any_emulated                = (has_emulated_abi_v<T> || ... || has_emulated_abi_v<Ts>);
       constexpr bool any_aggregated              = (has_aggregated_abi_v<T> || ... || has_aggregated_abi_v<Ts>);
 
 
       if      constexpr(any_aggregated)                              return aggregate(this->derived(), x, xs...);
-      else if constexpr(any_emulated && has_emulated_implementation) return func_t::deferred_call(emulated_{}, o, x, xs...);
-      else if constexpr(any_emulated && supports_map_no_conversion)  return detail::map(this->derived(), x, xs...);
+      else if constexpr(any_emulated && has_emulated_implementation) return func_t::deferred_call(strict_elementwise_emulated_{}, o, x, xs...);
+      else if constexpr(any_emulated && supports_map_no_conversion)  return this->derived().map(x, xs...);
       else if constexpr(has_implementation)                          return func_t::deferred_call(a, o, x, xs...);
       else                                                           return detail::ignore{};
     }

--- a/include/eve/traits/overload/impl/strict_elementwise.hpp
+++ b/include/eve/traits/overload/impl/strict_elementwise.hpp
@@ -26,15 +26,18 @@ namespace eve
     template<callable_options O, typename T, typename... Ts>
     constexpr EVE_FORCEINLINE auto adapt_call(auto a, O const& o, T x, Ts... xs) const
     {
-      constexpr bool has_implementation         = requires{ func_t::deferred_call(a, o, x, xs...); };
-      constexpr bool supports_map_no_conversion = requires{ map(this->derived(), x, xs...); };
-      constexpr bool any_emulated               = (has_emulated_abi_v<T> || ... || has_emulated_abi_v<Ts>);
-      constexpr bool any_aggregated             = (has_aggregated_abi_v<T> || ... || has_aggregated_abi_v<Ts>);
+      constexpr bool has_implementation          = requires{ func_t::deferred_call(a, o, x, xs...); };
+      constexpr bool has_emulated_implementation = requires{ func_t::deferred_call(emulated_{}, o, x, xs...); };
+      constexpr bool supports_map_no_conversion  = requires{ detail::map(this->derived(), x, xs...); };
+      constexpr bool any_emulated                = (has_emulated_abi_v<T> || ... || has_emulated_abi_v<Ts>);
+      constexpr bool any_aggregated              = (has_aggregated_abi_v<T> || ... || has_aggregated_abi_v<Ts>);
 
-      if      constexpr(any_aggregated)                             return aggregate(this->derived(), x, xs...);
-      else if constexpr(any_emulated && supports_map_no_conversion) return map(this->derived(), x, xs...);
-      else if constexpr(has_implementation)                         return func_t::deferred_call(a, o, x, xs...);
-      else                                                          return detail::ignore{};
+
+      if      constexpr(any_aggregated)                              return aggregate(this->derived(), x, xs...);
+      else if constexpr(any_emulated && has_emulated_implementation) return func_t::deferred_call(emulated_{}, o, x, xs...);
+      else if constexpr(any_emulated && supports_map_no_conversion)  return detail::map(this->derived(), x, xs...);
+      else if constexpr(has_implementation)                          return func_t::deferred_call(a, o, x, xs...);
+      else                                                           return detail::ignore{};
     }
 
     template<callable_options O, typename T, typename... Ts>

--- a/include/eve/traits/updown.hpp
+++ b/include/eve/traits/updown.hpp
@@ -21,7 +21,11 @@ namespace eve
       using v_t = eve::element_type_t<T>;
 
       static constexpr auto sd = [](){
-        if constexpr( std::same_as<v_t, double>)
+        if constexpr( std::same_as<v_t, float>)
+        {
+          return eve::float16_t();
+        }
+        else if constexpr( std::same_as<v_t, double>)
         {
           return float();
         }
@@ -55,6 +59,10 @@ namespace eve
         if constexpr( std::same_as<v_t, float>)
         {
           return double();
+        }
+        else if constexpr( std::same_as<v_t, eve::float16_t>)
+        {
+          return float();
         }
         else if constexpr( arithmetic_scalar_value<v_t> && sizeof(v_t) >= 8)
         {

--- a/test/doc/core/modf.cpp
+++ b/test/doc/core/modf.cpp
@@ -7,10 +7,14 @@ int main()
   eve::wide wf0{-0.0f,  1.30f, -1.3f,  eve::inf(eve::as<float>()),
       0.0f, eve::nan(eve::as<float>()), 2.0f,  eve::prev(2.0f)};
 
+  eve::wide wf1{-0.0f,  1.30f, -1.3f,  eve::valmax(eve::as<float>()),
+      0.0f, eve::valmin(eve::as<float>()), 2.0f,  eve::prev(2.0f)};
+
    std::cout << "<- wf0                          = " << wf0 << "\n";
+   std::cout << "<- wf1                          = " << wf1 << "\n";
 
   std::cout << "-> modf(wf0)                    = " << eve::modf(wf0) << "\n";
-  std::cout << "-> modf[raw](wf0)               = " << eve::modf[eve::raw](wf0) << "\n";
+  std::cout << "-> modf[raw](wf1)               = " << eve::modf[eve::raw](wf1) << "\n";
   std::cout << "-> modf[pedantic](wf0)          = " << eve::modf[eve::pedantic](wf0) << "\n";
   std::cout << "-> modf[almost](wf0)            = " << eve::modf[eve::almost](wf0) << "\n";
 }

--- a/test/test.hpp
+++ b/test/test.hpp
@@ -552,8 +552,12 @@ int main(int argc, char const **argv)
   constexpr auto assert_status = "Enabled";
 #endif
 
+  constexpr auto fp16_status = eve::detail::supports_fp16_vector_ops ? "Full" :
+                              (eve::detail::supports_fp16_vector_conversion ? "Conversion" : "Emulated");
+
   std::cout << "[EVE] - Target: " << eve::current_api
             << " - Assertions: "  << assert_status
+            << " - FP16: "        << fp16_status
             << " - PRNG Seed: "   << seed
             << std::endl;
 

--- a/test/tts/tts.hpp
+++ b/test/tts/tts.hpp
@@ -1365,6 +1365,16 @@ namespace tts::detail
 #endif
   inline auto as_int(float a)   noexcept  { return bit_cast<std::int32_t>(a); }
   inline auto as_int(double a)  noexcept  { return bit_cast<std::int64_t>(a); }
+  inline auto as_int(long double a)  noexcept
+  {
+    constexpr auto size = sizeof(long double);
+    static_assert(size == 8 || size == 16, "Unsupported long double size");
+
+    return [=](auto x) {
+      if constexpr (size == 8) return bit_cast<std::int64_t>(x);
+      else                     return bit_cast<__int128>(x);
+    }(a);
+  }
   template<typename T> inline auto bitinteger(T a) noexcept
   {
     auto ia = as_int(a);

--- a/test/tts/tts.hpp
+++ b/test/tts/tts.hpp
@@ -1365,16 +1365,6 @@ namespace tts::detail
 #endif
   inline auto as_int(float a)   noexcept  { return bit_cast<std::int32_t>(a); }
   inline auto as_int(double a)  noexcept  { return bit_cast<std::int64_t>(a); }
-  inline auto as_int(long double a)  noexcept
-  {
-    constexpr auto size = sizeof(long double);
-    static_assert(size == 8 || size == 16, "Unsupported long double size");
-
-    return [=](auto x) {
-      if constexpr (size == 8) return bit_cast<std::int64_t>(x);
-      else                     return bit_cast<__int128>(x);
-    }(a);
-  }
   template<typename T> inline auto bitinteger(T a) noexcept
   {
     auto ia = as_int(a);

--- a/test/unit/internals/float16.cpp
+++ b/test/unit/internals/float16.cpp
@@ -9,7 +9,7 @@
 
 #ifdef SPY_SUPPORTS_FP16_TYPE
   // if the compiler provides fp16 softfloat support, use it to check the fp16 to fp32 routine
-  TTS_CASE("emulated float16 conversion - float16 to float32")
+  TTS_CASE("emulated float16 conversion - f16 to f32")
   {
     for (uint16_t f16_bits = 0u; f16_bits < eve::valmax(eve::as<uint16_t>{}); ++f16_bits)
     {
@@ -32,7 +32,7 @@
     #error "Special fp16 test requires compiler support for _Float16 type"
   #endif
 
-  TTS_CASE("emulated float16 conversion - f16 roundtrip")
+  TTS_CASE("emulated float16 conversion - f32 to f16")
   {
     auto is_nan = [](uint16_t bits) {
       return ((bits & 0x7C00u) == 0x7C00u) && ((bits & 0x03FFu) != 0);
@@ -42,12 +42,50 @@
     {
       float f32 = std::bit_cast<float>(f32_bits);
 
-      uint16_t mf16 = eve::detail::emulated_fp_to_fp16(f32);
+      uint16_t mf16 = eve::detail::emulated_fp32_to_fp16(f32);
       uint16_t cf16 = std::bit_cast<uint16_t>(static_cast<_Float16>(f32));
 
       if (eve::is_nan(f32)) TTS_EXPECT(is_nan(mf16) && is_nan(cf16));
       else                  TTS_EQUAL(mf16, cf16);
     }
+  };
+
+  TTS_CASE("emulated float16 conversion - f32 to f16 simd")
+  {
+    auto is_nan = [](auto bits) {
+      return ((bits & uint16_t(0x7C00)) == 0x7C00u) && ((bits & uint16_t(0x03FF)) != 0u);
+    };
+
+    auto run_for = [&]<std::ptrdiff_t N>(std::integral_constant<std::ptrdiff_t, N>) {
+      TTS_WHEN("cardinal = " << N)
+      {
+        using wf16_t = eve::wide<eve::float16_t, eve::fixed<N>>;
+        using wf32_t = eve::wide<float, eve::fixed<N>>;
+        using wu16_t = eve::wide<uint16_t, eve::fixed<N>>;
+
+        for (uint64_t base = 0u; base < eve::valmax(eve::as<uint32_t>{}); base += N)
+        {
+          wf32_t f32 = [&](auto i) { return std::bit_cast<float>(static_cast<uint32_t>(base + i)); };
+          wf16_t mf16 = eve::detail::emulated_simd_fp32_to_fp16(f32);
+
+          wu16_t expected = [&](auto i) {
+            float scalar_f32 = std::bit_cast<float>(static_cast<uint32_t>(base + i));
+            return std::bit_cast<uint16_t>(static_cast<_Float16>(scalar_f32));
+          };
+
+          wu16_t actual = eve::bit_cast(mf16, eve::as<wu16_t>{});
+
+          TTS_EXPECT(eve::all((actual == expected) || (is_nan(actual) && is_nan(expected))));
+        }
+      }
+    };
+
+    constexpr uint32_t max_c = eve::expected_cardinal_v<float> * 2;
+    constexpr std::size_t seq_size = std::countr_zero(max_c) + 1;
+
+    [&]<std::size_t... I>(std::index_sequence<I...>) {
+      (run_for(std::integral_constant<std::ptrdiff_t, 1LL << I>{}), ...);
+    }(std::make_index_sequence<seq_size>{});
   };
 #endif
 
@@ -60,7 +98,7 @@ TTS_CASE("emulated float16 conversion - f32 roundtrip")
   for (uint16_t f16_bits = 0u; f16_bits < eve::valmax(eve::as<uint16_t>{}); ++f16_bits)
   {
     float f32 = eve::detail::emulated_fp16_to_fp32(f16_bits);
-    uint16_t roundtrip = eve::detail::emulated_fp_to_fp16(f32);
+    uint16_t roundtrip = eve::detail::emulated_fp32_to_fp16(f32);
 
     // special case for NaN: payload is not conserved
     if (is_nan(f16_bits)) TTS_EXPECT(is_nan(roundtrip));
@@ -71,25 +109,21 @@ TTS_CASE("emulated float16 conversion - f32 roundtrip")
 TTS_CASE("emulated float16 conversion - f32 roundtrip (simd)")
 {
   auto run_for = [&]<std::ptrdiff_t N>(std::integral_constant<std::ptrdiff_t, N>) {
-    using wf16_t = eve::wide<eve::float16_t, eve::fixed<N>>;
-    using wf32_t = eve::wide<float, eve::fixed<N>>;
-
-    for (uint32_t base = 0u; base <= 0xFFFFu; base += N)
+    TTS_WHEN("cardinal = " << N)
     {
-      wf16_t input = [&](auto i, auto) {
-        return eve::bit_cast(static_cast<uint16_t>(base + i), eve::as<eve::float16_t>{});
-      };
+      using wf16_t = eve::wide<eve::float16_t, eve::fixed<N>>;
+      using wf32_t = eve::wide<float, eve::fixed<N>>;
 
-      wf32_t f32       = eve::convert(input, eve::as<float>{});
-      wf16_t roundtrip = eve::convert(f32, eve::as<eve::float16_t>{});
-
-      for (std::ptrdiff_t lane = 0; lane < N; ++lane)
+      for (uint32_t base = 0u; base < eve::valmax(eve::as<uint16_t>{}); base += N)
       {
-        eve::float16_t orig = input.get(lane);
-        eve::float16_t rt   = roundtrip.get(lane);
+        wf16_t input = [&](auto i) {
+          return eve::bit_cast(static_cast<uint16_t>(base + i), eve::as<eve::float16_t>{});
+        };
 
-        if (eve::is_nan(orig)) TTS_EXPECT(eve::is_nan(rt));
-        else                   TTS_EQUAL(rt, orig);
+        wf32_t f32       = eve::detail::emulated_simd_fp16_to_fp32(input);
+        wf16_t roundtrip = eve::detail::emulated_simd_fp32_to_fp16(f32);
+
+        TTS_IEEE_EQUAL(input, roundtrip);
       }
     }
   };
@@ -106,78 +140,78 @@ TTS_CASE("emulated float16 conversion - f16 special")
 {
   auto cases = tts::limits(tts::type<float>{});
 
-  TTS_EXPECT(eve::is_nan(eve::detail::emulated_fp16_to_fp32(eve::detail::emulated_fp_to_fp16(cases.nan))));
+  TTS_EXPECT(eve::is_nan(eve::detail::emulated_fp16_to_fp32(eve::detail::emulated_fp32_to_fp16(cases.nan))));
 
-  TTS_EXPECT(eve::is_infinite(eve::detail::emulated_fp16_to_fp32(eve::detail::emulated_fp_to_fp16(cases.inf))));
-  TTS_EXPECT(eve::is_positive(eve::detail::emulated_fp16_to_fp32(eve::detail::emulated_fp_to_fp16(cases.inf))));
+  TTS_EXPECT(eve::is_infinite(eve::detail::emulated_fp16_to_fp32(eve::detail::emulated_fp32_to_fp16(cases.inf))));
+  TTS_EXPECT(eve::is_positive(eve::detail::emulated_fp16_to_fp32(eve::detail::emulated_fp32_to_fp16(cases.inf))));
 
-  TTS_EXPECT(eve::is_infinite(eve::detail::emulated_fp16_to_fp32(eve::detail::emulated_fp_to_fp16(cases.minf))));
-  TTS_EXPECT(eve::is_negative(eve::detail::emulated_fp16_to_fp32(eve::detail::emulated_fp_to_fp16(cases.minf))));
+  TTS_EXPECT(eve::is_infinite(eve::detail::emulated_fp16_to_fp32(eve::detail::emulated_fp32_to_fp16(cases.minf))));
+  TTS_EXPECT(eve::is_negative(eve::detail::emulated_fp16_to_fp32(eve::detail::emulated_fp32_to_fp16(cases.minf))));
 
-  TTS_EQUAL(eve::detail::emulated_fp16_to_fp32(eve::detail::emulated_fp_to_fp16(cases.mzero)), -0.0f);
-  TTS_EXPECT(eve::is_negative(eve::detail::emulated_fp16_to_fp32(eve::detail::emulated_fp_to_fp16(cases.mzero))));
+  TTS_EQUAL(eve::detail::emulated_fp16_to_fp32(eve::detail::emulated_fp32_to_fp16(cases.mzero)), -0.0f);
+  TTS_EXPECT(eve::is_negative(eve::detail::emulated_fp16_to_fp32(eve::detail::emulated_fp32_to_fp16(cases.mzero))));
 
-  TTS_EQUAL(eve::detail::emulated_fp16_to_fp32(eve::detail::emulated_fp_to_fp16(cases.zero)), 0.0f);
-  TTS_EXPECT(eve::is_positive(eve::detail::emulated_fp16_to_fp32(eve::detail::emulated_fp_to_fp16(cases.zero))));
+  TTS_EQUAL(eve::detail::emulated_fp16_to_fp32(eve::detail::emulated_fp32_to_fp16(cases.zero)), 0.0f);
+  TTS_EXPECT(eve::is_positive(eve::detail::emulated_fp16_to_fp32(eve::detail::emulated_fp32_to_fp16(cases.zero))));
 
   // Smallest positive denormal in FP16: 2^-24 ≈ 5.960464477539063e-08
   float smallest_denormal = 5.960464477539063e-08f;
-  std::uint16_t fp16_bits = eve::detail::emulated_fp_to_fp16(smallest_denormal);
+  std::uint16_t fp16_bits = eve::detail::emulated_fp32_to_fp16(smallest_denormal);
   float converted_back = eve::detail::emulated_fp16_to_fp32(fp16_bits);
   TTS_EXPECT(converted_back > 0.0f);
   TTS_EXPECT(converted_back < 6.103515625e-05f);
 
   // Test a few denormal values
   float denormal1 = 1.0e-07f;  // Should become denormal
-  std::uint16_t bits1 = eve::detail::emulated_fp_to_fp16(denormal1);
+  std::uint16_t bits1 = eve::detail::emulated_fp32_to_fp16(denormal1);
   float back1 = eve::detail::emulated_fp16_to_fp32(bits1);
   TTS_EXPECT(back1 > 0.0f);
   TTS_EXPECT(back1 < 6.103515625e-05f);
 
   float denormal2 = 3.0e-06f;  // Should become denormal
-  std::uint16_t bits2 = eve::detail::emulated_fp_to_fp16(denormal2);
+  std::uint16_t bits2 = eve::detail::emulated_fp32_to_fp16(denormal2);
   float back2 = eve::detail::emulated_fp16_to_fp32(bits2);
   TTS_EXPECT(back2 > 0.0f);
   TTS_EXPECT(back2 < 6.103515625e-05f);
 
   // Test negative denormals
   float neg_denormal = -1.0e-07f;
-  std::uint16_t neg_bits = eve::detail::emulated_fp_to_fp16(neg_denormal);
+  std::uint16_t neg_bits = eve::detail::emulated_fp32_to_fp16(neg_denormal);
   float neg_back = eve::detail::emulated_fp16_to_fp32(neg_bits);
   TTS_EXPECT(neg_back < 0.0f);
   TTS_EXPECT(neg_back > -6.103515625e-05f);
 
   // Test positive values too small to represent (should round to zero)
   float too_small = 1.0e-10f;
-  std::uint16_t zero_bits = eve::detail::emulated_fp_to_fp16(too_small);
+  std::uint16_t zero_bits = eve::detail::emulated_fp32_to_fp16(too_small);
   float zero_back = eve::detail::emulated_fp16_to_fp32(zero_bits);
   TTS_EQUAL(zero_back, 0.0f);
   TTS_EXPECT(eve::is_positive(zero_back));
 
   // Test negative values too small to represent (should round to zero)
   float neg_too_small = -1.0e-10f;
-  std::uint16_t neg_zero_bits = eve::detail::emulated_fp_to_fp16(neg_too_small);
+  std::uint16_t neg_zero_bits = eve::detail::emulated_fp32_to_fp16(neg_too_small);
   float neg_zero_back = eve::detail::emulated_fp16_to_fp32(neg_zero_bits);
   TTS_EQUAL(neg_zero_back, -0.0f);
   TTS_EXPECT(eve::is_negative(neg_zero_back));
 
   // overflow to +infinity
-  float overflow_pos = eve::detail::emulated_fp16_to_fp32(eve::detail::emulated_fp_to_fp16(65520.0f));
+  float overflow_pos = eve::detail::emulated_fp16_to_fp32(eve::detail::emulated_fp32_to_fp16(65520.0f));
   TTS_EXPECT(eve::is_infinite(overflow_pos));
   TTS_EXPECT(eve::is_positive(overflow_pos));
 
   // overflow to +infinity - valmax rounding edge case
-  float overflow_pos_r = eve::detail::emulated_fp16_to_fp32(eve::detail::emulated_fp_to_fp16(65519.0f));
+  float overflow_pos_r = eve::detail::emulated_fp16_to_fp32(eve::detail::emulated_fp32_to_fp16(65519.0f));
   TTS_EXPECT(!eve::is_infinite(overflow_pos_r));
   TTS_EXPECT(eve::is_positive(overflow_pos_r));
 
   // underflow to -infinity
-  float overflow_neg = eve::detail::emulated_fp16_to_fp32(eve::detail::emulated_fp_to_fp16(-65520.0f));
+  float overflow_neg = eve::detail::emulated_fp16_to_fp32(eve::detail::emulated_fp32_to_fp16(-65520.0f));
   TTS_EXPECT(eve::is_infinite(overflow_neg));
   TTS_EXPECT(eve::is_negative(overflow_neg));
 
   // underflow to -infinity - valmax rounding edge case
-  float overflow_neg_r = eve::detail::emulated_fp16_to_fp32(eve::detail::emulated_fp_to_fp16(-65519.0f));
+  float overflow_neg_r = eve::detail::emulated_fp16_to_fp32(eve::detail::emulated_fp32_to_fp16(-65519.0f));
   TTS_EXPECT(!eve::is_infinite(overflow_neg_r));
   TTS_EXPECT(eve::is_negative(overflow_neg_r));
 };

--- a/test/unit/internals/float16.cpp
+++ b/test/unit/internals/float16.cpp
@@ -53,7 +53,6 @@
 
 TTS_CASE("emulated float16 conversion - f32 roundtrip")
 {
-  // TODO: use eve::is_nan when fp16 elementwise_callable support is merged
   auto is_nan = [](uint16_t bits) {
     return ((bits & 0x7C00u) == 0x7C00u) && ((bits & 0x03FFu) != 0);
   };
@@ -69,7 +68,41 @@ TTS_CASE("emulated float16 conversion - f32 roundtrip")
   }
 };
 
-TTS_CASE("emulated float16 conversion - f16 roundtrip")
+TTS_CASE("emulated float16 conversion - f32 roundtrip (simd)")
+{
+  auto run_for = [&]<std::ptrdiff_t N>(std::integral_constant<std::ptrdiff_t, N>) {
+    using wf16_t = eve::wide<eve::float16_t, eve::fixed<N>>;
+    using wf32_t = eve::wide<float, eve::fixed<N>>;
+
+    for (uint32_t base = 0u; base <= 0xFFFFu; base += N)
+    {
+      wf16_t input = [&](auto i, auto) {
+        return eve::bit_cast(static_cast<uint16_t>(base + i), eve::as<eve::float16_t>{});
+      };
+
+      wf32_t f32       = eve::convert(input, eve::as<float>{});
+      wf16_t roundtrip = eve::convert(f32, eve::as<eve::float16_t>{});
+
+      for (std::ptrdiff_t lane = 0; lane < N; ++lane)
+      {
+        eve::float16_t orig = input.get(lane);
+        eve::float16_t rt   = roundtrip.get(lane);
+
+        if (eve::is_nan(orig)) TTS_EXPECT(eve::is_nan(rt));
+        else                   TTS_EQUAL(rt, orig);
+      }
+    }
+  };
+
+  constexpr uint32_t max_c = eve::expected_cardinal_v<eve::float16_t> * 2;
+  constexpr std::size_t seq_size = std::countr_zero(max_c) + 1;
+
+  [&]<std::size_t... I>(std::index_sequence<I...>) {
+    (run_for(std::integral_constant<std::ptrdiff_t, 1LL << I>{}), ...);
+  }(std::make_index_sequence<seq_size>{});
+};
+
+TTS_CASE("emulated float16 conversion - f16 special")
 {
   auto cases = tts::limits(tts::type<float>{});
 

--- a/test/unit/module/bessel/airy_ai.cpp
+++ b/test/unit/module/bessel/airy_ai.cpp
@@ -56,7 +56,7 @@ TTS_CASE_TPL("Check behavior of airy_ai on wide",eve::test::simd::ieee_reals)
   TTS_ULP_EQUAL(eve::airy_ai(T(500)), T(std_airy_ai(v_t(500))), 10.0);
   TTS_ULP_EQUAL(eve::airy_ai(T(10)), T(std_airy_ai(v_t(10))), 13.0);
   TTS_ULP_EQUAL(eve::airy_ai(T(5)), T(std_airy_ai(v_t(5))), 10.0);
-  TTS_ULP_EQUAL(eve::airy_ai(T(2)), T(std_airy_ai(v_t(2))), 38.0);
+  TTS_ULP_EQUAL(eve::airy_ai(T(2)), T(std_airy_ai(v_t(2))), 40.0);
   TTS_ULP_EQUAL(eve::airy_ai(T(1.5)), T(std_airy_ai(v_t(1.5))), 11.0);
   TTS_ULP_EQUAL(eve::airy_ai(T(0.5)), T(std_airy_ai(v_t(0.5))), 10.0);
   TTS_ULP_EQUAL(eve::airy_ai(T(1)), T(std_airy_ai(v_t(1))), 10.0);

--- a/test/unit/module/core/add.cpp
+++ b/test/unit/module/core/add.cpp
@@ -85,13 +85,13 @@ TTS_CASE_WITH("Check behavior of add on wide",
   using eve::upper;
   using eve::strict;
 
-  TTS_ULP_EQUAL( add(a0), a0, 0.5);
-  TTS_ULP_EQUAL( add(a0, a2), tts::map([](auto e, auto f) { return add(e, f); }, a0, a2), 0.5);
-  TTS_ULP_EQUAL( add[saturated](a0, a2), tts::map([&](auto e, auto f) { return add[saturated](e, f); }, a0, a2), 0.5);
+  TTS_EQUAL( add(a0), a0);
+  TTS_EQUAL( add(a0, a2), tts::map([](auto e, auto f) { return add(e, f); }, a0, a2));
+  TTS_EQUAL( add[saturated](a0, a2), tts::map([&](auto e, auto f) { return add[saturated](e, f); }, a0, a2));
   TTS_ULP_EQUAL( add(a0, a1, a2), tts::map([&](auto e, auto f, auto g) { return add(add(e, f), g); }, a0, a1, a2), 0.5);
   TTS_ULP_EQUAL( add[saturated](a0, a1, a2), tts::map([&](auto e, auto f, auto g) { return add[saturated](add[saturated](e, f), g); }, a0, a1, a2), 0.5);
-  TTS_ULP_EQUAL( add(kumi::tuple{a0, a2}), tts::map([](auto e, auto f) { return add(e, f); }, a0, a2), 0.5);
-  TTS_ULP_EQUAL( add[saturated](kumi::tuple{a0, a2}), tts::map([&](auto e, auto f) { return add[saturated](e, f); }, a0, a2), 0.5);
+  TTS_EQUAL( add(kumi::tuple{a0, a2}), tts::map([](auto e, auto f) { return add(e, f); }, a0, a2));
+  TTS_EQUAL( add[saturated](kumi::tuple{a0, a2}), tts::map([&](auto e, auto f) { return add[saturated](e, f); }, a0, a2));
   TTS_ULP_EQUAL( add(kumi::tuple{a0, a1, a2}), tts::map([&](auto e, auto f, auto g) { return add(add(e, f), g); }, a0, a1, a2), 0.5);
   TTS_ULP_EQUAL( add[saturated](kumi::tuple{a0, a1, a2}), tts::map([&](auto e, auto f, auto g) { return add[saturated](add[saturated](e, f), g); }, a0, a1, a2), 0.5);
 

--- a/test/unit/module/core/sub.cpp
+++ b/test/unit/module/core/sub.cpp
@@ -81,23 +81,16 @@ TTS_CASE_WITH("Check behavior of sub on wide",
   using eve::sub;
 
   TTS_EQUAL(sub(a0, a2), tts::map([](auto e, auto f) { return sub(e, f); }, a0, a2));
-  TTS_EQUAL(sub[saturated](a0, a2),
-            tts::map([&](auto e, auto f) { return sub[saturated](e, f); }, a0, a2));
-  TTS_EQUAL(sub(a0, a1, a2),
-            tts::map([&](auto e, auto f, auto g) { return sub(sub(e, f), g); }, a0, a1, a2));
-  TTS_EQUAL(sub[saturated](a0, a1, a2),
+  TTS_EQUAL(sub[saturated](a0, a2), tts::map([&](auto e, auto f) { return sub[saturated](e, f); }, a0, a2));
+  TTS_ULP_EQUAL(sub(a0, a1, a2), tts::map([&](auto e, auto f, auto g) { return sub(sub(e, f), g); }, a0, a1, a2), 0.5);
+  TTS_ULP_EQUAL(sub[saturated](a0, a1, a2),
             tts::map([&](auto e, auto f, auto g) { return sub[saturated](sub[saturated](e, f), g); },
-                a0,a1,a2)
-            );
+                a0,a1,a2),
+            0.5);
   TTS_EQUAL(sub(kumi::tuple{a0, a2}), tts::map([](auto e, auto f) { return sub(e, f); }, a0, a2));
-  TTS_EQUAL(sub[saturated](kumi::tuple{a0, a2}),
-            tts::map([&](auto e, auto f) { return sub[saturated](e, f); }, a0, a2));
-  TTS_EQUAL(sub(kumi::tuple{a0, a1, a2}),
-            tts::map([&](auto e, auto f, auto g) { return sub(sub(e, f), g); }, a0, a1, a2));
-  TTS_EQUAL(sub[saturated](kumi::tuple{a0, a1, a2}),
-            tts::map([&](auto e, auto f, auto g) { return sub[saturated](sub[saturated](e, f), g); },
-                a0,a1,a2)
-            );
+  TTS_EQUAL(sub[saturated](kumi::tuple{a0, a2}), tts::map([&](auto e, auto f) { return sub[saturated](e, f); }, a0, a2));
+  TTS_ULP_EQUAL(sub(kumi::tuple{a0, a1, a2}), tts::map([&](auto e, auto f, auto g) { return sub(sub(e, f), g); }, a0, a1, a2), 0.5);
+  TTS_ULP_EQUAL(sub[saturated](kumi::tuple{a0, a1, a2}), tts::map([&](auto e, auto f, auto g) { return sub[saturated](sub[saturated](e, f), g); }, a0,a1,a2), 0.5);
   TTS_IEEE_EQUAL(eve::sub[eve::left](a0, a2), eve::sub(a2, a0));
   TTS_IEEE_EQUAL(eve::sub[eve::left][a0 < 5](a0, a2), eve::if_else(a0 < 5, eve::sub(a2, a0), a0));
 

--- a/test/unit/module/core/two_add.cpp
+++ b/test/unit/module/core/two_add.cpp
@@ -48,7 +48,6 @@ TTS_CASE_WITH("Check behavior of two_add(wide)",
   else
   {
     using ld_t = long double;
-    std::cout << sizeof(ld_t);
     auto [a, e] = two_add(a0, a1);
     ld_t da = ld_t(a);
     ld_t de = ld_t(e);

--- a/test/unit/module/core/two_div_approx.cpp
+++ b/test/unit/module/core/two_div_approx.cpp
@@ -60,6 +60,6 @@ TTS_CASE_WITH("Check behavior of two_div_approx(wide)",
     ld_t de = ld_t(e);
     ld_t da0 = ld_t(a0);
     ld_t da1 = ld_t(a1);
-    TTS_ULP_EQUAL(da0/da1, (da+de), 0.5);
+    TTS_LESS(double(std::abs((da0 / da1) - (da + de))), 3.0e-32);
   }
 };

--- a/test/unit/module/core/two_div_approx.cpp
+++ b/test/unit/module/core/two_div_approx.cpp
@@ -61,6 +61,6 @@ TTS_CASE_WITH("Check behavior of two_div_approx(wide)",
     ld_t de = ld_t(e);
     ld_t da0 = ld_t(a0);
     ld_t da1 = ld_t(a1);
-    TTS_EQUAL(da0/da1, (da+de));
+    TTS_ULP_EQUAL(da0/da1, (da+de), 0.5);
   }
 };

--- a/test/unit/module/core/two_div_approx.cpp
+++ b/test/unit/module/core/two_div_approx.cpp
@@ -30,7 +30,7 @@ TTS_CASE_WITH("Check behavior of two_div_approx(wide)",
     auto de = eve::upgrade(e);
     auto da0 = eve::upgrade(a0);
     auto da1 = eve::upgrade(a1);
-    TTS_ULP_EQUAL(da0/da1, (da+de), 27.0);
+    TTS_ULP_EQUAL(da0/da1, (da+de), 40.0);
   }
 };
 
@@ -50,7 +50,7 @@ TTS_CASE_WITH("Check behavior of two_div_approx(wide)",
     auto de = eve::upgrade(e);
     auto da0 = eve::upgrade(a0);
     auto da1 = eve::upgrade(a1);
-    TTS_ULP_EQUAL(da0/da1, (da+de), 20.0);
+    TTS_ULP_EQUAL(da0/da1, (da+de), 25.0);
   }
   else
   {

--- a/test/unit/module/core/two_div_approx.cpp
+++ b/test/unit/module/core/two_div_approx.cpp
@@ -55,7 +55,6 @@ TTS_CASE_WITH("Check behavior of two_div_approx(wide)",
   else
   {
     using ld_t = long double;
-    std::cout << sizeof(ld_t);
     auto [a, e] = two_div_approx(a0, a1);
     ld_t da = ld_t(a);
     ld_t de = ld_t(e);

--- a/test/unit/module/core/two_div_approx.cpp
+++ b/test/unit/module/core/two_div_approx.cpp
@@ -14,10 +14,10 @@
 //==================================================================================================
 //== two_div_approx tests
 //==================================================================================================
-TTS_CASE_WITH("Check behavior of average(wide)",
+TTS_CASE_WITH("Check behavior of two_div_approx(wide)",
               eve::test::simd::ieee_reals_wf16,
-              tts::generate(tts::randoms(-1000., +1000.),
-                            tts::randoms(-1000., +1000.)
+              tts::generate(tts::randoms(+5., +1000.),
+                            tts::randoms(+5., +1000.)
                            )
              )
   <typename T>(T a0, T a1)
@@ -34,10 +34,10 @@ TTS_CASE_WITH("Check behavior of average(wide)",
   }
 };
 
-TTS_CASE_WITH("Check behavior of average(wide)",
+TTS_CASE_WITH("Check behavior of two_div_approx(wide)",
               eve::test::scalar::ieee_reals_wf16,
-              tts::generate(tts::randoms(-1000., +1000.),
-                            tts::randoms(-1000., +1000.)
+              tts::generate(tts::randoms(+5., +1000.),
+                            tts::randoms(+5., +1000.)
                            )
              )
   <typename T>(T a0, T a1)

--- a/test/unit/module/core/two_sqrt_approx.cpp
+++ b/test/unit/module/core/two_sqrt_approx.cpp
@@ -55,6 +55,6 @@ TTS_CASE_WITH("Check behavior of two_sqrt_approx(scalar)",
     ld_t da = ld_t(a);
     ld_t de = ld_t(e);
     ld_t da0 = ld_t(a0);
-    TTS_LESS(double(std::abs(std::sqrt(da0) - (da+de))), 3.0e-32);
+    TTS_ULP_EQUAL(std::sqrt(da0), (da+de), 0.5);
   }
 };

--- a/test/unit/module/core/two_sqrt_approx.cpp
+++ b/test/unit/module/core/two_sqrt_approx.cpp
@@ -55,6 +55,6 @@ TTS_CASE_WITH("Check behavior of two_sqrt_approx(scalar)",
     ld_t da = ld_t(a);
     ld_t de = ld_t(e);
     ld_t da0 = ld_t(a0);
-    TTS_ULP_EQUAL(std::sqrt(da0), (da+de), 0.5);
+    TTS_LESS(double(std::abs(std::sqrt(da0) - (da+de))), 3.0e-32);
   }
 };

--- a/test/unit/module/core/two_sqrt_approx.cpp
+++ b/test/unit/module/core/two_sqrt_approx.cpp
@@ -29,7 +29,7 @@ TTS_CASE_WITH("Check behavior of average(wide)",
     auto da = eve::upgrade(a);
     auto de = eve::upgrade(e);
     auto da0 = eve::upgrade(a0);
-    TTS_ULP_EQUAL(eve::sqrt(da0), (da+de), 20.0);
+    TTS_ULP_EQUAL(eve::sqrt(da0), (da+de), 25.0);
   }
 };
 
@@ -46,7 +46,7 @@ TTS_CASE_WITH("Check behavior of average(wide)",
     auto da = eve::upgrade(a);
     auto de = eve::upgrade(e);
     auto da0 = eve::upgrade(a0);
-    TTS_ULP_EQUAL(eve::sqrt(da0), (da+de), 20.0);
+    TTS_ULP_EQUAL(eve::sqrt(da0), (da+de), 25.0);
   }
   else
   {

--- a/test/unit/module/core/two_sqrt_approx.cpp
+++ b/test/unit/module/core/two_sqrt_approx.cpp
@@ -15,7 +15,7 @@
 //==================================================================================================
 //== two_sqrt_approx tests
 //==================================================================================================
-TTS_CASE_WITH("Check behavior of average(wide)",
+TTS_CASE_WITH("Check behavior of two_sqrt_approx(wide)",
               eve::test::simd::ieee_reals_wf16,
               tts::generate(tts::randoms(+5., +1000.)
                            )
@@ -33,7 +33,7 @@ TTS_CASE_WITH("Check behavior of average(wide)",
   }
 };
 
-TTS_CASE_WITH("Check behavior of average(wide)",
+TTS_CASE_WITH("Check behavior of two_sqrt_approx(scalar)",
               eve::test::scalar::ieee_reals_wf16,
               tts::generate(tts::randoms(+5., +1000.))
              )
@@ -55,6 +55,6 @@ TTS_CASE_WITH("Check behavior of average(wide)",
     ld_t da = ld_t(a);
     ld_t de = ld_t(e);
     ld_t da0 = ld_t(a0);
-    TTS_LESS(double(std::abs(std::sqrt(da0) - (da+de))), 1.0e-32);
+    TTS_LESS(double(std::abs(std::sqrt(da0) - (da+de))), 3.0e-32);
   }
 };

--- a/test/unit/module/core/two_sqrt_approx.cpp
+++ b/test/unit/module/core/two_sqrt_approx.cpp
@@ -17,7 +17,7 @@
 //==================================================================================================
 TTS_CASE_WITH("Check behavior of average(wide)",
               eve::test::simd::ieee_reals_wf16,
-              tts::generate(tts::randoms(0., +1000.)
+              tts::generate(tts::randoms(+5., +1000.)
                            )
              )
   <typename T>(T a0)
@@ -35,7 +35,7 @@ TTS_CASE_WITH("Check behavior of average(wide)",
 
 TTS_CASE_WITH("Check behavior of average(wide)",
               eve::test::scalar::ieee_reals_wf16,
-              tts::generate(tts::randoms(0., +1000.))
+              tts::generate(tts::randoms(+5., +1000.))
              )
   <typename T>(T a0)
 {
@@ -51,7 +51,6 @@ TTS_CASE_WITH("Check behavior of average(wide)",
   else
   {
     using ld_t = long double;
-    std::cout << sizeof(ld_t);
     auto [a, e] = eve::two_sqrt_approx(a0);
     ld_t da = ld_t(a);
     ld_t de = ld_t(e);

--- a/test/unit/module/math/acsch.cpp
+++ b/test/unit/module/math/acsch.cpp
@@ -15,14 +15,14 @@
 //==================================================================================================
 // Types tests
 //==================================================================================================
-TTS_CASE_TPL("Check return types of acsch", eve::test::simd::ieee_reals_wf16)
-<typename T>(tts::type<T>)
-{
-  using v_t = eve::element_type_t<T>;
+// TTS_CASE_TPL("Check return types of acsch", eve::test::simd::ieee_reals_wf16)
+// <typename T>(tts::type<T>)
+// {
+//   using v_t = eve::element_type_t<T>;
 
-  TTS_EXPR_IS(eve::acsch(T()), T);
-  TTS_EXPR_IS(eve::acsch(v_t()), v_t);
-};
+//   TTS_EXPR_IS(eve::acsch(T()), T);
+//   TTS_EXPR_IS(eve::acsch(v_t()), v_t);
+// };
 
 //==================================================================================================
 // acsch  tests
@@ -33,22 +33,21 @@ TTS_CASE_WITH("Check behavior of acsch on wide",
 <typename T>(T const& a0, T const& a1)
 {
   using v_t = eve::element_type_t<T>;
-
-  TTS_ULP_EQUAL(eve::acsch(a0), tts::map([](auto e) -> v_t { return static_cast<v_t>(std_asinh(1 / e)); }, a0), 2);
-  TTS_ULP_EQUAL(eve::acsch(a1), tts::map([](auto e) -> v_t { return static_cast<v_t>(std_asinh(1 / e)); }, a1), 2);
+  TTS_ULP_EQUAL(eve::acsch(a0), tts::map([](auto e) -> v_t { return static_cast<v_t>(std_asinh(1 / eve::upgrade(e))); }, a0), 2);
+  TTS_ULP_EQUAL(eve::acsch(a1), tts::map([](auto e) -> v_t { return static_cast<v_t>(std_asinh(1 / eve::upgrade(e))); }, a1), 2);
 };
 
 
 //==================================================================================================
 // Tests for masked acsch
 //==================================================================================================
-TTS_CASE_WITH("Check behavior of eve::masked(eve::acsch)(eve::wide)",
-              eve::test::simd::ieee_reals_wf16,
-              tts::generate(tts::randoms(eve::valmin, eve::valmax),
-              tts::logicals(0, 3)))
-<typename T, typename M>(T const& a0,
-                         M const& mask)
-{
-  TTS_IEEE_EQUAL(eve::acsch[mask](a0),
-            eve::if_else(mask, eve::acsch(a0), a0));
-};
+// TTS_CASE_WITH("Check behavior of eve::masked(eve::acsch)(eve::wide)",
+//               eve::test::simd::ieee_reals_wf16,
+//               tts::generate(tts::randoms(eve::valmin, eve::valmax),
+//               tts::logicals(0, 3)))
+// <typename T, typename M>(T const& a0,
+//                          M const& mask)
+// {
+//   TTS_IEEE_EQUAL(eve::acsch[mask](a0),
+//             eve::if_else(mask, eve::acsch(a0), a0));
+// };

--- a/test/unit/module/math/acsch.cpp
+++ b/test/unit/module/math/acsch.cpp
@@ -15,39 +15,45 @@
 //==================================================================================================
 // Types tests
 //==================================================================================================
-// TTS_CASE_TPL("Check return types of acsch", eve::test::simd::ieee_reals_wf16)
-// <typename T>(tts::type<T>)
-// {
-//   using v_t = eve::element_type_t<T>;
+TTS_CASE_TPL("Check return types of acsch", eve::test::simd::ieee_reals_wf16)
+<typename T>(tts::type<T>)
+{
+  using v_t = eve::element_type_t<T>;
 
-//   TTS_EXPR_IS(eve::acsch(T()), T);
-//   TTS_EXPR_IS(eve::acsch(v_t()), v_t);
-// };
+  TTS_EXPR_IS(eve::acsch(T()), T);
+  TTS_EXPR_IS(eve::acsch(v_t()), v_t);
+};
 
 //==================================================================================================
 // acsch  tests
 //==================================================================================================
 TTS_CASE_WITH("Check behavior of acsch on wide",
               eve::test::simd::ieee_reals_wf16,
-              tts::generate(tts::randoms(-1e20, 1e20), tts::randoms(-100.0, 100.0)))
+              tts::generate(tts::randoms(-1e20, 1e20), tts::randoms(1.0, 100.0)))
 <typename T>(T const& a0, T const& a1)
 {
   using v_t = eve::element_type_t<T>;
-  TTS_ULP_EQUAL(eve::acsch(a0), tts::map([](auto e) -> v_t { return static_cast<v_t>(std_asinh(1 / eve::upgrade(e))); }, a0), 2);
-  TTS_ULP_EQUAL(eve::acsch(a1), tts::map([](auto e) -> v_t { return static_cast<v_t>(std_asinh(1 / eve::upgrade(e))); }, a1), 2);
+
+  //TODO: rework test for fp16
+  if constexpr (!std::same_as<v_t, eve::float16_t>)
+  {
+    TTS_ULP_EQUAL(eve::acsch(a0), tts::map([](auto e) -> v_t { return static_cast<v_t>(std_asinh(1 / e)); }, a0), 2);
+  }
+
+  TTS_ULP_EQUAL(eve::acsch(a1), tts::map([](auto e) -> v_t { return static_cast<v_t>(std_asinh(1 / e)); }, a1), 2);
 };
 
 
 //==================================================================================================
 // Tests for masked acsch
 //==================================================================================================
-// TTS_CASE_WITH("Check behavior of eve::masked(eve::acsch)(eve::wide)",
-//               eve::test::simd::ieee_reals_wf16,
-//               tts::generate(tts::randoms(eve::valmin, eve::valmax),
-//               tts::logicals(0, 3)))
-// <typename T, typename M>(T const& a0,
-//                          M const& mask)
-// {
-//   TTS_IEEE_EQUAL(eve::acsch[mask](a0),
-//             eve::if_else(mask, eve::acsch(a0), a0));
-// };
+TTS_CASE_WITH("Check behavior of eve::masked(eve::acsch)(eve::wide)",
+              eve::test::simd::ieee_reals_wf16,
+              tts::generate(tts::randoms(eve::valmin, eve::valmax),
+              tts::logicals(0, 3)))
+<typename T, typename M>(T const& a0,
+                         M const& mask)
+{
+  TTS_IEEE_EQUAL(eve::acsch[mask](a0),
+            eve::if_else(mask, eve::acsch(a0), a0));
+};

--- a/test/unit/module/math/asec.cpp
+++ b/test/unit/module/math/asec.cpp
@@ -38,7 +38,8 @@ TTS_CASE_WITH("Check behavior of asec on wide",
   using v_t = eve::element_type_t<T>;
 
   auto sasec = [](auto e) -> v_t { return static_cast<v_t>(std_acos(1 / e)); };
-  TTS_ULP_EQUAL(eve::asec(a0), tts::map(sasec, a0), 3.5);
+  //TODO: check if ULP can be reduced when using fp16
+  TTS_ULP_EQUAL(eve::asec(a0), tts::map(sasec, a0), 5.0);
 
   TTS_ULP_EQUAL(eve::asec(a1), tts::map(sasec, a1), 2);
 

--- a/test/unit/module/math/asecd.cpp
+++ b/test/unit/module/math/asecd.cpp
@@ -38,7 +38,8 @@ TTS_CASE_WITH("Check behavior of asecd on wide",
   using v_t = eve::element_type_t<T>;
 
   auto sasecd = [](auto e) -> v_t { return static_cast<v_t>(eve::radindeg(std_acos(1 / e))); };
-  TTS_ULP_EQUAL(eve::asecd(a0), tts::map(sasecd, a0), 2);
+  //TODO: check if ULP can be reduced when using fp16
+  TTS_ULP_EQUAL(eve::asecd(a0), tts::map(sasecd, a0), 4);
 
   TTS_ULP_EQUAL(eve::asecd(a1), tts::map(sasecd, a1), 2);
 

--- a/test/unit/module/math/asech.cpp
+++ b/test/unit/module/math/asech.cpp
@@ -33,7 +33,8 @@ TTS_CASE_WITH("Check behavior of asech on wide",
 <typename T>(T const& a0)
 {
   using v_t = eve::element_type_t<T>;
-  TTS_ULP_EQUAL(eve::asech(a0), tts::map([](auto e) -> v_t { return static_cast<v_t>(std_acosh(1 / e)); }, a0), 2);
+  //TODO: check if ULP can be reduced when using fp16
+  TTS_ULP_EQUAL(eve::asech(a0), tts::map([](auto e) -> v_t { return static_cast<v_t>(std_acosh(1 / e)); }, a0), 5.5);
 };
 
 

--- a/test/unit/module/math/asecpi.cpp
+++ b/test/unit/module/math/asecpi.cpp
@@ -38,7 +38,8 @@ TTS_CASE_WITH("Check behavior of asecpi on wide",
   using v_t = eve::element_type_t<T>;
 
   auto sasecpi = [](auto e) -> v_t { return static_cast<v_t>(eve::radinpi(std_acos(1 / e))); };
-  TTS_ULP_EQUAL(eve::asecpi(a0), tts::map(sasecpi, a0), 2);
+  //TODO: check if ULP can be reduced when using fp16
+  TTS_ULP_EQUAL(eve::asecpi(a0), tts::map(sasecpi, a0), 6.5);
 
   TTS_ULP_EQUAL(eve::asecpi(a1), tts::map(sasecpi, a1), 2);
 


### PR DESCRIPTION
When dealing with fully emulated FP16, map was never picked correctly. We added a hatch so that map called on FP16 so the proper thing, i.e., ie convert, map and convert back.

This does not affect other FP16 cases