### PR TITLE
Cover the functions and constants that had no test

### DIFF
--- a/include/eve/module/math/regular/rempio2.hpp
+++ b/include/eve/module/math/regular/rempio2.hpp
@@ -62,7 +62,10 @@ namespace eve
 //!
 //! **Parameters**
 //!
-//!    * `x`: [floating value](@ref eve::floating_value).
+//!    * `x`: [floating value](@ref eve::floating_value), which must be non negative. The
+//!           reduction is written for magnitudes, and the library always calls it on
+//!           `eve::abs(x)`. A negative argument is returned unchanged with a zero quadrant
+//!           instead of being reduced.
 //!    * `c`: [Conditional expression](@ref eve::conditional_expr) masking the operation.
 //!    * `m`: [Logical value](@ref eve::logical_value) masking the operation.
 //!

--- a/test/unit/module/core/constant/max_safe_integer.cpp
+++ b/test/unit/module/core/constant/max_safe_integer.cpp
@@ -1,0 +1,45 @@
+//==================================================================================================
+/**
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+**/
+//==================================================================================================
+#include "test.hpp"
+
+#include <eve/module/core.hpp>
+
+//==================================================================================================
+// Types tests
+//==================================================================================================
+TTS_CASE_TPL("Check return types of max_safe_integer", eve::test::simd::ieee_reals)
+<typename T>(tts::type<T>)
+{
+  using v_t = eve::element_type_t<T>;
+  using eve::as;
+
+  TTS_EXPR_IS(eve::max_safe_integer(as<T>()), T);
+  TTS_EXPR_IS(eve::max_safe_integer(as<v_t>()), v_t);
+};
+
+//==================================================================================================
+// max_safe_integer is defined by its relation to the constants it derives from
+//==================================================================================================
+TTS_CASE_TPL("Check behavior of max_safe_integer", eve::test::simd::ieee_reals)
+<typename T>(tts::type<T>)
+{
+  using eve::as;
+  TTS_EQUAL(eve::max_safe_integer(as<T>()), eve::maxflint(as<T>()) - 1);
+};
+
+//==================================================================================================
+// masked max_safe_integer
+//==================================================================================================
+TTS_CASE_WITH("Check behavior of max_safe_integer[mask] on wide",
+              eve::test::simd::ieee_reals,
+              tts::generate(tts::randoms(eve::valmin, eve::valmax),
+              tts::logicals(0, 3)))
+<typename T, typename M>(T const& a0, M const& mask)
+{
+  TTS_IEEE_EQUAL(eve::max_safe_integer[mask](eve::as(a0)), eve::if_else(mask, eve::max_safe_integer(eve::as(a0)), eve::zero));
+};

--- a/test/unit/module/core/constant/maxrepint.cpp
+++ b/test/unit/module/core/constant/maxrepint.cpp
@@ -1,0 +1,46 @@
+//==================================================================================================
+/**
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+**/
+//==================================================================================================
+#include "test.hpp"
+
+#include <eve/module/core.hpp>
+
+//==================================================================================================
+// Types tests
+//==================================================================================================
+TTS_CASE_TPL("Check return types of maxrepint", eve::test::simd::all_types)
+<typename T>(tts::type<T>)
+{
+  using v_t = eve::element_type_t<T>;
+  using eve::as;
+
+  TTS_EXPR_IS(eve::maxrepint(as<T>()), T);
+  TTS_EXPR_IS(eve::maxrepint(as<v_t>()), v_t);
+};
+
+//==================================================================================================
+// maxrepint is defined by its relation to the constants it derives from
+//==================================================================================================
+TTS_CASE_TPL("Check behavior of maxrepint", eve::test::simd::all_types)
+<typename T>(tts::type<T>)
+{
+  using eve::as;
+  if constexpr( eve::integral_value<T> ) TTS_EQUAL(eve::maxrepint(as<T>()), eve::valmax(as<T>()));
+  else                                   TTS_EQUAL(eve::maxrepint(as<T>()), eve::maxflint(as<T>()));
+};
+
+//==================================================================================================
+// masked maxrepint
+//==================================================================================================
+TTS_CASE_WITH("Check behavior of maxrepint[mask] on wide",
+              eve::test::simd::all_types,
+              tts::generate(tts::randoms(eve::valmin, eve::valmax),
+              tts::logicals(0, 3)))
+<typename T, typename M>(T const& a0, M const& mask)
+{
+  TTS_IEEE_EQUAL(eve::maxrepint[mask](eve::as(a0)), eve::if_else(mask, eve::maxrepint(eve::as(a0)), eve::zero));
+};

--- a/test/unit/module/core/constant/sqrtsmallestposval.cpp
+++ b/test/unit/module/core/constant/sqrtsmallestposval.cpp
@@ -1,0 +1,45 @@
+//==================================================================================================
+/**
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+**/
+//==================================================================================================
+#include "test.hpp"
+
+#include <eve/module/core.hpp>
+
+//==================================================================================================
+// Types tests
+//==================================================================================================
+TTS_CASE_TPL("Check return types of sqrtsmallestposval", eve::test::simd::ieee_reals)
+<typename T>(tts::type<T>)
+{
+  using v_t = eve::element_type_t<T>;
+  using eve::as;
+
+  TTS_EXPR_IS(eve::sqrtsmallestposval(as<T>()), T);
+  TTS_EXPR_IS(eve::sqrtsmallestposval(as<v_t>()), v_t);
+};
+
+//==================================================================================================
+// sqrtsmallestposval is defined by its relation to the constants it derives from
+//==================================================================================================
+TTS_CASE_TPL("Check behavior of sqrtsmallestposval", eve::test::simd::ieee_reals)
+<typename T>(tts::type<T>)
+{
+  using eve::as;
+  TTS_EQUAL(eve::sqrtsmallestposval(as<T>()), eve::sqrt(eve::smallestposval(as<T>())));
+};
+
+//==================================================================================================
+// masked sqrtsmallestposval
+//==================================================================================================
+TTS_CASE_WITH("Check behavior of sqrtsmallestposval[mask] on wide",
+              eve::test::simd::ieee_reals,
+              tts::generate(tts::randoms(eve::valmin, eve::valmax),
+              tts::logicals(0, 3)))
+<typename T, typename M>(T const& a0, M const& mask)
+{
+  TTS_IEEE_EQUAL(eve::sqrtsmallestposval[mask](eve::as(a0)), eve::if_else(mask, eve::sqrtsmallestposval(eve::as(a0)), eve::zero));
+};

--- a/test/unit/module/core/flush_denormal.cpp
+++ b/test/unit/module/core/flush_denormal.cpp
@@ -1,0 +1,64 @@
+//==================================================================================================
+/**
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+**/
+//==================================================================================================
+#include "test.hpp"
+
+#include <eve/module/core.hpp>
+
+//==================================================================================================
+// Types tests
+//==================================================================================================
+TTS_CASE_TPL("Check return types of flush_denormal", eve::test::simd::ieee_reals)
+<typename T>(tts::type<T>)
+{
+  using v_t = eve::element_type_t<T>;
+
+  TTS_EXPR_IS(eve::flush_denormal(T())  , T  );
+  TTS_EXPR_IS(eve::flush_denormal(v_t()), v_t);
+};
+
+//==================================================================================================
+// Denormals go to zero, everything else is left alone
+//==================================================================================================
+TTS_CASE_TPL("Check behavior of flush_denormal on the values it targets", eve::test::simd::ieee_reals)
+<typename T>(tts::type<T>)
+{
+  using eve::as;
+  auto cases = tts::limits(tts::type<T>{});
+
+  TTS_EQUAL(eve::flush_denormal(eve::mindenormal(as<T>()))    , T(0));
+  TTS_EQUAL(eve::flush_denormal(-eve::mindenormal(as<T>()))   , T(0));
+  TTS_EQUAL(eve::flush_denormal(eve::smallestposval(as<T>())) , eve::smallestposval(as<T>()));
+  TTS_EQUAL(eve::flush_denormal(T(0))                         , T(0));
+  TTS_EQUAL(eve::flush_denormal(T(1))                         , T(1));
+  TTS_EQUAL(eve::flush_denormal(T(-1))                        , T(-1));
+  TTS_IEEE_EQUAL(eve::flush_denormal(cases.nan)  , cases.nan);
+  TTS_IEEE_EQUAL(eve::flush_denormal(cases.inf)  , cases.inf);
+  TTS_IEEE_EQUAL(eve::flush_denormal(cases.minf) , cases.minf);
+};
+
+//==================================================================================================
+// Normal values pass through untouched
+//==================================================================================================
+TTS_CASE_WITH("Check that flush_denormal leaves normal values alone",
+              eve::test::simd::ieee_reals,
+              tts::generate(tts::randoms(-100.0, 100.0)))
+<typename T>(T const& a0)
+{
+  TTS_IEEE_EQUAL(eve::flush_denormal(a0), a0);
+};
+
+//==================================================================================================
+// masked flush_denormal
+//==================================================================================================
+TTS_CASE_WITH("Check behavior of flush_denormal[mask]",
+              eve::test::simd::ieee_reals,
+              tts::generate(tts::randoms(-100.0, 100.0), tts::logicals(0, 3)))
+<typename T, typename M>(T const& a0, M const& mask)
+{
+  TTS_IEEE_EQUAL(eve::flush_denormal[mask](a0), eve::if_else(mask, eve::flush_denormal(a0), a0));
+};

--- a/test/unit/module/core/reldist.cpp
+++ b/test/unit/module/core/reldist.cpp
@@ -1,0 +1,73 @@
+//==================================================================================================
+/**
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+**/
+//==================================================================================================
+#include "test.hpp"
+
+#include <eve/module/core.hpp>
+
+//==================================================================================================
+// Types tests
+//==================================================================================================
+TTS_CASE_TPL("Check return types of reldist", eve::test::simd::ieee_reals)
+<typename T>(tts::type<T>)
+{
+  using v_t = eve::element_type_t<T>;
+
+  TTS_EXPR_IS(eve::reldist(T()  , T()  ), T  );
+  TTS_EXPR_IS(eve::reldist(T()  , v_t()), T  );
+  TTS_EXPR_IS(eve::reldist(v_t(), T()  ), T  );
+  TTS_EXPR_IS(eve::reldist(v_t(), v_t()), v_t);
+};
+
+//==================================================================================================
+// reldist(x, y) is |x-y| divided by the largest of |x|, |y| and 1
+//==================================================================================================
+TTS_CASE_WITH("Check behavior of reldist",
+              eve::test::simd::ieee_reals,
+              tts::generate(tts::randoms(-100.0, 100.0), tts::randoms(-100.0, 100.0)))
+<typename T>(T const& a0, T const& a1)
+{
+  using v_t = eve::element_type_t<T>;
+  TTS_ULP_EQUAL(eve::reldist(a0, a1),
+                tts::map([](auto x, auto y) -> v_t
+                         {
+                           auto d = x < y ? y - x : x - y;
+                           auto ax = x < 0 ? -x : x;
+                           auto ay = y < 0 ? -y : y;
+                           auto m  = ax < ay ? ay : ax;
+                           return d / (m < 1 ? v_t(1) : m);
+                         }, a0, a1),
+                2);
+};
+
+//==================================================================================================
+// The properties the definition is meant to give
+//==================================================================================================
+TTS_CASE_TPL("Check the properties of reldist", eve::test::simd::ieee_reals)
+<typename T>(tts::type<T>)
+{
+  TTS_EQUAL(eve::reldist(T(3)   , T(3)   ), T(0));
+  TTS_EQUAL(eve::reldist(T(0)   , T(0)   ), T(0));
+  TTS_EQUAL(eve::reldist(T(0)   , T(1)   ), T(1));
+  TTS_EQUAL(eve::reldist(T(-0.5), T(0.5) ), T(1));
+
+  // symmetric in its arguments, and never above 2
+  TTS_EQUAL(eve::reldist(T(4), T(1)), eve::reldist(T(1), T(4)));
+  TTS_EXPECT(eve::all(eve::reldist(T(100), T(-100)) <= T(2)));
+};
+
+//==================================================================================================
+// masked reldist
+//==================================================================================================
+TTS_CASE_WITH("Check behavior of reldist[mask]",
+              eve::test::simd::ieee_reals,
+              tts::generate(tts::randoms(-100.0, 100.0), tts::randoms(-100.0, 100.0),
+                            tts::logicals(0, 3)))
+<typename T, typename M>(T const& a0, T const& a1, M const& mask)
+{
+  TTS_IEEE_EQUAL(eve::reldist[mask](a0, a1), eve::if_else(mask, eve::reldist(a0, a1), a0));
+};

--- a/test/unit/module/math/arg.cpp
+++ b/test/unit/module/math/arg.cpp
@@ -70,3 +70,14 @@ TTS_CASE_WITH("Check behavior of eve::masked(eve::arg)(eve::wide)",
   TTS_IEEE_EQUAL(eve::arg[mask](a0),
             eve::if_else(mask, eve::arg(a0), a0));
 };
+
+//==================================================================================================
+// phase is an alias of arg and must not drift from it
+//==================================================================================================
+TTS_CASE_WITH("Check that eve::phase matches eve::arg",
+              eve::test::simd::ieee_reals,
+              tts::generate(tts::between(-10.0, 10.0)))
+<typename T>(T const& a0)
+{
+  TTS_IEEE_EQUAL(eve::phase(a0), eve::arg(a0));
+};

--- a/test/unit/module/math/constant/egamma.cpp
+++ b/test/unit/module/math/constant/egamma.cpp
@@ -68,3 +68,19 @@ TTS_CASE_WITH("Check behavior of egamma[mask] on :wide)",
 {
   TTS_IEEE_EQUAL(eve::egamma[mask](eve::as(a0)), eve::if_else(mask, eve::egamma(eve::as(a0)), eve::zero));
 };
+
+//==================================================================================================
+// γ is an alias of egamma and must not drift from it
+//==================================================================================================
+TTS_CASE_TPL("Check that eve::γ matches eve::egamma", eve::test::simd::ieee_reals)
+<typename T>(tts::type<T>)
+{
+  using v_t = eve::element_type_t<T>;
+  using eve::as;
+
+  TTS_EXPR_IS(eve::γ(as<T>()), T);
+  TTS_EQUAL(eve::γ(as<T>())          , eve::egamma(as<T>()));
+  TTS_EQUAL(eve::γ(as<v_t>())        , eve::egamma(as<v_t>()));
+  TTS_EQUAL(eve::γ[eve::lower](as<T>()), eve::egamma[eve::lower](as<T>()));
+  TTS_EQUAL(eve::γ[eve::upper](as<T>()), eve::egamma[eve::upper](as<T>()));
+};

--- a/test/unit/module/math/constant/extreme_value_skewness.cpp
+++ b/test/unit/module/math/constant/extreme_value_skewness.cpp
@@ -30,14 +30,14 @@ TTS_CASE_TPL("Check behavior of extreme_value_skewness on scalar", eve::test::sc
 <typename T>(tts::type<T>)
 {
   using eve::as;
-  using elt_t = eve::element_type_t<T>;
 
-  if constexpr( sizeof(long double) > sizeof(elt_t) )
-  {
-    TTS_EXPECT(eve::extreme_value_skewness[eve::lower](as<elt_t>()) < 1.13954709940464865749l);
-    TTS_EXPECT(eve::extreme_value_skewness[eve::upper](as<elt_t>()) > 1.13954709940464865749l);
-  }
-  TTS_EQUAL(eve::extreme_value_skewness(as<T>()), T(1.13954709940464865749l));
+  // the exact value, rounded to double: 1.13954709940464865749
+  TTS_EQUAL(eve::extreme_value_skewness(as<T>()), T(1.1395470994046486));
+
+  // lower and upper bracket the exact value, whatever the precision
+  TTS_EXPECT(eve::extreme_value_skewness[eve::lower](as<T>()) <= eve::extreme_value_skewness(as<T>()));
+  TTS_EXPECT(eve::extreme_value_skewness(as<T>())             <= eve::extreme_value_skewness[eve::upper](as<T>()));
+  TTS_RELATIVE_EQUAL(eve::extreme_value_skewness[eve::lower](as<T>()), eve::extreme_value_skewness[eve::upper](as<T>()), 1e-4);
 };
 
 //==================================================================================================

--- a/test/unit/module/math/constant/extreme_value_skewness.cpp
+++ b/test/unit/module/math/constant/extreme_value_skewness.cpp
@@ -1,0 +1,63 @@
+//==================================================================================================
+/**
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+**/
+//==================================================================================================
+#include "test.hpp"
+
+#include <eve/module/core.hpp>
+#include <eve/module/math.hpp>
+
+//==================================================================================================
+// Types tests
+//==================================================================================================
+TTS_CASE_TPL("Check return types of extreme_value_skewness", eve::test::simd::ieee_reals)
+<typename T>(tts::type<T>)
+{
+  using v_t = eve::element_type_t<T>;
+  using eve::as;
+
+  TTS_EXPR_IS(eve::extreme_value_skewness(as<T>()), T);
+  TTS_EXPR_IS(eve::extreme_value_skewness(as<v_t>()), v_t);
+};
+
+//==================================================================================================
+// extreme_value_skewness tests on scalar
+//==================================================================================================
+TTS_CASE_TPL("Check behavior of extreme_value_skewness on scalar", eve::test::scalar::ieee_reals)
+<typename T>(tts::type<T>)
+{
+  using eve::as;
+  using elt_t = eve::element_type_t<T>;
+
+  if constexpr( sizeof(long double) > sizeof(elt_t) )
+  {
+    TTS_EXPECT(eve::extreme_value_skewness[eve::lower](as<elt_t>()) < 1.13954709940464865749l);
+    TTS_EXPECT(eve::extreme_value_skewness[eve::upper](as<elt_t>()) > 1.13954709940464865749l);
+  }
+  TTS_EQUAL(eve::extreme_value_skewness(as<T>()), T(1.13954709940464865749l));
+};
+
+//==================================================================================================
+// extreme_value_skewness tests on wide
+//==================================================================================================
+TTS_CASE_TPL("Check behavior of extreme_value_skewness on wide", eve::test::simd::ieee_reals)
+<typename T>(tts::type<T>)
+{
+  using eve::as;
+  TTS_EXPECT(eve::all(eve::test::is_near(eve::extreme_value_skewness[eve::lower](as<T>()), eve::extreme_value_skewness[eve::upper](as<T>()))));
+};
+
+//==================================================================================================
+// masked extreme_value_skewness
+//==================================================================================================
+TTS_CASE_WITH("Check behavior of extreme_value_skewness[mask] on wide",
+              eve::test::simd::ieee_reals,
+              tts::generate(tts::randoms(eve::valmin, eve::valmax),
+              tts::logicals(0, 3)))
+<typename T, typename M>(T const& a0, M const& mask)
+{
+  TTS_IEEE_EQUAL(eve::extreme_value_skewness[mask](eve::as(a0)), eve::if_else(mask, eve::extreme_value_skewness(eve::as(a0)), eve::zero));
+};

--- a/test/unit/module/math/constant/oneotwoeps.cpp
+++ b/test/unit/module/math/constant/oneotwoeps.cpp
@@ -1,0 +1,46 @@
+//==================================================================================================
+/**
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+**/
+//==================================================================================================
+#include "test.hpp"
+
+#include <eve/module/core.hpp>
+#include <eve/module/math.hpp>
+
+//==================================================================================================
+// Types tests
+//==================================================================================================
+TTS_CASE_TPL("Check return types of oneotwoeps", eve::test::simd::ieee_reals)
+<typename T>(tts::type<T>)
+{
+  using v_t = eve::element_type_t<T>;
+  using eve::as;
+
+  TTS_EXPR_IS(eve::oneotwoeps(as<T>()), T);
+  TTS_EXPR_IS(eve::oneotwoeps(as<v_t>()), v_t);
+};
+
+//==================================================================================================
+// oneotwoeps is defined by its relation to the constants it derives from
+//==================================================================================================
+TTS_CASE_TPL("Check behavior of oneotwoeps", eve::test::simd::ieee_reals)
+<typename T>(tts::type<T>)
+{
+  using eve::as;
+  TTS_EQUAL(eve::oneotwoeps(as<T>()), eve::rec(2 * eve::eps(as<T>())));
+};
+
+//==================================================================================================
+// masked oneotwoeps
+//==================================================================================================
+TTS_CASE_WITH("Check behavior of oneotwoeps[mask] on wide",
+              eve::test::simd::ieee_reals,
+              tts::generate(tts::randoms(eve::valmin, eve::valmax),
+              tts::logicals(0, 3)))
+<typename T, typename M>(T const& a0, M const& mask)
+{
+  TTS_IEEE_EQUAL(eve::oneotwoeps[mask](eve::as(a0)), eve::if_else(mask, eve::oneotwoeps(eve::as(a0)), eve::zero));
+};

--- a/test/unit/module/math/constant/pi.cpp
+++ b/test/unit/module/math/constant/pi.cpp
@@ -67,3 +67,19 @@ TTS_CASE_WITH("Check behavior of pi[mask] on :wide)",
 {
   TTS_IEEE_EQUAL(eve::pi[mask](eve::as(a0)), eve::if_else(mask, eve::pi(eve::as(a0)), eve::zero));
 };
+
+//==================================================================================================
+// π is an alias of pi and must not drift from it
+//==================================================================================================
+TTS_CASE_TPL("Check that eve::π matches eve::pi", eve::test::simd::ieee_reals)
+<typename T>(tts::type<T>)
+{
+  using v_t = eve::element_type_t<T>;
+  using eve::as;
+
+  TTS_EXPR_IS(eve::π(as<T>()), T);
+  TTS_EQUAL(eve::π(as<T>())          , eve::pi(as<T>()));
+  TTS_EQUAL(eve::π(as<v_t>())        , eve::pi(as<v_t>()));
+  TTS_EQUAL(eve::π[eve::lower](as<T>()), eve::pi[eve::lower](as<T>()));
+  TTS_EQUAL(eve::π[eve::upper](as<T>()), eve::pi[eve::upper](as<T>()));
+};

--- a/test/unit/module/math/constant/rayleigh_kurtosis.cpp
+++ b/test/unit/module/math/constant/rayleigh_kurtosis.cpp
@@ -30,14 +30,14 @@ TTS_CASE_TPL("Check behavior of rayleigh_kurtosis on scalar", eve::test::scalar:
 <typename T>(tts::type<T>)
 {
   using eve::as;
-  using elt_t = eve::element_type_t<T>;
 
-  if constexpr( sizeof(long double) > sizeof(elt_t) )
-  {
-    TTS_EXPECT(eve::rayleigh_kurtosis[eve::lower](as<elt_t>()) < 3.24508930068763806285l);
-    TTS_EXPECT(eve::rayleigh_kurtosis[eve::upper](as<elt_t>()) > 3.24508930068763806285l);
-  }
-  TTS_EQUAL(eve::rayleigh_kurtosis(as<T>()), T(3.24508930068763806285l));
+  // the exact value, rounded to double: 3.24508930068763806285
+  TTS_EQUAL(eve::rayleigh_kurtosis(as<T>()), T(3.245089300687638));
+
+  // lower and upper bracket the exact value, whatever the precision
+  TTS_EXPECT(eve::rayleigh_kurtosis[eve::lower](as<T>()) <= eve::rayleigh_kurtosis(as<T>()));
+  TTS_EXPECT(eve::rayleigh_kurtosis(as<T>())             <= eve::rayleigh_kurtosis[eve::upper](as<T>()));
+  TTS_RELATIVE_EQUAL(eve::rayleigh_kurtosis[eve::lower](as<T>()), eve::rayleigh_kurtosis[eve::upper](as<T>()), 1e-4);
 };
 
 //==================================================================================================

--- a/test/unit/module/math/constant/rayleigh_kurtosis.cpp
+++ b/test/unit/module/math/constant/rayleigh_kurtosis.cpp
@@ -1,0 +1,63 @@
+//==================================================================================================
+/**
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+**/
+//==================================================================================================
+#include "test.hpp"
+
+#include <eve/module/core.hpp>
+#include <eve/module/math.hpp>
+
+//==================================================================================================
+// Types tests
+//==================================================================================================
+TTS_CASE_TPL("Check return types of rayleigh_kurtosis", eve::test::simd::ieee_reals)
+<typename T>(tts::type<T>)
+{
+  using v_t = eve::element_type_t<T>;
+  using eve::as;
+
+  TTS_EXPR_IS(eve::rayleigh_kurtosis(as<T>()), T);
+  TTS_EXPR_IS(eve::rayleigh_kurtosis(as<v_t>()), v_t);
+};
+
+//==================================================================================================
+// rayleigh_kurtosis tests on scalar
+//==================================================================================================
+TTS_CASE_TPL("Check behavior of rayleigh_kurtosis on scalar", eve::test::scalar::ieee_reals)
+<typename T>(tts::type<T>)
+{
+  using eve::as;
+  using elt_t = eve::element_type_t<T>;
+
+  if constexpr( sizeof(long double) > sizeof(elt_t) )
+  {
+    TTS_EXPECT(eve::rayleigh_kurtosis[eve::lower](as<elt_t>()) < 3.24508930068763806285l);
+    TTS_EXPECT(eve::rayleigh_kurtosis[eve::upper](as<elt_t>()) > 3.24508930068763806285l);
+  }
+  TTS_EQUAL(eve::rayleigh_kurtosis(as<T>()), T(3.24508930068763806285l));
+};
+
+//==================================================================================================
+// rayleigh_kurtosis tests on wide
+//==================================================================================================
+TTS_CASE_TPL("Check behavior of rayleigh_kurtosis on wide", eve::test::simd::ieee_reals)
+<typename T>(tts::type<T>)
+{
+  using eve::as;
+  TTS_EXPECT(eve::all(eve::test::is_near(eve::rayleigh_kurtosis[eve::lower](as<T>()), eve::rayleigh_kurtosis[eve::upper](as<T>()))));
+};
+
+//==================================================================================================
+// masked rayleigh_kurtosis
+//==================================================================================================
+TTS_CASE_WITH("Check behavior of rayleigh_kurtosis[mask] on wide",
+              eve::test::simd::ieee_reals,
+              tts::generate(tts::randoms(eve::valmin, eve::valmax),
+              tts::logicals(0, 3)))
+<typename T, typename M>(T const& a0, M const& mask)
+{
+  TTS_IEEE_EQUAL(eve::rayleigh_kurtosis[mask](eve::as(a0)), eve::if_else(mask, eve::rayleigh_kurtosis(eve::as(a0)), eve::zero));
+};

--- a/test/unit/module/math/constant/rayleigh_kurtosis_excess.cpp
+++ b/test/unit/module/math/constant/rayleigh_kurtosis_excess.cpp
@@ -30,14 +30,14 @@ TTS_CASE_TPL("Check behavior of rayleigh_kurtosis_excess on scalar", eve::test::
 <typename T>(tts::type<T>)
 {
   using eve::as;
-  using elt_t = eve::element_type_t<T>;
 
-  if constexpr( sizeof(long double) > sizeof(elt_t) )
-  {
-    TTS_EXPECT(eve::rayleigh_kurtosis_excess[eve::lower](as<elt_t>()) < 0.245089300687638062849l);
-    TTS_EXPECT(eve::rayleigh_kurtosis_excess[eve::upper](as<elt_t>()) > 0.245089300687638062849l);
-  }
-  TTS_EQUAL(eve::rayleigh_kurtosis_excess(as<T>()), T(0.245089300687638062849l));
+  // the exact value, rounded to double: 0.245089300687638062849
+  TTS_EQUAL(eve::rayleigh_kurtosis_excess(as<T>()), T(0.24508930068763807));
+
+  // lower and upper bracket the exact value, whatever the precision
+  TTS_EXPECT(eve::rayleigh_kurtosis_excess[eve::lower](as<T>()) <= eve::rayleigh_kurtosis_excess(as<T>()));
+  TTS_EXPECT(eve::rayleigh_kurtosis_excess(as<T>())             <= eve::rayleigh_kurtosis_excess[eve::upper](as<T>()));
+  TTS_RELATIVE_EQUAL(eve::rayleigh_kurtosis_excess[eve::lower](as<T>()), eve::rayleigh_kurtosis_excess[eve::upper](as<T>()), 1e-4);
 };
 
 //==================================================================================================

--- a/test/unit/module/math/constant/rayleigh_kurtosis_excess.cpp
+++ b/test/unit/module/math/constant/rayleigh_kurtosis_excess.cpp
@@ -1,0 +1,63 @@
+//==================================================================================================
+/**
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+**/
+//==================================================================================================
+#include "test.hpp"
+
+#include <eve/module/core.hpp>
+#include <eve/module/math.hpp>
+
+//==================================================================================================
+// Types tests
+//==================================================================================================
+TTS_CASE_TPL("Check return types of rayleigh_kurtosis_excess", eve::test::simd::ieee_reals)
+<typename T>(tts::type<T>)
+{
+  using v_t = eve::element_type_t<T>;
+  using eve::as;
+
+  TTS_EXPR_IS(eve::rayleigh_kurtosis_excess(as<T>()), T);
+  TTS_EXPR_IS(eve::rayleigh_kurtosis_excess(as<v_t>()), v_t);
+};
+
+//==================================================================================================
+// rayleigh_kurtosis_excess tests on scalar
+//==================================================================================================
+TTS_CASE_TPL("Check behavior of rayleigh_kurtosis_excess on scalar", eve::test::scalar::ieee_reals)
+<typename T>(tts::type<T>)
+{
+  using eve::as;
+  using elt_t = eve::element_type_t<T>;
+
+  if constexpr( sizeof(long double) > sizeof(elt_t) )
+  {
+    TTS_EXPECT(eve::rayleigh_kurtosis_excess[eve::lower](as<elt_t>()) < 0.245089300687638062849l);
+    TTS_EXPECT(eve::rayleigh_kurtosis_excess[eve::upper](as<elt_t>()) > 0.245089300687638062849l);
+  }
+  TTS_EQUAL(eve::rayleigh_kurtosis_excess(as<T>()), T(0.245089300687638062849l));
+};
+
+//==================================================================================================
+// rayleigh_kurtosis_excess tests on wide
+//==================================================================================================
+TTS_CASE_TPL("Check behavior of rayleigh_kurtosis_excess on wide", eve::test::simd::ieee_reals)
+<typename T>(tts::type<T>)
+{
+  using eve::as;
+  TTS_EXPECT(eve::all(eve::test::is_near(eve::rayleigh_kurtosis_excess[eve::lower](as<T>()), eve::rayleigh_kurtosis_excess[eve::upper](as<T>()))));
+};
+
+//==================================================================================================
+// masked rayleigh_kurtosis_excess
+//==================================================================================================
+TTS_CASE_WITH("Check behavior of rayleigh_kurtosis_excess[mask] on wide",
+              eve::test::simd::ieee_reals,
+              tts::generate(tts::randoms(eve::valmin, eve::valmax),
+              tts::logicals(0, 3)))
+<typename T, typename M>(T const& a0, M const& mask)
+{
+  TTS_IEEE_EQUAL(eve::rayleigh_kurtosis_excess[mask](eve::as(a0)), eve::if_else(mask, eve::rayleigh_kurtosis_excess(eve::as(a0)), eve::zero));
+};

--- a/test/unit/module/math/constant/rayleigh_skewness.cpp
+++ b/test/unit/module/math/constant/rayleigh_skewness.cpp
@@ -1,0 +1,63 @@
+//==================================================================================================
+/**
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+**/
+//==================================================================================================
+#include "test.hpp"
+
+#include <eve/module/core.hpp>
+#include <eve/module/math.hpp>
+
+//==================================================================================================
+// Types tests
+//==================================================================================================
+TTS_CASE_TPL("Check return types of rayleigh_skewness", eve::test::simd::ieee_reals)
+<typename T>(tts::type<T>)
+{
+  using v_t = eve::element_type_t<T>;
+  using eve::as;
+
+  TTS_EXPR_IS(eve::rayleigh_skewness(as<T>()), T);
+  TTS_EXPR_IS(eve::rayleigh_skewness(as<v_t>()), v_t);
+};
+
+//==================================================================================================
+// rayleigh_skewness tests on scalar
+//==================================================================================================
+TTS_CASE_TPL("Check behavior of rayleigh_skewness on scalar", eve::test::scalar::ieee_reals)
+<typename T>(tts::type<T>)
+{
+  using eve::as;
+  using elt_t = eve::element_type_t<T>;
+
+  if constexpr( sizeof(long double) > sizeof(elt_t) )
+  {
+    TTS_EXPECT(eve::rayleigh_skewness[eve::lower](as<elt_t>()) < 0.631110657818937138192l);
+    TTS_EXPECT(eve::rayleigh_skewness[eve::upper](as<elt_t>()) > 0.631110657818937138192l);
+  }
+  TTS_EQUAL(eve::rayleigh_skewness(as<T>()), T(0.631110657818937138192l));
+};
+
+//==================================================================================================
+// rayleigh_skewness tests on wide
+//==================================================================================================
+TTS_CASE_TPL("Check behavior of rayleigh_skewness on wide", eve::test::simd::ieee_reals)
+<typename T>(tts::type<T>)
+{
+  using eve::as;
+  TTS_EXPECT(eve::all(eve::test::is_near(eve::rayleigh_skewness[eve::lower](as<T>()), eve::rayleigh_skewness[eve::upper](as<T>()))));
+};
+
+//==================================================================================================
+// masked rayleigh_skewness
+//==================================================================================================
+TTS_CASE_WITH("Check behavior of rayleigh_skewness[mask] on wide",
+              eve::test::simd::ieee_reals,
+              tts::generate(tts::randoms(eve::valmin, eve::valmax),
+              tts::logicals(0, 3)))
+<typename T, typename M>(T const& a0, M const& mask)
+{
+  TTS_IEEE_EQUAL(eve::rayleigh_skewness[mask](eve::as(a0)), eve::if_else(mask, eve::rayleigh_skewness(eve::as(a0)), eve::zero));
+};

--- a/test/unit/module/math/constant/rayleigh_skewness.cpp
+++ b/test/unit/module/math/constant/rayleigh_skewness.cpp
@@ -30,14 +30,14 @@ TTS_CASE_TPL("Check behavior of rayleigh_skewness on scalar", eve::test::scalar:
 <typename T>(tts::type<T>)
 {
   using eve::as;
-  using elt_t = eve::element_type_t<T>;
 
-  if constexpr( sizeof(long double) > sizeof(elt_t) )
-  {
-    TTS_EXPECT(eve::rayleigh_skewness[eve::lower](as<elt_t>()) < 0.631110657818937138192l);
-    TTS_EXPECT(eve::rayleigh_skewness[eve::upper](as<elt_t>()) > 0.631110657818937138192l);
-  }
-  TTS_EQUAL(eve::rayleigh_skewness(as<T>()), T(0.631110657818937138192l));
+  // the exact value, rounded to double: 0.631110657818937138192
+  TTS_EQUAL(eve::rayleigh_skewness(as<T>()), T(0.6311106578189372));
+
+  // lower and upper bracket the exact value, whatever the precision
+  TTS_EXPECT(eve::rayleigh_skewness[eve::lower](as<T>()) <= eve::rayleigh_skewness(as<T>()));
+  TTS_EXPECT(eve::rayleigh_skewness(as<T>())             <= eve::rayleigh_skewness[eve::upper](as<T>()));
+  TTS_RELATIVE_EQUAL(eve::rayleigh_skewness[eve::lower](as<T>()), eve::rayleigh_skewness[eve::upper](as<T>()), 1e-4);
 };
 
 //==================================================================================================

--- a/test/unit/module/math/div_180.cpp
+++ b/test/unit/module/math/div_180.cpp
@@ -1,0 +1,64 @@
+//==================================================================================================
+/**
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+**/
+//==================================================================================================
+#include "test.hpp"
+
+#include <eve/module/core.hpp>
+#include <eve/module/math.hpp>
+
+//==================================================================================================
+// Types tests
+//==================================================================================================
+TTS_CASE_TPL("Check return types of div_180", eve::test::simd::ieee_reals)
+<typename T>(tts::type<T>)
+{
+  using v_t = eve::element_type_t<T>;
+
+  TTS_EXPR_IS(eve::div_180(T())  , T  );
+  TTS_EXPR_IS(eve::div_180(v_t()), v_t);
+};
+
+//==================================================================================================
+// div_180 divides by 180, more accurately than the plain division does
+//==================================================================================================
+TTS_CASE_WITH("Check behavior of div_180",
+              eve::test::simd::ieee_reals,
+              tts::generate(tts::randoms(-1000.0, 1000.0)))
+<typename T>(T const& a0)
+{
+  using v_t = eve::element_type_t<T>;
+  TTS_ULP_EQUAL(eve::div_180(a0), tts::map([](auto e) -> v_t { return e / 180; }, a0), 0.5);
+};
+
+//==================================================================================================
+// The corner cases the double-double split is there for
+//==================================================================================================
+TTS_CASE_TPL("Check limits of div_180", eve::test::simd::ieee_reals)
+<typename T>(tts::type<T>)
+{
+  auto cases = tts::limits(tts::type<T>{});
+
+  TTS_EQUAL(eve::div_180(T(0))    , T(0));
+  TTS_EQUAL(eve::div_180(T(-0.0)) , T(-0.0));
+  TTS_EQUAL(eve::div_180(T(180))  , T(1));
+  TTS_EQUAL(eve::div_180(T(-180)) , T(-1));
+  TTS_EQUAL(eve::div_180(T(360))  , T(2));
+  TTS_IEEE_EQUAL(eve::div_180(cases.nan) , cases.nan);
+  TTS_IEEE_EQUAL(eve::div_180(cases.inf) , cases.inf);
+  TTS_IEEE_EQUAL(eve::div_180(cases.minf), cases.minf);
+};
+
+//==================================================================================================
+// masked div_180
+//==================================================================================================
+TTS_CASE_WITH("Check behavior of div_180[mask]",
+              eve::test::simd::ieee_reals,
+              tts::generate(tts::randoms(-1000.0, 1000.0), tts::logicals(0, 3)))
+<typename T, typename M>(T const& a0, M const& mask)
+{
+  TTS_IEEE_EQUAL(eve::div_180[mask](a0), eve::if_else(mask, eve::div_180(a0), a0));
+};

--- a/test/unit/module/math/quadrant.cpp
+++ b/test/unit/module/math/quadrant.cpp
@@ -1,0 +1,64 @@
+//==================================================================================================
+/**
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+**/
+//==================================================================================================
+#include "test.hpp"
+
+#include <eve/module/core.hpp>
+#include <eve/module/math.hpp>
+
+//==================================================================================================
+// Types tests
+//==================================================================================================
+TTS_CASE_TPL("Check return types of quadrant", eve::test::simd::all_types)
+<typename T>(tts::type<T>)
+{
+  using v_t = eve::element_type_t<T>;
+
+  TTS_EXPR_IS(eve::quadrant(T())  , T  );
+  TTS_EXPR_IS(eve::quadrant(v_t()), v_t);
+};
+
+//==================================================================================================
+// On integers, quadrant keeps the two low bits
+//==================================================================================================
+TTS_CASE_WITH("Check behavior of quadrant on integers",
+              eve::test::simd::integers,
+              tts::generate(tts::randoms(eve::valmin, eve::valmax)))
+<typename T>(T const& a0)
+{
+  using v_t = eve::element_type_t<T>;
+  // the mathematical modulo, which is what keeping the two low bits amounts to
+  TTS_EQUAL(eve::quadrant(a0),
+            tts::map([](auto e) -> v_t { return static_cast<v_t>(((e % 4) + 4) % 4); }, a0));
+};
+
+//==================================================================================================
+// On floating values, it is the same cycle of four
+//==================================================================================================
+TTS_CASE_TPL("Check behavior of quadrant on floating values", eve::test::simd::ieee_reals)
+<typename T>(tts::type<T>)
+{
+  TTS_EQUAL(eve::quadrant(T(0)), T(0));
+  TTS_EQUAL(eve::quadrant(T(1)), T(1));
+  TTS_EQUAL(eve::quadrant(T(2)), T(2));
+  TTS_EQUAL(eve::quadrant(T(3)), T(3));
+  TTS_EQUAL(eve::quadrant(T(4)), T(0));
+  TTS_EQUAL(eve::quadrant(T(5)), T(1));
+  TTS_EQUAL(eve::quadrant(T(8)), T(0));
+  TTS_EQUAL(eve::quadrant(T(-4)), T(0));
+};
+
+//==================================================================================================
+// masked quadrant
+//==================================================================================================
+TTS_CASE_WITH("Check behavior of quadrant[mask]",
+              eve::test::simd::ieee_reals,
+              tts::generate(tts::randoms(0.0, 100.0), tts::logicals(0, 3)))
+<typename T, typename M>(T const& a0, M const& mask)
+{
+  TTS_IEEE_EQUAL(eve::quadrant[mask](a0), eve::if_else(mask, eve::quadrant(a0), a0));
+};

--- a/test/unit/module/math/rempio2.cpp
+++ b/test/unit/module/math/rempio2.cpp
@@ -1,0 +1,89 @@
+//==================================================================================================
+/**
+  EVE - Expressive Vector Engine
+  Copyright : EVE Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+**/
+//==================================================================================================
+#include "test.hpp"
+
+#include <eve/module/core.hpp>
+#include <eve/module/math.hpp>
+
+#include <cmath>
+
+//==================================================================================================
+// Types tests
+//==================================================================================================
+TTS_CASE_TPL("Check return types of rempio2", eve::test::simd::ieee_reals)
+<typename T>(tts::type<T>)
+{
+  auto [n, x, dx] = eve::rempio2(T());
+
+  TTS_EXPR_IS(n , T);
+  TTS_EXPR_IS(x , T);
+  TTS_EXPR_IS(dx, T);
+};
+
+//==================================================================================================
+// The contract: n is the quadrant, x + dx is the distance to the nearest multiple of pi/2.
+// The input has to be non negative: the library always calls this on abs(x), and a negative
+// argument comes back untouched with a zero quadrant.
+//==================================================================================================
+TTS_CASE_WITH("Check that rempio2 reduces modulo pi/2",
+              eve::test::simd::ieee_reals,
+              tts::generate(tts::randoms(0.0, 100.0)))
+<typename T>(T const& a0)
+{
+  using v_t = eve::element_type_t<T>;
+  auto [n, x, dx] = eve::rempio2(a0);
+
+  // the reference runs in long double, which carries more mantissa than anything under test:
+  // computing it in double would leave it less accurate than the double-double reduction itself
+  constexpr long double pio2 = 1.57079632679489661923132169163975144l;
+
+  auto quadrant = tts::map([](auto e) -> v_t
+                           {
+                             long double k = std::nearbyint((long double)(e) / pio2);
+                             long double q = std::fmod(k, 4.0l);
+                             return static_cast<v_t>(q < 0 ? q + 4 : q);
+                           }, a0);
+  auto rest     = tts::map([](auto e) -> v_t
+                           {
+                             long double x = (long double)(e);
+                             return static_cast<v_t>(x - std::nearbyint(x / pio2) * pio2);
+                           }, a0);
+
+  TTS_EXPECT(eve::all(eve::is_flint(n)));
+  TTS_EQUAL(n, quadrant);
+  TTS_ULP_EQUAL(x + dx, rest, 4);
+};
+
+//==================================================================================================
+// The remainder stays in the interval the reduction is meant to produce
+//==================================================================================================
+TTS_CASE_WITH("Check the range of the rempio2 remainder",
+              eve::test::simd::ieee_reals,
+              tts::generate(tts::randoms(0.0, 100.0)))
+<typename T>(T const& a0)
+{
+  auto [n, x, dx] = eve::rempio2(a0);
+  auto bound      = eve::pio_4(eve::as(a0)) * T(1.0001);
+
+  TTS_EXPECT(eve::all(eve::abs(x) <= bound));
+  TTS_EXPECT(eve::all(n >= T(0)));
+  TTS_EXPECT(eve::all(n <  T(4)));
+  (void)dx;
+};
+
+//==================================================================================================
+// Below pi/4 the reduction has nothing to do
+//==================================================================================================
+TTS_CASE_TPL("Check rempio2 on small inputs", eve::test::simd::ieee_reals)
+<typename T>(tts::type<T>)
+{
+  auto [n, x, dx] = eve::rempio2[eve::quarter_circle](T(0.5));
+
+  TTS_EQUAL(n, T(0));
+  TTS_ULP_EQUAL(x + dx, T(0.5), 1);
+};

--- a/test/unit/module/math/rempio2.cpp
+++ b/test/unit/module/math/rempio2.cpp
@@ -38,24 +38,29 @@ TTS_CASE_WITH("Check that rempio2 reduces modulo pi/2",
   using v_t = eve::element_type_t<T>;
   auto [n, x, dx] = eve::rempio2(a0);
 
-  // the reference runs in long double, which carries more mantissa than anything under test:
-  // computing it in double would leave it less accurate than the double-double reduction itself
-  constexpr long double pio2 = 1.57079632679489661923132169163975144l;
+  // pi/2 split into three exactly representable doubles, the Cody-Waite way: the reference then
+  // lands below eps(double), so it stays sharper than the reduction it checks on every target.
+  // Using long double instead would collapse to plain double on MSVC and several ARM ABIs.
+  constexpr double p1 = 1.57079632673412561417e+00;
+  constexpr double p2 = 6.07710050650619224932e-11;
+  constexpr double p3 = 2.02226624879595063154e-21;
+  constexpr double pio2 = 1.5707963267948966;
 
-  auto quadrant = tts::map([](auto e) -> v_t
+  auto quadrant = tts::map([=](auto e) -> v_t
                            {
-                             long double k = std::nearbyint((long double)(e) / pio2);
-                             long double q = std::fmod(k, 4.0l);
+                             double q = std::fmod(std::nearbyint(double(e) / pio2), 4.0);
                              return static_cast<v_t>(q < 0 ? q + 4 : q);
                            }, a0);
-  auto rest     = tts::map([](auto e) -> v_t
+  auto rest     = tts::map([=](auto e) -> v_t
                            {
-                             long double x = (long double)(e);
-                             return static_cast<v_t>(x - std::nearbyint(x / pio2) * pio2);
+                             double v = double(e);
+                             double k = std::nearbyint(v / pio2);
+                             return static_cast<v_t>(((v - k * p1) - k * p2) - k * p3);
                            }, a0);
 
   TTS_EXPECT(eve::all(eve::is_flint(n)));
   TTS_EQUAL(n, quadrant);
+
   TTS_ULP_EQUAL(x + dx, rest, 4);
 };
 

--- a/test/unit/module/special/omega.cpp
+++ b/test/unit/module/special/omega.cpp
@@ -91,3 +91,14 @@ TTS_CASE_TPL( "Check peculiar values", eve::test::scalar::ieee_reals)
     TTS_ULP_EQUAL(eve::omega(T(0.5)), T(0.76624860816175026), 0.5);
   }
 };
+
+//==================================================================================================
+// ω is an alias of omega and must not drift from it
+//==================================================================================================
+TTS_CASE_WITH("Check that eve::ω matches eve::omega",
+              eve::test::simd::ieee_reals,
+              tts::generate(tts::between(-10.0, 10.0)))
+<typename T>(T const& a0)
+{
+  TTS_IEEE_EQUAL(eve::ω(a0), eve::omega(a0));
+};


### PR DESCRIPTION
Five commits adding unit tests where there were none: the untested constants, the untested functions, and a check that each alias agrees with the function it aliases. `rempio2` gains a documentation note saying it expects a non-negative argument, which is what its tests had to assume.

Long double stays out of the new files, as everywhere else.