### PR TITLE
add compile-time indexes to insert and extract

### DIFF
--- a/include/eve/detail/function/simd/common/subscript.hpp
+++ b/include/eve/detail/function/simd/common/subscript.hpp
@@ -49,6 +49,12 @@ namespace eve::_
     }
   }
 
+  template<callable_options O, typename Wide, std::ptrdiff_t I>
+  EVE_FORCEINLINE auto extract_(EVE_REQUIRES(cpu_), O const&, Wide p, index_t<I>) noexcept
+  {
+    return extract(p, static_cast<std::size_t>(I));
+  }
+
   //================================================================================================
   // Insert value
   //================================================================================================
@@ -96,5 +102,11 @@ namespace eve::_
       std::memcpy((char*)(&p),(char*)(&data[0]),sizeof(data));
       EVE_RESTORE_ALLOW_UNINITIALIZED_VARIABLES_PRAGMA
     }
+  }
+
+  template<callable_options O, typename Wide, std::ptrdiff_t I, typename Value>
+  EVE_FORCEINLINE void insert_(EVE_REQUIRES(cpu_), O const&, Wide& p, index_t<I>, Value v) noexcept
+  {
+    insert(p, static_cast<std::size_t>(I), v);
   }
 }

--- a/include/eve/detail/function/subscript.hpp
+++ b/include/eve/detail/function/subscript.hpp
@@ -20,6 +20,12 @@ namespace eve::_
       return EVE_DISPATCH_CALL_NT(translate_ref(w), idx, v);
     }
 
+    template<typename Wide, std::ptrdiff_t I, typename Val>
+    EVE_FORCEINLINE constexpr void operator()(Wide& w, index_t<I> idx, Val v) const noexcept
+    {
+      return EVE_DISPATCH_CALL_NT(translate_ref(w), idx, v);
+    }
+
     EVE_CALLABLE_OBJECT(insert_t, insert_);
   };
 
@@ -30,6 +36,12 @@ namespace eve::_
   {
     template<typename Wide>
     EVE_FORCEINLINE constexpr element_type_t<Wide> operator()(Wide w, std::size_t idx) const noexcept
+    {
+      return EVE_DISPATCH_CALL(w, idx);
+    }
+
+    template<typename Wide, std::ptrdiff_t I>
+    EVE_FORCEINLINE constexpr element_type_t<Wide> operator()(Wide w, index_t<I> idx) const noexcept
     {
       return EVE_DISPATCH_CALL(w, idx);
     }

--- a/test/unit/api/regular/wide.cpp
+++ b/test/unit/api/regular/wide.cpp
@@ -264,6 +264,9 @@ TTS_CASE_TPL("Check eve::wide insert/set", eve::test::simd::all_types)
   {
     T data { 0 };
 
+    eve::_::insert(data, eve::index_t<0>{}, static_cast<v_t>(42));
+    TTS_EQUAL(eve::_::extract(data, eve::index_t<0>{}), static_cast<v_t>(42));
+
     for (std::ptrdiff_t i = 0; i < T::size(); ++i)
     {
       data.set(i, static_cast<v_t>(1 + i));


### PR DESCRIPTION
## what changed

insert and extract now accept eve::index_t for compile-time lane indexes. the common implementation forwards to the existing runtime path for now, while leaving room for architecture-specific implementations.

## why

a compile-time lane index gives the implementation enough information to specialize this operation on architectures where that helps.

## checks

- git diff --check passes.
- the local machine does not have cmake or a c++ compiler installed, so repository ci will do the native validation.

fixes #2362