### PR TITLE
Fix RVV headers relying on include order for names they never declare

### DIFF
--- a/include/eve/arch/riscv/rvv_utils.hpp
+++ b/include/eve/arch/riscv/rvv_utils.hpp
@@ -8,6 +8,13 @@
 #pragma once
 #if defined(EVE_INCLUDE_RISCV_HEADER)
 
+#  include <eve/arch/cardinals.hpp>
+#  include <eve/concept/scalar.hpp>
+#  include <eve/detail/wide_forward.hpp>
+
+#  include <algorithm>
+#  include <cstddef>
+
 #  ifndef __riscv_v_fixed_vlen
 #    error __riscv_v_fixed_vlen must be defined
 #  endif

--- a/include/eve/detail/function/simd/riscv/combine.hpp
+++ b/include/eve/detail/function/simd/riscv/combine.hpp
@@ -9,6 +9,7 @@
 
 #include <eve/arch.hpp>
 #include <eve/detail/abi.hpp>
+#include <eve/forward.hpp>
 
 namespace eve::_
 {
@@ -27,8 +28,8 @@ requires rvv_abi<abi_t<T, N>>
   }
   else
   {
-    auto           wider_l        = simd_cast(l, as<that_t> {});
-    auto           wider_h        = simd_cast(h, as<that_t> {});
+    auto           wider_l        = call_simd_cast(l, as<that_t> {});
+    auto           wider_h        = call_simd_cast(h, as<that_t> {});
     constexpr auto shift_size     = N::value;
     constexpr size_t combined_vl    = N::combined_type::value;
     that_t         wider_h_placed = __riscv_vslideup(wider_h, wider_h, shift_size, combined_vl);

--- a/include/eve/detail/function/simd/riscv/make.hpp
+++ b/include/eve/detail/function/simd/riscv/make.hpp
@@ -15,6 +15,7 @@
 #include <eve/detail/category.hpp>
 #include <eve/detail/function/load.hpp>
 #include <eve/detail/meta.hpp>
+#include <eve/forward.hpp>
 #include <eve/module/core/regular/safe.hpp>
 #include <eve/traits/as_integer.hpp>
 
@@ -173,9 +174,9 @@ requires rvv_abi<abi_t<T, N>>
     auto tgt          = as<wide<e_t, fundamental_cardinal<T>>> {};
     auto full_bits    = bit_cast(bits, tgt);
     auto full_logical = full_bits > static_cast<e_t>(0);
-    return simd_cast(full_logical, logic_tgt);
+    return call_simd_cast(full_logical, logic_tgt);
   }
-  else return simd_cast(bits > static_cast<e_t>(0), logic_tgt);
+  else return call_simd_cast(bits > static_cast<e_t>(0), logic_tgt);
 }
 
 }

--- a/include/eve/detail/function/simd/riscv/slice.hpp
+++ b/include/eve/detail/function/simd/riscv/slice.hpp
@@ -7,9 +7,10 @@
 //==================================================================================================
 #pragma once
 
+#include <eve/arch/riscv/rvv_utils.hpp>
 #include <eve/detail/category.hpp>
 #include <eve/detail/implementation.hpp>
-#include <eve/module/core/regular/simd_cast.hpp>
+#include <eve/forward.hpp>
 
 // Return first or second part of vector.
 
@@ -28,7 +29,7 @@ requires rvv_abi<abi_t<T, N>>
   constexpr auto in_lmul  = rvv_lmul_v<T, N>;
   constexpr auto out_lmul = rvv_lmul_v<T, typename N::split_type>;
   if constexpr( in_lmul == out_lmul ) return a.storage();
-  else { return simd_cast(a, as<wide<T, typename N::split_type>> {}); }
+  else { return call_simd_cast(a, as<wide<T, typename N::split_type>> {}); }
 }
 
 template<callable_options O, typename T, typename N>
@@ -44,7 +45,7 @@ requires rvv_abi<abi_t<T, N>>
   else
   {
     // we need to lower lmul - call lmul trunc.
-    return simd_cast(res, as<wide<T, typename N::split_type>> {});
+    return call_simd_cast(res, as<wide<T, typename N::split_type>> {});
   }
 }
 
@@ -53,7 +54,7 @@ EVE_FORCEINLINE logical<wide<T, typename N::split_type>>
                 slice_(EVE_REQUIRES(rvv_), O const&, logical<wide<T, N>> a, lower_slice_t) noexcept
 requires rvv_abi<abi_t<T, N>>
 {
-  return simd_cast(a, as<logical<wide<T, typename N::split_type>>> {});
+  return call_simd_cast(a, as<logical<wide<T, typename N::split_type>>> {});
 }
 
 template<callable_options O, typename T, typename N>
@@ -64,7 +65,7 @@ requires rvv_abi<abi_t<T, N>>
   auto bits_slice = a.bits().slice(upper_slice_t {});
   // TODO: could be improved when `simd_cast` for RISC-V will support casts between logical-wide.
   auto neq = bits_slice != 0;
-  return simd_cast(neq, as<logical<wide<T, typename N::split_type>>> {});
+  return call_simd_cast(neq, as<logical<wide<T, typename N::split_type>>> {});
 }
 
 //================================================================================================


### PR DESCRIPTION
`rvv_utils.hpp` used `plain_scalar_value`, `wide` and `fixed` while including nothing at all, so a translation unit starting from `<eve/wide.hpp>` failed outright on RISC-V. `combine.hpp` and make.hpp called simd_cast with no declaration in scope.

Both now go through `eve::_::call_simd_cast`. 

`slice.hpp` reached the same symbol by including the module-level `simd_cast.hpp` directly.

This makes every example but `start_here.cpp` compile for RVV, where most of them did not before.