### PR TITLE
Install the external headers without configuring their tests

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -140,21 +140,21 @@ jobs:
           cd 3rdparty
           git clone https://github.com/jfalcou/kumi.git
           cd kumi 
-          cmake -B build -G Ninja
+          cmake -B build -G Ninja -DKUMI_BUILD_TEST=OFF
           cmake --install build --prefix /usr
       - name: Install RABERU
         run: |
           cd 3rdparty
           git clone https://github.com/jfalcou/raberu.git
           cd raberu
-          cmake -B build -G Ninja
+          cmake -B build -G Ninja -DRABERU_BUILD_TEST=OFF
           cmake --install build --prefix /usr
       - name: Install SPY 
         run: |
           cd 3rdparty
           git clone https://github.com/jfalcou/spy.git
           cd spy
-          cmake -B build -G Ninja
+          cmake -B build -G Ninja -DSPY_BUILD_TEST=OFF
           cmake --install build --prefix /usr
       - name: Fetch current branch
         uses: actions/checkout@v6


### PR DESCRIPTION
The externals job installs kumi, raberu and spy for their headers, and configured each of them in full to do it, test tree included. Turning their test option off leaves the installed headers and config packages identical while dropping the job's dependency on what those projects need to build their own tests.

A cold configure of kumi or raberu currently fails on a dangling tts::tts, which is what turned this job red. That ordering defect is fixed in their own repositories; this change stops eve from depending on it either way.
