### PR TITLE
CI Infrastructure rework

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -76,6 +76,30 @@ jobs:
         run:  |
           cd build && ctest --output-on-failure -j 4 -R ^doc.*.exe
 
+  ##################################################################################################
+  ## The documentation examples on Windows
+  ##################################################################################################
+  windows:
+    runs-on: [windows-2022]
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Fetch current branch
+        uses: actions/checkout@v6
+      ## Ninja needs the MSVC environment already loaded.
+      - name: Load the MSVC environment
+        uses: ilammy/msvc-dev-cmd@v1
+      - name: Prepare EVE with MSVC
+        run:  |
+          cmake -G Ninja -B build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS="-DEVE_NO_FORCEINLINE"
+      - name: Compile Documentation Tests
+        run:  |
+          cd build && cmake --build . --target doc.exe --parallel 4
+      - name: Run Documentation Tests
+        run:  |
+          cd build && ctest --output-on-failure -j 4 -R ^doc.*.exe
+
   #################################################################################################
   # DOXYGEN WARNINGS
   #

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -28,10 +28,6 @@ jobs:
         - { comp: 'clang' }
         - { comp: 'gcc'   }
     steps:
-      - name: Print Runner Info
-        run: |
-          system_profiler SPHardwareDataType | grep -E "(Memory|Cores)"
-          df -h /System/Volumes/Data
       - name: Fetch current branch
         uses: actions/checkout@v6
       - name: Running CMake for ${{ matrix.cfg.comp }}
@@ -57,11 +53,6 @@ jobs:
         - { comp: gcc  , arch: sve128 , opts: -Wno-psabi }
         - { comp: gcc  , arch: ppc64  , opts: -Wno-psabi }
     steps:
-      - name: Print Runner Info
-        run: |
-          echo "CPU cores: $(nproc)"
-          echo "Memory: $(free -h | grep '^Mem:' | awk '{print $2}')"
-          echo "Available disk space: $(df -h / | tail -1 | awk '{print $4 "/" $2}')"
       - name: Fetch current branch
         uses: actions/checkout@v6
       - name: Prepare EVE with ${{ matrix.cfg.comp }} @ ${{ matrix.cfg.arch }} with ${{ matrix.cfg.opts }}

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -405,12 +405,9 @@ jobs:
         ## One runner per chunk. They used to be seven steps of one job, each cleaning the build the
         ## previous one left, because a single runner has a single disk.
         chunk:
-        - {name: arch    , targets: "unit.arch.exe unit.internals.exe unit.meta.exe examples.exe"                      , tests: "unit.arch|unit.internals|unit.meta|examples"}
-        - {name: api     , targets: "unit.api.exe unit.memory.exe"                                                       , tests: "unit.api|unit.memory"}
-        - {name: core    , targets: "unit.core.exe"                                                                      , tests: "unit.core"}
-        - {name: math    , targets: "unit.math.exe"                                                                      , tests: "unit.math"}
-        - {name: advanced, targets: "unit.bessel.exe unit.combinatorial.exe unit.elliptic.exe unit.polynomial.exe unit.special.exe", tests: "unit.bessel|unit.combinatorial|unit.elliptic|unit.polynomial|unit.special"}
-        - {name: algo    , targets: "unit.algo.exe"                                                                      , tests: "unit.algo"}
+        - {name: core , targets: "unit.core.exe"                                                                                  , tests: "unit.core"}
+        - {name: api  , targets: "unit.api.exe unit.memory.exe unit.bessel.exe unit.combinatorial.exe unit.elliptic.exe unit.polynomial.exe unit.special.exe" , tests: "unit.api|unit.memory|unit.bessel|unit.combinatorial|unit.elliptic|unit.polynomial|unit.special"}
+        - {name: algo , targets: "unit.algo.exe unit.math.exe unit.arch.exe unit.internals.exe unit.meta.exe examples.exe"         , tests: "unit.algo|unit.math|unit.arch|unit.internals|unit.meta|examples"}
 
     steps:
       - name: Fetch current branch

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -405,13 +405,12 @@ jobs:
         ## One runner per chunk. They used to be seven steps of one job, each cleaning the build the
         ## previous one left, because a single runner has a single disk.
         chunk:
-        - {name: arch    , targets: "unit.arch.exe"                                                                      , tests: "unit.arch"}
+        - {name: arch    , targets: "unit.arch.exe examples.exe"                                                        , tests: "unit.arch|examples"}
         - {name: api     , targets: "unit.api.exe unit.memory.exe"                                                       , tests: "unit.api|unit.memory"}
         - {name: core    , targets: "unit.core.exe unit.internals.exe unit.meta.exe"                                      , tests: "unit.core|unit.internals|unit.meta"}
         - {name: math    , targets: "unit.math.exe"                                                                      , tests: "unit.math"}
         - {name: advanced, targets: "unit.bessel.exe unit.combinatorial.exe unit.elliptic.exe unit.polynomial.exe unit.special.exe", tests: "unit.bessel|unit.combinatorial|unit.elliptic|unit.polynomial|unit.special"}
         - {name: algo    , targets: "unit.algo.exe"                                                                      , tests: "unit.algo"}
-        - {name: doc     , targets: "doc.exe examples.exe"                                                               , tests: "doc|examples"}
 
     steps:
       - name: Fetch current branch

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -402,79 +402,35 @@ jobs:
         cfg:
         - {name: "MSVC"   , mode: Debug   , options: "-DEVE_NO_FORCEINLINE"}
         # - {name: "ClangCL", mode: Debug   , options: "-DEVE_NO_FORCEINLINE", toolchain: "-T ClangCL -DEVE_USE_PCH=OFF"}
-  
+        ## One runner per chunk. They used to be seven steps of one job, each cleaning the build the
+        ## previous one left, because a single runner has a single disk.
+        chunk:
+        - {name: arch    , targets: "unit.arch.exe"                                                                      , tests: "unit.arch"}
+        - {name: api     , targets: "unit.api.exe unit.memory.exe"                                                       , tests: "unit.api|unit.memory"}
+        - {name: core    , targets: "unit.core.exe unit.internals.exe unit.meta.exe"                                      , tests: "unit.core|unit.internals|unit.meta"}
+        - {name: math    , targets: "unit.math.exe"                                                                      , tests: "unit.math"}
+        - {name: advanced, targets: "unit.bessel.exe unit.combinatorial.exe unit.elliptic.exe unit.polynomial.exe unit.special.exe", tests: "unit.bessel|unit.combinatorial|unit.elliptic|unit.polynomial|unit.special"}
+        - {name: algo    , targets: "unit.algo.exe"                                                                      , tests: "unit.algo"}
+        - {name: doc     , targets: "doc.exe examples.exe"                                                               , tests: "doc|examples"}
+
     steps:
       - name: Fetch current branch
         uses: actions/checkout@v6
-      - name: Running CMake for ${{ matrix.cfg.name }} with ${{ matrix.cfg.options }} 
+      - name: Running CMake for ${{ matrix.cfg.name }} with ${{ matrix.cfg.options }}
         run: |
           cmake -G "Visual Studio 17 2022" -A x64 -B build ${{ matrix.cfg.toolchain }} -DCMAKE_CXX_FLAGS="${{ matrix.cfg.options }}"
 
-      - name: Arch Tests
+      - name: Compiling ${{ matrix.chunk.name }}
         run: |
           cd build
-          cmake --build . --target unit.arch.exe --config ${{ matrix.cfg.mode }}  --parallel 2
-          ctest -C ${{ matrix.cfg.mode }} --output-on-failure -R unit.arch        --parallel 2
-         
-      - name: API Tests
-        run: |
-          cd build
-          cmake --build . --target clean            --config ${{ matrix.cfg.mode }}
-          cmake --build . --target unit.api.exe     --config ${{ matrix.cfg.mode }} --parallel 2
-          cmake --build . --target unit.memory.exe  --config ${{ matrix.cfg.mode }} --parallel 2
-          ctest -C ${{ matrix.cfg.mode }} --output-on-failure -R unit.api           --parallel 2 
-          ctest -C ${{ matrix.cfg.mode }} --output-on-failure -R unit.memory        --parallel 2
- 
-      - name: Core Tests
-        run: |
-          cd build
-          cmake --build . --target clean                --config ${{ matrix.cfg.mode }}
-          cmake --build . --target unit.core.exe        --config ${{ matrix.cfg.mode }} --parallel 2
-          cmake --build . --target unit.internals.exe   --config ${{ matrix.cfg.mode }} --parallel 2
-          cmake --build . --target unit.meta.exe        --config ${{ matrix.cfg.mode }} --parallel 2
-          ctest -C ${{ matrix.cfg.mode }} --output-on-failure -R unit.core              --parallel 2       
-          ctest -C ${{ matrix.cfg.mode }} --output-on-failure -R unit.internals         --parallel 2 
-          ctest -C ${{ matrix.cfg.mode }} --output-on-failure -R unit.meta              --parallel 2 
+          for target in ${{ matrix.chunk.targets }}; do
+            cmake --build . --target $target --config ${{ matrix.cfg.mode }} --parallel 4
+          done
 
-      - name: Math Tests
+      - name: Running ${{ matrix.chunk.name }}
         run: |
           cd build
-          cmake --build . --target clean          --config ${{ matrix.cfg.mode }}
-          cmake --build . --target unit.math.exe  --config ${{ matrix.cfg.mode }} --parallel 2
-          ctest -C ${{ matrix.cfg.mode }} --output-on-failure -R unit.math        --parallel 2
-
-      - name: Advanced Maths Tests 
-        run: |
-          cd build
-          cmake --build . --target clean --config ${{ matrix.cfg.mode }}
-          cmake --build . --target unit.bessel.exe          --config ${{ matrix.cfg.mode }} --parallel 2
-          cmake --build . --target unit.combinatorial.exe   --config ${{ matrix.cfg.mode }} --parallel 2
-          cmake --build . --target unit.elliptic.exe        --config ${{ matrix.cfg.mode }} --parallel 2
-          cmake --build . --target unit.polynomial.exe      --config ${{ matrix.cfg.mode }} --parallel 2
-          cmake --build . --target unit.special.exe         --config ${{ matrix.cfg.mode }} --parallel 2
-          ctest -C ${{ matrix.cfg.mode }} --output-on-failure -R unit.bessel                --parallel 2 
-          ctest -C ${{ matrix.cfg.mode }} --output-on-failure -R unit.combinatorial         --parallel 2 
-          ctest -C ${{ matrix.cfg.mode }} --output-on-failure -R unit.elliptic              --parallel 2 
-          ctest -C ${{ matrix.cfg.mode }} --output-on-failure -R unit.polynomial            --parallel 2 
-          ctest -C ${{ matrix.cfg.mode }} --output-on-failure -R unit.special               --parallel 2   
-
-      - name: Algorithms Tests 
-        run: |
-          cd build
-          cmake --build . --target clean          --config ${{ matrix.cfg.mode }}
-          cmake --build . --target unit.algo.exe  --config ${{ matrix.cfg.mode }} --parallel 2
-          ctest -C ${{ matrix.cfg.mode }} --output-on-failure -R unit.algo        --parallel 2
-
-      - name: Doc & Examples Tests 
-        run: |
-          cd build
-          cmake --build . --target clean          --config ${{ matrix.cfg.mode }}
-          cmake --build . --target doc.exe        --config ${{ matrix.cfg.mode }} --parallel 2
-          cmake --build . --target examples.exe   --config ${{ matrix.cfg.mode }} --parallel 2
-          ctest -C ${{ matrix.cfg.mode }} --output-on-failure -R doc              --parallel 2
-          ctest -C ${{ matrix.cfg.mode }} --output-on-failure -R examples         --parallel 2
-
-
+          ctest -C ${{ matrix.cfg.mode }} --output-on-failure -R "${{ matrix.chunk.tests }}" --parallel 4
   ##################################################################################################
   ## Host 1 - Pre-Skylake SIMD ISA - clang
   ##################################################################################################

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -453,7 +453,7 @@ jobs:
       - name: Running CMake for ${{ matrix.cfg.comp }} on ${{ matrix.cfg.arch }} with ${{ matrix.cfg.opts }}
         run: |
           mkdir build && cd build
-          cmake .. -G Ninja -DEVE_OPTIONS="${{ matrix.cfg.opts }}" -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchain/${{ matrix.cfg.comp }}.${{ matrix.cfg.arch }}.cmake
+          cmake .. -G Ninja -DEVE_OPTIONS="${{ matrix.cfg.opts }}" -DEVE_HEAVY_POOL=3 -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchain/${{ matrix.cfg.comp }}.${{ matrix.cfg.arch }}.cmake
       - name: Compiling Unit Tests
         run:  cd build && ninja unit.exe -j 10
       - name: Running Unit Tests
@@ -482,7 +482,7 @@ jobs:
         run:  |
           mkdir build
           cd build
-          cmake ..  -G Ninja -DEVE_OPTIONS="${{ matrix.cfg.opts }}" \
+          cmake ..  -G Ninja -DEVE_OPTIONS="${{ matrix.cfg.opts }}" -DEVE_HEAVY_POOL=3 \
                     -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchain/${{ matrix.cfg.comp }}.${{ matrix.cfg.arch }}.cmake
       - name: Compiling Unit Tests
         run:  cd build && ninja unit.exe -j 10
@@ -512,7 +512,7 @@ jobs:
       - name: Running CMake for ${{ matrix.cfg.comp }} on ${{ matrix.cfg.arch }} with ${{ matrix.cfg.opts }}
         run: |
           mkdir build && cd build
-          cmake .. -G Ninja -DEVE_OPTIONS="${{ matrix.cfg.opts }}" -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchain/${{ matrix.cfg.comp }}.${{ matrix.cfg.arch }}.cmake
+          cmake .. -G Ninja -DEVE_OPTIONS="${{ matrix.cfg.opts }}" -DEVE_HEAVY_POOL=3 -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchain/${{ matrix.cfg.comp }}.${{ matrix.cfg.arch }}.cmake
       - name: Compiling Unit Tests
         run:  cd build && ninja unit.exe -j 10
       - name: Running Unit Tests
@@ -538,9 +538,9 @@ jobs:
       - name: Running CMake for ${{ matrix.cfg.comp }} on ${{ matrix.cfg.arch }} with ${{ matrix.cfg.opts }}
         run: |
           mkdir build && cd build
-          cmake .. -G Ninja -DEVE_OPTIONS="${{ matrix.cfg.opts }}" -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchain/${{ matrix.cfg.comp }}.${{ matrix.cfg.arch }}.cmake
+          cmake .. -G Ninja -DEVE_OPTIONS="${{ matrix.cfg.opts }}" -DEVE_HEAVY_POOL=3 -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchain/${{ matrix.cfg.comp }}.${{ matrix.cfg.arch }}.cmake
       - name: Compiling Unit Tests
-        run:  cd build && ninja unit.exe -j 5
+        run:  cd build && ninja unit.exe -j 8
       - name: Running Unit Tests
         run:  cd build && ctest --output-on-failure -j 4 --timeout 3600 -E ^doc.*.exe
 
@@ -565,9 +565,9 @@ jobs:
       - name: Running CMake for ${{ matrix.cfg.comp }} on ${{ matrix.cfg.arch }} with ${{ matrix.cfg.opts }}
         run: |
           mkdir build && cd build
-          cmake .. -G Ninja -DEVE_OPTIONS="${{ matrix.cfg.opts }}" -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchain/${{ matrix.cfg.comp }}.${{ matrix.cfg.arch }}.cmake
+          cmake .. -G Ninja -DEVE_OPTIONS="${{ matrix.cfg.opts }}" -DEVE_HEAVY_POOL=3 -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchain/${{ matrix.cfg.comp }}.${{ matrix.cfg.arch }}.cmake
       - name: Compiling Unit Tests
-        run:  cd build && ninja unit.exe -j 5
+        run:  cd build && ninja unit.exe -j 8
       - name: Running Unit Tests
         run: cd build && ctest --output-on-failure -j 4 --timeout 3600 -E ^doc.*.exe
 

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -405,9 +405,9 @@ jobs:
         ## One runner per chunk. They used to be seven steps of one job, each cleaning the build the
         ## previous one left, because a single runner has a single disk.
         chunk:
-        - {name: arch    , targets: "unit.arch.exe examples.exe"                                                        , tests: "unit.arch|examples"}
+        - {name: arch    , targets: "unit.arch.exe unit.internals.exe unit.meta.exe examples.exe"                      , tests: "unit.arch|unit.internals|unit.meta|examples"}
         - {name: api     , targets: "unit.api.exe unit.memory.exe"                                                       , tests: "unit.api|unit.memory"}
-        - {name: core    , targets: "unit.core.exe unit.internals.exe unit.meta.exe"                                      , tests: "unit.core|unit.internals|unit.meta"}
+        - {name: core    , targets: "unit.core.exe"                                                                      , tests: "unit.core"}
         - {name: math    , targets: "unit.math.exe"                                                                      , tests: "unit.math"}
         - {name: advanced, targets: "unit.bessel.exe unit.combinatorial.exe unit.elliptic.exe unit.polynomial.exe unit.special.exe", tests: "unit.bessel|unit.combinatorial|unit.elliptic|unit.polynomial|unit.special"}
         - {name: algo    , targets: "unit.algo.exe"                                                                      , tests: "unit.algo"}

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -416,21 +416,25 @@ jobs:
     steps:
       - name: Fetch current branch
         uses: actions/checkout@v6
+      ## Ninja needs the MSVC environment already loaded, where the Visual Studio generator found it
+      ## on its own.
+      - name: Load the MSVC environment
+        uses: ilammy/msvc-dev-cmd@v1
       - name: Running CMake for ${{ matrix.cfg.name }} with ${{ matrix.cfg.options }}
         run: |
-          cmake -G "Visual Studio 17 2022" -A x64 -B build ${{ matrix.cfg.toolchain }} -DCMAKE_CXX_FLAGS="${{ matrix.cfg.options }}"
+          cmake -G Ninja -B build -DCMAKE_BUILD_TYPE=${{ matrix.cfg.mode }} ${{ matrix.cfg.toolchain }} -DCMAKE_CXX_FLAGS="${{ matrix.cfg.options }}"
 
       - name: Compiling ${{ matrix.chunk.name }}
         run: |
           cd build
           for target in ${{ matrix.chunk.targets }}; do
-            cmake --build . --target $target --config ${{ matrix.cfg.mode }} --parallel 4
+            cmake --build . --target $target --parallel 4
           done
 
       - name: Running ${{ matrix.chunk.name }}
         run: |
           cd build
-          ctest -C ${{ matrix.cfg.mode }} --output-on-failure -R "${{ matrix.chunk.tests }}" --parallel 4
+          ctest --output-on-failure -R "${{ matrix.chunk.tests }}" --parallel 4
   ##################################################################################################
   ## Host 1 - Pre-Skylake SIMD ISA - clang
   ##################################################################################################

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -392,6 +392,7 @@ jobs:
   ## Windows Targets
   ##################################################################################################
   windows:
+    name: windows (${{ matrix.cfg.name }}, ${{ matrix.chunk.name }})
     runs-on: [windows-2022]
     defaults:
       run:

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -493,7 +493,8 @@ jobs:
   ## Host 1 - Pre-Skylake SIMD ISA - g++
   ##################################################################################################
   x86-gcc:
-    needs: other-arch
+    ## Chaining this behind other-arch lowers no load: two agents run two legs either way.
+    needs: x86-clang
     runs-on: [self-hosted, generic-x86]
     container:
       image: ghcr.io/jfalcou/compilers:v10

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ if( EVE_BUILD_TEST )
   include(config/pch)
   include(config/proc-stat)
   include(config/time-trace)
+  include(config/job-pools)
 
   include(target/add_parent_target)
   include(target/targets)

--- a/cmake/config/heavy-units.cmake
+++ b/cmake/config/heavy-units.cmake
@@ -1,0 +1,90 @@
+##====================================================================================================================
+##  EVE - Expressive Vector Engine
+##  Copyright : EVE Project Contributors
+##  SPDX-License-Identifier: BSL-1.0
+##====================================================================================================================
+
+## Targets peaking at 1.5 GiB or more, from the last measurement on main.
+## Regenerate with: tools/compile_cost.py <csv> --heavy cmake/config/heavy-units.cmake
+
+set( EVE_HEAVY_TARGETS
+     unit.algo.algorithm.copy_backward_generic.exe
+     unit.algo.algorithm.copy_generic.exe
+     unit.algo.algorithm.equal_generic.exe
+     unit.algo.algorithm.inclusive_scan_to_generic.exe
+     unit.algo.algorithm.mismatch_generic.exe
+     unit.algo.algorithm.reverse_copy_generic.exe
+     unit.algo.algorithm.swap_ranges_generic.exe
+     unit.algo.algorithm.transform_to_generic.exe
+     unit.algo.views.converting_eve_iterator.exe
+     unit.algo.views.map_eve_iterator.exe
+     unit.algo.views.zip_iterator.exe
+     unit.api.compress.compress_copy_scalar_wide.large.exe
+     unit.api.compress.compress_copy_scalar_wide.small.exe
+     unit.api.compress.compress_copy_simd_tuple.small.exe
+     unit.api.compress.compress_copy_simd_wide.large.exe
+     unit.api.compress.compress_copy_simd_wide.small.exe
+     unit.api.compress.compress_copy_wide.large.exe
+     unit.api.compress.compress_copy_wide.small.exe
+     unit.api.compress.compress_logical.exe
+     unit.api.regular.interleave.exe
+     unit.api.regular.shuffle_v2.blend.exe
+     unit.api.regular.shuffle_v2.broadcast_lane.exe
+     unit.api.regular.shuffle_v2.reverse_in_subgroups.exe
+     unit.api.regular.shuffle_v2.shuffle_v2_driver.exe
+     unit.api.regular.shuffle_v2.shuffle_v2_driver_intergration.exe
+     unit.api.regular.shuffle_v2.slide_left_1.exe
+     unit.api.regular.swizzle.broadcast.exe
+     unit.api.translation.ctor.exe
+     unit.api.tuple.swizzle.broadcast.exe
+     unit.core.absmax.exe
+     unit.core.absmin.exe
+     unit.core.add.exe
+     unit.core.average.exe
+     unit.core.bit_and.exe
+     unit.core.bit_andnot.exe
+     unit.core.bit_notand.exe
+     unit.core.bit_notor.exe
+     unit.core.bit_or.exe
+     unit.core.bit_ornot.exe
+     unit.core.bit_ternary.exe
+     unit.core.bit_xor.exe
+     unit.core.dec.exe
+     unit.core.decorated.div.exe
+     unit.core.decorated.rem.exe
+     unit.core.div.exe
+     unit.core.fam.exe
+     unit.core.fanm.exe
+     unit.core.fma.exe
+     unit.core.fms.exe
+     unit.core.fnma.exe
+     unit.core.fnms.exe
+     unit.core.fsm.exe
+     unit.core.fsnm.exe
+     unit.core.inc.exe
+     unit.core.is_equal.exe
+     unit.core.is_not_equal.exe
+     unit.core.logical_and.exe
+     unit.core.logical_andnot.exe
+     unit.core.logical_notand.exe
+     unit.core.logical_notor.exe
+     unit.core.logical_or.exe
+     unit.core.logical_ornot.exe
+     unit.core.logical_xor.exe
+     unit.core.max.exe
+     unit.core.maxabs.exe
+     unit.core.maxmag.exe
+     unit.core.min.exe
+     unit.core.minabs.exe
+     unit.core.minmax.exe
+     unit.core.mul.exe
+     unit.core.rec.exe
+     unit.core.reduce.exe
+     unit.core.sort.exe
+     unit.core.sqr.exe
+     unit.core.sub.exe
+     unit.internals.aggregation.exe
+     unit.memory.load.aligned.arithmetic_if.exe
+     unit.memory.load.aligned.logical_if.exe
+     unit.memory.stack_buffer.exe
+   )

--- a/cmake/config/job-pools.cmake
+++ b/cmake/config/job-pools.cmake
@@ -1,0 +1,29 @@
+##======================================================================================================================
+##  EVE - Expressive Vector Engine
+##  Copyright : EVE Project Contributors
+##  SPDX-License-Identifier: BSL-1.0
+##======================================================================================================================
+
+##======================================================================================================================
+## How many of the heaviest units may compile at once.
+##
+## A build's appetite is set by its unluckiest draw: at -j 10 with nothing holding them back, ten of
+## the heaviest units can land together and ask for 31 GiB. A Ninja pool bounds that set, and the
+## bound is what lets two agents share a host without the reaper arbitrating between them.
+##
+## The depth belongs to the machine, not to the repository: it is a cache variable each job sets.
+## Zero leaves every target where it was, which is what a generator other than Ninja gets anyway.
+##
+## The list of targets comes from the measurement, see config/heavy-units.cmake.
+##======================================================================================================================
+set( EVE_HEAVY_POOL 0
+     CACHE STRING "How many targets from heavy-units.cmake may compile at once, 0 to not pool them"
+   )
+
+include(${PROJECT_SOURCE_DIR}/cmake/config/heavy-units.cmake)
+
+if( EVE_HEAVY_POOL GREATER 0 )
+  set_property(GLOBAL APPEND PROPERTY JOB_POOLS heavy=${EVE_HEAVY_POOL})
+  list(LENGTH EVE_HEAVY_TARGETS eve_heavy_count)
+  message(STATUS "[eve] ${eve_heavy_count} heavy targets compile ${EVE_HEAVY_POOL} at a time")
+endif()

--- a/cmake/target/generate_test.cmake
+++ b/cmake/target/generate_test.cmake
@@ -21,6 +21,11 @@ function(generate_test root rootpath dep file)
 
   add_executable( ${test}  "${rootpath}${file}")
 
+  ## A target the measurement found heavy waits for a slot rather than piling onto the others.
+  if( EVE_HEAVY_POOL GREATER 0 AND ${test} IN_LIST EVE_HEAVY_TARGETS )
+    set_target_properties(${test} PROPERTIES JOB_POOL_COMPILE heavy)
+  endif()
+
   if( ${ARGC} EQUAL 5)
     target_compile_definitions( ${test} PUBLIC ${ARGV4})
   endif()

--- a/tools/compile_cost.py
+++ b/tools/compile_cost.py
@@ -70,6 +70,26 @@ def module_of(unit):
     return "/".join(parts[:2]) if len(parts) > 2 else (parts[0] if len(parts) > 1 else "top level")
 
 
+def read_targets(path):
+    """Peak RSS and CPU of every compilation, keyed by the target the object belongs to.
+
+    A pool is set on a target, where the rest of this tool reasons in translation units.
+    """
+    out = {}
+    with open(path, newline="") as f:
+        for row in csv.reader(f):
+            if len(row) != FIELDS or row[0] not in COMPILERS:
+                continue
+            i, j = row[1].find("CMakeFiles/"), row[1].find(".dir/")
+            if i < 0 or j < 0:
+                continue
+            try:
+                out[row[1][i + len("CMakeFiles/"):j]] = (int(row[4]), int(row[3]))
+            except ValueError:
+                continue
+    return out
+
+
 def read(path, strip="", linking=False):
     """Peak RSS in KiB and CPU microseconds, keyed by the unit or by the target.
 
@@ -186,6 +206,30 @@ def headline(measures, title, level, grew_line=None, noun="translation unit", gr
     return "\n".join(out) + "\n"
 
 
+def write_heavy(measures, path, threshold_gib):
+    """The CMake list of targets a job pool has to hold back.
+
+    A pool is sized against a worst case, so the bound is only worth what the list is: a unit that
+    crosses the threshold without being written here brings the unlucky draw back.
+    """
+    kib = threshold_gib * 1024 * 1024
+    heavy = sorted((k for k, v in measures.items() if v[0] >= kib))
+    with open(path, "w") as f:
+        f.write("##" + "=" * 116 + "\n")
+        f.write("##  EVE - Expressive Vector Engine\n")
+        f.write("##  Copyright : EVE Project Contributors\n")
+        f.write("##  SPDX-License-Identifier: BSL-1.0\n")
+        f.write("##" + "=" * 116 + "\n\n")
+        f.write("## Targets peaking at %.1f GiB or more, from the last measurement on main.\n"
+                "## Regenerate with: tools/compile_cost.py <csv> --heavy %s\n\n"
+                % (threshold_gib, path))
+        f.write("set( EVE_HEAVY_TARGETS\n")
+        for name in heavy:
+            f.write("     %s\n" % name)
+        f.write("   )\n")
+    return len(heavy)
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("current")
@@ -195,7 +239,15 @@ def main():
     ap.add_argument("--full", help="write the complete per-unit table, as Markdown, to this file")
     ap.add_argument("--summary", help="write the summary to this file rather than to stdout")
     ap.add_argument("--strip", default="", help="path segment a multi-config generator adds, e.g. Debug/")
+    ap.add_argument("--heavy", help="write the CMake list of pooled targets to this file")
+    ap.add_argument("--heavy-threshold", type=float, default=1.5, help="GiB above which a target is pooled (default 1.5)")
     args = ap.parse_args()
+
+    if args.heavy:
+        targets = read_targets(args.current)
+        n = write_heavy(targets, args.heavy, args.heavy_threshold)
+        print("%d targets at or above %.1f GiB written to %s" % (n, args.heavy_threshold, args.heavy))
+        return 0
 
     out = open(args.summary, "w") if args.summary else sys.stdout
 


### PR DESCRIPTION
To shorten the long path on CI machines : 
 + Windows now uses Ninja on 3 parallel workers, reducing its time to completion by 66%
 + Other jobs use the Ninja pool feature to be sure we always compile a fixed amount of heavy RAM jobs at once, letting us run at full -j.
 + Legen has a looser ordering to let the gcc/other arch targets order themselves as best as they can.

We tried using G++ 16 so that SVE machines could use PCH, but it turns out we have a bunch of code to fix to do so. So we'regoing to fix EVE for g++-16 then do that in another PR.

Total time goes down from 4h05 to 3h20.