### PR TITLE
Fix #2397 - Name the array type at the add_shuffle_levels call site

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -629,6 +629,7 @@ jobs:
         cfg:
         - { comp: clang20, arch: x86    , opts: "-std=c++26"  }
         - { comp: gcc15  , arch: x86    , opts: "-std=c++26"  }
+        - { comp: gcc    , arch: x86    , opts: "-std=c++26"  }
     steps:
       - name: Fetch current branch
         uses: actions/checkout@v6

--- a/include/eve/detail/shuffle_v2/idxm.hpp
+++ b/include/eve/detail/shuffle_v2/idxm.hpp
@@ -1283,7 +1283,10 @@ add_shuffle_levels(std::span<const std::ptrdiff_t> ls)
 constexpr auto
 add_shuffle_levels(std::integral auto a, std::integral auto... as)
 {
-  return add_shuffle_levels(std::array {static_cast<std::ptrdiff_t>(a), static_cast<std::ptrdiff_t>(as)...});
+  return add_shuffle_levels ( std::array{ static_cast<std::ptrdiff_t>(a)
+                                        , static_cast<std::ptrdiff_t>(as)...
+                                        }
+                            );
 }
 
 template<std::ptrdiff_t... ls>

--- a/include/eve/detail/shuffle_v2/idxm.hpp
+++ b/include/eve/detail/shuffle_v2/idxm.hpp
@@ -1280,14 +1280,11 @@ add_shuffle_levels(std::span<const std::ptrdiff_t> ls)
   return base + use_masks;
 }
 
-// In C++26 the {} can be used with spans, so it's not needed anymore
-#if __cplusplus <= 202302L
 constexpr auto
-add_shuffle_levels(std::array<std::ptrdiff_t, 3> ls)
+add_shuffle_levels(std::ptrdiff_t a, std::ptrdiff_t b, std::ptrdiff_t c)
 {
-  return add_shuffle_levels(std::span(ls));
+  return add_shuffle_levels(std::array {a, b, c});
 }
-#endif
 
 template<std::ptrdiff_t... ls>
 constexpr auto

--- a/include/eve/detail/shuffle_v2/idxm.hpp
+++ b/include/eve/detail/shuffle_v2/idxm.hpp
@@ -1281,9 +1281,9 @@ add_shuffle_levels(std::span<const std::ptrdiff_t> ls)
 }
 
 constexpr auto
-add_shuffle_levels(std::ptrdiff_t a, std::ptrdiff_t b, std::ptrdiff_t c)
+add_shuffle_levels(std::integral auto a, std::integral auto... as)
 {
-  return add_shuffle_levels(std::array {a, b, c});
+  return add_shuffle_levels(std::array {static_cast<std::ptrdiff_t>(a), static_cast<std::ptrdiff_t>(as)...});
 }
 
 template<std::ptrdiff_t... ls>

--- a/include/eve/module/core/named_shuffles/blend.hpp
+++ b/include/eve/module/core/named_shuffles/blend.hpp
@@ -121,7 +121,7 @@ struct blend_t
         auto [p0, p1] = _::idxm::slice_pattern<pattern_t<I...>::size() / 2>(p);
         auto l0       = level(as<half_t> {}, as<half_t> {}, g, p0);
         auto l1       = level(as<half_t> {}, as<half_t> {}, g, p1);
-        return _::idxm::add_shuffle_levels(std::array<std::ptrdiff_t, 3> {l0, l1, 4});
+        return _::idxm::add_shuffle_levels(l0, l1, 4);
       }
       if( current_api >= sse4_1 ) return g_size >= 4 ? 2 : 3;
 

--- a/include/eve/module/core/named_shuffles/swap_adjacent.hpp
+++ b/include/eve/module/core/named_shuffles/swap_adjacent.hpp
@@ -98,7 +98,7 @@ struct swap_adjacent_t
       std::ptrdiff_t half_l = level(eve::as<half_t> {}, g);
       // since we are adding, we need to deal with aggregation
       if( reg_size > 32 ) return half_l;
-      return _::idxm::add_shuffle_levels({half_l, half_l, 4});
+      return _::idxm::add_shuffle_levels(std::array<std::ptrdiff_t, 3> {half_l, half_l, 4});
     }
 
     if( current_api >= sse2 )

--- a/include/eve/module/core/named_shuffles/swap_adjacent.hpp
+++ b/include/eve/module/core/named_shuffles/swap_adjacent.hpp
@@ -98,7 +98,7 @@ struct swap_adjacent_t
       std::ptrdiff_t half_l = level(eve::as<half_t> {}, g);
       // since we are adding, we need to deal with aggregation
       if( reg_size > 32 ) return half_l;
-      return _::idxm::add_shuffle_levels(std::array<std::ptrdiff_t, 3> {half_l, half_l, 4});
+      return _::idxm::add_shuffle_levels(half_l, half_l, 4);
     }
 
     if( current_api >= sse2 )


### PR DESCRIPTION
A braced list at the `add_shuffle_levels` call site resolves differently on every standard library: libstdc++ 15 sees both the `span` and the `std::array` overload and calls it ambiguous, libstdc++ 14 and 16 find neither viable. A named `std::array` is an exact match in all three, leaves the C++26 guard added for #2317 untouched, and is already how `blend.hpp` writes the same call.

The preemptive matrix gains gcc 14, whose libstdc++ has no `span` constructor from an `initializer_list`. That is the regime gcc 16 reports and the one gcc 15 hides, so the job covers it without changing the image.
