### PR TITLE
Force if any misconception

### DIFF
--- a/include/eve/module/core/decorator/core.hpp
+++ b/include/eve/module/core/decorator/core.hpp
@@ -37,6 +37,7 @@ namespace eve
   struct mod_mode             {};
   struct modular_mode         {};
   struct numeric_mode         {};
+  struct nan_aware_mode       {};
   struct p_kind_mode          {};
   struct promote_mode         {};
   struct q_kind_mode          {};
@@ -84,6 +85,7 @@ namespace eve
   [[maybe_unused]] inline constexpr auto left             = ::rbr::flag( left_mode{}            );
   [[maybe_unused]] inline constexpr auto modular          = ::rbr::flag( modular_mode{}         );
   [[maybe_unused]] inline constexpr auto numeric          = ::rbr::flag( numeric_mode{}         );
+  [[maybe_unused]] inline constexpr auto nan_aware        = ::rbr::flag( nan_aware_mode{}       );
   [[maybe_unused]] inline constexpr auto pedantic         = ::rbr::flag( pedantic_mode{}        );
   [[maybe_unused]] inline constexpr auto p_kind           = ::rbr::flag( p_kind_mode{}          );
   [[maybe_unused]] inline constexpr auto promote          = ::rbr::flag( promote_mode{}         );
@@ -124,6 +126,7 @@ namespace eve
   struct kind_2_option          : detail::exact_option<kind_2>          {};
   struct left_option            : detail::exact_option<left>            {};
   struct modular_option         : detail::exact_option<modular>         {};
+  struct nan_aware_option       : detail::exact_option<nan_aware>       {};
   struct numeric_option         : detail::exact_option<numeric>         {};
   struct p_kind_option          : detail::exact_option<p_kind>          {};
   struct promote_option         : detail::exact_option<promote>         {};

--- a/include/eve/module/core/decorator/core.hpp
+++ b/include/eve/module/core/decorator/core.hpp
@@ -37,7 +37,7 @@ namespace eve
   struct mod_mode             {};
   struct modular_mode         {};
   struct numeric_mode         {};
-  struct nan_aware_mode       {};
+  struct drastic_mode       {};
   struct p_kind_mode          {};
   struct promote_mode         {};
   struct q_kind_mode          {};
@@ -85,7 +85,7 @@ namespace eve
   [[maybe_unused]] inline constexpr auto left             = ::rbr::flag( left_mode{}            );
   [[maybe_unused]] inline constexpr auto modular          = ::rbr::flag( modular_mode{}         );
   [[maybe_unused]] inline constexpr auto numeric          = ::rbr::flag( numeric_mode{}         );
-  [[maybe_unused]] inline constexpr auto nan_aware        = ::rbr::flag( nan_aware_mode{}       );
+  [[maybe_unused]] inline constexpr auto drastic        = ::rbr::flag( drastic_mode{}       );
   [[maybe_unused]] inline constexpr auto pedantic         = ::rbr::flag( pedantic_mode{}        );
   [[maybe_unused]] inline constexpr auto p_kind           = ::rbr::flag( p_kind_mode{}          );
   [[maybe_unused]] inline constexpr auto promote          = ::rbr::flag( promote_mode{}         );
@@ -126,7 +126,7 @@ namespace eve
   struct kind_2_option          : detail::exact_option<kind_2>          {};
   struct left_option            : detail::exact_option<left>            {};
   struct modular_option         : detail::exact_option<modular>         {};
-  struct nan_aware_option       : detail::exact_option<nan_aware>       {};
+  struct drastic_option       : detail::exact_option<drastic>       {};
   struct numeric_option         : detail::exact_option<numeric>         {};
   struct p_kind_option          : detail::exact_option<p_kind>          {};
   struct promote_option         : detail::exact_option<promote>         {};

--- a/include/eve/module/core/detail/force_if_any.hpp
+++ b/include/eve/module/core/detail/force_if_any.hpp
@@ -19,8 +19,8 @@ namespace eve::detail
     using r_t = common_value_t<Ts...>;
     if constexpr(O::contains(pedantic) && floating_value<r_t>)
     {
-      auto inf_found =  (test(r_t(ts)) || ...);
-      return if_else(inf_found, r_t(value), r);
+      auto found =  (test(r_t(ts)) || ...);
+      return if_else(found, r_t(value), r);
     }
     else
       return r;

--- a/include/eve/module/core/regular/impl/maxabs.hpp
+++ b/include/eve/module/core/regular/impl/maxabs.hpp
@@ -10,6 +10,7 @@
 #include <eve/module/core/regular/abs.hpp>
 #include <eve/module/core/regular/max.hpp>
 #include <eve/concept/value.hpp>
+#include <iostream>
 
 namespace eve::detail
 {
@@ -26,15 +27,20 @@ namespace eve::detail
         return upgrade(maxabs[o.drop(widen)](t0, as...));
     }
     else if constexpr(sizeof...(Ts) == 0)
-      return abs[o.drop(pedantic,numeric)](r_t(t0));
+      return abs[o.drop(pedantic,numeric,nan_aware)](r_t(t0));
     else
     {
-      auto abso = abs[o.drop(pedantic,numeric)];
+      auto abso = abs[o.drop(pedantic,numeric,nan_aware)];
       auto r = eve::max[o.drop(saturated)](abso(t0), abso(as)...);
-      if constexpr(integral_value<r_t> || !O::contains(pedantic))
-        return r;
-      else
+      if constexpr(O::contains(nan_aware))
+      {
+        auto nan_found = (eve::is_nan(r_t(t0)) || (eve::is_nan(r_t(as)) || ...));
+        return if_else(nan_found, allbits, r);
+      }
+      else if constexpr(!integral_value<r_t> && O::contains(pedantic))
         return force_if_any(o, r, eve::is_infinite, inf(eve::as(r)), t0, as...);
+      else
+        return r;
     }
   }
 }

--- a/include/eve/module/core/regular/impl/maxabs.hpp
+++ b/include/eve/module/core/regular/impl/maxabs.hpp
@@ -10,7 +10,6 @@
 #include <eve/module/core/regular/abs.hpp>
 #include <eve/module/core/regular/max.hpp>
 #include <eve/concept/value.hpp>
-#include <iostream>
 
 namespace eve::detail
 {
@@ -27,12 +26,12 @@ namespace eve::detail
         return upgrade(maxabs[o.drop(widen)](t0, as...));
     }
     else if constexpr(sizeof...(Ts) == 0)
-      return abs[o.drop(pedantic,numeric,nan_aware)](r_t(t0));
+      return abs[o.drop(pedantic,numeric,drastic)](r_t(t0));
     else
     {
-      auto abso = abs[o.drop(pedantic,numeric,nan_aware)];
+      auto abso = abs[o.drop(pedantic,numeric,drastic)];
       auto r = eve::max[o.drop(saturated)](abso(t0), abso(as)...);
-      if constexpr(O::contains(nan_aware))
+      if constexpr(O::contains(drastic))
       {
         auto nan_found = (eve::is_nan(r_t(t0)) || (eve::is_nan(r_t(as)) || ...));
         return if_else(nan_found, allbits, r);

--- a/include/eve/module/core/regular/impl/minabs.hpp
+++ b/include/eve/module/core/regular/impl/minabs.hpp
@@ -26,13 +26,13 @@ namespace eve::detail
     }
     else if constexpr(sizeof...(Ts) == 0)
     {
-      return abs[o.drop(pedantic,numeric,nan_aware)](r_t(t0));
+      return abs[o.drop(pedantic,numeric,drastic)](r_t(t0));
     }
     else
     {
-     auto abso = abs[o.drop(pedantic,numeric,nan_aware)];
+     auto abso = abs[o.drop(pedantic,numeric,drastic)];
       auto r = eve::min[o.drop(saturated)](abso(t0), abso(as)...);
-      if constexpr(O::contains(nan_aware))
+      if constexpr(O::contains(drastic))
       {
         auto nan_found = (eve::is_nan(r_t(t0)) || (eve::is_nan(r_t(as)) || ...));
         return if_else(nan_found, allbits, r);

--- a/include/eve/module/core/regular/impl/minabs.hpp
+++ b/include/eve/module/core/regular/impl/minabs.hpp
@@ -26,16 +26,21 @@ namespace eve::detail
     }
     else if constexpr(sizeof...(Ts) == 0)
     {
-      return abs[o.drop(pedantic,numeric)](r_t(t0));
+      return abs[o.drop(pedantic,numeric,nan_aware)](r_t(t0));
     }
     else
     {
-      auto abso = abs[o.drop(pedantic,numeric)];
+     auto abso = abs[o.drop(pedantic,numeric,nan_aware)];
       auto r = eve::min[o.drop(saturated)](abso(t0), abso(as)...);
-      if constexpr(integral_value<r_t> || !O::contains(pedantic))
-        return r;
+      if constexpr(O::contains(nan_aware))
+      {
+        auto nan_found = (eve::is_nan(r_t(t0)) || (eve::is_nan(r_t(as)) || ...));
+        return if_else(nan_found, allbits, r);
+      }
+      else if constexpr(!integral_value<r_t> && O::contains(pedantic))
+        return force_if_any(o, r, eve::is_eqz, zero(eve::as(r)), t0, as...);
       else
-        return force_if_any(o, r, eve::is_eqz, eve::zero(eve::as(r)), t0, as...);
+        return r;
     }
   }
 }

--- a/include/eve/module/core/regular/impl/simd/x86/maxabs.hpp
+++ b/include/eve/module/core/regular/impl/simd/x86/maxabs.hpp
@@ -22,7 +22,7 @@ namespace eve::detail
                                      wide<T, N> const & v1) noexcept
   requires x86_abi<abi_t<T, N>>
   {
-    if constexpr(O::contains(numeric) || O::contains(pedantic) || O::contains(saturated))
+    if constexpr(O::contains(numeric) || O::contains(pedantic) || O::contains(saturated) || O::contains(nan_aware))
       return maxabs.behavior(cpu_{}, opts, v0, v1);
     else
     {
@@ -57,7 +57,7 @@ namespace eve::detail
                                      wide<T, N> const &w) noexcept
   requires x86_abi<abi_t<T, N>>
   {
-    if constexpr(O::contains(numeric) || O::contains(pedantic) || O::contains(saturated))
+    if constexpr(O::contains(numeric) || O::contains(pedantic) || O::contains(saturated)|| O::contains(nan_aware))
       return maxabs[opts][cx].retarget(cpu_{}, v, w);
     else
     {

--- a/include/eve/module/core/regular/impl/simd/x86/maxabs.hpp
+++ b/include/eve/module/core/regular/impl/simd/x86/maxabs.hpp
@@ -22,7 +22,7 @@ namespace eve::detail
                                      wide<T, N> const & v1) noexcept
   requires x86_abi<abi_t<T, N>>
   {
-    if constexpr(O::contains(numeric) || O::contains(pedantic) || O::contains(saturated) || O::contains(nan_aware))
+    if constexpr(O::contains(numeric) || O::contains(pedantic) || O::contains(saturated) || O::contains(drastic))
       return maxabs.behavior(cpu_{}, opts, v0, v1);
     else
     {
@@ -57,7 +57,7 @@ namespace eve::detail
                                      wide<T, N> const &w) noexcept
   requires x86_abi<abi_t<T, N>>
   {
-    if constexpr(O::contains(numeric) || O::contains(pedantic) || O::contains(saturated)|| O::contains(nan_aware))
+    if constexpr(O::contains(numeric) || O::contains(pedantic) || O::contains(saturated)|| O::contains(drastic))
       return maxabs[opts][cx].retarget(cpu_{}, v, w);
     else
     {

--- a/include/eve/module/core/regular/impl/simd/x86/minabs.hpp
+++ b/include/eve/module/core/regular/impl/simd/x86/minabs.hpp
@@ -22,7 +22,7 @@ namespace eve::detail
                                      wide<T, N> const & v1) noexcept
   requires x86_abi<abi_t<T, N>>
   {
-    if constexpr(O::contains(numeric) || O::contains(pedantic) || O::contains(saturated))
+    if constexpr(O::contains(numeric) || O::contains(pedantic) || O::contains(saturated) || O::contains(drastic))
       return minabs.behavior(cpu_{}, opts, v0, v1);
     else
     {
@@ -56,7 +56,7 @@ namespace eve::detail
                                      wide<T, N> const & v,
                                      wide<T, N> const & w) noexcept requires x86_abi<abi_t<T, N>>
   {
-    if constexpr(O::contains(numeric) || O::contains(pedantic) || O::contains(saturated))
+    if constexpr(O::contains(numeric) || O::contains(pedantic) || O::contains(saturated) || O::contains(drastic))
       return minabs[opts][cx].retarget(cpu_{}, v, w);
     else
     {

--- a/include/eve/module/core/regular/manhattan.hpp
+++ b/include/eve/module/core/regular/manhattan.hpp
@@ -125,7 +125,7 @@ namespace eve
           else if constexpr(O::contains(pedantic))
           {
             return [&](auto x){
-              nan_found = nan_found || is_nan(x);
+              nan_found = is_nan(x);
               return if_else(eve::is_nan(x), zero, eve::abs(x));
             };
           }

--- a/include/eve/module/core/regular/manhattan.hpp
+++ b/include/eve/module/core/regular/manhattan.hpp
@@ -20,7 +20,7 @@
 namespace eve
 {
   template<typename Options>
-  struct manhattan_t : tuple_callable<manhattan_t, Options, pedantic_option, saturated_option, lower_option,
+  struct manhattan_t : tuple_callable<manhattan_t, Options, raw_option, pedantic_option, saturated_option, lower_option,
                                 upper_option, strict_option, widen_option, kahan_option>
   {
 
@@ -62,7 +62,7 @@ namespace eve
 //!   {
 //!      // Regular overloads
 //!      constexpr auto manhattan(value auto x, value auto ... xs)                          noexcept; // 1
-//!      constexpr auto manhattan(eve::non_empty_product_type auto const& tup)             noexcept; // 2
+//!      constexpr auto manhattan(eve::non_empty_product_type auto const& tup)              noexcept; // 2
 //!
 //!      // Lanes masking
 //!      constexpr auto manhattan[conditional_expr auto c](/*any of the above overloads*/)  noexcept; // 3
@@ -88,7 +88,7 @@ namespace eve
 //!       2. equivalent to the call on the elements of the tuple.
 //!       3. [The operation is performed conditionnaly](@ref conditional)
 //!       4. internally uses `saturated` options.
-//!       5. returns \f$\infty\f$ as soon as one of its parameter is infinite, regardless of possible `Nan` values.
+//!       5. returns \f$\infty\f$ as soon as after disabling possible `Nan` parameters the result is \f$\infty\f$.
 //!       6. uses kahan like compensated algorithm for better accuracy.
 //!
 //!  @groupheader{External references}
@@ -114,29 +114,36 @@ namespace eve
         return manhattan[o.drop(widen)](upgrade(args)...);
       else if constexpr(std::same_as<e_t, eve::float16_t>)
         return eve::detail::apply_fp16_as_fp32(eve::manhattan[o], args...);
+      else if constexpr((sizeof...(Ts) == 1))
+        return eve::abs(args...);
       else
       {
-        auto nan_found = eve::false_(eve::as<r_t>());
+        auto  nan_found = eve::false_(eve::as<r_t>());
         auto l_abs = [&nan_found](){
           if constexpr(integral_value<r_t> && O::contains(saturated))
           return eve::abs[saturated];
-          else
+          else if constexpr(O::contains(pedantic))
+          {
             return [&nan_found](auto x){
               nan_found = nan_found || is_nan(x);
-              return if_else(eve::is_nan(x), zero, eve::abs(x));};
+              return if_else(eve::is_nan(x), zero, eve::abs(x));
+            };
+          }
+          else
+            return eve::abs;
         }();
-        if constexpr(sizeof...(Ts) == 1)
-          return eve::abs(args...);
-        else
+        if constexpr(O::contains(pedantic))
         {
           r_t r = eve::add[o](l_abs(r_t(args))...);
           if constexpr(integral_value<r_t>)
             return r;
           else
           {
-            return if_else(nan_found && eve::is_infinite(r), eve::allbits, r);
+            return if_else(nan_found && !eve::is_infinite(r), eve::allbits, r);
           }
         }
+        else
+          return eve::add[o](eve::abs(r_t(args))...);
       }
     }
   }

--- a/include/eve/module/core/regular/manhattan.hpp
+++ b/include/eve/module/core/regular/manhattan.hpp
@@ -118,13 +118,13 @@ namespace eve
         return eve::abs(args...);
       else
       {
-        auto  nan_found = eve::false_(eve::as<r_t>());
-        auto l_abs = [&nan_found](){
+        [[maybe_unused]] auto nan_found = eve::false_(eve::as<r_t>());
+        auto l_abs = [&](){
           if constexpr(integral_value<r_t> && O::contains(saturated))
-          return eve::abs[saturated];
+             return eve::abs[saturated];
           else if constexpr(O::contains(pedantic))
           {
-            return [&nan_found](auto x){
+            return [&](auto x){
               nan_found = nan_found || is_nan(x);
               return if_else(eve::is_nan(x), zero, eve::abs(x));
             };

--- a/include/eve/module/core/regular/maxabs.hpp
+++ b/include/eve/module/core/regular/maxabs.hpp
@@ -16,7 +16,7 @@ namespace eve
 {
 
   template<typename Options>
-  struct maxabs_t : tuple_callable<maxabs_t, Options, nan_aware_option, numeric_option, pedantic_option,
+  struct maxabs_t : tuple_callable<maxabs_t, Options, drastic_option, numeric_option, pedantic_option,
                                                       saturated_option, widen_option>
   {
 
@@ -64,7 +64,7 @@ namespace eve
 //!      constexpr auto maxabs[pedantic](/* any of the above overloads */)                noexcept; // 4
 //!      constexpr auto maxabs[numeric ](/* any of the above overloads */)                noexcept; // 5
 //!      constexpr auto maxabs[widen](/* any of the above overloads */)                   noexcept; // 6
-//!      constexpr auto maxabs[nan_aware](/* any of the above overloads */)               noexcept; // 7
+//!      constexpr auto maxabs[drastic](/* any of the above overloads */)               noexcept; // 7
 //!   }
 //!   @endcode
 //!

--- a/include/eve/module/core/regular/maxabs.hpp
+++ b/include/eve/module/core/regular/maxabs.hpp
@@ -16,7 +16,7 @@ namespace eve
 {
 
   template<typename Options>
-  struct maxabs_t : tuple_callable<maxabs_t, Options, numeric_option, pedantic_option,
+  struct maxabs_t : tuple_callable<maxabs_t, Options, nan_aware_option, numeric_option, pedantic_option,
                                                       saturated_option, widen_option>
   {
 
@@ -54,7 +54,7 @@ namespace eve
 //!   {
 //!      // Regular overloads
 //!      constexpr auto maxabs(eve::value auto x, eve::value auto ... xs)                 noexcept; // 1
-//!      constexpr auto maxabs(eve::non_empty_product_type auto const& tup)              noexcept; // 2
+//!      constexpr auto maxabs(eve::non_empty_product_type auto const& tup)               noexcept; // 2
 //!
 //!      // Lanes masking
 //!      constexpr auto maxabs[conditional_expr auto c](/* any of the above overloads */) noexcept; // 3
@@ -64,6 +64,7 @@ namespace eve
 //!      constexpr auto maxabs[pedantic](/* any of the above overloads */)                noexcept; // 4
 //!      constexpr auto maxabs[numeric ](/* any of the above overloads */)                noexcept; // 5
 //!      constexpr auto maxabs[widen](/* any of the above overloads */)                   noexcept; // 6
+//!      constexpr auto maxabs[nan_aware](/* any of the above overloads */)               noexcept; // 7
 //!   }
 //!   @endcode
 //!
@@ -87,6 +88,7 @@ namespace eve
 //!        (with no consideration of `Nans`)
 //!     5. `NaNs` are considered less than anything else.
 //!     6. compute the upgraded result if available.
+//!     7. returns NaN as soon as one of the parameters is a NaN.
 //!
 //!  @groupheader{Example}
 //!  @godbolt{doc/core/maxabs.cpp}

--- a/include/eve/module/core/regular/minabs.hpp
+++ b/include/eve/module/core/regular/minabs.hpp
@@ -16,7 +16,7 @@ namespace eve
 {
 
   template<typename Options>
-  struct minabs_t : tuple_callable<minabs_t, Options, numeric_option, widen_option,
+  struct minabs_t : tuple_callable<minabs_t, Options, nan_aware_option, numeric_option, widen_option,
                                    pedantic_option, saturated_option>
   {
 
@@ -66,6 +66,7 @@ namespace eve
 //!      constexpr auto minabs[pedantic](/* any of the above overloads */)                noexcept; // 4
 //!      constexpr auto minabs[numeric ](/* any of the above overloads */)                noexcept; // 5
 //!      constexpr auto minabs[widen](/* any of the above overloads */)                   noexcept; // 6
+//!      constexpr auto maxabs[nan_aware](/* any of the above overloads */)               noexcept; // 7
 //!
 //!   }
 //!   @endcode
@@ -89,6 +90,7 @@ namespace eve
 //!        returns \f$0\f$ even if some other arguments are NaNs.
 //!     5. `NaNs` are considered greater than anything else.
 //!     6. compute the upgraded result if available.
+//!     7. returns NaN as soon as one of the parameters is a NaN.
 //!
 //!  @groupheader{Example}
 //!  @godbolt{doc/core/minabs.cpp}

--- a/include/eve/module/core/regular/minabs.hpp
+++ b/include/eve/module/core/regular/minabs.hpp
@@ -16,7 +16,7 @@ namespace eve
 {
 
   template<typename Options>
-  struct minabs_t : tuple_callable<minabs_t, Options, nan_aware_option, numeric_option, widen_option,
+  struct minabs_t : tuple_callable<minabs_t, Options, drastic_option, numeric_option, widen_option,
                                    pedantic_option, saturated_option>
   {
 
@@ -66,7 +66,7 @@ namespace eve
 //!      constexpr auto minabs[pedantic](/* any of the above overloads */)                noexcept; // 4
 //!      constexpr auto minabs[numeric ](/* any of the above overloads */)                noexcept; // 5
 //!      constexpr auto minabs[widen](/* any of the above overloads */)                   noexcept; // 6
-//!      constexpr auto maxabs[nan_aware](/* any of the above overloads */)               noexcept; // 7
+//!      constexpr auto maxabs[drastic](/* any of the above overloads */)               noexcept; // 7
 //!
 //!   }
 //!   @endcode

--- a/include/eve/module/core/regular/minabs.hpp
+++ b/include/eve/module/core/regular/minabs.hpp
@@ -19,19 +19,6 @@ namespace eve
   struct minabs_t : tuple_callable<minabs_t, Options, numeric_option, widen_option,
                                    pedantic_option, saturated_option>
   {
-//     template<value... Ts>
-//     requires(eve::same_lanes_or_scalar<Ts...> && !Options::contains(widen))
-//     EVE_FORCEINLINE constexpr common_value_t<Ts...> operator()(Ts...ts) const noexcept
-//     {
-//       return EVE_DISPATCH_CALL(ts...);
-//     }
-
-//     template<value... Ts>
-//     requires(eve::same_lanes_or_scalar<Ts...> && Options::contains(widen))
-//     EVE_FORCEINLINE constexpr upgrade_t<common_value_t<Ts...>> operator()(Ts...ts) const noexcept
-//     {
-//       return EVE_DISPATCH_CALL(ts...);
-//     }
 
     template<value... Ts>
     requires(eve::same_lanes_or_scalar<Ts...>)
@@ -39,18 +26,6 @@ namespace eve
     {
       return EVE_DISPATCH_CALL(ts...);
     }
-
-//     template<eve::non_empty_product_type Tup>
-//     requires(eve::same_lanes_or_scalar_tuple<Tup> && !Options::contains(widen))
-//     EVE_FORCEINLINE constexpr  kumi::apply_traits_t<eve::common_value,Tup>
-//     operator()(Tup t) const noexcept
-//     { return EVE_DISPATCH_CALL(t); }
-
-//     template<eve::non_empty_product_type Tup>
-//     requires(eve::same_lanes_or_scalar_tuple<Tup> && Options::contains(widen))
-//     EVE_FORCEINLINE constexpr  upgrade_t<kumi::apply_traits_t<eve::common_value,Tup>>
-//     operator()(Tup t) const noexcept
-//     { return EVE_DISPATCH_CALL(t); }
 
     template<eve::non_empty_product_type Tup>
     requires(eve::same_lanes_or_scalar_tuple<Tup>)
@@ -81,7 +56,7 @@ namespace eve
 //!   {
 //!      // Regular overloads
 //!      constexpr auto minabs(eve::value auto x, eve::value auto ... xs)                 noexcept; // 1
-//!      constexpr auto minabs(eve::non_empty_product_type auto const& tup)              noexcept; // 2
+//!      constexpr auto minabs(eve::non_empty_product_type auto const& tup)               noexcept; // 2
 //!
 //!      // Lanes masking
 //!      constexpr auto minabs[conditional_expr auto c](/* any of the above overloads */) noexcept; // 3

--- a/include/eve/module/math/regular/hypot.hpp
+++ b/include/eve/module/math/regular/hypot.hpp
@@ -79,8 +79,10 @@ namespace eve
 //!        and avoid overflows.
 //!    2. equivalent to the call on the elements of the tuple.
 //!    3. [The operation is performed conditionnaly](@ref conditional)
-//!    4. the naive formula is used.
-//!    5. The pedantic option` computes the result without undue overflow or underflow
+//!    4. the naive formula is used.This option is speedier, but does not care about avoiding overflows
+//!       or treating 'Nans' in special ways.
+//!    5. The pedantic option. returns \f$\infty\f$ as soon as after disabling possible `Nan` parameters
+//!       the result is \f$\infty\f$,  and computes the result without undue overflows or underflows.
 //!        at intermediate stages of the computation.
 //!    6. A kahan like compensated algorithm  is used internal for more accurate results.
 //!    7. The computation is done in the double sized element type (if available).
@@ -168,28 +170,37 @@ namespace eve
             auto r0d = r0*id;
             auto r1d = r1*id;
             auto r = d*eve::sqrt(eve::sum_of_prod[pedantic](r0d, r0d, r1d, r1d));
-            return if_else(is_infinite(r0) || is_infinite(r1), inf(as(r)), r);
+            return r; //if_else(is_infinite(r0) || is_infinite(r1), inf(as(r)), r);
           }
         }
         else //N > 2  parameters
         {
-          if constexpr(O::contains(pedantic))
-          {
-            auto nan_found = eve::false_(eve::as<r_t>());
-            auto expo = [&](auto x){return if_else(is_nan(x), zero, exponent(r_t(x))); };
-            auto e  = -maxmag(expo(r0), expo(r1), expo(rs)...);
-            auto f = [&](auto a){
-              nan_found =  nan_found || eve::is_nan(a);
-              return if_else(eve::is_nan(a), zero, sqr(ldexp[o](r_t(a), e)));
-            };
-            r_t that = eve::add[o](f(r0), f(r1), f(rs)...);
-            auto r = ldexp[pedantic](sqrt(that), -e);
-            return if_else(nan_found && !is_infinite(r), allbits, r);
-          }
-          else
+          if constexpr(O::contains(raw))
           {
             r_t that = sum_of_squares[o](r_t(r0), r_t(r1), r_t(rs)...);
             return eve::sqrt(that);
+          }
+          else
+          {
+            auto expo = [&](auto x){return if_else(is_nan(x), zero, exponent(r_t(x))); };
+            auto e  = -maxmag(expo(r0), expo(r1), expo(rs)...);
+            if constexpr(O::contains(pedantic))
+            {
+              auto nan_found = eve::false_(eve::as<r_t>());
+              auto f = [&](auto a){
+                nan_found =  nan_found || eve::is_nan(a);
+                return if_else(eve::is_nan(a), zero, sqr(ldexp[o](r_t(a), e)));
+              };
+              r_t that = eve::add[o](f(r0), f(r1), f(rs)...);
+              auto r = ldexp[pedantic](sqrt(that), -e);
+              return if_else(nan_found && !is_infinite(r), allbits, r);
+            }
+            else
+            {
+              auto f = [&](auto a){ return sqr(ldexp[o](r_t(a), e)); };
+              r_t that = eve::add[o](f(r0), f(r1), f(rs)...);
+              return ldexp[pedantic](sqrt(that), -e);
+            }
           }
         }
       }

--- a/include/eve/module/math/regular/hypot.hpp
+++ b/include/eve/module/math/regular/hypot.hpp
@@ -81,7 +81,7 @@ namespace eve
 //!    3. [The operation is performed conditionnaly](@ref conditional)
 //!    4. the naive formula is used.
 //!    5. The pedantic option` computes the result without undue overflow or underflow
-//!        at intermediate stages of the computation and can be more accurate than the regular call.
+//!        at intermediate stages of the computation.
 //!    6. A kahan like compensated algorithm  is used internal for more accurate results.
 //!    7. The computation is done in the double sized element type (if available).
 //!
@@ -171,13 +171,20 @@ namespace eve
             return if_else(is_infinite(r0) || is_infinite(r1), inf(as(r)), r);
           }
         }
-        else //N parameters
+        else //N > 2  parameters
         {
           if constexpr(O::contains(pedantic))
           {
-            r_t that(hypot[o](r_t(r0), r_t(r1)));
-            ((that = hypot[o](that, r_t(rs))), ...);
-            return that;
+            auto nan_found = eve::false_(eve::as<r_t>());
+            auto expo = [&](auto x){return if_else(is_nan(x), zero, exponent(r_t(x))); };
+            auto e  = -maxmag(expo(r0), expo(r1), expo(rs)...);
+            auto f = [&](auto a){
+              nan_found =  nan_found || eve::is_nan(a);
+              return if_else(eve::is_nan(a), zero, sqr(ldexp[o](r_t(a), e)));
+            };
+            r_t that = eve::add[o](f(r0), f(r1), f(rs)...);
+            auto r = ldexp[pedantic](sqrt(that), -e);
+            return if_else(nan_found && !is_infinite(r), allbits, r);
           }
           else
           {

--- a/include/eve/module/math/regular/hypot.hpp
+++ b/include/eve/module/math/regular/hypot.hpp
@@ -189,7 +189,7 @@ namespace eve
             {
               auto nan_found = eve::false_(eve::as<r_t>());
               auto f = [&](auto a){
-                nan_found =  nan_found || eve::is_nan(a);
+                nan_found = eve::is_nan(a);
                 return if_else(eve::is_nan(a), zero, sqr(ldexp[o](r_t(a), e)));
               };
               r_t that = eve::add[o](f(r0), f(r1), f(rs)...);

--- a/include/eve/module/math/regular/hypot.hpp
+++ b/include/eve/module/math/regular/hypot.hpp
@@ -153,7 +153,6 @@ namespace eve
             h /= scale;
             h = if_else(is_eqz(ay), zero, h);
             h = if_else(ax <= ay*eve::sqrteps(as<r_t>()), ay, h);
-            h = if_else(is_infinite(ax) || is_infinite(ay), inf(as<r_t>()), h);
             return h;
           }
           else if constexpr(O::contains(raw))

--- a/include/eve/module/math/regular/hypot.hpp
+++ b/include/eve/module/math/regular/hypot.hpp
@@ -153,6 +153,7 @@ namespace eve
             h /= scale;
             h = if_else(is_eqz(ay), zero, h);
             h = if_else(ax <= ay*eve::sqrteps(as<r_t>()), ay, h);
+            h = if_else(is_infinite(r0) || is_infinite(r1), inf(as(h)), h);
             return h;
           }
           else if constexpr(O::contains(raw))
@@ -164,12 +165,13 @@ namespace eve
           {
             // scaling using the algorithm suggested by
             // https://members.loria.fr/PZimmermann/papers/split.pdf
-            auto d = eve::safe_scale(average(eve::abs(r0), eve::abs(r1)));
+            auto avg = average(eve::abs(r0), eve::abs(r1));
+            auto d = eve::safe_scale(avg);
             auto id= eve::rec(d);
             auto r0d = r0*id;
             auto r1d = r1*id;
             auto r = d*eve::sqrt(eve::sum_of_prod[pedantic](r0d, r0d, r1d, r1d));
-            return r; //if_else(is_infinite(r0) || is_infinite(r1), inf(as(r)), r);
+            return if_else(is_not_finite(r0) || is_not_finite(r1), avg, r);
           }
         }
         else //N > 2  parameters

--- a/include/eve/module/math/regular/lpnorm.hpp
+++ b/include/eve/module/math/regular/lpnorm.hpp
@@ -126,7 +126,6 @@ namespace eve
           {
             auto nan_found = eve::false_(eve::as<r_t>());
             auto rp = r_t(p);
-            auto any_is_inf = (is_infinite(r_t(args)) || ...);
             auto e  = -maxmag(if_else(is_nan(args), zero, exponent(r_t(args)))...);
             auto f = [&](auto a){
               nan_found =  nan_found || eve::is_nan(a);

--- a/include/eve/module/math/regular/lpnorm.hpp
+++ b/include/eve/module/math/regular/lpnorm.hpp
@@ -18,7 +18,7 @@
 namespace eve
 {
   template<typename Options>
-  struct lpnorm_t : strict_elementwise_callable<lpnorm_t, Options, pedantic_option,
+  struct lpnorm_t : strict_elementwise_callable<lpnorm_t, Options, raw_option, pedantic_option,
                                                 kahan_option, widen_option>
   {
     template<value P, floating_value... Ts>
@@ -56,33 +56,38 @@ namespace eve
 //!   namespace eve
 //!   {
 //!      // Regular overload
-//!      constexpr auto lpnorm(floating_value auto p, floating_value auto x,floating_value auto... xs )                         noexcept; // 1
+//!      constexpr auto lpnorm(value auto p, floating_value auto... xs )                                  noexcept; // 1
+//!      constexpr auto lpnorm(value auto p, non_empty_product_type tup)                                  noexcept; // 2
 //!
 //!      // Lanes masking
-//!      constexpr auto lpnorm[conditional_expr auto c](loating_value auto p, floating_value auto x,floating_value auto... xs)  noexcept; // 2
-//!      constexpr auto lpnorm[logical_value auto m](loating_value auto p, floating_value auto x,floating_value auto... xs)     noexcept; // 2
+//!      constexpr auto lpnorm[conditional_expr auto c](value auto p, floating_value auto... xs)          noexcept; // 3
+//!      constexpr auto lpnorm[logical_value auto m](value auto p,floating_value auto... xs)              noexcept; // 3
 //!
 //!      // Semantic options
-//!      constexpr auto lpnorm[pedantic](/* any of the above overloads */)                                                     noexcept; // 3
-//!      constexpr auto lpnorm[widen](/* any of the above overloads */)                                                        noexcept; // 4
-//!      constexpr auto lpnorm[kahan](/* any of the above overloads */)                                                        noexcept; // 5
+//!      constexpr auto lpnorm[pedantic](/* any of the above overloads */)                                noexcept; // 4
+//!      constexpr auto lpnorm[widen](/* any of the above overloads */)                                   noexcept; // 5
+//!      constexpr auto lpnorm[kahan](/* any of the above overloads */)                                   noexcept; // 6
+//!      constexpr auto lpnorm[raw](/* any of the above overloads */)                                     noexcept; // 7
 //!   }
 //!   @endcode
 //!
 //! **Parameters**
 //!
-//!   * `p`: [floating value](@ref eve::floating_value)
+//!   * `p`: [positive value](@ref eve::floating_value)
 //!   * `x`, `... xs`: [floating values](@ref eve::floating_value)
+//!   * `tup': kumi tuple (of the xs)
 //!   * `c`: [Conditional expression](@ref eve::conditional_expr) masking the operation.
 //!   * `m`: [Logical value](@ref eve::logical_value) masking the operation.
 //!
 //! **Return value**
 //!
-//!   1. \f$ \left(\sum_{i = 0}^n |x_i|^p\right)^{\frac1p} \f$.
-//!   2. [The operation is performed conditionnaly](@ref conditional)
-//!   3. returns \f$\infty\f$ as soon as one of its parameter is infinite, regardless of possible `Nan` values.
-//!   4. The summation is computed in the double sized element type (if available).
-//!   5. Kahan like compensated algorithm is used in internal summation for better precision.
+//!   1. \f$ \left(\sum_{i = 0}^n |x_i|^p\right)^{\frac1p} \f$ and \f$ \max_{i = 0}^n |x_i|} \f$ if 'p' is infinite.
+//!   2. same as 1. on the tuple elements.
+//!   3. [The operation is performed conditionnaly](@ref conditional)
+//!   4. returns \f$\infty\f$ as soon as after disabling possible `Nan` parameters the result is \f$\infty\f$.
+//!   5. The summation is computed in the double sized element type (if available).
+//!   6. Kahan like compensated algorithm is used in internal summation for better precision (see [add](@ref eve::add)).
+//!   7. This option is speedier does not care about avoiding overflows or treating 'Nans' in special ways.
 //!
 //!  @groupheader{Example}
 //!  @godbolt{doc/math/lpnorm.cpp}
@@ -94,10 +99,11 @@ namespace eve
 
   namespace detail
   {
-    template<typename P, typename... Ts, callable_options O>
-    EVE_FORCEINLINE constexpr auto
+
+    template<typename P, floating_value... Ts, callable_options O>
+    EVE_NOINLINE constexpr auto
     lpnorm_(EVE_REQUIRES(cpu_), O const & o, P p, Ts... args) noexcept
-    requires(sizeof...(Ts) !=  0)
+    requires(sizeof...(Ts) >=  1)
     {
       using c_t = common_value_t<Ts...>;
       using r_t = as_wide_as_t<c_t, P>;
@@ -113,42 +119,54 @@ namespace eve
       {
         if( eve::all(p == P(2)) )                 return hypot[o](r_t(args)...);
         else if( eve::all(p == P(1)) )            return manhattan[o](r_t(args)...);
-        else if( eve::all(p == eve::inf(as(p))) ) return maxabs[o.drop(kahan)](r_t(args)...);
+        else if(!O::contains(pedantic) && eve::all(p == eve::inf(as(p))) ) return maxabs[o.drop(kahan)](r_t(args)...);
         else
         {
           if (O::contains(pedantic))
           {
+            auto nan_found = eve::false_(eve::as<r_t>());
             auto rp = r_t(p);
             auto any_is_inf = (is_infinite(r_t(args)) || ...);
-            auto e  = -maxmag(exponent(r_t(args))...);
-            auto f = [&](auto a){return pow_abs(ldexp[o](r_t(a), e), rp); };
-            r_t that = add[o](f(args)...);
+            auto e  = -maxmag(if_else(is_nan(args), zero, exponent(r_t(args)))...);
+            auto f = [&](auto a){
+              nan_found =  nan_found || eve::is_nan(a);
+              return if_else(eve::is_nan(a), zero, pow_abs(ldexp[o](r_t(a), e), rp));
+            };
+            r_t that = eve::add[o](f(args)...);
             auto r = ldexp[pedantic](pow_abs(that, rec[pedantic](rp)), -e);
+            r = if_else(nan_found && !is_infinite(r), allbits, r);
             auto isinfp = is_infinite(rp);
             if (eve::none(isinfp))
-              return force_if_any(o, r, eve::is_infinite, inf(eve::as(r)), args...);
+              return r;
             else
             {
               auto rinf = maxabs[o](r_t(args)...);
               r = if_else(isinfp, rinf, r);
-              r = if_else(any_is_inf, inf(as<r_t>()), r);
-              return force_if_any(o, r, eve::is_infinite, inf(eve::as(r)), args...);
+              return if_else(nan_found && !is_infinite(r), allbits, r);
             }
           }
-          else
+          else if constexpr(O::contains(raw))
           {
             auto rp = r_t(p);
-            r_t that = add[o](pow_abs(r_t(args), rp)...);
+            r_t that = manhattan[o](pow(r_t(args), rp)...);
             auto r = pow(that, rec[pedantic](rp));
             auto isinfp = is_infinite(rp);
             if (eve::none(isinfp)) return r;
             else return if_else(is_infinite(rp), eve::maxabs[o](args...), r);
           }
+          else
+          {
+            auto rp = r_t(p);
+            auto e  = -maxmag(if_else(is_nan(args), zero, exponent(r_t(args)))...);
+            auto f = [&](auto a){ return pow_abs(ldexp[o](r_t(a), e), rp);};
+            r_t that = eve::add[o](f(args)...);
+            return ldexp[pedantic](pow_abs(that, rec[pedantic](rp)), -e);
+          }
         }
       }
     }
 
-    template<typename P, typename Tup, callable_options O>
+    template<typename P, eve::non_empty_product_type Tup, callable_options O>
     EVE_FORCEINLINE constexpr auto
     lpnorm_(EVE_REQUIRES(cpu_), O const & o, P p, Tup tup) noexcept
     {

--- a/include/eve/module/math/regular/lpnorm.hpp
+++ b/include/eve/module/math/regular/lpnorm.hpp
@@ -87,7 +87,7 @@ namespace eve
 //!   4. returns \f$\infty\f$ as soon as after disabling possible `Nan` parameters the result is \f$\infty\f$.
 //!   5. The summation is computed in the double sized element type (if available).
 //!   6. Kahan like compensated algorithm is used in internal summation for better precision (see [add](@ref eve::add)).
-//!   7. This option is speedier does not care about avoiding overflows or treating 'Nans' in special ways.
+//!   7. This option is speedier, but does not care about avoiding overflows or treating 'Nans' in special ways.
 //!
 //!  @groupheader{Example}
 //!  @godbolt{doc/math/lpnorm.cpp}

--- a/include/eve/module/math/regular/lpnorm.hpp
+++ b/include/eve/module/math/regular/lpnorm.hpp
@@ -128,7 +128,7 @@ namespace eve
             auto rp = r_t(p);
             auto e  = -maxmag(if_else(is_nan(args), zero, exponent(r_t(args)))...);
             auto f = [&](auto a){
-              nan_found =  nan_found || eve::is_nan(a);
+              nan_found = eve::is_nan(a);
               return if_else(eve::is_nan(a), zero, pow_abs(ldexp[o](r_t(a), e), rp));
             };
             r_t that = eve::add[o](f(args)...);

--- a/test/doc/core/manhattan.cpp
+++ b/test/doc/core/manhattan.cpp
@@ -38,4 +38,28 @@ int main()
   auto tup = kumi::tuple{1.0f, eps_2, eps_2, eps_2};
   std::cout << "-> manhattan[kahan](tup)   = " << eve::manhattan[eve::kahan](tup) << "\n";
 
+
+  float o = 1.0f;
+  float i = eve::inf(eve::as(o));
+  float n = eve::nan(eve::as(o));
+  float m = (eve::valmax(eve::as(o))/3)*2;
+  std::cout << "<- o                                   = " << o << "\n";
+  std::cout << "-> i                                   = " << i << "\n";
+  std::cout << "-> n                                   = " << n << "\n";
+  std::cout << "-> manhattan(i, o, -i)                 = " << eve::manhattan(i, o, -i) << "\n";
+  std::cout << "-> manhattan(i, o, n)                  = " << eve::manhattan(i, o,  n) << "\n";
+  std::cout << "-> manhattan[pedantic](i, o, -i)       = " << eve::manhattan[eve::pedantic](i, o, -i) << "\n";
+  std::cout << "-> manhattan[pedantic](i, o, n)        = " << eve::manhattan[eve::pedantic](i, o,  n) << "\n";
+  std::cout << "-> manhattan[pedantic](o, o, n)        = " << eve::manhattan[eve::pedantic](o, o, n) << "\n";
+  std::cout << "-> manhattan[pedantic](o, n, o)        = " << eve::manhattan[eve::pedantic](o, n, o) << "\n";
+  std::cout << "-> manhattan[pedantic](n, o, o)        = " << eve::manhattan[eve::pedantic](n, o, o) << "\n";
+  std::cout << "-> manhattan          (o, o, n)        = " << eve::manhattan(o, o, n) << "\n";
+  std::cout << "-> manhattan          (o, n, o)        = " << eve::manhattan(o, n, o) << "\n";
+  std::cout << "-> manhattan          (n, o, o)        = " << eve::manhattan(n, o, o) << "\n";
+  std::cout << "-> manhattan(n, n, n)                  = " << eve::manhattan(n, n, n) << "\n";
+  std::cout << "-> manhattan(m, o, o)                  = " << eve::manhattan(m, o, o)<< "\n";
+  std::cout << "-> manhattan(m, m, n)                  = " << eve::manhattan(m, m, n)<< "\n";
+  std::cout << "-> manhattan(i, n)                     = " << eve::manhattan(i, n) << "\n";
+  std::cout << "-> manhattan[pedantic](m, m, n)        = " << eve::manhattan[eve::pedantic](m, m, n)<< "\n";
+  std::cout << "-> manhattan[pedantic](i, n)           = " << eve::manhattan[eve::pedantic](i, n) << "\n";
 }

--- a/test/doc/core/maxabs.cpp
+++ b/test/doc/core/maxabs.cpp
@@ -17,7 +17,7 @@ int main()
   std::cout << "<- wi1                              = " << wi1 << "\n";
   std::cout << "<- wu0                              = " << wu0 << "\n";
   std::cout << "<- wu1                              = " << wu1 << "\n";
-                                                    
+
   std::cout << "-> maxabs(wf0, wf1)                 = " << eve::maxabs(wf0, wf1) << "\n";
   std::cout << "-> maxabs[ignore_last(2)](wf0, wf1) = " << eve::maxabs[eve::ignore_last(2)](wf0, wf1) << "\n";
   std::cout << "-> maxabs[wf0 != 0](wf0, wf1)       = " << eve::maxabs[wf0 != 0](wf0, wf1) << "\n";
@@ -25,4 +25,29 @@ int main()
   std::cout << "-> maxabs[numeric ](wf0, wf1)       = " << eve::maxabs[eve::numeric ](wf0, wf1) << "\n";
   std::cout << "-> maxabs(wu0, wu1)                 = " << eve::maxabs(wu0, wu1) << "\n";
   std::cout << "-> maxabs(wi0, wi1)                 = " << eve::maxabs(wi0, wi1) << "\n";
+
+  float o = 1.0f;
+  float i = eve::inf(eve::as(o));
+  float n = eve::nan(eve::as(o));
+  float m = (eve::valmax(eve::as(o))/3)*2;
+  std::cout << "<- o                                = " << o << "\n";
+  std::cout << "-> i                                = " << i << "\n";
+  std::cout << "-> n                                = " << n << "\n";
+  std::cout << "-> maxabs(i, o, -i)                 = " << eve::maxabs(i, o, -i) << "\n";
+  std::cout << "-> maxabs(i, o, n)                  = " << eve::maxabs(i, o, -i) << "\n";
+  std::cout << "-> maxabs[pedantic](o, o, n)        = " << eve::maxabs[eve::pedantic](o, o, n) << "\n";
+  std::cout << "-> maxabs[pedantic](o, n, o)        = " << eve::maxabs[eve::pedantic](o, n, o) << "\n";
+  std::cout << "-> maxabs[pedantic](n, o, o)        = " << eve::maxabs[eve::pedantic](n, o, o) << "\n";
+  std::cout << "-> maxabs[numeric ](o, o, n)        = " << eve::maxabs[eve::numeric ](o, o, n) << "\n";
+  std::cout << "-> maxabs[numeric](o, n, o)         = " << eve::maxabs[eve::numeric](o, n, o) << "\n";
+  std::cout << "-> maxabs[numeric](n, o, o)         = " << eve::maxabs[eve::numeric](n, o, o) << "\n";
+  std::cout << "-> maxabs          (o, o, n)        = " << eve::maxabs(o, o, n) << "\n";
+  std::cout << "-> maxabs          (o, n, o)        = " << eve::maxabs(o, n, o) << "\n";
+  std::cout << "-> maxabs          (n, o, o)        = " << eve::maxabs(n, o, o) << "\n";
+  std::cout << "-> maxabs(n, n, n)                  = " << eve::maxabs(n, n, n) << "\n";
+  std::cout << "-> maxabs(m, o, o)                  = " << eve::maxabs(m, o, o)<< "\n";
+  std::cout << "-> maxabs(i, o, n)                  = " << eve::maxabs(i, o, n)<< "\n";
+  std::cout << "-> maxabs[nan_aware](i, o, n)       = " << eve::maxabs[eve::nan_aware](i, o, n)<< "\n";
+  std::cout << "-> maxabs(i, o, n)                  = " << eve::maxabs(i, o, n)<< "\n";
+
 }

--- a/test/doc/core/maxabs.cpp
+++ b/test/doc/core/maxabs.cpp
@@ -47,7 +47,7 @@ int main()
   std::cout << "-> maxabs(n, n, n)                  = " << eve::maxabs(n, n, n) << "\n";
   std::cout << "-> maxabs(m, o, o)                  = " << eve::maxabs(m, o, o)<< "\n";
   std::cout << "-> maxabs(i, o, n)                  = " << eve::maxabs(i, o, n)<< "\n";
-  std::cout << "-> maxabs[nan_aware](i, o, n)       = " << eve::maxabs[eve::nan_aware](i, o, n)<< "\n";
+  std::cout << "-> maxabs[drastic](i, o, n)       = " << eve::maxabs[eve::drastic](i, o, n)<< "\n";
   std::cout << "-> maxabs(i, o, n)                  = " << eve::maxabs(i, o, n)<< "\n";
 
 }

--- a/test/doc/core/minabs.cpp
+++ b/test/doc/core/minabs.cpp
@@ -48,7 +48,7 @@ int main()
   std::cout << "-> minabs(n, n, n)                  = " << eve::minabs(n, n, n) << "\n";
   std::cout << "-> minabs(m, o, o)                  = " << eve::minabs(m, o, o)<< "\n";
   std::cout << "-> minabs(i, o, n)                  = " << eve::minabs(i, o, n)<< "\n";
-  std::cout << "-> minabs[nan_aware](z, o, n)       = " << eve::minabs[eve::nan_aware](z, o, n)<< "\n";
+  std::cout << "-> minabs[drastic](z, o, n)       = " << eve::minabs[eve::drastic](z, o, n)<< "\n";
   std::cout << "-> minabs[numeric](z, o, n)         = " << eve::minabs[eve::numeric](z, o, n)<< "\n";
   std::cout << "-> minabs[pedantic](z, o, n)        = " << eve::minabs[eve::pedantic](z, o, n)<< "\n";
   std::cout << "-> minabs(z, o, n)                  = " << eve::minabs(z, o, n)<< "\n";

--- a/test/doc/core/minabs.cpp
+++ b/test/doc/core/minabs.cpp
@@ -17,7 +17,7 @@ int main()
   std::cout << "<- wi1                              = " << wi1 << "\n";
   std::cout << "<- wu0                              = " << wu0 << "\n";
   std::cout << "<- wu1                              = " << wu1 << "\n";
-                                                    
+
   std::cout << "-> minabs(wf0, wf1)                 = " << eve::minabs(wf0, wf1) << "\n";
   std::cout << "-> minabs[ignore_last(2)](wf0, wf1) = " << eve::minabs[eve::ignore_last(2)](wf0, wf1) << "\n";
   std::cout << "-> minabs[wf0 != 0](wf0, wf1)       = " << eve::minabs[wf0 != 0](wf0, wf1) << "\n";
@@ -25,4 +25,31 @@ int main()
   std::cout << "-> minabs[numeric ](wf0, wf1)       = " << eve::minabs[eve::numeric ](wf0, wf1) << "\n";
   std::cout << "-> minabs(wu0, wu1)                 = " << eve::minabs(wu0, wu1) << "\n";
   std::cout << "-> minabs(wi0, wi1)                 = " << eve::minabs(wi0, wi1) << "\n";
+
+  float o = 1.0f;
+  float i = eve::inf(eve::as(o));
+  float n = eve::nan(eve::as(o));
+  float z = eve::zero(eve::as(o));
+  float m = (eve::valmax(eve::as(o))/3)*2;
+  std::cout << "<- o                                = " << o << "\n";
+  std::cout << "-> i                                = " << i << "\n";
+  std::cout << "-> n                                = " << n << "\n";
+  std::cout << "-> minabs(i, o, -i)                 = " << eve::minabs(i, o, -i) << "\n";
+  std::cout << "-> minabs(i, o, n)                  = " << eve::minabs(i, o, -i) << "\n";
+  std::cout << "-> minabs[pedantic](o, o, n)        = " << eve::minabs[eve::pedantic](o, o, n) << "\n";
+  std::cout << "-> minabs[pedantic](o, n, o)        = " << eve::minabs[eve::pedantic](o, n, o) << "\n";
+  std::cout << "-> minabs[pedantic](n, o, o)        = " << eve::minabs[eve::pedantic](n, o, o) << "\n";
+  std::cout << "-> minabs[numeric ](o, o, n)        = " << eve::minabs[eve::numeric ](o, o, n) << "\n";
+  std::cout << "-> minabs[numeric](o, n, o)         = " << eve::minabs[eve::numeric](o, n, o) << "\n";
+  std::cout << "-> minabs[numeric](n, o, o)         = " << eve::minabs[eve::numeric](n, o, o) << "\n";
+  std::cout << "-> minabs          (o, o, n)        = " << eve::minabs(o, o, n) << "\n";
+  std::cout << "-> minabs          (o, n, o)        = " << eve::minabs(o, n, o) << "\n";
+  std::cout << "-> minabs          (n, o, o)        = " << eve::minabs(n, o, o) << "\n";
+  std::cout << "-> minabs(n, n, n)                  = " << eve::minabs(n, n, n) << "\n";
+  std::cout << "-> minabs(m, o, o)                  = " << eve::minabs(m, o, o)<< "\n";
+  std::cout << "-> minabs(i, o, n)                  = " << eve::minabs(i, o, n)<< "\n";
+  std::cout << "-> minabs[nan_aware](z, o, n)       = " << eve::minabs[eve::nan_aware](z, o, n)<< "\n";
+  std::cout << "-> minabs[numeric](z, o, n)         = " << eve::minabs[eve::numeric](z, o, n)<< "\n";
+  std::cout << "-> minabs[pedantic](z, o, n)        = " << eve::minabs[eve::pedantic](z, o, n)<< "\n";
+  std::cout << "-> minabs(z, o, n)                  = " << eve::minabs(z, o, n)<< "\n";
 }

--- a/test/doc/math/hypot.cpp
+++ b/test/doc/math/hypot.cpp
@@ -4,21 +4,54 @@
 
 int main()
 {
-  eve::wide pf = {-1.0, 2.0, -3.0, eve::valmax(eve::as<double>())};
-  eve::wide qf = {-4.0, 3.0, -2.0, eve::inf(eve::as<double>())};
-  eve::wide rf = {-40.0, 0.03, -2.0, eve::nan(eve::as<double>())};
-  kumi::tuple wt{pf, qf};
+//   eve::wide pf = {-1.0, 2.0, -3.0, eve::valmax(eve::as<double>())};
+//   eve::wide qf = {-4.0, 3.0, -2.0, eve::inf(eve::as<double>())};
+//   eve::wide rf = {-40.0, 0.03, -2.0, eve::nan(eve::as<double>())};
+//   kumi::tuple wt{pf, qf};
 
-   std::cout << "<- pf = " << pf << "\n";
-   std::cout << "<- qf = " << qf << "\n";
-   std::cout << "<- rf = " << rf << "\n";
-   std::cout << "<- wt = " << wt << "\n";
+//    std::cout << "<- pf = " << pf << "\n";
+//    std::cout << "<- qf = " << qf << "\n";
+//    std::cout << "<- rf = " << rf << "\n";
+//    std::cout << "<- wt = " << wt << "\n";
 
-   std::cout << "-> hypot(pf,qf)                = " << eve::hypot(pf,qf) << "\n";
-   std::cout << "-> hypot(wt)                   = " << eve::hypot(wt) << "\n";
-   std::cout << "-> hypot[ignore_last(2)](pf,qf)= " << eve::hypot[eve::ignore_last(2)](pf,qf) << "\n";
-   std::cout << "-> hypot[pf > 0.0](pf,qf)      = " << eve::hypot[pf > 0.0](pf,qf) << "\n";
-   std::cout << "-> hypot[pedantic](pf,qf)      = " << eve::hypot[eve::pedantic](pf,qf) << "\n";
-   std::cout << "-> hypot(pf,qf,rf)             = " << eve::hypot(pf,qf,rf) << "\n";
-   std::cout << "-> hypot[pedantic](pf,qf,rf)   = " << eve::hypot[eve::pedantic](pf,qf,rf) << "\n";
+//    std::cout << "-> hypot(pf,qf)                = " << eve::hypot(pf,qf) << "\n";
+//    std::cout << "-> hypot(wt)                   = " << eve::hypot(wt) << "\n";
+//    std::cout << "-> hypot[ignore_last(2)](pf,qf)= " << eve::hypot[eve::ignore_last(2)](pf,qf) << "\n";
+//    std::cout << "-> hypot[pf > 0.0](pf,qf)      = " << eve::hypot[pf > 0.0](pf,qf) << "\n";
+//    std::cout << "-> hypot[pedantic](pf,qf)      = " << eve::hypot[eve::pedantic](pf,qf) << "\n";
+//    std::cout << "-> hypot(pf,qf,rf)             = " << eve::hypot(pf,qf,rf) << "\n";
+//    std::cout << "-> hypot[pedantic](pf,qf,rf)   = " << eve::hypot[eve::pedantic](pf,qf,rf) << "\n";
+
+  float o = 1.0f;
+  float i = eve::inf(eve::as(o));
+  float n = eve::nan(eve::as(o));
+  float v = eve::valmax(eve::as(o));
+  float m = (v/3)*2;
+  std::cout << "<- o                               = " << o << "\n";
+  std::cout << "-> i                               = " << i << "\n";
+  std::cout << "-> n                               = " << n << "\n";
+  std::cout << "-> m                               = " << m << "\n";
+  std::cout << "-> hypot(i, o, -i)                 = " << eve::hypot(i, o, -i) << "\n";
+  std::cout << "-> hypot(i, o, n)                  = " << eve::hypot(i, o,  n) << "\n";
+  std::cout << "-> hypot[pedantic](i, o, -i)       = " << eve::hypot[eve::pedantic](i, o, -i) << "\n";
+  std::cout << "-> hypot[pedantic](i, o, n)        = " << eve::hypot[eve::pedantic](i, o,  n) << "\n";
+  std::cout << "-> hypot[pedantic](o, o, n)        = " << eve::hypot[eve::pedantic](o, o, n) << "\n";
+  std::cout << "-> hypot[pedantic](o, n, o)        = " << eve::hypot[eve::pedantic](o, n, o) << "\n";
+  std::cout << "-> hypot[pedantic](n, o, o)        = " << eve::hypot[eve::pedantic](n, o, o) << "\n";
+  std::cout << "-> hypot          (o, o, n)        = " << eve::hypot(o, o, n) << "\n";
+  std::cout << "-> hypot          (o, n, o)        = " << eve::hypot(o, n, o) << "\n";
+  std::cout << "-> hypot          (n, o, o)        = " << eve::hypot(n, o, o) << "\n";
+  std::cout << "-> hypot(n, n, n)                  = " << eve::hypot(n, n, n) << "\n";
+  std::cout << "-> hypot(m, o, o)                  = " << eve::hypot(m, o, o)<< "\n";
+  std::cout << "-> hypot(m, m, n)                  = " << eve::hypot(m, m, n)<< "\n";
+  std::cout << "-> hypot(i, n)                     = " << eve::hypot(i, n) << "\n";
+  std::cout << "-> hypot[pedantic](m, m)           = " << eve::hypot[eve::pedantic](m, m)<< "\n";
+  std::cout << "-> hypot[pedantic](m, m, n)        = " << eve::hypot[eve::pedantic](m, m, n)<< "\n";
+  std::cout << "-> hypot[pedantic](i, n)           = " << eve::hypot[eve::pedantic](i, n) << "\n";
+  std::cout << "-> hypot[pedantic](v, v, n)        = " << eve::hypot[eve::pedantic](v, v, n)<< "\n";
+  std::cout << "-> hypot[pedantic](m, m)           = " << eve::hypot[eve::pedantic](m, m)<< "\n";
+  std::cout << "-> hypot(m, m, n)                  = " << eve::hypot(m, m, n)<< "\n";
+  std::cout << "-> hypot(i, n, n)                  = " << eve::hypot(i, n, n) << "\n";
+  std::cout << "-> hypot(i, n)                     = " << eve::hypot(i, n)    << "\n";
+  std::cout << "-> hypot(v, v, n)                  = " << eve::hypot(v, v, n)<< "\n";
 }

--- a/test/doc/math/lpnorm.cpp
+++ b/test/doc/math/lpnorm.cpp
@@ -1,24 +1,92 @@
-// revision 1
 #include <eve/module/math.hpp>
+#include <eve/wide.hpp>
 #include <iostream>
 #include <iomanip>
 
+using wide_ft = eve::wide<float, eve::fixed<4>>;
+
 int main()
 {
-  eve::wide x = {eve::nan(eve::as<float>()), 1.0f, 1.0f, 1.0f};
-  eve::wide y = {-1.5f, 2.9f, 3.5f, -11.0f};
-  eve::wide z = { eve::inf(eve::as(1.0f)), -2.0f, 1.0f, 15.0f};
-  eve::wide p = { 3.2f, 3.0f, 2.0f, eve::inf(eve::as(1.0f))};
+  wide_ft x = {eve::nan(eve::as<float>()), 1.0f, 1.0f, 1.0f};
+  wide_ft y = {-1.5f, 2.9f, 3.5f, -11.0f};
+  wide_ft z = { eve::inf(eve::as(1.0f)), -2.0f, 1.0f, eve::nan(eve::as<float>())};
+  wide_ft p = { 3.2f, 3.0f, 2.0f, eve::inf(eve::as(1.0f))};
 
-  std::cout << std::setprecision(15) << '\n';
-  std::cout << "<- p                                      = " << p  << '\n';
-  std::cout << "<- x                                      = " << x  << '\n';
-  std::cout << "<- y                                      = " << y  << '\n';
-  std::cout << "<- z                                      = " << z  << '\n';
-  std::cout << "-> lpnorm(p, x, y, z)                     = " << eve::lpnorm(p, x, y, z) << '\n';
-  std::cout << "-> lpnorm[pedantic](p, x, y, z)           = " << eve::lpnorm[eve::pedantic](p, x, y, z) << '\n';
-  std::cout << "-> lpnorm[kahan](p, x, y, z)              = " << eve::lpnorm[eve::kahan](p, x, y, z) << '\n';
-  std::cout << "-> lpnorm[kahan][pedantic](p, x, y, z)    = " << eve::lpnorm[eve::kahan][eve::pedantic](p, x, y, z) << '\n';
-  std::cout << "-> lpnorm[widen](p, x, y, z)              = " << eve::lpnorm[eve::widen](p, x, y, z) << '\n';
-  std::cout << "-> lpnorm[widen][pedantic](p, x, y, z)    = " << eve::lpnorm[eve::widen][eve::pedantic](p, x, y, z) << '\n';
+    std::cout << "---- simd" << std::setprecision(5) << '\n'
+              << "<- p                            = " << p  << '\n'
+              << "<- x                            = " << x  << '\n'
+              << "<- y                            = " << y  << '\n'
+              << "<- z                            = " << z  << '\n'
+              << "-> lpnorm(p, x, y, z)           = " << eve::lpnorm(p, x, y, z) << '\n'
+              << "-> lpnorm[pedantic](p, x, y, z) = " << eve::lpnorm[eve::pedantic](p, x, y, z) << '\n'
+
+
+              ;
+
+  double        xf = 10.0;
+  double        yf = 1.0;
+  double        zf = 111.0;
+  double        pf = 2.0;
+
+  std::cout << "---- scalar" << '\n'
+            << "<- pf                               = " << pf << '\n'
+            << "<- xf                               = " << xf << '\n'
+            << "<- yf                               = " << yf << '\n'
+            << "<- zf                               = " << zf << '\n'
+            << "-> lpnorm(pf, xf, yf, zf)           = " << eve::lpnorm(pf, xf, yf, zf) << '\n'
+            << "-> lpnorm[pedantic](pf, xf, yf, zf) = " << eve::lpnorm[eve::pedantic](pf, xf, yf, zf) << '\n';
+
+  float o = 1.0f;
+  float i = eve::inf(eve::as(o));
+  float n = eve::nan(eve::as(o));
+  float ma= eve::valmax(eve::as(o));
+  float m = (ma/3)*2;
+  std::cout << "<- o                                = " << o << "\n";
+  std::cout << "-> i                                = " << i << "\n";
+  std::cout << "-> n                                = " << n << "\n";
+  std::cout << "-> lpnorm(3, i, o, -i)                 = " << eve::lpnorm(3, i, o, -i) << "\n";
+  std::cout << "-> lpnorm(3, i, o, n)                  = " << eve::lpnorm(3, i, o, n) << "\n";
+  std::cout << "-> lpnorm[pedantic](3, o, o, n)        = " << eve::lpnorm[eve::pedantic](3, o, o, n) << "\n";
+  std::cout << "-> lpnorm[pedantic](3, o, n, o)        = " << eve::lpnorm[eve::pedantic](3, o, n, o) << "\n";
+  std::cout << "-> lpnorm[pedantic](3, n, o, o)        = " << eve::lpnorm[eve::pedantic](3, n, o, o) << "\n";
+  std::cout << "-> lpnorm[pedantic](3, n, m, m)        = " << eve::lpnorm[eve::pedantic](3, n, m, m) << "\n";
+  std::cout << "-> lpnorm          (3, o, o, n)        = " << eve::lpnorm(3, o, o, n) << "\n";
+  std::cout << "-> lpnorm          (3, o, n, o)        = " << eve::lpnorm(3, o, n, o) << "\n";
+  std::cout << "-> lpnorm          (3, n, o, o)        = " << eve::lpnorm(3, n, o, o) << "\n";
+  std::cout << "-> lpnorm          (3, n, m, m)        = " << eve::lpnorm(3, n, m, m) << "\n";
+  std::cout << "-> lpnorm(3, n, n, n)                  = " << eve::lpnorm(3, n, n, n) << "\n";
+  std::cout << "-> lpnorm(3, m, o, o)                  = " << eve::lpnorm(3, m, o, o)<< "\n";
+  std::cout << "-> lpnorm[pedantic](3, m, o, o)        = " << eve::lpnorm[eve::pedantic](3, m, o, o)<< "\n";
+  std::cout << "-> lpnorm[pedantic](3, i, o, n)        = " << eve::lpnorm[eve::pedantic](3, i, o, n) << "\n";
+  std::cout << "-> lpnorm[pedantic](3, m)              = " << eve::lpnorm[eve::pedantic](3, m) << "\n";
+  std::cout << "-> lpnorm[pedantic](3, m, m)           = " << eve::lpnorm[eve::pedantic](3, m, m) << "\n";
+  std::cout << "-> lpnorm[pedantic](3, m, m, m)        = " << eve::lpnorm[eve::pedantic](3, m, m, m) << "\n";
+  std::cout << "-> lpnorm[pedantic](3, m, m, m, m)     = " << eve::lpnorm[eve::pedantic](3, m, m, m, m) << "\n";
+  std::cout << "-> lpnorm[pedantic](3, m, o, o)        = " << eve::lpnorm[eve::pedantic](3, m, o, o)<< "\n";
+  std::cout << "-> lpnorm(3, i, o, n)                  = " << eve::lpnorm(3, i, o, n) << "\n";
+  std::cout << "-> lpnorm(3, m)                        = " << eve::lpnorm(3, m) << "\n";
+  std::cout << "-> lpnorm(3, m, m)                     = " << eve::lpnorm(3, m, m) << "\n";
+  std::cout << "-> lpnorm(3, m, m, m)                  = " << eve::lpnorm(3, m, m, m) << "\n";
+  std::cout << "-> lpnorm(3, m, m, m, m)               = " << eve::lpnorm(3, m, m, m, m) << "\n";
+
+  std::cout << "-> lpnorm[pedantic](3, m, n)              = " << eve::lpnorm[eve::pedantic](3, m, n) << "\n";
+  std::cout << "-> lpnorm[pedantic](3, m, m, n)           = " << eve::lpnorm[eve::pedantic](3, m, m, n) << "\n";
+  std::cout << "-> lpnorm[pedantic](3, m, m, m, n)        = " << eve::lpnorm[eve::pedantic](3, m, m, m, n) << "\n";
+  std::cout << "-> lpnorm[pedantic](3, m, m, m, m, n)     = " << eve::lpnorm[eve::pedantic](3, m, m, m, m, n) << "\n";
+
+  std::cout << "-> lpnorm(i, m)                        = " << eve::lpnorm(i, m) << "\n";
+  std::cout << "-> lpnorm(i, m, m)                     = " << eve::lpnorm(i, m, m) << "\n";
+  std::cout << "-> lpnorm(i, m, m, m)                  = " << eve::lpnorm(i, m, m, m) << "\n";
+  std::cout << "-> lpnorm(i, m, m, m, m)               = " << eve::lpnorm(i, m, m, m, m) << "\n";
+
+  std::cout << "-> lpnorm[pedantic](i, m, n)              = " << eve::lpnorm[eve::pedantic](i, m, n) << "\n";
+  std::cout << "-> lpnorm[pedantic](i, m, m, n)           = " << eve::lpnorm[eve::pedantic](i, m, m, n) << "\n";
+  std::cout << "-> lpnorm[pedantic](i, m, m, m, n)        = " << eve::lpnorm[eve::pedantic](i, m, m, m, n) << "\n";
+  std::cout << "-> lpnorm[pedantic](i, m, m, m, m, n)     = " << eve::lpnorm[eve::pedantic](i, m, m, m, m, n) << "\n";
+
+  std::cout << "-> lpnorm[raw](3, m)                        = " << eve::lpnorm[eve::raw](3, m) << "\n";
+  std::cout << "-> lpnorm[raw](3, m, m)                     = " << eve::lpnorm[eve::raw](3, m, m) << "\n";
+  std::cout << "-> lpnorm[raw](3, m, m, m)                  = " << eve::lpnorm[eve::raw](3, m, m, m) << "\n";
+  std::cout << "-> lpnorm[raw](3, m, m, m, m)               = " << eve::lpnorm[eve::raw](3, m, m, m, m) << "\n";
+ return 0;
 }

--- a/test/doc/math/regular/lpnorm.cpp
+++ b/test/doc/math/regular/lpnorm.cpp
@@ -3,37 +3,59 @@
 #include <iostream>
 #include <iomanip>
 
-using wide_ft = eve::wide<float, eve::fixed<4>>;
+//using wide_ft = eve::wide<float, eve::fixed<4>>;
 
 int main()
 {
-  wide_ft x = {eve::nan(eve::as<float>()), 1.0f, 1.0f, 1.0f};
-  wide_ft y = {-1.5f, 2.9f, 3.5f, -11.0f};
-  wide_ft z = { eve::inf(eve::as(1.0f)), -2.0f, 1.0f, eve::nan(eve::as<float>())};
-  wide_ft p = { 3.2f, 3.0f, 2.0f, eve::inf(eve::as(1.0f))};
+//   wide_ft x = {eve::nan(eve::as<float>()), 1.0f, 1.0f, 1.0f};
+//   wide_ft y = {-1.5f, 2.9f, 3.5f, -11.0f};
+//   wide_ft z = { eve::inf(eve::as(1.0f)), -2.0f, 1.0f, eve::nan(eve::as<float>())};
+//   wide_ft p = { 3.2f, 3.0f, 2.0f, eve::inf(eve::as(1.0f))};
 
-    std::cout << "---- simd" << std::setprecision(5) << '\n'
-              << "<- p                            = " << p  << '\n'
-              << "<- x                            = " << x  << '\n'
-              << "<- y                            = " << y  << '\n'
-              << "<- z                            = " << z  << '\n'
-              << "-> lpnorm(p, x, y, z)           = " << eve::lpnorm(p, x, y, z) << '\n'
-              << "-> lpnorm[pedantic](p, x, y, z) = " << eve::lpnorm[eve::pedantic](p, x, y, z) << '\n'
+//     std::cout << "---- simd" << std::setprecision(5) << '\n'
+//               << "<- p                            = " << p  << '\n'
+//               << "<- x                            = " << x  << '\n'
+//               << "<- y                            = " << y  << '\n'
+//               << "<- z                            = " << z  << '\n'
+//               << "-> lpnorm(p, x, y, z)           = " << eve::lpnorm(p, x, y, z) << '\n'
+//               << "-> lpnorm[pedantic](p, x, y, z) = " << eve::lpnorm[eve::pedantic](p, x, y, z) << '\n'
 
 
-              ;
+//               ;
 
-  double        xf = 10.0;
-  double        yf = 1.0;
-  double        zf = 111.0;
-  double        pf = 2.0;
+//   double        xf = 10.0;
+//   double        yf = 1.0;
+//   double        zf = 111.0;
+//   double        pf = 2.0;
 
-  std::cout << "---- scalar" << '\n'
-            << "<- pf                               = " << pf << '\n'
-            << "<- xf                               = " << xf << '\n'
-            << "<- yf                               = " << yf << '\n'
-            << "<- zf                               = " << zf << '\n'
-            << "-> lpnorm(pf, xf, yf, zf)           = " << eve::lpnorm(pf, xf, yf, zf) << '\n'
-            << "-> lpnorm[pedantic](pf, xf, yf, zf) = " << eve::lpnorm[eve::pedantic](pf, xf, yf, zf) << '\n';
-  return 0;
+//   std::cout << "---- scalar" << '\n'
+//             << "<- pf                               = " << pf << '\n'
+//             << "<- xf                               = " << xf << '\n'
+//             << "<- yf                               = " << yf << '\n'
+//             << "<- zf                               = " << zf << '\n'
+//             << "-> lpnorm(pf, xf, yf, zf)           = " << eve::lpnorm(pf, xf, yf, zf) << '\n'
+//             << "-> lpnorm[pedantic](pf, xf, yf, zf) = " << eve::lpnorm[eve::pedantic](pf, xf, yf, zf) << '\n';
+
+  float o = 1.0f;
+  float i = eve::inf(eve::as(o));
+  float n = eve::nan(eve::as(o));
+  float m = (eve::valmax(eve::as(o))/3)*2;
+  std::cout << "<- o                                = " << o << "\n";
+  std::cout << "-> i                                = " << i << "\n";
+  std::cout << "-> n                                = " << n << "\n";
+  std::cout << "-> lpnorm(3, i, o, -i)                 = " << eve::lpnorm(3, i, o, -i) << "\n";
+  std::cout << "-> lpnorm(3, i, o, n)                  = " << eve::lpnorm(3, i, o, -i) << "\n";
+  std::cout << "-> lpnorm[pedantic](3, o, o, n)        = " << eve::lpnorm[eve::pedantic](3, o, o, n) << "\n";
+  std::cout << "-> lpnorm[pedantic](3, o, n, o)        = " << eve::lpnorm[eve::pedantic](3, o, n, o) << "\n";
+  std::cout << "-> lpnorm[pedantic](3, n, o, o)        = " << eve::lpnorm[eve::pedantic](3, n, o, o) << "\n";
+  std::cout << "-> lpnorm[numeric ](3, o, o, n)        = " << eve::lpnorm[eve::numeric ](3, o, o, n) << "\n";
+  std::cout << "-> lpnorm[numeric](3, o, n, o)         = " << eve::lpnorm[eve::numeric](3, o, n, o) << "\n";
+  std::cout << "-> lpnorm[numeric](3, n, o, o)         = " << eve::lpnorm[eve::numeric](3, n, o, o) << "\n";
+  std::cout << "-> lpnorm          (3, o, o, n)        = " << eve::lpnorm(3, o, o, n) << "\n";
+  std::cout << "-> lpnorm          (3, o, n, o)        = " << eve::lpnorm(3, o, n, o) << "\n";
+  std::cout << "-> lpnorm          (3, n, o, o)        = " << eve::lpnorm(3, n, o, o) << "\n";
+  std::cout << "-> lpnorm(3, n, n, n)                  = " << eve::lpnorm(3, n, n, n) << "\n";
+  std::cout << "-> lpnorm(3, m, o, o)                  = " << eve::lpnorm(3, m, o, o)<< "\n";
+
+   return 0;
 }

--- a/test/unit/module/math/hypot.cpp
+++ b/test/unit/module/math/hypot.cpp
@@ -162,8 +162,8 @@ TTS_CASE_WITH("Check corner-cases behavior of eve::hypot variants on wide",
   TTS_IEEE_EQUAL(eve::hypot[eve::raw](cases.mzero, cases.mzero), T(0));
   TTS_IEEE_EQUAL(eve::hypot(cases.nan, a0), cases.nan);
   TTS_IEEE_EQUAL(eve::hypot(cases.minf, a0), cases.inf);
-  TTS_IEEE_EQUAL(eve::hypot(cases.nan, cases.minf), cases.inf);
-  TTS_IEEE_EQUAL(eve::hypot(cases.inf, cases.nan), cases.inf);
+  TTS_IEEE_EQUAL(eve::hypot(cases.nan, cases.minf), cases.nan);
+  TTS_IEEE_EQUAL(eve::hypot(cases.inf, cases.nan), cases.nan);
   TTS_IEEE_EQUAL(eve::hypot(cases.mzero, cases.mzero), T(0));
 #endif
                 };


### PR DESCRIPTION
force_if_any was meant to ignore nans is any param was inf. In fact in certainscases we need more : "ignore nans if the result after suppressing nans from the call would be inf". This pr brings correctives and some enhancements to the invloved functions, namely functions computing lp-norm like functions.