### PR TITLE
Add compile-time subscript indices

### DIFF
--- a/include/eve/arch/cpu/logical_wide.hpp
+++ b/include/eve/arch/cpu/logical_wide.hpp
@@ -391,8 +391,20 @@ namespace eve
       _::insert(*this, i, v);
     }
 
+    template<std::ptrdiff_t I>
+    EVE_FORCEINLINE void set(index_t<I> i, std::convertible_to<bool> auto v) noexcept
+    {
+      _::insert(*this, i, v);
+    }
+
     //! Retrieve the value from a given lane
     EVE_FORCEINLINE auto get(std::size_t i) const noexcept
+    {
+      return _::extract(*this, i);
+    }
+
+    template<std::ptrdiff_t I>
+    EVE_FORCEINLINE auto get(index_t<I> i) const noexcept
     {
       return _::extract(*this, i);
     }

--- a/include/eve/arch/cpu/wide.hpp
+++ b/include/eve/arch/cpu/wide.hpp
@@ -327,8 +327,17 @@ namespace eve
       _::insert(*this, i, v);
     }
 
+    template<std::ptrdiff_t I>
+    EVE_FORCEINLINE void set(index_t<I> i, scalar_value auto v) noexcept
+    {
+      _::insert(*this, i, v);
+    }
+
     //! Retrieve the value from a given lane
     EVE_FORCEINLINE Type get(std::size_t i) const noexcept { return _::extract(*this, i); }
+
+    template<std::ptrdiff_t I>
+    EVE_FORCEINLINE Type get(index_t<I> i) const noexcept { return _::extract(*this, i); }
 
     //! Retrieve the value from the last lane
     EVE_FORCEINLINE Type back() const noexcept { return get(Cardinal::value - 1); }

--- a/include/eve/detail/function/subscript.hpp
+++ b/include/eve/detail/function/subscript.hpp
@@ -20,6 +20,12 @@ namespace eve::_
       return EVE_DISPATCH_CALL_NT(translate_ref(w), idx, v);
     }
 
+    template<typename Wide, std::ptrdiff_t I, typename Val>
+    EVE_FORCEINLINE constexpr void operator()(Wide& w, index_t<I> idx, Val v) const noexcept
+    {
+      return EVE_DISPATCH_CALL_NT(translate_ref(w), idx, v);
+    }
+
     EVE_CALLABLE_OBJECT(insert_t, insert_);
   };
 
@@ -30,6 +36,12 @@ namespace eve::_
   {
     template<typename Wide>
     EVE_FORCEINLINE constexpr element_type_t<Wide> operator()(Wide w, std::size_t idx) const noexcept
+    {
+      return EVE_DISPATCH_CALL(w, idx);
+    }
+
+    template<typename Wide, std::ptrdiff_t I>
+    EVE_FORCEINLINE constexpr element_type_t<Wide> operator()(Wide w, index_t<I> idx) const noexcept
     {
       return EVE_DISPATCH_CALL(w, idx);
     }

--- a/test/unit/api/regular/wide.cpp
+++ b/test/unit/api/regular/wide.cpp
@@ -291,6 +291,33 @@ TTS_CASE_TPL("Check eve::wide insert/set", eve::test::simd::all_types)
 };
 
 //==================================================================================================
+// Compile-time extract and insert
+//==================================================================================================
+TTS_CASE_TPL("Check eve::wide extract/get and insert/set with compile-time indices",
+             eve::test::simd::all_types)
+<typename T>(tts::type<T>)
+{
+  using v_t = typename T::value_type;
+
+  T data { 0 };
+  data.set(eve::index<0>, v_t{42});
+  TTS_EQUAL(data.get(eve::index<0>), v_t{42});
+
+  eve::logical<T> logical_data { false };
+  logical_data.set(eve::index<0>, true);
+  TTS_EQUAL(logical_data.get(eve::index<0>), true);
+
+  if constexpr(T::size() > 1)
+  {
+    data.set(eve::index<1>, v_t{7});
+    TTS_EQUAL(data.get(eve::index<1>), v_t{7});
+
+    logical_data.set(eve::index<1>, true);
+    TTS_EQUAL(logical_data.get(eve::index<1>), true);
+  }
+};
+
+//==================================================================================================
 // Split/Combine
 //==================================================================================================
 template<typename T>


### PR DESCRIPTION
Closes #2362.

Adds `index_t` overloads to the subscript dispatch points and forwards them through `wide::get`/`set` and `logical<wide>::get`/`set`. This keeps the runtime-index overloads unchanged while allowing architecture-specific implementations to recognize a compile-time lane index.

The added API test covers numeric and logical wides at lanes 0 and 1.

Validation:
- `git diff --check`

I could not run the unit binary locally because this host has no C++ compiler or CMake installation. The PR unit workflow builds `unit.api` across the supported toolchains.