### PR TITLE
Measure the link cost alongside the compile cost

### DIFF
--- a/.github/workflows/compile-cost.yml
+++ b/.github/workflows/compile-cost.yml
@@ -28,6 +28,9 @@ on:
   push:
     branches:
       - main
+  ## Re-runnable by hand, on any branch: a measurement is worth taking again after a machine or an
+  ## image has moved, with nothing to push for it.
+  workflow_dispatch:
 
 concurrency:
   group: compile-cost-${{ github.ref }}
@@ -79,7 +82,7 @@ jobs:
       ##############################################################################################
       - name: Find the reference run
         id: reference
-        if: github.event_name == 'pull_request'
+        if: github.event_name != 'push'
         uses: actions/github-script@v7
         with:
           result-encoding: string
@@ -110,7 +113,7 @@ jobs:
             baseline="--baseline reference/compile-cost.csv"
           else
             baseline=""
-            if [ "${{ github.event_name }}" = "pull_request" ]; then
+            if [ "${{ github.event_name }}" != "push" ]; then
               echo "> No reference from main was found, so this run has no delta." >> "$GITHUB_STEP_SUMMARY"
             fi
           fi

--- a/cmake/config/proc-stat.cmake
+++ b/cmake/config/proc-stat.cmake
@@ -5,20 +5,23 @@
 ##======================================================================================================================
 
 ##======================================================================================================================
-## What a translation unit costs to compile, measured on every unit of the build.
+## What a translation unit costs to compile and an executable to link, on every unit of the build.
 ##
 ## -fproc-stat-report makes clang append one line per invocation with the wall time, the user time
 ## and, above all, the peak memory of that process. Being per process, it is unaffected by -j: the
 ## figure for a file is the same whether it built alone or alongside fifteen others, where a wall
 ## clock is not. It writes no JSON and costs nothing measurable, so it can run on every build.
 ##
+## The driver spawns the linker too, so the same flag on the link line records it under the linker's
+## own name in the first column. Without it, the suite's executables link unmeasured.
+##
 ## The template-level breakdown is a different tier, see config/time-trace.cmake. That one is heavy
 ## and stays local.
 ##======================================================================================================================
-option(EVE_PROC_STAT "Record per-translation-unit time and peak memory" OFF)
+option(EVE_PROC_STAT "Record per-process time and peak memory, compiling and linking" OFF)
 
 set( EVE_PROC_STAT_REPORT "${PROJECT_BINARY_DIR}/compile-cost.csv"
-     CACHE FILEPATH "CSV receiving one line per compiler invocation"
+     CACHE FILEPATH "CSV receiving one line per compiler and linker invocation"
    )
 
 if( NOT EVE_PROC_STAT )
@@ -34,5 +37,6 @@ endif()
 file(REMOVE "${EVE_PROC_STAT_REPORT}")
 
 add_compile_options(-fproc-stat-report=${EVE_PROC_STAT_REPORT})
+add_link_options(-fproc-stat-report=${EVE_PROC_STAT_REPORT})
 
-message(STATUS "[eve] Recording compile cost into ${EVE_PROC_STAT_REPORT}")
+message(STATUS "[eve] Recording compile and link cost into ${EVE_PROC_STAT_REPORT}")

--- a/doc/compile-cost.html
+++ b/doc/compile-cost.html
@@ -344,6 +344,9 @@ footer a { color: var(--primary-color); }
 
 // ---- reading -----------------------------------------------------------------------------------
 // clang writes, with no header: "program","output",total_us,user_us,peak_rss_kb
+// The first field names the tool, so a compilation and a link are told apart by it. They are two
+// populations: an object file and an executable answer different questions.
+var COMPILERS = { clang: 1, "clang++": 1, "clang-cl": 1 };
 
 // The source a CMake object path came from. Objects live in
 // <build>/test/unit/CMakeFiles/<target>.dir/<path>.o, so everything before the .dir/ is build
@@ -374,7 +377,7 @@ function splitRow(line) {
 }
 
 function parse(text) {
-  var rows = [], seen = Object.create(null);
+  var rows = [], links = [], seen = Object.create(null), seenLink = Object.create(null);
   var lines = text.split(/\r?\n/);
   for (var i = 0; i < lines.length; i++) {
     if (!lines[i]) continue;
@@ -382,10 +385,17 @@ function parse(text) {
     if (f.length !== 5) continue;
     var rss = parseInt(f[4], 10), cpu = parseInt(f[3], 10);
     if (!isFinite(rss) || !isFinite(cpu)) continue;
-    var unit = unitOf(f[1]);
-    seen[unit] = { unit: unit, module: moduleOf(unit), rss: rss, cpu: cpu };
+    if (COMPILERS[f[0]]) {
+      var unit = unitOf(f[1]);
+      seen[unit] = { unit: unit, module: moduleOf(unit), rss: rss, cpu: cpu };
+    } else {
+      var target = f[1].slice(f[1].lastIndexOf("/") + 1);
+      seenLink[target] = { unit: target, rss: rss, cpu: cpu };
+    }
   }
   for (var k in seen) rows.push(seen[k]);
+  for (var l in seenLink) links.push(seenLink[l]);
+  rows.links = links;
   return rows;
 }
 
@@ -497,6 +507,14 @@ function renderFacts() {
   out.push("<span class=\"mono\">" + esc(top.module) + "</span> carries " + duration(top.cpu) +
            " of that CPU on its own, " + (100 * top.cpu / totalCpu).toFixed(0) +
            " % of the build, over " + top.units.length + " units.");
+
+  var links = rows.links || [];
+  if (links.length) {
+    var linkCpu = links.reduce(function (a, r) { return a + r.cpu; }, 0);
+    var worstLink = links.reduce(function (a, r) { return r.rss > a.rss ? r : a; }, links[0]);
+    out.push(links.length + " links, " + duration(linkCpu) + " of CPU, the heaviest <span class=\"mono\">" +
+             esc(worstLink.unit) + "</span> at " + size(worstLink.rss) + ".");
+  }
 
   if (state.base) {
     var grew = rows.filter(function (r) {

--- a/doc/compile-cost.html
+++ b/doc/compile-cost.html
@@ -8,6 +8,9 @@
     compile cost workflow. Everything happens in the browser: the file is read locally and never
     leaves the machine, so a measurement can be opened from a laptop with no network at all.
 
+    The file holds two populations, told apart by the tool in its first column: one row per
+    compilation and one per link. The tabs describe the first, the last one describes the second.
+
     The theme variables are copied from doxygen-awesome.css rather than linked, so the page survives
     being saved and opened on its own.
 ==================================================================================================-->
@@ -298,6 +301,7 @@ footer a { color: var(--primary-color); }
       <button type="button" role="tab" id="tab-modules-cpu" aria-controls="panel-modules-cpu" aria-selected="false">Modules by CPU time</button>
       <button type="button" role="tab" id="tab-modules-rss" aria-controls="panel-modules-rss" aria-selected="false">Modules by peak RSS</button>
       <button type="button" role="tab" id="tab-units" aria-controls="panel-units" aria-selected="false">Every unit</button>
+      <button type="button" role="tab" id="tab-links" aria-controls="panel-links" aria-selected="false" hidden>Linking</button>
     </div>
 
     <div class="panel chart" id="panel-hist" role="tabpanel" aria-labelledby="tab-hist">
@@ -315,6 +319,16 @@ footer a { color: var(--primary-color); }
     <div class="panel chart" id="panel-modules-rss" role="tabpanel" aria-labelledby="tab-modules-rss" hidden>
       <button type="button" class="icon save" data-chart="modules-rss" title="Save as PNG" aria-label="Save as PNG"></button>
       <svg id="modules-rss" viewBox="0 0 1080 320" role="img" aria-label="Peak memory per module"></svg>
+    </div>
+    <div class="panel chart" id="panel-links" role="tabpanel" aria-labelledby="tab-links" hidden>
+      <button type="button" class="icon save" data-chart="links" title="Save as PNG" aria-label="Save as PNG"></button>
+      <svg id="links" viewBox="0 0 1080 380" role="img" aria-label="Histogram of link peak memory"></svg>
+      <div class="tablewrap">
+        <table>
+          <thead><tr><th>Executable</th><th class="num">Peak RSS</th><th class="num">CPU</th></tr></thead>
+          <tbody id="links-body"></tbody>
+        </table>
+      </div>
     </div>
     <div class="panel" id="panel-units" role="tabpanel" aria-labelledby="tab-units" hidden>
       <div class="controls">
@@ -556,11 +570,12 @@ function groupByModule(rows) {
 // ---- charts ------------------------------------------------------------------------------------
 function clear(svg) { while (svg.firstChild) svg.removeChild(svg.firstChild); }
 
-function histogram() {
-  var svg = document.getElementById("hist");
+function histogram(id, source, noun) {
+  var svg = document.getElementById(id || "hist");
   clear(svg);
   var W = 1080, H = 380, L = 44, R = 8, T = 14, B = 34;
-  var peaks = state.rows.map(function (r) { return r.rss; }).sort(function (a, b) { return a - b; });
+  noun = noun || "unit";
+  var peaks = (source || state.rows).map(function (r) { return r.rss; }).sort(function (a, b) { return a - b; });
   var max = peaks[peaks.length - 1], bins = 48, counts = new Array(bins).fill(0);
   peaks.forEach(function (v) { counts[Math.min(bins - 1, Math.floor(v / max * bins))]++; });
   var top = Math.max.apply(null, counts);
@@ -578,7 +593,7 @@ function histogram() {
     var h = (H - T - B) * c / top;
     var rect = el("rect", { class: "bar", x: L + i * bw + 0.5, y: H - B - h,
                             width: Math.max(1, bw - 1), height: h, rx: 1 });
-    attachTip(rect, "<b>" + c + " unit" + (c === 1 ? "" : "s") + "</b><br/>between " +
+    attachTip(rect, "<b>" + c + " " + noun + (c === 1 ? "" : "s") + "</b><br/>between " +
                     size(max * i / bins) + " and " + size(max * (i + 1) / bins));
     svg.appendChild(rect);
   });
@@ -789,6 +804,29 @@ function renderModuleFilter() {
   sel.value = keep;
 }
 
+// The twenty heaviest links, plain: there is no module to group them by and no baseline to compare
+// them against, since a link is named by its executable rather than by a source.
+function renderLinkTable() {
+  var body = document.getElementById("links-body");
+  body.innerHTML = "";
+  var links = (state.rows.links || []).slice()
+                .sort(function (a, b) { return b.rss - a.rss; }).slice(0, 20);
+  links.forEach(function (r) {
+    var tr = document.createElement("tr");
+    var name = document.createElement("td");
+    name.className = "mono";
+    name.textContent = r.unit;
+    var rss = document.createElement("td");
+    rss.className = "num";
+    rss.textContent = size(r.rss);
+    var cpu = document.createElement("td");
+    cpu.className = "num";
+    cpu.textContent = duration(r.cpu);
+    tr.appendChild(name); tr.appendChild(rss); tr.appendChild(cpu);
+    body.appendChild(tr);
+  });
+}
+
 function renderAll() {
   if (!state.rows.length) return;
   var groups = groupByModule(state.rows);
@@ -796,13 +834,20 @@ function renderAll() {
   document.getElementById("empty").hidden = true;
   document.getElementById("report").hidden = false;
   renderFacts();
-  histogram();
+  histogram("hist", state.rows, "unit");
   scatter();
   moduleBars("modules-cpu", "cpu");
   moduleBars("modules-rss", "rss");
   renderModuleFilter();
   renderHead();
   renderTable();
+
+  var links = state.rows.links || [];
+  document.getElementById("tab-links").hidden = !links.length;
+  if (links.length) {
+    histogram("links", links, "link");
+    renderLinkTable();
+  }
 }
 
 // ---- loading -------------------------------------------------------------------------------

--- a/tools/compile_cost.py
+++ b/tools/compile_cost.py
@@ -6,6 +6,10 @@
 ##======================================================================================================================
 """Turn clang's -fproc-stat-report output into a Markdown report.
 
+The file carries two kinds of line, one per compiler invocation and one per linker invocation, told
+apart by the tool in the first column. They are reported separately: an object file and an
+executable answer different questions, and adding them would hide both.
+
 The summary is written for $GITHUB_STEP_SUMMARY, where GitHub renders it on the run page, and the full
 table for a file the run attaches. Give it a baseline to get a delta column, which is the part worth
 reading: a ranking of what is expensive today gets looked at twice, where "this file gained 400 MB
@@ -29,6 +33,9 @@ import sys
 # clang writes, with no header: "program","output",total_us,user_us,peak_rss_kb
 FIELDS = 5
 
+# The compiler names itself; every other tool the driver spawns is the linker, whichever one it is.
+COMPILERS = ("clang", "clang++", "clang-cl")
+
 
 def unit_of(output):
     """The source a CMake object path came from, as `module/core/add.cpp`.
@@ -42,14 +49,29 @@ def unit_of(output):
     return name[:-2] if name.endswith(".o") else name
 
 
+def target_of(output):
+    """The executable a link produced, as `unit.api.compress.small`, without its extension."""
+    name = os.path.basename(output)
+    return name[:-4] if name.endswith(".exe") else name
+
+
+def family_of(target):
+    """Where a target sits in the suite, as `core.regular`. Every name opens on the aggregate it
+    belongs to, `unit` or `doc`, which says nothing once the report is titled."""
+    parts = target.split(".")
+    if len(parts) > 1 and parts[0] in ("unit", "doc", "random", "examples"):
+        parts = parts[1:]
+    return ".".join(parts[:2]) if len(parts) > 2 else parts[0]
+
+
 def module_of(unit):
     """The two first path components, which is how the suite is laid out and reported."""
     parts = unit.split("/")
     return "/".join(parts[:2]) if len(parts) > 2 else (parts[0] if len(parts) > 1 else "top level")
 
 
-def read(path, strip=""):
-    """Peak RSS in KiB and CPU microseconds, keyed by the translation unit.
+def read(path, strip="", linking=False):
+    """Peak RSS in KiB and CPU microseconds, keyed by the unit or by the target.
 
     A multi-config generator files the objects under `<target>.dir/<config>/`, and that segment is
     build layout too: `strip` names it, and is left alone where it is not there.
@@ -59,11 +81,16 @@ def read(path, strip=""):
         for row in csv.reader(f):
             if len(row) != FIELDS:
                 continue
+            if (row[0] in COMPILERS) == linking:
+                continue
             try:
-                unit = unit_of(row[1])
-                if strip and unit.startswith(strip):
-                    unit = unit[len(strip):]
-                out[unit] = (int(row[4]), int(row[3]))
+                if linking:
+                    name = target_of(row[1])
+                else:
+                    name = unit_of(row[1])
+                    if strip and name.startswith(strip):
+                        name = name[len(strip):]
+                out[name] = (int(row[4]), int(row[3]))
             except ValueError:
                 continue
     return out
@@ -124,35 +151,35 @@ def table(rows, header, with_delta):
     return "\n".join(out)
 
 
-def by_module(measures):
+def by_module(measures, group=module_of):
     """Units grouped under their module, each group sorted heaviest first."""
     groups = {}
     for unit, (mem, cpu) in measures.items():
-        groups.setdefault(module_of(unit), []).append((unit, mem, cpu))
+        groups.setdefault(group(unit), []).append((unit, mem, cpu))
     for units in groups.values():
         units.sort(key=lambda u: u[1], reverse=True)
     return groups
 
 
-def headline(measures, title, level, grew_line=None):
+def headline(measures, title, level, grew_line=None, noun="translation unit", group=module_of):
     """The facts worth stating before any table, as a list rather than a paragraph."""
     peaks = sorted(m for m, _ in measures.values())
     total_cpu = sum(c for _, c in measures.values())
     worst, (worst_mem, worst_cpu) = max(measures.items(), key=lambda kv: kv[1][0])
 
-    groups = by_module(measures)
+    groups = by_module(measures, group)
     top_mod, top_units = max(groups.items(), key=lambda kv: sum(u[2] for u in kv[1]))
     top_cpu = sum(u[2] for u in top_units)
 
     out = ["%s %s\n" % ("#" * level, title)]
-    out.append("- **%d translation units**, %s of CPU in all."
-               % (len(measures), duration(total_cpu)))
+    out.append("- **%d %ss**, %s of CPU in all."
+               % (len(measures), noun, duration(total_cpu)))
     out.append("- The heaviest one is `%s`, peaking at **%s** over %s."
                % (worst, size(worst_mem), duration(worst_cpu)))
     out.append("- Half of them peak under %s, a tenth above %s."
                % (size(quantile(peaks, 0.5)), size(quantile(peaks, 0.9))))
     share = "%.0f %%" % (100.0 * top_cpu / total_cpu) if total_cpu else "n/a"
-    out.append("- `%s` carries %s of that CPU on its own, %s of the build, over %d units."
+    out.append("- `%s` carries %s of that CPU on its own, %s of the total, over %d of them."
                % (top_mod, duration(top_cpu), share, len(top_units)))
     if grew_line:
         out.append(grew_line)
@@ -173,11 +200,13 @@ def main():
     out = open(args.summary, "w") if args.summary else sys.stdout
 
     now = read(args.current, args.strip)
+    links = read(args.current, linking=True)
     if not now:
         print("No measurement in `%s`." % args.current, file=out)
         return 0
 
     was = read(args.baseline, args.strip) if args.baseline else {}
+    was_links = read(args.baseline, linking=True) if args.baseline else {}
     d = bool(was)
 
     # Regressions first: what changed is what gets acted on.
@@ -216,6 +245,13 @@ def main():
                 for u in units[: args.top]]
         print(table(rows, "Translation unit", d), file=out)
 
+    # Linking is a second population: one process per executable, against one per source above.
+    if links:
+        print("\n%s" % headline(links, "Linking", 3, noun="executable", group=family_of), file=out)
+        ranked_links = sorted(links.items(), key=lambda kv: kv[1][0], reverse=True)
+        print(table([(k, v[0], v[1], delta_cell(v[0], was_links.get(k, (None,))[0]))
+                     for k, v in ranked_links[:10]], "Executable", bool(was_links)), file=out)
+
     if args.full:
         # The summary is capped at a mebibyte and nobody reads seven hundred rows on a run page.
         # The whole table goes to a file the workflow attaches, so nothing measured is thrown away.
@@ -226,9 +262,20 @@ def main():
             f.write(table([(k, v[0], v[1], delta_cell(v[0], was.get(k, (None,))[0]))
                            for k, v in ranked], "Translation unit", d))
             f.write("\n")
-        print("\n*Every unit is measured. The complete table and the raw CSV are attached to this run.*", file=out)
+            if links:
+                ranked_links = sorted(links.items(), key=lambda kv: kv[1][0], reverse=True)
+                f.write("\n")
+                f.write(headline(links, "Linking, every executable", 1,
+                                 noun="executable", group=family_of))
+                f.write("\n")
+                f.write(table([(k, v[0], v[1], delta_cell(v[0], was_links.get(k, (None,))[0]))
+                               for k, v in ranked_links], "Executable", bool(was_links)))
+                f.write("\n")
+        print("\n*Every compilation and every link is measured. The complete tables and the raw CSV"
+              " are attached to this run.*", file=out)
     else:
-        print("\n*Every unit is measured; the full table is in the attached CSV.*", file=out)
+        print("\n*Every compilation and every link is measured; the full tables are in the attached"
+              " CSV.*", file=out)
 
     if args.summary:
         out.close()


### PR DESCRIPTION
`proc-stat.cmake` set `-fproc-stat-report` through `add_compile_options`, which never reaches a link line, so the suite's 771 executables linked unmeasured. The same flag on the link line records the linker, and the reader splits on the tool column rather than on a list of linker names.
