### PR TITLE
Fix #2353 - Improve popcount code generation on X86

### DIFF
--- a/include/eve/module/core/regular/impl/popcount.hpp
+++ b/include/eve/module/core/regular/impl/popcount.hpp
@@ -23,35 +23,7 @@ namespace eve::_
   template<typename T, callable_options O>
   EVE_FORCEINLINE constexpr auto popcount_(EVE_REQUIRES(cpu_), O const&, T x) noexcept
   {
-    if constexpr( scalar_value<T> )
-      return T(std::popcount(x));
-    else
-    {
-      constexpr auto siz = sizeof(eve::element_type_t<T>) * 8;
-      if constexpr( siz == 8 )
-      {
-        x -= ((x >> 1) & T(0x55));
-        x = ((x >> 2) & T(0x33)) + (x & T(0x33));
-        return ((x + (x >> 4)) & T(0xF));
-      }
-      else if constexpr( siz <= 16 )
-      {
-        x -= ((x >> 1) & T(0x5555));
-        x = ((x >> 2) & T(0x3333)) + (x & T(0x3333));
-        return ((((x + (x >> 4)) & T(0xF0F)) * T(0x101)) >> 8);
-      }
-      else if constexpr( siz == 32 )
-      {
-        x -= ((x >> 1) & T(0x55555555));
-        x = ((x >> 2) & T(0x33333333)) + (x & T(0x33333333));
-        return ((((x + (x >> 4)) & T(0xF0F0F0F)) * T(0x1010101)) >> 24);
-      }
-      else if constexpr( siz == 64 )
-      {
-        x -= (x >> 1) & T(0x5555555555555555ULL);
-        x = ((x >> 2) & T(0x3333333333333333ULL)) + (x & T(0x3333333333333333ULL));
-        return ((((x + (x >> 4)) & T(0xF0F0F0F0F0F0F0FULL)) * T(0x101010101010101ULL)) >> 56);
-      }
-    }
+    if constexpr( scalar_value<T> ) return T(std::popcount(x));
+    else                            return map(popcount,x);
   }
 }

--- a/include/eve/module/core/regular/impl/simd/x86/popcount.hpp
+++ b/include/eve/module/core/regular/impl/simd/x86/popcount.hpp
@@ -15,7 +15,7 @@
 
 namespace eve::_
 {
-  template<unsigned_scalar_value T, typename N, callable_options O>
+ template<unsigned_scalar_value T, typename N, callable_options O>
   EVE_FORCEINLINE auto popcount_(EVE_REQUIRES(sse2_), O const& o, wide<T, N> x) noexcept
   requires std::same_as<abi_t<T, N>, x86_128_>
   {
@@ -37,8 +37,12 @@ namespace eve::_
 
       __m128i count16 = _mm_add_epi16(count8, _mm_srli_epi16(count8, 8));
 
-      if constexpr (sizeof(T) == 2) return wide<T,N>{count16};
-      if constexpr (sizeof(T) == 4) return wide<T,N>{_mm_add_epi32(count16, _mm_srli_epi32(count16, 16))};
+      if constexpr (sizeof(T) == 2) return wide<T,N>{_mm_and_si128(count16, _mm_set1_epi16(0x00FF))};
+      if constexpr (sizeof(T) == 4)
+      {
+        __m128i count32 = _mm_add_epi32(count16, _mm_srli_epi32(count16, 16));
+        return wide<T,N>{_mm_and_si128(count32, _mm_set1_epi32(0x000000FF))};
+      }
     }
     else
     {
@@ -46,8 +50,6 @@ namespace eve::_
     }
   }
 
-  /////////////////////////////////////////////////////////////////////////////
-  // 256 bits
   template<unsigned_scalar_value T, typename N, callable_options O>
   EVE_FORCEINLINE auto popcount_(EVE_REQUIRES(avx_), O const& o, wide<T, N> x) noexcept
   requires std::same_as<abi_t<T, N>, x86_256_>
@@ -70,10 +72,14 @@ namespace eve::_
       if constexpr (sizeof(T) == 1) return wide<T,N>{count8};
       if constexpr (sizeof(T) == 8) return wide<T,N>{_mm256_sad_epu8(count8, _mm256_setzero_si256())};
 
-      __m256i count16 = _mm256_add_epi16(count8,_mm256_srli_epi16(count8, 8));
+      __m256i count16 = _mm256_add_epi16(count8, _mm256_srli_epi16(count8, 8));
 
-      if constexpr (sizeof(T) == 2) return wide<T,N>{count16};
-      if constexpr (sizeof(T) == 4) return wide<T,N>{_mm256_add_epi32(count16, _mm256_srli_epi32(count16, 16))};
+      if constexpr (sizeof(T) == 2) return wide<T,N>{_mm256_and_si256(count16, _mm256_set1_epi16(0x00FF))};
+      if constexpr (sizeof(T) == 4)
+      {
+        __m256i count32 = _mm256_add_epi32(count16, _mm256_srli_epi32(count16, 16));
+        return wide<T,N>{_mm256_and_si256(count32, _mm256_set1_epi32(0x000000FF))};
+      }
     }
     else
     {
@@ -82,11 +88,9 @@ namespace eve::_
     }
   }
 
-  /////////////////////////////////////////////////////////////////////////////
-  // 512 bits
   template<unsigned_scalar_value T, typename N, callable_options O>
   EVE_FORCEINLINE auto popcount_(EVE_REQUIRES(avx_), O const& o, wide<T, N> x) noexcept
-    requires std::same_as<abi_t<T, N>, x86_512_>
+  requires std::same_as<abi_t<T, N>, x86_512_>
   {
     if      constexpr (sizeof(T) == 1 && supports_avx512vl && supports_avx512bitalg_  ) return _mm512_popcnt_epi8(x);
     else if constexpr (sizeof(T) == 2 && supports_avx512vl && supports_avx512bitalg_  ) return _mm512_popcnt_epi16(x);

--- a/include/eve/module/core/regular/impl/simd/x86/popcount.hpp
+++ b/include/eve/module/core/regular/impl/simd/x86/popcount.hpp
@@ -25,32 +25,20 @@ namespace eve::_
     else if constexpr (sizeof(T) == 8 && supports_avx512vl && supports_avx512popcntdq_) return _mm_popcnt_epi64(x);
     else if constexpr (current_api >= eve::ssse3)
     {
-      if constexpr (sizeof(T) == 1)
-      {
-        wide<T,fixed<16>> const lut = {0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4};
-        wide<T,N> nibbles{15};
-        wide<T,N> lo_count{_mm_shuffle_epi8(lut, x & nibbles)};
-        wide<T,N> hi_count{_mm_shuffle_epi8(lut, _mm_and_si128(_mm_srli_epi16(x,4), nibbles))};
-        return lo_count + hi_count;
-      }
-      else if constexpr (sizeof(T) == 2)
-      {
-        constexpr as<typename wide<T,N>::template rebind<std::uint8_t, eve::fixed<16>>> tgt = {};
-        auto byte_counts = popcount(bit_cast(x,tgt));
-        return wide<T,N>{_mm_maddubs_epi16(byte_counts, one(tgt))};
-      }
-      else if constexpr (sizeof(T) == 4)
-      {
-        constexpr as<typename wide<T,N>::template rebind<std::uint16_t, eve::fixed<8>>> tgt = {};
-        auto byte_counts = popcount(bit_cast(x,tgt));
-        return wide<T,N>{_mm_madd_epi16(byte_counts, one(tgt))};
-      }
-      else// if constexpr (sizeof(T) == 8)
-      {
-        constexpr as<typename wide<T,N>::template rebind<std::uint8_t, eve::fixed<16>>> tgt = {};
-        auto byte_counts = popcount(bit_cast(x,tgt));
-        return wide<T,N>{_mm_sad_epu8(byte_counts, _mm_setzero_si128())};
-      }
+      __m128i lut  = _mm_setr_epi8(0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4);
+      __m128i mask = _mm_set1_epi8(0x0F);
+
+      __m128i lo_count = _mm_shuffle_epi8(lut, _mm_and_si128(x, mask));
+      __m128i hi_count = _mm_shuffle_epi8(lut, _mm_and_si128(_mm_srli_epi16(x, 4), mask));
+      __m128i count8   = _mm_add_epi8(lo_count, hi_count);
+
+      if constexpr (sizeof(T) == 1) return wide<T,N>{count8};
+      if constexpr (sizeof(T) == 8) return wide<T,N>{_mm_sad_epu8(count8, _mm_setzero_si128())};
+
+      __m128i count16 = _mm_maddubs_epi16(count8, _mm_set1_epi8(1));
+
+      if constexpr (sizeof(T) == 2) return wide<T,N>{count16};
+      if constexpr (sizeof(T) == 4) return wide<T,N>{_mm_madd_epi16(count16, _mm_set1_epi16(1))};
     }
     else
     {
@@ -60,7 +48,7 @@ namespace eve::_
 
   /////////////////////////////////////////////////////////////////////////////
   // 256 bits
-  template<unsigned_scalar_value T, typename N, callable_options O>
+template<unsigned_scalar_value T, typename N, callable_options O>
   EVE_FORCEINLINE auto popcount_(EVE_REQUIRES(avx_), O const& o, wide<T, N> x) noexcept
     requires std::same_as<abi_t<T, N>, x86_256_>
   {
@@ -70,41 +58,28 @@ namespace eve::_
     else if constexpr (sizeof(T) == 8 && supports_avx512vl && supports_avx512popcntdq_) return _mm256_popcnt_epi64(x);
     else if constexpr (current_api >= eve::avx2)
     {
-      if constexpr (sizeof(T) == 1)
-      {
-        // Repeat LUT bit counts to fit 32bits
-        wide<T,fixed<32>> const lut = { 0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4
-                                      , 0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4
-                                      };
-        wide<T,N> nibbles{15};
-        wide<T,N> lo_count{_mm256_shuffle_epi8(lut, x & nibbles)};
-        wide<T,N> hi_count{_mm256_shuffle_epi8(lut, _mm256_and_si256(_mm256_srli_epi16(x,4), nibbles))};
-        return lo_count + hi_count;
-      }
-      else if constexpr (sizeof(T) == 2)
-      {
-        constexpr as<typename wide<T,N>::template rebind<std::uint8_t, eve::fixed<32>>> tgt = {};
-        auto byte_counts = popcount(bit_cast(x,tgt));
-        return wide<T,N>{_mm256_maddubs_epi16(byte_counts, one(tgt))};
-      }
-      else if constexpr (sizeof(T) == 4)
-      {
-        constexpr as<typename wide<T,N>::template rebind<std::uint16_t, eve::fixed<16>>> tgt = {};
-        auto byte_counts = popcount(bit_cast(x,tgt));
-        return wide<T,N>{_mm256_madd_epi16(byte_counts, one(tgt))};
-      }
-      else// if constexpr (sizeof(T) == 8)
-      {
-        constexpr as<typename wide<T,N>::template rebind<std::uint8_t, eve::fixed<32>>> tgt = {};
-        auto byte_counts = popcount(bit_cast(x,tgt));
-        return wide<T,N>{_mm256_sad_epu8(byte_counts, _mm256_setzero_si256())};
-      }
+      // We broadcast the 128bits LUT as it generates better codegen than using _mm256_setr_epi8
+      __m128i lut_128 = _mm_setr_epi8(0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4);
+      __m256i lut     = _mm256_broadcastsi128_si256(lut_128);
+      __m256i mask    = _mm256_set1_epi8(0x0F);
+
+      __m256i lo_count = _mm256_shuffle_epi8(lut, _mm256_and_si256(x, mask));
+      __m256i hi_count = _mm256_shuffle_epi8(lut, _mm256_and_si256(_mm256_srli_epi16(x, 4), mask));
+      __m256i count8   = _mm256_add_epi8(lo_count, hi_count);
+
+      if constexpr (sizeof(T) == 1) return wide<T,N>{count8};
+      if constexpr (sizeof(T) == 8) return wide<T,N>{_mm256_sad_epu8(count8, _mm256_setzero_si256())};
+
+      __m256i count16 = _mm256_maddubs_epi16(count8, _mm256_set1_epi8(1));
+
+      if constexpr (sizeof(T) == 2) return wide<T,N>{count16};
+      if constexpr (sizeof(T) == 4) return wide<T,N>{_mm256_madd_epi16(count16, _mm256_set1_epi16(1))};
     }
     else
     {
       auto[l,h] = x.slice();
-      return wide<T,N>(popcount[o](l),popcount[o](h));
-     }
+      return wide<T,N>(popcount[o](l), popcount[o](h));
+    }
   }
 
   /////////////////////////////////////////////////////////////////////////////

--- a/include/eve/module/core/regular/impl/simd/x86/popcount.hpp
+++ b/include/eve/module/core/regular/impl/simd/x86/popcount.hpp
@@ -35,13 +35,13 @@ namespace eve::_
       if constexpr (sizeof(T) == 1) return wide<T,N>{count8};
       if constexpr (sizeof(T) == 8) return wide<T,N>{_mm_sad_epu8(count8, _mm_setzero_si128())};
 
-      __m128i count16 = _mm_add_epi16(count8, _mm_srli_epi16(count8, 8));
+      __m128i unmasked_count16 = _mm_add_epi16(count8, _mm_srli_epi16(count8, 8));
 
-      if constexpr (sizeof(T) == 2) return wide<T,N>{_mm_and_si128(count16, _mm_set1_epi16(0x00FF))};
+      if constexpr (sizeof(T) == 2) return wide<T,N>{_mm_and_si128(unmasked_count16, _mm_set1_epi16(0x00FF))};
       if constexpr (sizeof(T) == 4)
       {
-        __m128i count32 = _mm_add_epi32(count16, _mm_srli_epi32(count16, 16));
-        return wide<T,N>{_mm_and_si128(count32, _mm_set1_epi32(0x000000FF))};
+        __m128i unmasked_count32 = _mm_add_epi32(unmasked_count16, _mm_srli_epi32(unmasked_count16, 16));
+        return wide<T,N>{_mm_and_si128(unmasked_count32, _mm_set1_epi32(0x000000FF))};
       }
     }
     else
@@ -72,13 +72,13 @@ namespace eve::_
       if constexpr (sizeof(T) == 1) return wide<T,N>{count8};
       if constexpr (sizeof(T) == 8) return wide<T,N>{_mm256_sad_epu8(count8, _mm256_setzero_si256())};
 
-      __m256i count16 = _mm256_add_epi16(count8, _mm256_srli_epi16(count8, 8));
+      __m256i unmasked_count16 = _mm256_add_epi16(count8, _mm256_srli_epi16(count8, 8));
 
-      if constexpr (sizeof(T) == 2) return wide<T,N>{_mm256_and_si256(count16, _mm256_set1_epi16(0x00FF))};
+      if constexpr (sizeof(T) == 2) return wide<T,N>{_mm256_and_si256(unmasked_count16, _mm256_set1_epi16(0x00FF))};
       if constexpr (sizeof(T) == 4)
       {
-        __m256i count32 = _mm256_add_epi32(count16, _mm256_srli_epi32(count16, 16));
-        return wide<T,N>{_mm256_and_si256(count32, _mm256_set1_epi32(0x000000FF))};
+        __m256i unmasked_count32 = _mm256_add_epi32(unmasked_count16, _mm256_srli_epi32(unmasked_count16, 16));
+        return wide<T,N>{_mm256_and_si256(unmasked_count32, _mm256_set1_epi32(0x000000FF))};
       }
     }
     else

--- a/include/eve/module/core/regular/impl/simd/x86/popcount.hpp
+++ b/include/eve/module/core/regular/impl/simd/x86/popcount.hpp
@@ -35,19 +35,19 @@ namespace eve::_
       }
       else if constexpr (sizeof(T) == 2)
       {
-        constexpr as<wide<std::uint8_t, eve::fixed<16>>> tgt = {};
+        constexpr as<typename wide<T,N>::template rebind<std::uint8_t, eve::fixed<16>>> tgt = {};
         auto byte_counts = popcount(bit_cast(x,tgt));
         return wide<T,N>{_mm_maddubs_epi16(byte_counts, one(tgt))};
       }
       else if constexpr (sizeof(T) == 4)
       {
-        constexpr as<wide<std::uint16_t, eve::fixed<8>>> tgt = {};
+        constexpr as<typename wide<T,N>::template rebind<std::uint16_t, eve::fixed<8>>> tgt = {};
         auto byte_counts = popcount(bit_cast(x,tgt));
         return wide<T,N>{_mm_madd_epi16(byte_counts, one(tgt))};
       }
       else// if constexpr (sizeof(T) == 8)
       {
-        constexpr as<wide<std::uint8_t, eve::fixed<16>>> tgt = {};
+        constexpr as<typename wide<T,N>::template rebind<std::uint8_t, eve::fixed<16>>> tgt = {};
         auto byte_counts = popcount(bit_cast(x,tgt));
         return wide<T,N>{_mm_sad_epu8(byte_counts, _mm_setzero_si128())};
       }
@@ -83,19 +83,19 @@ namespace eve::_
       }
       else if constexpr (sizeof(T) == 2)
       {
-        constexpr as<wide<std::uint8_t, eve::fixed<32>>> tgt = {};
+        constexpr as<typename wide<T,N>::template rebind<std::uint8_t, eve::fixed<32>>> tgt = {};
         auto byte_counts = popcount(bit_cast(x,tgt));
         return wide<T,N>{_mm256_maddubs_epi16(byte_counts, one(tgt))};
       }
       else if constexpr (sizeof(T) == 4)
       {
-        constexpr as<wide<std::uint16_t, eve::fixed<16>>> tgt = {};
+        constexpr as<typename wide<T,N>::template rebind<std::uint16_t, eve::fixed<16>>> tgt = {};
         auto byte_counts = popcount(bit_cast(x,tgt));
         return wide<T,N>{_mm256_madd_epi16(byte_counts, one(tgt))};
       }
       else// if constexpr (sizeof(T) == 8)
       {
-        constexpr as<wide<std::uint8_t, eve::fixed<32>>> tgt = {};
+        constexpr as<typename wide<T,N>::template rebind<std::uint8_t, eve::fixed<32>>> tgt = {};
         auto byte_counts = popcount(bit_cast(x,tgt));
         return wide<T,N>{_mm256_sad_epu8(byte_counts, _mm256_setzero_si256())};
       }

--- a/include/eve/module/core/regular/impl/simd/x86/popcount.hpp
+++ b/include/eve/module/core/regular/impl/simd/x86/popcount.hpp
@@ -12,49 +12,49 @@
 #include <eve/detail/implementation.hpp>
 #include <eve/forward.hpp>
 #include <eve/module/core/regular/bit_cast.hpp>
-#include <eve/module/core/regular/bit_shr.hpp>
-#include <eve/module/core/regular/if_else.hpp>
-#include <eve/module/core/regular/shr.hpp>
-
-#if defined(SPY_COMPILER_IS_MSVC)
-#  include <intrin.h>
-#endif
 
 namespace eve::_
 {
-  template<auto S, typename T, typename N>
-  EVE_FORCEINLINE auto putcounts(wide<T, N> in)
-  {
-    using i8_t = typename wide<T,N>::template rebind<std::uint8_t, fixed<S>>;
-
-    const i8_t pattern_2bit(0x55);
-    const i8_t pattern_4bit(0x33);
-    const i8_t pattern_16bit(0x0f);
-    auto xx = bit_cast(in, as<i8_t>()); // put
-
-    xx -= bit_shr(xx, 1) & pattern_2bit; // put
-    xx  = (xx & pattern_4bit) + (bit_shr(xx, 2) & pattern_4bit);
-    xx  = (xx + bit_shr(xx, 4)) & pattern_16bit; // put count of each 8 bits into those 8 bits
-
-    return bit_cast(xx,as(in));
-  };
-
   template<unsigned_scalar_value T, typename N, callable_options O>
-  EVE_FORCEINLINE auto popcount_(EVE_REQUIRES(sse2_), O const& opts, wide<T, N> x) noexcept
-    requires std::same_as<abi_t<T, N>, x86_128_>
+  EVE_FORCEINLINE auto popcount_(EVE_REQUIRES(sse2_), O const& o, wide<T, N> x) noexcept
+  requires std::same_as<abi_t<T, N>, x86_128_>
   {
-    if constexpr (sizeof(T) == 8)
+    if      constexpr (sizeof(T) == 1 && supports_avx512vl && supports_avx512bitalg_  ) return _mm_popcnt_epi8(x);
+    else if constexpr (sizeof(T) == 2 && supports_avx512vl && supports_avx512bitalg_  ) return _mm_popcnt_epi16(x);
+    else if constexpr (sizeof(T) == 4 && supports_avx512vl && supports_avx512popcntdq_) return _mm_popcnt_epi32(x);
+    else if constexpr (sizeof(T) == 8 && supports_avx512vl && supports_avx512popcntdq_) return _mm_popcnt_epi64(x);
+    else if constexpr (current_api >= eve::ssse3)
     {
-      using r_t = wide<T, N>;
-      using u16_t = typename wide<T,N>::template rebind<std::uint16_t, fixed<8>>;
-
-      auto xx = bit_cast(x, as<u16_t>());
-
-      return bit_cast(_mm_sad_epu8(putcounts<16>(xx), _mm_setzero_si128()), as<r_t>());
+      if constexpr (sizeof(T) == 1)
+      {
+        wide<T,fixed<16>> const lut = {0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4};
+        wide<T,N> nibbles{15};
+        wide<T,N> lo_count{_mm_shuffle_epi8(lut, x & nibbles)};
+        wide<T,N> hi_count{_mm_shuffle_epi8(lut, _mm_and_si128(_mm_srli_epi16(x,4), nibbles))};
+        return lo_count + hi_count;
+      }
+      else if constexpr (sizeof(T) == 2)
+      {
+        constexpr as<wide<std::uint8_t, eve::fixed<16>>> tgt = {};
+        auto byte_counts = popcount(bit_cast(x,tgt));
+        return wide<T,N>{_mm_maddubs_epi16(byte_counts, one(tgt))};
+      }
+      else if constexpr (sizeof(T) == 4)
+      {
+        constexpr as<wide<std::uint16_t, eve::fixed<8>>> tgt = {};
+        auto byte_counts = popcount(bit_cast(x,tgt));
+        return wide<T,N>{_mm_madd_epi16(byte_counts, one(tgt))};
+      }
+      else// if constexpr (sizeof(T) == 8)
+      {
+        constexpr as<wide<std::uint8_t, eve::fixed<16>>> tgt = {};
+        auto byte_counts = popcount(bit_cast(x,tgt));
+        return wide<T,N>{_mm_sad_epu8(byte_counts, _mm_setzero_si128())};
+      }
     }
     else
     {
-      return popcount.behavior(cpu_{}, opts, x);
+      return popcount.behavior(cpu_{}, o, x);
     }
   }
 
@@ -64,26 +64,63 @@ namespace eve::_
   EVE_FORCEINLINE auto popcount_(EVE_REQUIRES(avx_), O const& o, wide<T, N> x) noexcept
     requires std::same_as<abi_t<T, N>, x86_256_>
   {
-    using r_t = wide<T, N>;
-
-    if constexpr (sizeof(T) == 8)
+    if      constexpr (sizeof(T) == 1 && supports_avx512vl && supports_avx512bitalg_  ) return _mm256_popcnt_epi8(x);
+    else if constexpr (sizeof(T) == 2 && supports_avx512vl && supports_avx512bitalg_  ) return _mm256_popcnt_epi16(x);
+    else if constexpr (sizeof(T) == 4 && supports_avx512vl && supports_avx512popcntdq_) return _mm256_popcnt_epi32(x);
+    else if constexpr (sizeof(T) == 8 && supports_avx512vl && supports_avx512popcntdq_) return _mm256_popcnt_epi64(x);
+    else if constexpr (current_api >= eve::avx2)
     {
-      if constexpr (current_api >= avx2)
+      if constexpr (sizeof(T) == 1)
       {
-        using u16_t = typename wide<T,N>::template rebind<std::uint16_t, fixed<16>>;
-        auto xx = bit_cast(x, as<u16_t>());
-
-        return bit_cast(_mm256_sad_epu8(putcounts<32>(xx), _mm256_setzero_si256()), as<r_t>());
+        // Repeat LUT bit counts to fit 32bits
+        wide<T,fixed<32>> const lut = { 0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4
+                                      , 0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4
+                                      };
+        wide<T,N> nibbles{15};
+        wide<T,N> lo_count{_mm256_shuffle_epi8(lut, x & nibbles)};
+        wide<T,N> hi_count{_mm256_shuffle_epi8(lut, _mm256_and_si256(_mm256_srli_epi16(x,4), nibbles))};
+        return lo_count + hi_count;
       }
-      else
+      else if constexpr (sizeof(T) == 2)
       {
-        auto [lo, hi] = x.slice();
-        return r_t{popcount(lo), popcount(hi)};
+        constexpr as<wide<std::uint8_t, eve::fixed<32>>> tgt = {};
+        auto byte_counts = popcount(bit_cast(x,tgt));
+        return wide<T,N>{_mm256_maddubs_epi16(byte_counts, one(tgt))};
+      }
+      else if constexpr (sizeof(T) == 4)
+      {
+        constexpr as<wide<std::uint16_t, eve::fixed<16>>> tgt = {};
+        auto byte_counts = popcount(bit_cast(x,tgt));
+        return wide<T,N>{_mm256_madd_epi16(byte_counts, one(tgt))};
+      }
+      else// if constexpr (sizeof(T) == 8)
+      {
+        constexpr as<wide<std::uint8_t, eve::fixed<32>>> tgt = {};
+        auto byte_counts = popcount(bit_cast(x,tgt));
+        return wide<T,N>{_mm256_sad_epu8(byte_counts, _mm256_setzero_si256())};
       }
     }
     else
     {
-      return popcount.behavior(cpu_{}, o, x);
+      auto[l,h] = x.slice();
+      return wide<T,N>(popcount[o](l),popcount[o](h));
+     }
+  }
+
+  /////////////////////////////////////////////////////////////////////////////
+  // 512 bits
+  template<unsigned_scalar_value T, typename N, callable_options O>
+  EVE_FORCEINLINE auto popcount_(EVE_REQUIRES(avx_), O const& o, wide<T, N> x) noexcept
+    requires std::same_as<abi_t<T, N>, x86_512_>
+  {
+    if      constexpr (sizeof(T) == 1 && supports_avx512vl && supports_avx512bitalg_  ) return _mm512_popcnt_epi8(x);
+    else if constexpr (sizeof(T) == 2 && supports_avx512vl && supports_avx512bitalg_  ) return _mm512_popcnt_epi16(x);
+    else if constexpr (sizeof(T) == 4 && supports_avx512vl && supports_avx512popcntdq_) return _mm512_popcnt_epi32(x);
+    else if constexpr (sizeof(T) == 8 && supports_avx512vl && supports_avx512popcntdq_) return _mm512_popcnt_epi64(x);
+    else
+    {
+      auto[l,h] = x.slice();
+      return wide<T,N>(popcount[o](l),popcount[o](h));
     }
   }
 }

--- a/include/eve/module/core/regular/impl/simd/x86/popcount.hpp
+++ b/include/eve/module/core/regular/impl/simd/x86/popcount.hpp
@@ -35,10 +35,10 @@ namespace eve::_
       if constexpr (sizeof(T) == 1) return wide<T,N>{count8};
       if constexpr (sizeof(T) == 8) return wide<T,N>{_mm_sad_epu8(count8, _mm_setzero_si128())};
 
-      __m128i count16 = _mm_maddubs_epi16(count8, _mm_set1_epi8(1));
+      __m128i count16 = _mm_add_epi16(count8, _mm_srli_epi16(count8, 8));
 
       if constexpr (sizeof(T) == 2) return wide<T,N>{count16};
-      if constexpr (sizeof(T) == 4) return wide<T,N>{_mm_madd_epi16(count16, _mm_set1_epi16(1))};
+      if constexpr (sizeof(T) == 4) return wide<T,N>{_mm_add_epi32(count16, _mm_srli_epi32(count16, 16))};
     }
     else
     {
@@ -48,9 +48,9 @@ namespace eve::_
 
   /////////////////////////////////////////////////////////////////////////////
   // 256 bits
-template<unsigned_scalar_value T, typename N, callable_options O>
+  template<unsigned_scalar_value T, typename N, callable_options O>
   EVE_FORCEINLINE auto popcount_(EVE_REQUIRES(avx_), O const& o, wide<T, N> x) noexcept
-    requires std::same_as<abi_t<T, N>, x86_256_>
+  requires std::same_as<abi_t<T, N>, x86_256_>
   {
     if      constexpr (sizeof(T) == 1 && supports_avx512vl && supports_avx512bitalg_  ) return _mm256_popcnt_epi8(x);
     else if constexpr (sizeof(T) == 2 && supports_avx512vl && supports_avx512bitalg_  ) return _mm256_popcnt_epi16(x);
@@ -70,10 +70,10 @@ template<unsigned_scalar_value T, typename N, callable_options O>
       if constexpr (sizeof(T) == 1) return wide<T,N>{count8};
       if constexpr (sizeof(T) == 8) return wide<T,N>{_mm256_sad_epu8(count8, _mm256_setzero_si256())};
 
-      __m256i count16 = _mm256_maddubs_epi16(count8, _mm256_set1_epi8(1));
+      __m256i count16 = _mm256_add_epi16(count8,_mm256_srli_epi16(count8, 8));
 
       if constexpr (sizeof(T) == 2) return wide<T,N>{count16};
-      if constexpr (sizeof(T) == 4) return wide<T,N>{_mm256_madd_epi16(count16, _mm256_set1_epi16(1))};
+      if constexpr (sizeof(T) == 4) return wide<T,N>{_mm256_add_epi32(count16, _mm256_srli_epi32(count16, 16))};
     }
     else
     {

--- a/test/unit/module/core/popcount.cpp
+++ b/test/unit/module/core/popcount.cpp
@@ -24,6 +24,38 @@ TTS_CASE_TPL("Check return types of eve::popcount(simd)", eve::test::simd::unsig
 //==================================================================================================
 // Tests for eve::popcount
 //==================================================================================================
+TTS_CASE_TPL( "Pseudo-exhaustive behavior check of eve::popcount(simd)"
+            , eve::test::scalar::unsigned_integers
+            )
+<typename T>(tts::type<T>)
+{
+  if constexpr(sizeof(T) < 4)
+  {
+    eve::wide<T> bits = eve::iota(eve::as<eve::wide<T>>{});
+    constexpr T offset = eve::wide<T>::size();
+
+    while(eve::all(bits < eve::allbits(eve::as<T>{})))
+    {
+      TTS_EQUAL(eve::popcount(bits), tts::map([](T e) -> T { return std::popcount(e); }, bits));
+      bits += offset;
+    }
+  }
+  else
+  {
+    TTS_EQUAL(eve::popcount(eve::wide<T>{0}), eve::wide<T>{0});
+    TTS_EQUAL(eve::popcount(eve::allbits(eve::as<eve::wide<T>>{})), eve::wide<T>{8*sizeof(T)});
+
+    constexpr T base = 15;
+    eve::wide<T> bits{base / (1+eve::iota(eve::as<eve::wide<T>>{}))};
+
+    for(std::size_t i=0;i<(8*sizeof(T)-1);++i)
+    {
+      TTS_EQUAL(eve::popcount(bits), tts::map([](T e) -> T { return std::popcount(e); }, bits));
+      bits = eve::rotl(bits,1);
+    }
+  }
+};
+
 TTS_CASE_WITH("Check behavior of eve::popcount(simd)",
               eve::test::simd::unsigned_integers,
               tts::generate(tts::randoms(eve::valmin, eve::valmax), tts::logicals(0, 3)))


### PR DESCRIPTION
As per #2353 bug report, this improves X86 popcoutn codegen : 
  + Use a LUT based approach for pre-AVX512 implementation
  + Redierct to AVX512 popcnt intrinsic whenever possible
  + Use slice/combine trick for case like AVX or pre BITALG/PCNT AVX512